### PR TITLE
Add `trigger` in event `detail` 

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1525,7 +1525,7 @@ return (function () {
                                         doSettle();
                                     }
                                 } catch (e) {
-                                    triggerErrorEvent(elt, 'swapError.htmx', eventDetail);
+                                    triggerErrorEvent(elt, 'swapError.htmx', mergeObjects({error: e}, eventDetail));
                                     throw e;
                                 }
                             };
@@ -1537,7 +1537,7 @@ return (function () {
                             }
                         }
                     } else {
-                        triggerErrorEvent(elt, 'responseError.htmx', mergeObjects({error: "Response Status Error Code " + this.status + " from " + path}, eventDetail));
+                        triggerErrorEvent(elt, 'responseError.htmx', mergeObjects({error: {status: this.status, path: path, verb: verb}}, eventDetail));
                     }
                 } catch (e) {
                     triggerErrorEvent(elt, 'onLoadError.htmx', mergeObjects({error:e}, eventDetail));

--- a/test/core/events.js
+++ b/test/core/events.js
@@ -9,17 +9,22 @@ describe("Core htmx Events", function() {
     });
 
     it("load.htmx fires properly", function () {
-        var called = false;
+        var calls = [];
         var handler = htmx.on("load.htmx", function (evt) {
-            called = true;
+            calls.push({detailElt: evt.detail.elt, eventTarget: evt.target});
         });
         try {
             this.server.respondWith("GET", "/test", "");
-            this.server.respondWith("GET", "/test", "<div></div>");
+            this.server.respondWith("GET", "/test", "<div id='id1'><span></span></div><div id='id2'></div>");
             var div = make("<div hx-get='/test'></div>");
             div.click();
             this.server.respond();
-            should.equal(called, true);
+            // called for new "parents" element, ie div id1 & id2 but not the span
+            calls.length.should.equal(2);
+            calls[0].eventTarget.id.should.equal('id1');
+            calls[0].detailElt.id.should.equal('id1');
+            calls[1].eventTarget.id.should.equal('id2');
+            calls[1].detailElt.id.should.equal('id2');
         } finally {
             htmx.off("load.htmx", handler);
         }

--- a/test/core/events.js
+++ b/test/core/events.js
@@ -123,5 +123,252 @@ describe("Core htmx Events", function() {
         }
     });
 
+    it("configureRequest.htmx should contain correct elements", function () {
+        var calls = [];
+        var handler = htmx.on("configRequest.htmx", function (evt) {
+            calls.push({detailElt: evt.detail.elt, detailTrigger: evt.detail.trigger, detailTarget: evt.detail.target, eventTarget: evt.target});
+        });
+        try {
+            this.server.respondWith("GET", "/test", "<div id='id1'></div><div id='id2'></div>");
+            var div = make("<div hx-get='/test' id='id0'></div>");
+            div.click();
+            this.server.respond();
+            calls.length.should.equal(1);
+            calls[0].eventTarget.should.equal(div);
+            calls[0].detailTrigger.should.equal(div);
+            calls[0].detailTarget.should.equal(div);
+            calls[0].detailElt.should.equal(div);
+        } finally {
+            htmx.off("configRequest.htmx", handler);
+        }
+    });
+
+    it("beforeOnLoad.htmx should contain correct elements", function () {
+        var calls = [];
+        var handler = htmx.on("beforeOnLoad.htmx", function (evt) {
+            calls.push({detailElt: evt.detail.elt, detailTrigger: evt.detail.trigger, detailTarget: evt.detail.target, eventTarget: evt.target});
+        });
+        try {
+            this.server.respondWith("GET", "/test", "<div id='id1'></div><div id='id2'></div>");
+            var div = make("<div hx-get='/test' id='id0'></div>");
+            div.click();
+            this.server.respond();
+            calls.length.should.equal(1);
+            calls[0].eventTarget.should.equal(div);
+            calls[0].detailTrigger.should.equal(div);
+            calls[0].detailTarget.should.equal(div);
+            calls[0].detailElt.should.equal(div);
+        } finally {
+            htmx.off("beforeOnLoad.htmx", handler);
+        }
+    });
+
+    it("beforeSwap.htmx should contain correct elements (target == trigger)", function () {
+        var calls = [];
+        var handler = htmx.on("beforeSwap.htmx", function (evt) {
+            calls.push({detailElt: evt.detail.elt, detailTrigger: evt.detail.trigger, detailTarget: evt.detail.target, eventTarget: evt.target});
+        });
+        try {
+            this.server.respondWith("GET", "/test", "<div id='id1'></div><div id='id2'></div>");
+            var div = make("<div hx-get='/test' id='id0'></div>");
+            div.click();
+            this.server.respond();
+            calls.length.should.equal(1);
+            calls[0].eventTarget.should.equal(div);
+            calls[0].detailTrigger.should.equal(div);
+            calls[0].detailTarget.should.equal(div);
+            calls[0].detailElt.should.equal(div);
+        } finally {
+            htmx.off("beforeSwap.htmx", handler);
+        }
+    });
+
+    it("beforeSwap.htmx should contain correct elements (target != trigger)", function () {
+        var calls = [];
+        var handler = htmx.on("beforeSwap.htmx", function (evt) {
+            calls.push({detailElt: evt.detail.elt, detailTrigger: evt.detail.trigger, detailTarget: evt.detail.target, eventTarget: evt.target});
+        });
+        try {
+            this.server.respondWith("GET", "/test", "<div id='id1'></div><div id='id2'></div>");
+            var trigger = make("<div hx-get='/test' id='id0' hx-target='#id00 '></div>");
+            var target = make("<div id='id00'></div>");
+            trigger.click();
+            this.server.respond();
+            calls.length.should.equal(1);
+            calls[0].eventTarget.should.equal(target);
+            calls[0].detailTrigger.should.equal(trigger);
+            calls[0].detailTarget.should.equal(target);
+            calls[0].detailElt.should.equal(target);
+        } finally {
+            htmx.off("beforeSwap.htmx", handler);
+        }
+    });
+
+    it("afterSwap.htmx should contain correct elements (swap=innerHTML)", function () {
+        var calls = [];
+        var handler = htmx.on("afterSwap.htmx", function (evt) {
+            calls.push({detailElt: evt.detail.elt, detailTrigger: evt.detail.trigger, detailTarget: evt.detail.target, eventTarget: evt.target});
+        });
+        try {
+            this.server.respondWith("GET", "/test", "<div id='id1'></div><div id='id2'></div>");
+            var div = make("<div hx-get='/test' id='id0' hx-swap='innerHTML'></div>");
+            div.click();
+            this.server.respond();
+            // target is the only pseudo-root content updated
+            calls.length.should.equal(1);
+            calls[0].eventTarget.should.equal(div);
+            calls[0].detailTrigger.should.equal(div);
+            calls[0].detailTarget.should.equal(div);
+            calls[0].detailElt.should.equal(div);
+        } finally {
+            htmx.off("afterSwap.htmx", handler);
+        }
+    });
+
+    it("afterSwap.htmx should contain correct elements (swap=outerHTML)", function () {
+        var calls = [];
+        var handler = htmx.on("afterSwap.htmx", function (evt) {
+            calls.push({detailElt: evt.detail.elt, detailTrigger: evt.detail.trigger, detailTarget: evt.detail.target, eventTarget: evt.target});
+        });
+        try {
+            this.server.respondWith("GET", "/test", "<div id='id1'></div><div id='id2'></div>");
+            var div = make("<div hx-get='/test' id='id0' hx-swap='outerHTML'></div>");
+            div.click();
+            this.server.respond();
+            // target is replaced by two new pseudo-roots: id1 & id2
+            calls.length.should.equal(2);
+            calls[0].eventTarget.id.should.equal('id1');
+            calls[0].detailTrigger.should.equal(div);
+            calls[0].detailTarget.should.equal(div);
+            calls[0].detailElt.id.should.equal('id1');
+            calls[1].eventTarget.id.should.equal('id2');
+            calls[1].detailTrigger.should.equal(div);
+            calls[1].detailTarget.should.equal(div);
+            calls[1].detailElt.id.should.equal('id2');
+        } finally {
+            htmx.off("afterSwap.htmx", handler);
+        }
+    });
+
+    it("afterSwap.htmx should contain correct elements (swap=beforebegin)", function () {
+        var calls = [];
+        var handler = htmx.on("afterSwap.htmx", function (evt) {
+            calls.push({detailElt: evt.detail.elt, detailTrigger: evt.detail.trigger, detailTarget: evt.detail.target, eventTarget: evt.target});
+        });
+        try {
+            this.server.respondWith("GET", "/test", "<div id='id1'></div><div id='id2'></div>");
+            var div = make("<div hx-get='/test' id='id0' hx-swap='beforebegin'></div>");
+            div.click();
+            this.server.respond();
+            // target is preceded by two new pseudo-roots: id1 & id2
+            calls.length.should.equal(3);
+            calls[0].eventTarget.id.should.equal('id0');
+            calls[0].detailTrigger.should.equal(div);
+            calls[0].detailTarget.should.equal(div);
+            calls[0].detailElt.id.should.equal('id0');
+            calls[1].eventTarget.id.should.equal('id1');
+            calls[1].detailTrigger.should.equal(div);
+            calls[1].detailTarget.should.equal(div);
+            calls[1].detailElt.id.should.equal('id1');
+            calls[2].eventTarget.id.should.equal('id2');
+            calls[2].detailTrigger.should.equal(div);
+            calls[2].detailTarget.should.equal(div);
+            calls[2].detailElt.id.should.equal('id2');
+        } finally {
+            htmx.off("afterSwap.htmx", handler);
+        }
+    });
+
+    it("afterSwap.htmx should contain correct elements (swap=afterbegin)", function () {
+        var calls = [];
+        var handler = htmx.on("afterSwap.htmx", function (evt) {
+            calls.push({detailElt: evt.detail.elt, detailTrigger: evt.detail.trigger, detailTarget: evt.detail.target, eventTarget: evt.target});
+        });
+        try {
+            this.server.respondWith("GET", "/test", "<div id='id1'></div><div id='id2'></div>");
+            var div = make("<div hx-get='/test' id='id0' hx-swap='afterbegin'></div>");
+            div.click();
+            this.server.respond();
+            // target is still the only pseudo-root content updated
+            calls.length.should.equal(1);
+            calls[0].eventTarget.should.equal(div);
+            calls[0].detailTrigger.should.equal(div);
+            calls[0].detailTarget.should.equal(div);
+            calls[0].detailElt.should.equal(div);
+        } finally {
+            htmx.off("afterSwap.htmx", handler);
+        }
+    });
+
+    it("afterSwap.htmx should contain correct elements (swap=beforeend)", function () {
+        var calls = [];
+        var handler = htmx.on("afterSwap.htmx", function (evt) {
+            calls.push({detailElt: evt.detail.elt, detailTrigger: evt.detail.trigger, detailTarget: evt.detail.target, eventTarget: evt.target});
+        });
+        try {
+            this.server.respondWith("GET", "/test", "<div id='id1'></div><div id='id2'></div>");
+            var div = make("<div hx-get='/test' id='id0' hx-swap='beforeend'></div>");
+            div.click();
+            this.server.respond();
+            // target is still the only pseudo-root content updated
+            calls.length.should.equal(1);
+            calls[0].eventTarget.should.equal(div);
+            calls[0].detailTrigger.should.equal(div);
+            calls[0].detailTarget.should.equal(div);
+            calls[0].detailElt.should.equal(div);
+        } finally {
+            htmx.off("afterSwap.htmx", handler);
+        }
+    });
+
+    it("afterSwap.htmx should contain correct elements (swap=afterend)", function () {
+        var calls = [];
+        var handler = htmx.on("afterSwap.htmx", function (evt) {
+            calls.push({detailElt: evt.detail.elt, detailTrigger: evt.detail.trigger, detailTarget: evt.detail.target, eventTarget: evt.target});
+        });
+        try {
+            this.server.respondWith("GET", "/test", "<div id='id1'></div><div id='id2'></div>");
+            var div = make("<div hx-get='/test' id='id0' hx-swap='afterend'></div>");
+            div.click();
+            this.server.respond();
+            // target is followed by two new pseudo-roots: id1 & id2
+            calls.length.should.equal(3);
+            calls[0].eventTarget.id.should.equal('id0');
+            calls[0].detailTrigger.should.equal(div);
+            calls[0].detailTarget.should.equal(div);
+            calls[0].detailElt.id.should.equal('id0');
+            calls[1].eventTarget.id.should.equal('id1');
+            calls[1].detailTrigger.should.equal(div);
+            calls[1].detailTarget.should.equal(div);
+            calls[1].detailElt.id.should.equal('id1');
+            calls[2].eventTarget.id.should.equal('id2');
+            calls[2].detailTrigger.should.equal(div);
+            calls[2].detailTarget.should.equal(div);
+            calls[2].detailElt.id.should.equal('id2');
+        } finally {
+            htmx.off("afterSwap.htmx", handler);
+        }
+    });
+
+    it("afterOnLoad.htmx should contain correct elements", function () {
+        var calls = [];
+        var handler = htmx.on("afterOnLoad.htmx", function (evt) {
+            calls.push({detailElt: evt.detail.elt, detailTrigger: evt.detail.trigger, detailTarget: evt.detail.target, eventTarget: evt.target});
+        });
+        try {
+            this.server.respondWith("GET", "/test", "<div id='id1'></div><div id='id2'></div>");
+            var div = make("<div hx-get='/test' id='id0'></div>");
+            div.click();
+            this.server.respond();
+            calls.length.should.equal(1);
+            calls[0].eventTarget.should.equal(div);
+            calls[0].detailTrigger.should.equal(div);
+            calls[0].detailTarget.should.equal(div);
+            calls[0].detailElt.should.equal(div);
+        } finally {
+            htmx.off("afterSwap.htmx", handler);
+        }
+    });
+
 });
 

--- a/www/events.md
+++ b/www/events.md
@@ -113,20 +113,20 @@ This event is triggered when a cache miss occurs when restoring history
 * `detail.xhr` - the `XMLHttpRequest` that will retrieve the remote content for restoration
 * `detail.path` - the path and query of the page being restored
 
-### <a name="historyCacheMissError.htmx"></a> Event - [`historyCacheMissError.htmx`](#historyCacheMissError.htmx)
+### <a name="historyCacheMissLoad.htmx"></a> Event - [`historyCacheMissLoad.htmx`](#historyCacheMissLoad.htmx)
 
-This event is triggered when a cache miss occurs and a response has been retrieved from the server
-for the content to restore, but the response is an error (e.g. `404`)
+This event is triggered when a cache miss occurs and a response has been retrieved succesfully from the server
+for the content to restore 
 
 ##### Details
 
 * `detail.xhr` - the `XMLHttpRequest`
 * `detail.path` - the path and query of the page being restored
 
-### <a name="historyCacheMissLoad.htmx"></a> Event - [`historyCacheMissLoad.htmx`](#historyCacheMissLoad.htmx)
+### <a name="historyCacheMissLoadError.htmx"></a> Event - [`historyCacheMissLoadError.htmx`](#historyCacheMissLoadError.htmx)
 
-This event is triggered when a cache miss occurs and a response has been retrieved succesfully from the server
-for the content to restore 
+This event is triggered when a cache miss occurs and a response has been retrieved from the server
+for the content to restore, but the response is an error (e.g. `404`)
 
 ##### Details
 

--- a/www/events.md
+++ b/www/events.md
@@ -5,8 +5,12 @@ title: </> htmx - high power tools for html
 
 ## Events
 
-Htmx provides an extensive events system that can be used to modify and enhance behavior.  Events
-are listed below.
+Htmx provides an extensive events system that can be used to modify and enhance behavior.
+
+All events contain a `detail` object, with at least an `elt` key that is the event target (so also
+accessible via `event.target`)
+
+Events are listed below.
 
 ### <a name="afterOnLoad.htmx"></a> Event - [`afterOnLoad.htmx`](#afterOnLoad.htmx)
 
@@ -18,6 +22,7 @@ has been swapped or settled yet, only that the request has finished.
 * `detail.elt` - the element that dispatched the request
 * `detail.xhr` - the `XMLHttpRequest`
 * `detail.target` - the target of the request
+* `detail.trigger` - the element that dispatched the request
 
 ### <a name="afterRequest.htmx"></a> Event - [`afterRequest.htmx`](#afterRequest.htmx)
 
@@ -30,26 +35,49 @@ can be paried with [`beforeRequest.htmx`](#beforeRequest.htmx) to wrap behavior 
 * `detail.elt` - the element that dispatched the request
 * `detail.xhr` - the `XMLHttpRequest`
 * `detail.target` - the target of the request
+* `detail.trigger` - the element that dispatched the request
 
 ### <a name="afterSettle.htmx"></a> Event - [`afterSettle.htmx`](#afterSettle.htmx)
 
 This event is triggered after the DOM has [settled](/docs#settling).
 
+It can be called once or many times depending on `hx-swap`:
+
+* `innerHTML` - for the target of the request
+* `outerHTML` - once for each top level elements(s) added in place of the target of the request
+* `beforebegin` - for the target of the request + once for each top level element(s) added before this target
+* `beforeend` - for the target of the request
+* `afterend` - for the target of the request + once for each top level element(s) added after thistarget
+
+For each call, `event.detail.elt` (and `event.target`) will be one of these elements.
+
 ##### Details
 
-* `detail.elt` - the element that dispatched the request
+* `detail.elt` - the added/updated element
 * `detail.xhr` - the `XMLHttpRequest`
 * `detail.target` - the target of the request
+* `detail.trigger` - the element that dispatched the request
 
 ### <a name="afterSwap.htmx"></a> Event - [`afterSwap.htmx`](#afterSwap.htmx)
 
-This event is triggered after new content has been  [swapped into the DOM](/docs#swapping).
+This event is triggered after new content has been [swapped into the DOM](/docs#swapping).
+
+It can be called once or many times depending on `hx-swap`:
+
+* `innerHTML` - for the target of the request
+* `outerHTML` - once for each top level elements(s) added in place of the target of the request
+* `beforebegin` - for the target of the request + once for each top level element(s) added before this target
+* `beforeend` - for the target of the request
+* `afterend` - for the target of the request + once for each top level element(s) added after thistarget
+
+For each call, `event.detail.elt` (and `event.target`) will be one of these elements.
 
 ##### Details
 
-* `detail.elt` - the element that dispatched the request
+* `detail.elt` - the added/updated element
 * `detail.xhr` - the `XMLHttpRequest`
 * `detail.target` - the target of the request
+* `detail.trigger` - the element that dispatched the request
 
 ### <a name="beforeOnLoad.htmx"></a> Event - [`beforeOnLoad.htmx`](#beforeOnLoad.htmx)
 
@@ -60,6 +88,7 @@ This event is triggered before any response processing occurs.  If the event is 
 * `detail.elt` - the element that dispatched the request
 * `detail.xhr` - the `XMLHttpRequest`
 * `detail.target` - the target of the request
+* `detail.trigger` - the element that dispatched the request
 
 ### <a name="beforeRequest.htmx"></a> Event - [`beforeRequest.htmx`](#beforeRequest.htmx)
 
@@ -70,6 +99,7 @@ This event is triggered before an AJAX request is issued.  If the event is cance
 * `detail.elt` - the element that dispatched the request
 * `detail.xhr` - the `XMLHttpRequest`
 * `detail.target` - the target of the request
+* `detail.trigger` - the element that dispatched the request
 
 ### <a name="beforeSwap.htmx"></a> Event - [`beforeSwap.htmx`](#beforeSwap.htmx)
 
@@ -80,6 +110,7 @@ This event is triggered before any new content has been [swapped into the DOM](/
 * `detail.elt` - the element that dispatched the request
 * `detail.xhr` - the `XMLHttpRequest`
 * `detail.target` - the target of the request
+* `detail.trigger` - the element that dispatched the request
 
 ### <a name="configRequest.htmx"></a> Event - [`configRequest.htmx`](#configRequest.htmx)
 
@@ -104,6 +135,7 @@ than a single value.
 * `detail.path` - the request path
 * `detail.elt` - the element that triggered the request
 * `detail.target` - the target of the request
+* `detail.trigger` - the element that dispatched the request
 
 ### <a name="historyCacheMiss.htmx"></a> Event - [`historyCacheMiss.htmx`](#historyCacheMiss.htmx)
 
@@ -180,6 +212,7 @@ This event is triggered when an error occurs during the `load` handling of an AJ
 * `detail.xhr` - the `XMLHttpRequest`
 * `detail.elt` - the element that triggered the request
 * `detail.target` - the target of the request
+* `detail.trigger` - the element that dispatched the request
 * `detail.error` - the exception that occurred
 
 ### <a name="oobErrorNoTarget.htmx"></a> Event - [`oobErrorNoTarget.htmx`](#oobErrorNoTarget.htmx)
@@ -211,6 +244,7 @@ This event is triggered when an HTTP error response occurs
 * `detail.xhr` - the `XMLHttpRequest`
 * `detail.elt` - the element that triggered the request
 * `detail.target` - the target of the request
+* `detail.trigger` - the element that dispatched the request
 * `detail.error` - object with:
   * `status` - http status code of the response
   * `path` - request path
@@ -245,6 +279,7 @@ This event is triggered when an error occurs during the swap phase
 * `detail.xhr` - the `XMLHttpRequest`
 * `detail.elt` - the element that triggered the request
 * `detail.target` - the target of the request
+* `detail.trigger` - the element that dispatched the request
 * `detail.error` - the exception that occurred
 
 ### <a name="targetError.htmx"></a> Event - [`targetError.htmx`](#targetError.htmx)

--- a/www/events.md
+++ b/www/events.md
@@ -157,7 +157,7 @@ This event is triggered when htmx handles a history restoration action
 
 ### <a name="load.htmx"></a> Event - [`load.htmx`](#load.htmx)
 
-This event is triggered when a new node is loaded into the DOM by htmx.
+This event is triggered when a new node is loaded into the DOM by htmx. Called first with `body` when page is fully loaded.
 
 ##### Details
 

--- a/www/events.md
+++ b/www/events.md
@@ -100,9 +100,10 @@ than a single value.
 * `detail.parameters` - the parameters that will be submitted in the request
 * `detail.unfilteredParameters` - the parameters that were found before filtering by [`hx-select`](/attributes/hx-select)
 * `detail.headers` - the request headers
+* `detail.verb` - the HTTP verb in use
+* `detail.path` - the request path
 * `detail.elt` - the element that triggered the request
 * `detail.target` - the target of the request
-* `detail.verb` - the HTTP verb in use
 
 ### <a name="historyCacheMiss.htmx"></a> Event - [`historyCacheMiss.htmx`](#historyCacheMiss.htmx)
 
@@ -179,7 +180,7 @@ This event is triggered when an error occurs during the `load` handling of an AJ
 * `detail.xhr` - the `XMLHttpRequest`
 * `detail.elt` - the element that triggered the request
 * `detail.target` - the target of the request
-* `detail.exception` - the exception that occurred
+* `detail.error` - the exception that occurred
 
 ### <a name="oobErrorNoTarget.htmx"></a> Event - [`oobErrorNoTarget.htmx`](#oobErrorNoTarget.htmx)
 
@@ -210,6 +211,10 @@ This event is triggered when an HTTP error response occurs
 * `detail.xhr` - the `XMLHttpRequest`
 * `detail.elt` - the element that triggered the request
 * `detail.target` - the target of the request
+* `detail.error` - object with:
+  * `status` - http status code of the response
+  * `path` - request path
+  * `verb` - request verb
 
 ### <a name="sendError.htmx"></a> Event - [`sendError.htmx`](#sendError.htmx)
 
@@ -240,6 +245,7 @@ This event is triggered when an error occurs during the swap phase
 * `detail.xhr` - the `XMLHttpRequest`
 * `detail.elt` - the element that triggered the request
 * `detail.target` - the target of the request
+* `detail.error` - the exception that occurred
 
 ### <a name="targetError.htmx"></a> Event - [`targetError.htmx`](#targetError.htmx)
 

--- a/www/reference.md
+++ b/www/reference.md
@@ -104,8 +104,8 @@ title: </> htmx - Attributes
 | [`beforeSwap.htmx`](/events#beforeSwap.htmx)  | triggered before a swap is done
 | [`configRequest.htmx`](/events#configRequest.htmx)  | triggered before the request, allows you to customize parameters, headers
 | [`historyCacheMiss.htmx`](/events#historyCacheMiss.htmx)  | triggered on a cache miss in the history subsystem
-| [`historyCacheMissError.htmx`](/events#historyCacheMissError.htmx)  | triggered on a unsuccessful remote retrieval 
 | [`historyCacheMissLoad.htmx`](/events#historyCacheMissLoad.htmx)  | triggered on a succesful remote retrieval 
+| [`historyCacheMissLoadError.htmx`](/events#historyCacheMissLoadError.htmx)  | triggered on a unsuccessful remote retrieval
 | [`historyRestore.htmx`](/events#historyRestore.htmx)  | triggered when htmx handles a history restoration action
 | [`beforeHistorySave.htmx`](/events#beforeHistorySave.htmx)  | triggered before content is saved to the history cache
 | [`load.htmx`](/events#load.htmx)  | triggered when new content is added to the DOM


### PR DESCRIPTION
(this is a proposal for #97)

`detail.elt` can sometimes be the element that triggered the request, or
sometimes the target, so we cannot rely on it easily.

And as we always have the `target` key correctly filled, this commit
also adds the `trigger` key.

This also updates the `afterSwap.htmx` and `afterSettle.htmx` events to
be triggered for all newly added elements when `hx-swap` is
`beforebegin` and `beforeend`, for consistency with other modes.

**Tests**: many are added in `test/core/events.js` to check many cases.
**Doc**: `www/events.md` is updated accordingly.

**Note**: this PR also add 2 commits to fix some code/docs about existing events and one to enhance the `load.htmx` test