### PR TITLE
Add required fields for path-deps (fixes #201)

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1625,6 +1625,10 @@ return (function () {
             verb = requestConfig.verb;
             headers = requestConfig.headers;
             filteredParameters = requestConfig.parameters;
+            
+            // Required fields for path-deps.js
+            xhr.url = path;
+            xhr.method = verb.toUpperCase();
 
             var splitPath = path.split("#");
             var pathNoAnchor = splitPath[0];


### PR DESCRIPTION
In path-ext.js, the fields `xhr.url` and `xhr.method` are required.
The missing fields can be added after creating the `xhr` object.