### PR TITLE
Fixed typo in first line of CSS sample showing how to use a custom

### DIFF
--- a/www/attributes/hx-indicator.md
+++ b/www/attributes/hx-indicator.md
@@ -43,7 +43,7 @@ If you would prefer a different effect for showing the spinner you could define 
 CSS.  Here is an example that uses `display` rather than opacity:
 
 ```css
-    .htmx-indicator{
+    .my-indicator{
         display:none;
     }
     .htmx-request .my-indicator{


### PR DESCRIPTION
indicator class.