### PR TITLE
Switch afterRequest to standard event from error event if no error

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1307,7 +1307,7 @@ var htmx = htmx || (function () {
                     throw e;
                 } finally {
                     removeRequestIndicatorClasses(elt);
-                    triggerErrorEvent(elt, 'afterRequest.htmx', eventDetail);
+                    triggerEvent(elt, 'afterRequest.htmx', eventDetail);
                     triggerEvent(elt, 'afterOnLoad.htmx', eventDetail);
                     endRequestLock();
                 }


### PR DESCRIPTION
I don't think this was causing any problems, but it could confuse anyone watching the event.