### PR TITLE
Process elements with the _hyperscript attribute

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -921,7 +921,7 @@ return (function () {
 
         function findElementsToProcess(elt) {
             if (elt.querySelectorAll) {
-                var results = elt.querySelectorAll(VERB_SELECTOR + ", a, form, [hx-sse], [data-hx-sse], [hx-ws], [data-hx-ws]");
+                var results = elt.querySelectorAll(VERB_SELECTOR + ", a, form, [hx-sse], [data-hx-sse], [hx-ws], [data-hx-ws], [_]");
                 return results;
             } else {
                 return [];


### PR DESCRIPTION
When loading new elements into a page that have a hyperscript attribute set, but aren't `a` or `form` tags, and also don't have any htmx attributes, hyperscript won't be initialized on them.

This PR fixes that by adding a selector for elements with the hyperscript `_` attribute.