### PR TITLE
FEATURE: Swap HTML on Server Sent Events (like WebSockets) improved version

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -816,7 +816,7 @@ return (function () {
             var eventType = value[1]
 
             if (eventType == undefined) {
-                return
+                eventType = "message"
             }
 
             var source = htmx.createEventSource(sseSrc);

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -842,9 +842,7 @@ return (function () {
             }
 
             forEach(eventTypes, function(eventType) {
-                console.log("adding handler", eventType)
                 addServerSentEvent(elt, sseSrc, eventType, function(e) {
-                    console.log("received event", e)
                     if (maybeCloseSSESource(elt)) {return}
                     handleContent(elt, e.data)
                 })
@@ -883,7 +881,6 @@ return (function () {
             // Search all event handlers that match this element.
             eventSource.l = filter(eventSource.l, function(listener) {
                 if (listener.e === elt) {
-                    console.log("removing handler", eventSource)
                     eventSource.s.removeEventListener(listener.t, listener.fn)
                     return false
                 }
@@ -898,7 +895,6 @@ return (function () {
         }
 
         function maybeCloseSSESource(elt) {
-            console.log("maybeCloseSSESource")
             if (!bodyContains(elt)) {
                 closeServerSentEvent(elt)
                 return true;

--- a/test/index.html
+++ b/test/index.html
@@ -41,6 +41,15 @@
     </li>
 </ul>
 
+<h2>Server Sent Events Tests</h2>
+<p>(Dependency on external SSE server)</p>
+<ul>
+    <li><a href="manual/sse.html">Multiple SSE URLs</a></li>
+    <li><a href="manual/sse-multichannel.html">Single URL / Multiple Streams</a></li>
+    <li><a href="manual/sse-settle.html">Settling options</a></li>
+    <li><a href="manual/sse-target.html">Targeting options</a></li>
+</ul>
+
 <h2>Mocha Test Suite</h2>
 
 <script src="../node_modules/chai/chai.js"></script>

--- a/test/manual/sse-multichannel.html
+++ b/test/manual/sse-multichannel.html
@@ -1,0 +1,41 @@
+<html>
+	<head>
+		<script src="../../src/htmx.js"></script>
+		<script>
+			htmx.createEventSource = function(url){
+                return new EventSource(url, {withCredentials:false})
+            }
+		</script>
+		<style>
+			*{
+				font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+			}
+
+			body {
+				background-color: #eeeeee;
+			}
+
+			.container {
+				padding: 10px;
+				border: solid 1px gray;
+				margin-bottom: 20px;
+				background-color:white;
+			}
+
+			.bold {
+				font-weight:bold;
+			}			
+		</style>
+	</head>
+
+	<body>
+
+		<div id="page">
+			<h3>Multiple Listeners. message only</h3>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/posts/sse.html?types=Event1,Event2,Event3,Event4 Event1">Waiting for Posts in Event1 channel...</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/posts/sse.html?types=Event1,Event2,Event3,Event4 Event2">Waiting for Posts in Event2 channel...</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/posts/sse.html?types=Event1,Event2,Event3,Event4 Event3">Waiting for Posts in Event3 channel...</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/posts/sse.html?types=Event1,Event2,Event3,Event4 Event4">Waiting for Posts in Event4 channel...</div>
+		</div>
+	</body>
+</html>

--- a/test/manual/sse-multichannel.html
+++ b/test/manual/sse-multichannel.html
@@ -32,10 +32,10 @@
 
 		<div id="page">
 			<h3>Multiple Listeners. message only</h3>
-			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/posts/sse.html?types=Event1,Event2,Event3,Event4 Event1">Waiting for Posts in Event1 channel...</div>
-			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/posts/sse.html?types=Event1,Event2,Event3,Event4 Event2">Waiting for Posts in Event2 channel...</div>
-			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/posts/sse.html?types=Event1,Event2,Event3,Event4 Event3">Waiting for Posts in Event3 channel...</div>
-			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/posts/sse.html?types=Event1,Event2,Event3,Event4 Event4">Waiting for Posts in Event4 channel...</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/posts.html?types=Event1,Event2,Event3,Event4 Event1">Waiting for Posts in Event1 channel...</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/posts.html?types=Event1,Event2,Event3,Event4 Event2">Waiting for Posts in Event2 channel...</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/posts.html?types=Event1,Event2,Event3,Event4 Event3">Waiting for Posts in Event3 channel...</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/posts.html?types=Event1,Event2,Event3,Event4 Event4">Waiting for Posts in Event4 channel...</div>
 		</div>
 	</body>
 </html>

--- a/test/manual/sse-settle.html
+++ b/test/manual/sse-settle.html
@@ -37,11 +37,11 @@
 
 		<div id="page">
 			<h3>Settling Options</h3>
-			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/comments/sse.html" hx-swap="innerHTML settle:100ms">Waiting for Comments...</div>
-			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/comments/sse.html" hx-swap="innerHTML settle:200ms">Waiting for Comments...</div>
-			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/comments/sse.html" hx-swap="innerHTML settle:300ms">Waiting for Comments...</div>
-			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/comments/sse.html" hx-swap="innerHTML settle:400ms">Waiting for Comments...</div>
-			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/comments/sse.html" hx-swap="innerHTML settle:500ms">Waiting for Comments...</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/comments.html" hx-swap="innerHTML settle:100ms">Waiting for Comments...</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/comments.html" hx-swap="innerHTML settle:200ms">Waiting for Comments...</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/comments.html" hx-swap="innerHTML settle:300ms">Waiting for Comments...</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/comments.html" hx-swap="innerHTML settle:400ms">Waiting for Comments...</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/comments.html" hx-swap="innerHTML settle:500ms">Waiting for Comments...</div>
 		</div>
 	</body>
 </html>

--- a/test/manual/sse-settle.html
+++ b/test/manual/sse-settle.html
@@ -1,0 +1,47 @@
+<html>
+	<head>
+		<script src="../../src/htmx.js"></script>
+		<script>
+			htmx.createEventSource = function(url){
+                return new EventSource(url, {withCredentials:false})
+            }
+		</script>
+		<style>
+			*{
+				font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+			}
+
+			body {
+				background-color: #eeeeee;
+			}
+
+			.container {
+				padding: 10px;
+				border: solid 1px gray;
+				margin-bottom: 20px;
+				background-color:white;
+			}
+
+			.htmx-settling {
+				border:solid 3px red!important;
+				padding:8px!important;
+			}
+
+			.bold {
+				font-weight:bold;
+			}			
+		</style>
+	</head>
+
+	<body>
+
+		<div id="page">
+			<h3>Settling Options</h3>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/comments/sse.html" hx-swap="innerHTML settle:100ms">Waiting for Comments...</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/comments/sse.html" hx-swap="innerHTML settle:200ms">Waiting for Comments...</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/comments/sse.html" hx-swap="innerHTML settle:300ms">Waiting for Comments...</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/comments/sse.html" hx-swap="innerHTML settle:400ms">Waiting for Comments...</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/comments/sse.html" hx-swap="innerHTML settle:500ms">Waiting for Comments...</div>
+		</div>
+	</body>
+</html>

--- a/test/manual/sse-target.html
+++ b/test/manual/sse-target.html
@@ -39,11 +39,11 @@
 			<h3>Multiple Listeners using HX-Target to write to a single target node.</h3>
 			<div class="container" id="otherNode">Waiting for records from any of: Posts, Comments, Albums, ToDos, Users</div>
 
-			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/posts/sse.html" hx-target="#otherNode">Loading Posts.  This should not be replaced.</div>
-			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/comments/sse.html" hx-target="#otherNode">Loading Comments.  This should not be replaced.</div>
-			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/albums/sse.html" hx-target="#otherNode">Loading Albums.  This should not be replaced.</div>
-			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/todos/sse.html" hx-target="#otherNode">Loading ToDos.  This should not be replaced.</div>
-			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/users/sse.html" hx-target="#otherNode">Loading Users.  This should not be replaced.</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/posts.html" hx-target="#otherNode">Loading Posts.  This should not be replaced.</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/comments.html" hx-target="#otherNode">Loading Comments.  This should not be replaced.</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/albums.html" hx-target="#otherNode">Loading Albums.  This should not be replaced.</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/todos.html" hx-target="#otherNode">Loading ToDos.  This should not be replaced.</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/users.html" hx-target="#otherNode">Loading Users.  This should not be replaced.</div>
 		</div>
 	</body>
 </html>

--- a/test/manual/sse-target.html
+++ b/test/manual/sse-target.html
@@ -1,0 +1,49 @@
+<html>
+	<head>
+		<script src="../../src/htmx.js"></script>
+		<script>
+			htmx.createEventSource = function(url){
+                return new EventSource(url, {withCredentials:false})
+            }
+		</script>
+		<style>
+			*{
+				font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+			}
+
+			body {
+				background-color: #eeeeee;
+			}
+
+			.container {
+				padding: 10px;
+				border: solid 1px gray;
+				margin-bottom: 20px;
+				background-color:white;
+			}
+
+			.htmx-settling {
+				border:solid 3px red!important;
+				padding:8px!important;
+			}
+
+			.bold {
+				font-weight:bold;
+			}			
+		</style>
+	</head>
+
+	<body>
+
+		<div id="page">
+			<h3>Multiple Listeners using HX-Target to write to a single target node.</h3>
+			<div class="container" id="otherNode">Waiting for records from any of: Posts, Comments, Albums, ToDos, Users</div>
+
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/posts/sse.html" hx-target="#otherNode">Loading Posts.  This should not be replaced.</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/comments/sse.html" hx-target="#otherNode">Loading Comments.  This should not be replaced.</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/albums/sse.html" hx-target="#otherNode">Loading Albums.  This should not be replaced.</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/todos/sse.html" hx-target="#otherNode">Loading ToDos.  This should not be replaced.</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/users/sse.html" hx-target="#otherNode">Loading Users.  This should not be replaced.</div>
+		</div>
+	</body>
+</html>

--- a/test/manual/sse.html
+++ b/test/manual/sse.html
@@ -32,11 +32,11 @@
 
 		<div id="page">
 			<h3>Multiple Listeners. message only</h3>
-			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/posts/sse.html">Waiting for Posts...</div>
-			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/comments/sse.html">Waiting for Comments...</div>
-			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/albums/sse.html">Waiting for Albums...</div>
-			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/todos/sse.html">Waiting for ToDos...</div>
-			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/users/sse.html">Waiting for Users...</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/posts.html">Waiting for Posts...</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/comments.html">Waiting for Comments...</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/albums.html">Waiting for Albums...</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/todos.html">Waiting for ToDos...</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/users.html">Waiting for Users...</div>
 		</div>
 	</body>
 </html>

--- a/test/manual/sse.html
+++ b/test/manual/sse.html
@@ -1,0 +1,42 @@
+<html>
+	<head>
+		<script src="../../src/htmx.js"></script>
+		<script>
+			htmx.createEventSource = function(url){
+                return new EventSource(url, {withCredentials:false})
+            }
+		</script>
+		<style>
+			*{
+				font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+			}
+
+			body {
+				background-color: #eeeeee;
+			}
+
+			.container {
+				padding: 10px;
+				border: solid 1px gray;
+				margin-bottom: 20px;
+				background-color:white;
+			}
+
+			.bold {
+				font-weight:bold;
+			}			
+		</style>
+	</head>
+
+	<body>
+
+		<div id="page">
+			<h3>Multiple Listeners. message only</h3>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/posts/sse.html">Waiting for Posts...</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/comments/sse.html">Waiting for Comments...</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/albums/sse.html">Waiting for Albums...</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/todos/sse.html">Waiting for ToDos...</div>
+			<div class="container" hx-sse="http://sseplaceholder.openfollow.org/users/sse.html">Waiting for Users...</div>
+		</div>
+	</body>
+</html>

--- a/www/posts/2020-7-8-htmx-0.0.8-is-released.md
+++ b/www/posts/2020-7-8-htmx-0.0.8-is-released.md
@@ -17,7 +17,7 @@ I'm pleased to announce the [0.0.8 release](https://unpkg.com/browse/htmx.org@0.
 
 #### New Features
 
-* A bug fix on history when using local anchors: `&lt;a href="#example">...`
+* A bug fix on history when using local anchors: `<a href="#example">...`
 * A bug fix for the aforementioned `show` functionality
 
 Enjoy!


### PR DESCRIPTION
Since this is starting to get some scrutiny, I think this is actually the better code to review.  It also has the largest changes, so it NEEDS more work to review it.

This follows the design I laid out in my [original PR for SSE handling](https://github.com/bigskysoftware/htmx/pull/155#issuecomment-674971840) and uses a big chunk of work from @tomberek that pulls a lot of node replacement logic out of the AJAX call and into its own function.  This should be thoroughly vetted by someone with more experience than us, but it could lay the groundwork for updating the original AJAX calls as well, which would save a bunch of code.

```html
<!-- Server Sent Events: URLs and Event Names-->
<div hx-sse="/my-url"> Works on untyped "message" events
<div hx-sse="/my-url EventName"> Works on "EventName" events
<div hx-sse="/my-url EventName1 EventName2"> Works on both "EventName1" and "EventName2" events

<!-- hx-swap and hx-target-->
<div hx-sse="/my-url" hx-target="#nodeId"> fragment is swapped into a different node
<div hx-sse="/my-url" hx-swap="outerHTML"> changes how the fragment is swapped
<div hx-sse="/my-url" hx-swap="innerHTML settle:1s"> additional swap arguments work.  This one adds a settling timer.

<!-- hx-swap-oob in response fragments -->
<div id="anotherId" hx-swap-oob="true">
  This fragment is generated on the server.  When it arrives on the browser, 
  it is swapped into "anotherId" instead of the node that originated the call.
</div>

<!-- multple tags / connection pooling -->
In a single document, several DOM nodes can all connect to a single URL.  In the example below, 
events Event1, Event2, and Event3 are distributed to each tag from a single connection.  If one node 
is removed, then its event handlers are removed, but the handlers for the remaining nodes are 
untouched.  If all nodes are removed, then the connection is closed
<div hx-sse="/my-url Event1">
<div hx-sse="/my-url Event2">
<div hx-sse="/my-url Event2 Event3"> 
```

I know this leaves behind your "multiple event types" idea, but this syntax seems much clearer to me.  What do you think?

It would be really good to get some other eyes on this and to confirm that it's behaving correctly.  We've made a lot of changes so far, and we shouldn't go too much further without a solid check.  In case anyone has trouble verifying this, I've made [a tiny server program](https://github.com/benpate/sseExampleServer) (in go) that returns a bunch of random strings to HTMX at random (<2s) intervals.  I left it running for over an hour with no noticeable leaks in the browser.

### Next Steps
* Thorough vetting of `doSwap` to confirm that we're not making any subtle changes to HTMX's original behavior.

### Future Work
* Backport `doSwap` into WebSockets and regular AJAX requests.  This will save a lot of duplication in the code.
* Possibly use the listener pool to handle polling, mentioned in #164
* Possibly expose SSE functions to the outside page, so that external scripts can also use this connection pool.