### PR TITLE
FEATURE: Limit number of child elements in hx-swap

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -730,7 +730,7 @@ return (function () {
 
         function maybeReveal(elt) {
             var nodeData = getInternalData(elt);
-            if (!nodeData.revealed && isScrolledIntoView(elt)) {
+            if (isScrolledIntoView(elt) && (nodeData.revealed != true) && (nodeData.verb != undefined)) {
                 nodeData.revealed = true;
                 issueAjaxRequest(elt, nodeData.verb, nodeData.path);
             }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -716,15 +716,23 @@ return (function () {
             elt.addEventListener(triggerSpec.trigger, eventListener);
         }
 
+        var windowIsScrolling = false
         function initScrollHandler() {
             if (!window['htmxScrollHandler']) {
                 var scrollHandler = function() {
-                    forEach(getDocument().querySelectorAll("[hx-trigger='revealed'],[data-hx-trigger='revealed']"), function (elt) {
-                        maybeReveal(elt);
-                    });
+                    windowIsScrolling = true
                 };
                 window['htmxScrollHandler'] = scrollHandler;
                 window.addEventListener("scroll", scrollHandler)
+
+                setInterval(function() {
+                    if (windowIsScrolling) {
+                        windowIsScrolling = false;
+                        forEach(getDocument().querySelectorAll("[hx-trigger='revealed'],[data-hx-trigger='revealed']"), function (elt) {
+                            maybeReveal(elt);
+                        })
+                    }
+                }, 200);
             }
         }
 


### PR DESCRIPTION
This pull request partially addresses #130 by adding an optional `limit:` argument to the `hx-swap` attribute.  It looks at where new nodes are being added into the DOM, and removed nodes from the opposite end.  So, since `hx-swap="afterbegin"` adds new elements to the top of the node's list of children, `hx-swap="afterbegin limit:10"` will remove elements from the bottom of the node's list of children until there are only ten.

I think there may be more work to do here, and will continue that discussion in the original issue #130.

Along the way, this code also addresses a minor bug in the `maybeReveal` function that can crash if the user scrolls too quickly.  We address this by double checking that nodes have been initialized before allowing the "reveal" trigger to continue.