### PR TITLE
Cancel the AJAX request when user cancels prompt

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1107,7 +1107,10 @@ var htmx = htmx || (function () {
             var promptQuestion = getClosestAttributeValue(elt, "hx-prompt");
             if (promptQuestion) {
                 var promptResponse = prompt(promptQuestion);
-                if(!triggerEvent(elt, 'prompt.htmx', {prompt: promptResponse, target:target})) return endRequestLock();
+                // prompt returns null if cancelled and empty string if accepted with no entry
+                if (promptResponse === null ||
+                    !triggerEvent(elt, 'prompt.htmx', {prompt: promptResponse, target:target}))
+                    return endRequestLock();
             }
 
             var confirmQuestion = getClosestAttributeValue(elt, "hx-confirm");


### PR DESCRIPTION
The prompt command returns null in this case.  Note that empty string
is a valid return value, so we can't just check the boolean nature of
the return.