### PR TITLE
Renamed `Current-URL` header to `X-HX-Current-URL`

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1050,7 +1050,7 @@ var htmx = htmx || (function () {
                 "X-HX-Trigger" : getRawAttribute(elt, "id"),
                 "X-HX-Trigger-Name" : getRawAttribute(elt, "name"),
                 "X-HX-Target" : getAttributeValue(target, "id"),
-                "Current-URL" : getDocument().location.href,
+                "X-HX-Current-URL" : getDocument().location.href,
             }
             if (prompt !== undefined) {
                 headers["X-HX-Prompt"] = prompt;


### PR DESCRIPTION
In accordance with the docs at https://dev.htmx.org/docs/#request-headers.