### PR TITLE
Removed redundant parameter

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -452,7 +452,7 @@ return (function () {
 
         function makeAjaxLoadTask(child) {
             return function () {
-                processNode(child, true);
+                processNode(child);
                 processScripts(child);
                 triggerEvent(child, 'htmx:load', {});
             };
@@ -1757,7 +1757,7 @@ return (function () {
             mergeMetaConfig();
             insertIndicatorStyles();
             var body = getDocument().body;
-            processNode(body, true);
+            processNode(body);
             triggerEvent(body, 'htmx:load', {});
             window.onpopstate = function (event) {
                 if (event.state && event.state.htmx) {


### PR DESCRIPTION
Removed second parameter from `processNode` that is redundant as it does not exist in the function definition.