### PR TITLE
Add an extension to include the commonly-used X-Requested-With header

### DIFF
--- a/src/ext/ajax-header.js
+++ b/src/ext/ajax-header.js
@@ -1,0 +1,7 @@
+htmx.defineExtension('ajax-header', {
+    onEvent: function (name, evt) {
+        if (name === "configRequest.htmx") {
+            evt.detail.headers['X-Requested-With'] = 'XMLHttpRequest';
+        }
+    }
+});

--- a/test/ext/ajax-header.js
+++ b/test/ext/ajax-header.js
@@ -1,0 +1,21 @@
+describe("ajax-header extension", function() {
+    beforeEach(function () {
+        this.server = makeServer();
+        clearWorkArea();
+    });
+    afterEach(function () {
+        this.server.restore();
+        clearWorkArea();
+    });
+
+    it('Sends the X-Requested-With header', function () {
+        this.server.respondWith("GET", "/test", function (xhr) {
+            xhr.respond(200, {}, xhr.requestHeaders['X-Requested-With'])
+        });
+        var btn = make('<button hx-get="/test" hx-ext="ajax-header">Click Me!</button>')
+        btn.click();
+        this.server.respond();
+        btn.innerHTML.should.equal("XMLHttpRequest");
+    });
+
+});

--- a/test/index.html
+++ b/test/index.html
@@ -115,6 +115,8 @@
 <script src="../src/ext/include-vals.js"></script>
 <script src="ext/include-vals.js"></script>
 
+<script src="../src/ext/ajax-header.js"></script>
+<script src="ext/ajax-header.js"></script>
 
 <!-- events last so they don't screw up other tests -->
 <script src="core/events.js"></script>

--- a/www/extensions.md
+++ b/www/extensions.md
@@ -40,6 +40,7 @@ The following extensions that are tested and distributed with htmx:
 | [`class-tools`](/extensions/class-tools) | an extension for manipulating timed addition and removal of classes on HTML elements
 | [`remove-me`](/extensions/remove-me) | allows you to remove an element after a given amount of time
 | [`include-vals`](/extensions/include-vals) | allows you to include additional values in a request
+| [`ajax-header`](/extensions/ajax-header) | includes the commonly-used X-Requested-With header that identifies ajax requests in many backend frameworks
 
 </div>
 

--- a/www/extensions/ajax-header.md
+++ b/www/extensions/ajax-header.md
@@ -1,0 +1,22 @@
+---
+layout: layout.njk
+title: </> htmx - high power tools for html
+---
+
+## The `ajax-header` Extension
+
+This extension adds the X-Requested-With header to requests with the value "XMLHttpRequest".
+
+This header is commonly used by javascript frameworks to differentiate ajax requests from normal http requests.
+
+### Usage
+
+```html
+<body hx-ext="ajax-header">
+ ...
+</body>
+```
+
+### Source
+
+<https://unpkg.com/htmx.org/dist/ext/ajax-header.js>


### PR DESCRIPTION
This extension adds the X-Requested-With header, which is used by many javascript frameworks to identify ajax requests.

Specifically for my use case, laravel has helper functions to determine if a request was made through ajax that look at this header.