### PR TITLE
Close connections on swapInnerHTML

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -481,8 +481,10 @@ return (function () {
             if (firstChild) {
                 while (firstChild.nextSibling) {
                     target.removeChild(firstChild.nextSibling);
+                    closeConnections(firstChild.nextSibling)
                 }
                 target.removeChild(firstChild);
+                closeConnections(firstChild)
             }
         }
 

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -480,11 +480,11 @@ return (function () {
             insertNodesBefore(target, firstChild, fragment, settleInfo);
             if (firstChild) {
                 while (firstChild.nextSibling) {
-                    target.removeChild(firstChild.nextSibling);
                     closeConnections(firstChild.nextSibling)
+                    target.removeChild(firstChild.nextSibling);
                 }
-                target.removeChild(firstChild);
                 closeConnections(firstChild)
+                target.removeChild(firstChild);
             }
         }
 


### PR DESCRIPTION
Currently, HTMX does not close all WebSocket and SSE connections when a node's innerHTML is swapped.  This pull request adds `closeConnections` calls into the `swapInnerHTML` function, so that connections are not leaked after content is swapped.