### PR TITLE
Allows for empty verb attribute path

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -825,8 +825,8 @@ return (function () {
         function processVerbs(elt, nodeData, triggerSpecs) {
             var explicitAction = false;
             forEach(VERBS, function (verb) {
-                var path = getAttributeValue(elt, 'hx-' + verb);
-                if (path) {
+                if (elt.hasAttribute('hx-' + verb)) {
+                    var path = getAttributeValue(elt, 'hx-' + verb);
                     explicitAction = true;
                     nodeData.path = path;
                     nodeData.verb = verb;


### PR DESCRIPTION
No test written, but should fix https://github.com/bigskysoftware/htmx/issues/23.