### PR TITLE
Handle events and content after `handleSwap` in extensions

### DIFF
--- a/src/ext/morphdom-swap.js
+++ b/src/ext/morphdom-swap.js
@@ -5,7 +5,7 @@ htmx.defineExtension('morphdom-swap', {
     handleSwap: function (swapStyle, target, fragment) {
         if (swapStyle === 'morphdom') {
             morphdom(target, fragment.outerHTML);
-            return true;
+            return [target]; // let htmx handle the new content
         }
     }
 });

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -403,7 +403,7 @@ return (function () {
             while(fragment.childNodes.length > 0){
                 var child = fragment.firstChild;
                 parentNode.insertBefore(child, insertBefore);
-                if (child.nodeType !== Node.TEXT_NODE) {
+                if (child.nodeType !== Node.TEXT_NODE && child.nodeType !== Node.COMMENT_NODE) {
                     settleInfo.tasks.push(makeAjaxLoadTask(child));
                 }
             }
@@ -505,7 +505,17 @@ return (function () {
                     for (var i = 0; i < extensions.length; i++) {
                         var ext = extensions[i];
                         try {
-                            if (ext.handleSwap(swapStyle, target, fragment, settleInfo)) {
+                            var newElements = ext.handleSwap(swapStyle, target, fragment, settleInfo);
+                            if (newElements) {
+                                if (typeof newElements.length !== 'undefined') {
+                                    // if handleSwap returns an array (like) of elements, we handle them
+                                    for (var j = 0; j < newElements.length; j++) {
+                                        var child = newElements[j];
+                                        if (child.nodeType !== Node.TEXT_NODE && child.nodeType !== Node.COMMENT_NODE) {
+                                            settleInfo.tasks.push(makeAjaxLoadTask(child));
+                                        }
+                                    }
+                                }
                                 return;
                             }
                         } catch (e) {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -954,8 +954,8 @@ return (function () {
             return eventName === "processedNode.htmx"
         }
 
-        function withExtensions(elt, toDo) {
-            forEach(getExtensions(elt), function(extension){
+        function withExtensions(elt, toDo, extensions) {
+            forEach(typeof extensions === 'undefined' ? getExtensions(elt) : extensions, function(extension){
                 try {
                     toDo(extension);
                 } catch (e) {
@@ -988,7 +988,7 @@ return (function () {
             var eventResult = elt.dispatchEvent(event);
             withExtensions(elt, function (extension) {
                 eventResult = eventResult && (extension.onEvent(eventName, event) !== false)
-            });
+            }, detail.extensions);
             return eventResult;
         }
 
@@ -1407,7 +1407,7 @@ return (function () {
                 }
             }
 
-            var eventDetail = {xhr: xhr, target: target};
+            var eventDetail = {xhr: xhr, target: target, extensions: getExtensions(elt)};
             xhr.onload = function () {
                 try {
                     if (!triggerEvent(elt, 'beforeOnLoad.htmx', eventDetail)) return;

--- a/test/ext/index.js
+++ b/test/ext/index.js
@@ -1,0 +1,50 @@
+describe("default extensions behavior", function() {
+
+    var loadCalls, afterSwapCalls, afterSettleCalls;
+
+    beforeEach(function () {
+        loadCalls = afterSwapCalls = afterSettleCalls = 0;
+        this.server = makeServer();
+        clearWorkArea();
+
+        htmx.defineExtension("ext-testswap", {
+            onEvent : function(name, evt) {
+                if (name === "load.htmx") {
+                    loadCalls++;
+                }
+                if (name === "afterSwap.htmx") {
+                    afterSwapCalls++;
+                }
+                if (name === "afterSettle.htmx") {
+                    afterSettleCalls++;
+                }
+            },
+            handleSwap: function (swapStyle, target, fragment, settleInfo) {
+                // simple outerHTML replacement for tests
+                var parentEl = target.parentElement;
+                parentEl.removeChild(target);
+                parentEl.appendChild(fragment)
+                return true;
+            }
+
+        });
+
+    });
+
+    afterEach(function () {
+        this.server.restore();
+        clearWorkArea();
+        htmx.removeExtension("ext-testswap");
+    });
+
+    it('handleSwap: afterSwap and afterSettle triggered if extension defined on parent', function () {
+        this.server.respondWith("GET", "/test", '<button>Clicked!</button>');
+        var div = make('<div hx-ext="ext-testswap"><button hx-get="/test" hx-swap="testswap">Click Me!</button></div>');
+        var btn = div.firstChild;
+        btn.click()
+        this.server.respond();
+        afterSwapCalls.should.equal(1);
+        afterSettleCalls.should.equal(1);
+        loadCalls.should.equal(0); // load.htmlx event on new added button is not triggered
+    });
+});

--- a/test/ext/morphdom-swap.js
+++ b/test/ext/morphdom-swap.js
@@ -18,4 +18,14 @@ describe("morphdom-swap extension", function() {
         btn.innerHTML.should.equal("Clicked!");
     });
 
+    it('works with htmx elements in new content', function () {
+        this.server.respondWith("GET", "/test", '<button>Clicked!<span hx-get="/test-inner" hx-trigger="load" hx-swap="morphdom"></span></button>');
+        this.server.respondWith("GET", "/test-inner", 'Loaded!');
+        var btn = make('<div hx-ext="morphdom-swap"><button hx-get="/test" hx-swap="morphdom">Click Me!</button></div>').querySelector('button');
+        btn.click();
+        this.server.respond(); // call /test via button trigger=click
+        this.server.respond(); // call /test-inner via span trigger=load
+        btn.innerHTML.should.equal("Clicked!Loaded!");
+    });
+
 });

--- a/test/index.html
+++ b/test/index.html
@@ -83,6 +83,8 @@
 <script src="attributes/hx-ws.js"></script>
 
 <!-- extension tests -->
+<script src="ext/index.js"></script>
+
 <script src="../src/ext/method-override.js"></script>
 <script src="ext/method-override.js"></script>
 


### PR DESCRIPTION
When swap was handled by an extension via its `handleSwap` method, a few expected things didn't work:
- `afterSwap.htmx` and `afterSettle.htmx` events where not propagated to `onLoad` methods of extensions
- `load.htmx` was not called for newly added elements
- new content in the target was not handled by `htmx`, so for example if an element with ` hx-trigger=load` was included, nothing was done about it.

This is fixed in this PR, the work being split in two commits that touch two independent things.

See the description of these commits to know for each what the problem was, what was expected and how it is handled.