### PR TITLE
Fix issue with unquoted id attribute in query selector

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -395,7 +395,7 @@ return (function () {
         function handleAttributes(parentNode, fragment, settleInfo) {
             forEach(fragment.querySelectorAll("[id]"), function (newNode) {
                 if (newNode.id && newNode.id.length > 0) {
-                    var oldNode = parentNode.querySelector(newNode.tagName + "[id=" + newNode.id + "]");
+                    var oldNode = parentNode.querySelector(newNode.tagName + "[id='" + newNode.id + "']");
                     if (oldNode && oldNode !== parentNode) {
                         var newAttributes = newNode.cloneNode();
                         cloneAttributes(newNode, oldNode);

--- a/test/core/regressions.js
+++ b/test/core/regressions.js
@@ -64,5 +64,13 @@ describe("Core htmx Regression Tests", function(){
         this.server.respond();
         div.innerText.should.contain("Foo")
     });
+    
+    it ('id with dot in value doesnt cause an error', function(){
+        this.server.respondWith("GET", "/test", "Foo <div id='ViewModel.Test'></div>");
+        var div = make('<div hx-get="/test">Get It</div>');
+        div.click();
+        this.server.respond();
+        div.innerText.should.contain("Foo");
+    });
 
 })


### PR DESCRIPTION
When having a dot in the id-attribute of the response, the handleAttributes function throws an Exception:

> DOMException: Element.querySelector: 'DIV[id=ViewModel.Test]' is not a valid selector

The issue is the attribute-value in the selector isn't quoted.
```javascript
var oldNode = parentNode.querySelector(newNode.tagName + "[id=" + newNode.id + "]");
```

 This causes the exception when there is a dot in the value.

This PR fixes this issue and adds a testcase to the regressions test suite to demonstrate the issue.