### PR TITLE
Allow rendering element template strings with Nunjucks

### DIFF
--- a/src/ext/client-side-templates.js
+++ b/src/ext/client-side-templates.js
@@ -1,9 +1,9 @@
 htmx.defineExtension('client-side-templates', {
     transformResponse : function(text, xhr, elt) {
+        var data = JSON.parse(text);
 
         var mustacheTemplate = htmx.closest(elt, "[mustache-template]");
         if (mustacheTemplate) {
-            var data = JSON.parse(text);
             var templateId = mustacheTemplate.getAttribute('mustache-template');
             var template = htmx.find("#" + templateId);
             if (template) {
@@ -15,16 +15,19 @@ htmx.defineExtension('client-side-templates', {
 
         var handlebarsTemplate = htmx.closest(elt, "[handlebars-template]");
         if (handlebarsTemplate) {
-            var data = JSON.parse(text);
             var templateName = handlebarsTemplate.getAttribute('handlebars-template');
             return Handlebars.partials[templateName](data);
         }
 
         var nunjucksTemplate = htmx.closest(elt, "[nunjucks-template]");
         if (nunjucksTemplate) {
-            var data = JSON.parse(text);
             var templateName = nunjucksTemplate.getAttribute('nunjucks-template');
-            return nunjucks.render(templateName, data);
+            var template = htmx.find('#' + templateName);
+            try {
+              return nunjucks.render(templateName, data);
+            } catch (e) {
+              return nunjucks.renderString(template.innerHTML, data);
+            }
         }
 
         return text;


### PR DESCRIPTION
This change adds support for defining element blocks of text (like `<script>` tags similar to Mustache for example) with Nunjucks:

```html
<input
  type="text"
  name="query"
  hx-ext="json-enc, client-side-templates"
  hx-post="https://localhost:8080/v1/graphql"
  hx-trigger="keyup changed delay:500ms"
  nunjucks-template="employee-list"
  placeholder="query AllEmployees { employees { email } }"
  hx-swap="afterend"
/>

<script id="employee-list" type="nunjucks">
  {% for employee in data.employees %}
    <li>{{employee.email}}</li>
  {% endfor %}
</script>
```

The extension will try to use `nunjucks.render()` with the default/initial behavior (I'm actually not even certain how this works, it loads it from an URL? Never used a template rendering engine before today) first, if that fails and errors due to not being available, it will look for an element block matching the `nunjucks-template` ID and use it's `innerHTML` as the template string to `nunjucks.renderString()`, mirroring the Mustache functionality. This gives a nice flow where you can define "components" below where you intend to use them with Nunjucks (since Mustache is logicless it's not very featured for this) as `<script>` tags and then use `hx-swap="afterend"` or whatnot.

Also, minor change but moved the data parse function to top scope to not re-declare in each template handler block :+1:

![nunjucks-template](https://user-images.githubusercontent.com/26604994/83098279-2e358300-a078-11ea-987d-e859f5943172.gif)
