### PR TITLE
Add example of prompt and confirm dialogs

### DIFF
--- a/www/examples.md
+++ b/www/examples.md
@@ -21,3 +21,4 @@ You can copy and paste them and then adjust them for your needs.
 | [Active Search](/examples/active-search) | Demonstrates the active search box pattern
 | [Progress Bar](/examples/progress-bar) | Demonstrates a job-runner like progress bar
 | [Value Select](/examples/value-select) | Demonstrates making the values of a select dependent on another select
+| [Dialogs](/examples/dialogs) | Demonstrates the prompt and confirm dialogs

--- a/www/examples/dialogs.md
+++ b/www/examples/dialogs.md
@@ -1,0 +1,63 @@
+---
+layout: demo_layout.njk
+---
+
+## Dialogs
+
+Dialogs can be triggered with the [`hx-prompt`](/attributes/hx-prompt) and [`hx-confirm`](/attributes/hx-confirm) attributes.  These are triggered by the user interaction that would trigger the AJAX request, but the request is only sent if the dialog is accepted.
+
+```html
+<div>
+  <button class="btn"
+          hx-post="/submit"
+          hx-prompt="Enter a string"
+          hx-confirm="Are you sure?"
+          hx-target="#response">
+    Prompt Submission
+  </button>
+  <div id="response"></div>
+</div>
+```
+
+The value provided by the user to the prompt dialog is sent to the server in a `X-HX-Prompt` header.  In this case, the server simply echos the user input back.
+
+```html
+User entered <i>${response}</i>
+```
+
+{% include demo_ui.html.liquid %}
+
+<script>
+
+    //=========================================================================
+    // Fake Server Side Code
+    //=========================================================================
+
+    // routes
+    init("/demo", function(request, params){
+      return submitButton();
+    });
+
+    onPost("/submit", function(request, params){
+        var response = request.requestHeaders['X-HX-Prompt'];
+        return promptSubmit(response);
+    });
+
+    // templates
+    function submitButton() {
+      return `<div>
+  <button class="btn"
+          hx-post="/submit"
+          hx-prompt="Enter a string"
+          hx-confirm="Are you sure?"
+          hx-target="#response">
+    Prompt Submission
+  </button>
+  <div id="response"></div>
+</div>`;
+    }
+
+    function promptSubmit(response) {
+        return `User entered <i>${response}</i>`;
+    }
+</script>


### PR DESCRIPTION
Having both dialogs on the same element is not realistic, but it seemed like a cheap way to demonstrate both.