### PR TITLE
Make indicator and request classes customisable

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1522,7 +1522,7 @@ return (function () {
 
                             var swapSpec = getSwapSpecification(elt);
 
-                            target.classList.add("htmx-swapping");
+                            target.classList.add(htmx.config.swappingClass);
                             var doSwap = function () {
                                 try {
 
@@ -1544,10 +1544,10 @@ return (function () {
                                         newActiveElt.focus();
                                     }
 
-                                    target.classList.remove("htmx-swapping");
+                                    target.classList.remove(htmx.config.swappingClass);
                                     forEach(settleInfo.elts, function (elt) {
                                         if (elt.classList) {
-                                            elt.classList.add("htmx-settling");
+                                            elt.classList.add(htmx.config.settlingClass);
                                         }
                                         triggerEvent(elt, 'afterSwap.htmx', eventDetail);
                                     });
@@ -1560,7 +1560,7 @@ return (function () {
                                         });
                                         forEach(settleInfo.elts, function (elt) {
                                             if (elt.classList) {
-                                                elt.classList.remove("htmx-settling");
+                                                elt.classList.remove(htmx.config.settlingClass);
                                             }
                                             triggerEvent(elt, 'afterSettle.htmx', eventDetail);
                                         });
@@ -1734,7 +1734,9 @@ return (function () {
                 defaultSettleDelay:100,
                 includeIndicatorStyles:true,
                 indicatorClass:'htmx-indicator',
-                requestClass:'htmx-request'
+                requestClass:'htmx-request',
+                settlingClass:'htmx-settling',
+                swappingClass:'htmx-swapping',
             },
             parseInterval:parseInterval,
             _:internalEval,

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1149,7 +1149,7 @@ return (function () {
                 indicators = [elt];
             }
             forEach(indicators, function(ic) {
-                ic.classList[action].call(ic.classList, "htmx-request");
+                ic.classList[action].call(ic.classList, htmx.config.requestClass);
             });
         }
 
@@ -1668,18 +1668,16 @@ return (function () {
             }
         }
 
-        // insert htmx-indicator css rules immediate, if not configured otherwise
-        (function() {
-            var metaConfig = getMetaConfig();
-            if (metaConfig === null || metaConfig.includeIndicatorStyles !== false) {
+        function insertIndicatorStyles() {
+            if (htmx.config.includeIndicatorStyles !== false) {
                 getDocument().head.insertAdjacentHTML("beforeend",
                     "<style>\
-                      .htmx-indicator{opacity:0;transition: opacity 200ms ease-in;}\
-                      .htmx-request .htmx-indicator{opacity:1}\
-                      .htmx-request.htmx-indicator{opacity:1}\
+                      ." + htmx.config.indicatorClass + "{opacity:0;transition: opacity 200ms ease-in;}\
+                      ." + htmx.config.requestClass + " ." + htmx.config.indicatorClass + "{opacity:1}\
+                      ." + htmx.config.requestClass + "." + htmx.config.indicatorClass + "{opacity:1}\
                     </style>");
             }
-        })();
+        }
 
         function getMetaConfig() {
             var element = getDocument().querySelector('meta[name="htmx-config"]');
@@ -1700,6 +1698,7 @@ return (function () {
         // initialize the document
         ready(function () {
             mergeMetaConfig();
+            insertIndicatorStyles();
             var body = getDocument().body;
             processNode(body, true);
             triggerEvent(body, 'load.htmx', {});
@@ -1733,7 +1732,9 @@ return (function () {
                 defaultSwapStyle:'innerHTML',
                 defaultSwapDelay:0,
                 defaultSettleDelay:100,
-                includeIndicatorStyles:true
+                includeIndicatorStyles:true,
+                indicatorClass:'htmx-indicator',
+                requestClass:'htmx-request'
             },
             parseInterval:parseInterval,
             _:internalEval,

--- a/www/docs.md
+++ b/www/docs.md
@@ -684,6 +684,8 @@ Htmx allows you to configure a few defaults:
 |  `htmx.config.includeIndicatorStyles` | defaults to `true` (determines if the indicator styles are loaded)
 |  `htmx.config.indicatorClass` | defaults to `htmx-indicator`
 |  `htmx.config.requestClass` | defaults to `htmx-request`
+|  `htmx.config.settlingClass` | defaults to `htmx-settling`
+|  `htmx.config.swappingClass` | defaults to `htmx-swapping`
 
 </div>
 

--- a/www/docs.md
+++ b/www/docs.md
@@ -681,7 +681,9 @@ Htmx allows you to configure a few defaults:
 |  `htmx.config.defaultSwapStyle` | defaults to `innerHTML`
 |  `htmx.config.defaultSwapDelay` | defaults to 0
 |  `htmx.config.defaultSettleDelay` | defaults to 100
-|  `htmx.config.includeIndicatorStyles` | defaults to `true` (determines if the `htmx-indicator` default styles are loaded, must be set in a `meta` tag before the htmx js is included)
+|  `htmx.config.includeIndicatorStyles` | defaults to `true` (determines if the indicator styles are loaded)
+|  `htmx.config.indicatorClass` | defaults to `htmx-indicator`
+|  `htmx.config.requestClass` | defaults to `htmx-request`
 
 </div>
 


### PR DESCRIPTION
This makes the `htmx-indicator` and `htmx-request` classes customisable, both in meta tags _as well as_ directly in JavaScript. To accomplish this, the indicator styles are included on page load instead of immediately. Please let me know if this is unsafe to do for any reason @chg20.