### PR TITLE
Allow request to have empty header values

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1022,7 +1022,7 @@ var htmx = htmx || (function () {
                 "X-HX-Target" : getRawAttribute(target, "id"),
                 "Current-URL" : getDocument().location.href,
             }
-            if (prompt) {
+            if (prompt !== undefined) {
                 headers["X-HX-Prompt"] = prompt;
             }
             if (eventTarget) {
@@ -1153,7 +1153,7 @@ var htmx = htmx || (function () {
             // request headers
             for (var header in headers) {
                 if (headers.hasOwnProperty(header)) {
-                    if(headers[header]) xhr.setRequestHeader(header, headers[header]);
+                    if (headers[header] !== null) xhr.setRequestHeader(header, headers[header]);
                 }
             }
 


### PR DESCRIPTION
This is a rather odd one, and a silly rabbit hole to get drawn into, but I noticed in #16 that submitting an empty string resulted in the "server" echoing `undefined`.  It looks like there were several assumptions that the header values, and specifically the response to the prompt, must be truthy.  Empty string is a valid response, so that's not the case.

This may be such a corner case that it's not worth fixing.  But it appears to be fixable without getting too involved.