### PR TITLE
FEATURE: Support "autofocus" attribute when swapping content

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -411,8 +411,16 @@ return (function () {
             return function () {
                 processNode(child, true);
                 processScripts(child);
+                processFocus(child)
                 triggerEvent(child, 'htmx:load', {});
             };
+        }
+
+        function processFocus(child) {
+            var el = child.querySelector("[autofocus]")
+            if (el != null) {
+                el.focus()
+            }
         }
 
         function insertNodesBefore(parentNode, insertBefore, fragment, settleInfo) {


### PR DESCRIPTION
This adds an additional check to `makeAjaxLoadTask` that focuses on the first element with the HTML standard "autofocus" attribute set.  This addresses one of the original requests in #154

I've put it right next to the makeAjaxLoadTask function for clarity, but it should probably be organized into a different place, next to other corresponding functions.