### PR TITLE
Add test case

### DIFF
--- a/test/core/ajax.js
+++ b/test/core/ajax.js
@@ -240,6 +240,36 @@ describe("Core htmx AJAX Tests", function(){
         btn.innerHTML.should.equal("Click Me!");
     });
 
+    it('handles 304 NOT MODIFIED responses properly', function()
+    {
+        this.server.respondWith("GET", "/test-1", [200, {}, "Content for Tab 1"]);
+        this.server.respondWith("GET", "/test-2", [200, {}, "Content for Tab 2"]);
+
+        var target = make('<div id="target"></div>')
+        var btn1 = make('<button hx-get="/test-1" hx-target="#target">Tab 1</button>');
+        var btn2 = make('<button hx-get="/test-2" hx-target="#target">Tab 2</button>');
+
+        btn1.click();
+        target.innerHTML.should.equal("");
+        this.server.respond();
+        target.innerHTML.should.equal("Content for Tab 1");
+
+        btn2.click();
+        this.server.respond();
+        target.innerHTML.should.equal("Content for Tab 2");
+
+        this.server.respondWith("GET", "/test-1", [304, {}, "Content for Tab 1"]);
+        this.server.respondWith("GET", "/test-2", [304, {}, "Content for Tab 2"]);
+
+        btn1.click();
+        this.server.respond();
+        target.innerHTML.should.equal("Content for Tab 1");
+
+        btn2.click();
+        this.server.respond();
+        target.innerHTML.should.equal("Content for Tab 2");
+    });
+
     it('handles hx-trigger with non-default value', function()
     {
         this.server.respondWith("GET", "/test", "Clicked!");


### PR DESCRIPTION
Adds a test case to demonstrate that 304 "Not Modified" response should be treated just the same as a regular 200 "Ok" response.

This PR is a replacement for #188 which inadvernently included a bunch of other code (sorry)