### PR TITLE
Create extension to add X-Requested-With header

### DIFF
--- a/src/ext/ajax-header.js
+++ b/src/ext/ajax-header.js
@@ -1,0 +1,7 @@
+htmx.defineExtension('ajax-header', {
+    onEvent: function (name, evt) {
+        if (name === "configRequest.htmx") {
+            evt.detail.headers['X-Requested-With'] = 'XMLHttpRequest';
+        }
+    }
+});

--- a/www/examples/inline-validation.md
+++ b/www/examples/inline-validation.md
@@ -87,7 +87,7 @@ Below is a working demo of this example.  The only email that will be accepted i
 
     // routes
     init("/demo", function(request, params){
-      return formTemplate();
+      return demoTemplate();
     });
 
     onPost("/contact", function(request, params){
@@ -106,8 +106,13 @@ Below is a working demo of this example.  The only email that will be accepted i
      });
     
     // templates
-    function formTemplate(page) {
-      return `<h3>Signup Form</h3><form hx-post="/contact">
+    function demoTemplate() {
+        
+        return `<h3>Signup Form</h3><p>Enter an email into the input below and on tab out it will be validated.  Only "test@test.com" will pass.</p> ` + formTemplate();
+    }
+    
+    function formTemplate() {
+      return `<form hx-post="/contact">
   <div hx-target="this" hx-swap="outerHTML">
     <label>Email Address</label>
     <input name="email" hx-get="/contact/email" hx-indicator="#ind">
@@ -121,7 +126,7 @@ Below is a working demo of this example.  The only email that will be accepted i
     <label>Last Name</label>
     <input type="text" class="form-control" name="lastName">
   </div>
-  <button class="btn btn-default">Submit</button>
+  <button class="btn btn-default" disabled>Submit</button>
 </form>`;
     }
     

--- a/www/extensions.md
+++ b/www/extensions.md
@@ -38,6 +38,7 @@ The following extensions that are tested and distributed with htmx:
 | [`debug`](/extensions/debug) | an extension for debugging of a particular element using htmx
 | [`path-deps`](/extensions/path-deps) | an extension for expressing path-based dependencies [similar to intercoolerjs](http://intercoolerjs.org/docs.html#dependencies)
 | [`class-tools`](/extensions/class-tools) | an extension for manipulating timed addition and removal of classes on HTML elements
+| [`remove-me`](/extensions/rails-method) | includes the `_method` parameter in requests for rails compatibility
 | [`remove-me`](/extensions/remove-me) | allows you to remove an element after a given amount of time
 | [`include-vals`](/extensions/include-vals) | allows you to include additional values in a request
 

--- a/www/extensions.md
+++ b/www/extensions.md
@@ -38,7 +38,7 @@ The following extensions that are tested and distributed with htmx:
 | [`debug`](/extensions/debug) | an extension for debugging of a particular element using htmx
 | [`path-deps`](/extensions/path-deps) | an extension for expressing path-based dependencies [similar to intercoolerjs](http://intercoolerjs.org/docs.html#dependencies)
 | [`class-tools`](/extensions/class-tools) | an extension for manipulating timed addition and removal of classes on HTML elements
-| [`remove-me`](/extensions/rails-method) | includes the `_method` parameter in requests for rails compatibility
+| [`rails-method`](/extensions/rails-method) | includes the `_method` parameter in requests for rails compatibility
 | [`remove-me`](/extensions/remove-me) | allows you to remove an element after a given amount of time
 | [`include-vals`](/extensions/include-vals) | allows you to include additional values in a request
 

--- a/www/locality-of-behavior.md
+++ b/www/locality-of-behavior.md
@@ -1,0 +1,91 @@
+---
+layout: layout.njk
+title: </> htmx - high power tools for html
+---
+## Locality of Behavior (LoB)
+
+> "The primary feature for easy maintenance is locality: Locality is that characteristic of source code that enables a 
+> programmer to understand that source by looking at only a small portion of it." -- [Richard Gabriel](https://www.dreamsongs.com/Files/PatternsOfSoftware.pdf)
+
+### The LoB Principle:
+
+> The behavior of a code unit should be as obvious as possible by looking only at that unit of code
+
+### Discussion
+
+The LoB principle is a simple prescriptive formulation of the quoted statement from [Richard Gabriel](https://www.dreamsongs.com).
+In as much as it is possible, and in balance with other concerns, developers should strive to make the behavior of
+a code element obvious on inspection.
+
+Consider two different implementations of an AJAX request in HTML, the first in [htmx](https://htmx.org):
+
+```html
+<div hx-get="/clicked">Click Me</div>
+```
+
+and the second in [jQuery](https://jquery.com/):
+
+```javascript
+  $("#d1").on("click", function(){
+    $.ajax({
+         ...
+    });
+  });
+```
+
+```html
+<div id="d1">Click Me</div>
+```
+
+In the former, the behavior of the `div` element is obvious on inspection, satisfying the LoB principle.
+
+In the latter, the behavior of the `div` element is spread out amongst multiple files.  It is difficult to know
+exactly what the div does without a total knowledge of the code base.
+
+#### Surfacing Behavior vs. Inlining Implementation
+
+A common conflation is surfacing behavior with inlining implementation of that behavior.  These are separate concepts
+and, while inlining the implementation of a behavior isn't *always* incorrect, it may *often* be incorrect.
+
+Increasing the obviousness of the behavior of an element is, ceteris paribus, a good thing, but it falls to both end-developers
+and especially framework developers to make LoB as easy as possible.
+
+#### Conflict With Other Development Principles
+
+The LoB will often conflict with other software development principles.  Two important ones
+are:
+
+* [DRY - Don't Repeat Yourself](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)
+  
+  Software developers typically strive to avoid redundancy in their code or data.  This as come to be called "Staying DRY",
+  i.e. Don't Repeat Yourself.  Like other software design principles this, on its own, is a good thing.  htmx, for example, 
+  allows you to place many attributes on parent elements in a DOM and avoid repeating these attributes on children.  This is a 
+  violation of LoB, in favor of DRY, and such tradeoffs need to be made judiciously by developers.
+  
+  Note that the further behavior gets from the code unit it effects, the more severe the violation of LoB.  If it is
+  within a few lines of the code unit, this is less serious than if it is a page away, which is less serious than if
+  it is in a separate file entirely.  
+  
+  There is no hard and fast rule, but rather subjective tradeoffs that must be made as software developers.
+  
+* [SoC - Separation Of Concerns](https://en.wikipedia.org/wiki/Separation_of_concerns)
+  
+  Separation of concerns a design principle for separating a computer program into distinct sections such that each 
+  section addresses a separate concern.  A canonical example of this is CSS vs. Javascript.  Again, on its own and
+  in isolation this may, indeed, be a good thing.  Inlining styles has become more prevalent lately, but there are
+  still strong arguments in favor of SoC in this regard.
+  
+  Note that SoC is, however, in conflict with LoB.  By tweaking a CSS file the look and, to an extent, behavior of an
+  element can change dramatically, and it is not obvious where this dramatic change came from.  Tools help to an extent
+  here, but there is still "spooky action at a distance" going on.
+  
+  Again, this isn't to condemn SoC wholesale, just to say that there are subjective tradeoffs that must be made when
+  considering how to structure your code.  The fact that inline styles have become more prevalent as of late is an
+  indication that SoC is losing some support amongst developers.
+  
+#### Conclusion
+
+LoB is a software design principle that can help make a code bases more humane and maintainable.  It must be traded
+off against other design principles and be considered in terms of the limitations of the system a code unit is
+written in, but, as much as is it is practical, adherence to this principle will increase your developer productivity 
+and well-being. 

--- a/www/locality-of-behaviour.md
+++ b/www/locality-of-behaviour.md
@@ -2,19 +2,19 @@
 layout: layout.njk
 title: </> htmx - high power tools for html
 ---
-## Locality of Behavior (LoB)
+## Locality of Behaviour (LoB)
 
 > "The primary feature for easy maintenance is locality: Locality is that characteristic of source code that enables a 
 > programmer to understand that source by looking at only a small portion of it." -- [Richard Gabriel](https://www.dreamsongs.com/Files/PatternsOfSoftware.pdf)
 
 ### The LoB Principle:
 
-> The behavior of a code unit should be as obvious as possible by looking only at that unit of code
+> The behaviour of a code unit should be as obvious as possible by looking only at that unit of code
 
 ### Discussion
 
 The LoB principle is a simple prescriptive formulation of the quoted statement from [Richard Gabriel](https://www.dreamsongs.com).
-In as much as it is possible, and in balance with other concerns, developers should strive to make the behavior of
+In as much as it is possible, and in balance with other concerns, developers should strive to make the behaviour of
 a code element obvious on inspection.
 
 Consider two different implementations of an AJAX request in HTML, the first in [htmx](https://htmx.org):
@@ -37,17 +37,17 @@ and the second in [jQuery](https://jquery.com/):
 <div id="d1">Click Me</div>
 ```
 
-In the former, the behavior of the `div` element is obvious on inspection, satisfying the LoB principle.
+In the former, the behaviour of the `div` element is obvious on inspection, satisfying the LoB principle.
 
-In the latter, the behavior of the `div` element is spread out amongst multiple files.  It is difficult to know
+In the latter, the behaviour of the `div` element is spread out amongst multiple files.  It is difficult to know
 exactly what the div does without a total knowledge of the code base.
 
-#### Surfacing Behavior vs. Inlining Implementation
+#### Surfacing Behaviour vs. Inlining Implementation
 
-A common conflation is surfacing behavior with inlining implementation of that behavior.  These are separate concepts
-and, while inlining the implementation of a behavior isn't *always* incorrect, it may *often* be incorrect.
+A common conflation is surfacing behaviour with inlining implementation of that behaviour.  These are separate concepts
+and, while inlining the implementation of a behaviour isn't *always* incorrect, it may *often* be incorrect.
 
-Increasing the obviousness of the behavior of an element is, ceteris paribus, a good thing, but it falls to both end-developers
+Increasing the obviousness of the behaviour of an element is, ceteris paribus, a good thing, but it falls to both end-developers
 and especially framework developers to make LoB as easy as possible.
 
 #### Conflict With Other Development Principles
@@ -62,7 +62,7 @@ are:
   allows you to place many attributes on parent elements in a DOM and avoid repeating these attributes on children.  This is a 
   violation of LoB, in favor of DRY, and such tradeoffs need to be made judiciously by developers.
   
-  Note that the further behavior gets from the code unit it effects, the more severe the violation of LoB.  If it is
+  Note that the further behaviour gets from the code unit it effects, the more severe the violation of LoB.  If it is
   within a few lines of the code unit, this is less serious than if it is a page away, which is less serious than if
   it is in a separate file entirely.  
   
@@ -75,7 +75,7 @@ are:
   in isolation this may, indeed, be a good thing.  Inlining styles has become more prevalent lately, but there are
   still strong arguments in favor of SoC in this regard.
   
-  Note that SoC is, however, in conflict with LoB.  By tweaking a CSS file the look and, to an extent, behavior of an
+  Note that SoC is, however, in conflict with LoB.  By tweaking a CSS file the look and, to an extent, behaviour of an
   element can change dramatically, and it is not obvious where this dramatic change came from.  Tools help to an extent
   here, but there is still "spooky action at a distance" going on.
   


### PR DESCRIPTION
This extension adds a header that identifies ajax requests with the common X-Requested-With header.

Specifically for my purposes, this allows me to use laravel's `request()->ajax()` helper to identify ajax requests made with htmx.