### PR TITLE
FEATURE: Swap HTML on Server Sent Events (like WebSockets)

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -839,7 +839,6 @@ return (function () {
             // then process the fragments in the same way as WebSockets
             if (eventName != undefined) {
                 source.addEventListener(eventName, function(event) {
-                    console.log(event)
                     processFragments(elt, event.data)
                 })
             }


### PR DESCRIPTION
This pull request updates SSE content to swap HTML into the current page, just like WebSockets, without removing the existing `hx-trigger` behavior that also uses SSE data.  

I believe it addresses issue #66, although it does not use the syntax that you described there.  Instead, it looks like this:

```html
<div hx-sse="connect /my-events EventNameToListenFor">
```

Now, the hx-sse attribute takes a third (optional) parameter that specifies an event name to listen for.  When events using this name come through the SSE channel, that is treated as an "out-of-band swap" and swapped into the underlying DOM (just like WebSockets do now).

To do this, I added the optional event handler to the `processSSEInfo` function, and moved some of the existing WebSockets code into a common place -- a new function called `processFragments` -- that is called by both the WebSockets implementation and the SSE implementation.


Hopefully, this code fits the style and spirit that you're building in HTMX.  I'm excited to see all of the potential applications of this toolkit and will be happy to work on any enhancement suggestions, corrections, improvements to this code.

🤘