### PR TITLE
Changes to use actual requested verb, instead of POST

### DIFF
--- a/src/ext/actual-verb.js
+++ b/src/ext/actual-verb.js
@@ -1,0 +1,7 @@
+htmx.defineExtension('actual-verb', {
+    onEvent: function (name, evt) {
+        if (name === "configRequest.htmx") {
+            evt.detail.xhrVerb = evt.detail.verb.toUpperCase();
+        }
+    }
+});

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1334,7 +1334,8 @@ return (function () {
                 unfilteredParameters:rawParameters,
                 headers:headers,
                 target:target,
-                verb:verb
+                verb:verb,
+                xhrVerb: (verb === 'get') ? "GET" : "POST"
             };
             if(!triggerEvent(elt, 'configRequest.htmx', requestConfig)) return endRequestLock();
 
@@ -1357,7 +1358,7 @@ return (function () {
                 }
                 xhr.open('GET', finalPathForGet, true);
             } else {
-                xhr.open('POST', path, true);
+                xhr.open( requestConfig.xhrVerb, path, true);
             }
 
             xhr.overrideMimeType("text/html");


### PR DESCRIPTION
Created a extension to use the actual verb instead of POST with override.  Saw a feature request for it.  Just wanted to make it available is someone needs it.  I know it would have eliminated a hack I used for flask to had the POST + overrride.  

example:

`        <div hx-include="#checked-contacts" hx-target="#tbody">
            <a class="btn" hx-put="/activate" hx-ext="actual-verb">Activate</a>
            <a class="btn" hx-put="/deactivate" hx-ext="actual-verb">Deactivate</a>
        </div>
` 

* Might be nice if I could apply to all hx-put, patch, delete, etc calls globally.
