### PR TITLE
capture sse data and treat as rawparameters to ajax call

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1315,10 +1315,8 @@ return (function () {
             var xhr = new XMLHttpRequest();
 
             var headers = getHeaders(elt, target, promptResponse, eventTarget);
-
-            var rawParameters = (getInternalData(elt).sseEvent !== undefined) ? 
-            {'data':getInternalData(elt).sseEvent.data} : getInputValues(elt, verb);
-
+            var rawParameters = (eltData.sseEvent !== undefined) ? 
+            {'data':eltData.sseEvent.data} : getInputValues(elt, verb);
             var filteredParameters = filterValues(rawParameters, elt);
 
             if (verb !== 'get') {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -792,9 +792,10 @@ return (function () {
             });
             if (sseSourceElt) {
                 var sseEventSource = getInternalData(sseSourceElt).sseEventSource;
-                var sseListener = function () {
+                var sseListener = function (sseEvent) {
                     if (!maybeCloseSSESource(sseSourceElt)) {
                         if (bodyContains(elt)) {
+                            getInternalData(elt).sseEvent = sseEvent;
                             issueAjaxRequest(elt, verb, path);
                         } else {
                             sseEventSource.removeEventListener(sseEventName, sseListener);
@@ -1314,7 +1315,10 @@ return (function () {
             var xhr = new XMLHttpRequest();
 
             var headers = getHeaders(elt, target, promptResponse, eventTarget);
-            var rawParameters = getInputValues(elt, verb);
+
+            var rawParameters = (getInternalData(elt).sseEvent !== undefined) ? 
+            {'data':getInternalData(elt).sseEvent.data} : getInputValues(elt, verb);
+
             var filteredParameters = filterValues(rawParameters, elt);
 
             if (verb !== 'get') {


### PR DESCRIPTION
This adds the feature of passing on the sse event data to the ajax call as raw parameters.  All tests are still passing.  