### PR TITLE
FEATURE: find selector option of the hx-target attribute

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -321,6 +321,8 @@ return (function () {
                     return explicitTarget;
                 } else if (targetStr.indexOf("closest ") === 0) {
                     return closest(elt, targetStr.substr(8));
+                } else if (targetStr.indexOf("find ") === 0) {
+                    return find(elt, targetStr.substr(5));   
                 } else {
                     return getDocument().querySelector(targetStr);
                 }

--- a/test/attributes/hx-target.js
+++ b/test/attributes/hx-target.js
@@ -47,6 +47,18 @@ describe("hx-target attribute", function(){
         this.server.respond();
         div1.innerHTML.should.equal("Clicked!");
     });
+    
+    it('targets a `find` element properly', function()
+    {
+        this.server.respondWith("GET", "/test", "Clicked!");
+        var div1 = make('<div hx-target="find span" hx-get="/test">Click Me! <div><span id="s1"></span><span id="s2"></span></div></div>')
+        div1.click();
+        this.server.respond();
+        var span1 = byId("s1")
+        var span2 = byId("s2")
+        span1.innerHTML.should.equal("Clicked!");
+        span2.innerHTML.should.equal("");
+    });
 
     it('targets an inner element properly', function()
     {

--- a/www/attributes/hx-target.md
+++ b/www/attributes/hx-target.md
@@ -12,6 +12,8 @@ request.  The value of this attribute can be:
  * `this` which indicates that the element that the `hx-target` attribute is on is the target
  * `closest <CSS selector>` which will find the closest parent ancestor that matches the given CSS selector. 
     (e.g. `closest tr` will target the closest table row to the element)
+ * `find <CSS selector>` which will find the first child descendant element that matches the given CSS selector.
+    (e.g `find tr` will target the first child descendant row to the element)
 
 Here is an example that targets a div:
 


### PR DESCRIPTION
This adds the `find` selector option to the `hx-target` attribute which allows targetting child descendant nodes.