### PR TITLE
Ensure submit type button values get captured

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1104,6 +1104,10 @@ return (function () {
             if(elt.name === "" || elt.name == null || elt.disabled) {
                 return false;
             }
+            // include buttons with values
+            if (elt.type === "submit" && elt.name) {
+              return true;
+            }
             // ignore "submitter" types (see jQuery src/serialize.js)
             if (elt.type === "button" || elt.type === "submit" || elt.tagName === "image" || elt.tagName === "reset" || elt.tagName === "file" ) {
                 return false;

--- a/test/core/regressions.js
+++ b/test/core/regressions.js
@@ -49,4 +49,18 @@ describe("Core htmx Regression Tests", function(){
         form.innerHTML.should.equal("variable=")
     });
 
+    it ('Handles button values properly', function() {
+        this.server.respondWith("POST", "/htmx.php", function (xhr) {
+            xhr.respond(200, {}, xhr.requestBody);
+        });
+
+        var form = make('<form hx-trigger="click" hx-post="/htmx.php">\n' +
+            '<button type="submit" name="variable" value="test">Submit</button>\n' +
+            '</form>');
+
+        form.click();
+        this.server.respond();
+        form.innerHTML.should.equal("variable=test");
+    });
+
 })


### PR DESCRIPTION
This PR adds support for including values on submit buttons.

`<button>` tags with a type of `submit` can have associated `name` and `value` attributes that'll be included in form submissions if that button was [clicked](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button), however, line [1108](https://github.com/bigskysoftware/htmx/blob/c39e902cfd6ce078999fefae5019a7a23308bf82/src/htmx.js#L1108) seems to prevent htmx from respecting this, as it skips all buttons when serializing a forms inputs.

Here's a little demo page against httpbin. When the `Test default` button is clicked, httpbin reports that the forms data is

```
{
  "test": "some value"
}
```

However, when the htmx handled `Test htmx` button is clicked, httpbin reports empty form data.

```html
<!DOCTYPE html>
<head>
  <script src="https://unpkg.com/htmx.org@0.0.4"></script>
</head>

<p>Logs {}</p>
<form hx-post="https://httpbin.org/post">
  <button name="test" value="some value">Test htmx</button>
</form>

<p>Logs { "test": "some value" }</p>
<form method="post" action="https://httpbin.org/post">
  <button name="test" value="some value">Test default</button>
</form>
```