### PR TITLE
Some docs cleanup

### DIFF
--- a/www/docs.md
+++ b/www/docs.md
@@ -470,7 +470,7 @@ When a user hits the back button, htmx will retrieve the old content from storag
 
 ### Specifying History Snapshot Element
 
-By default, htmx will use the `body` to take and restore the history snapshop from.  This is usually the right thing, but
+By default, htmx will use the `body` to take and restore the history snapshot from.  This is usually the right thing, but
 if you want to use a narrower element for snapshotting you can use the [hx-history-elt](/attributes/hx-history-elt)
 attribute to specify a different one.  
 

--- a/www/extensions/event-header.md
+++ b/www/extensions/event-header.md
@@ -3,10 +3,11 @@ layout: layout.njk
 title: </> htmx - high power tools for html
 ---
 
-## The `ajax-header` Extension
+## The `event-header` Extension
 
-This extension adds the `Triggering-Event` header to requests.  The value
-of the header is a JSON serialized version of the event that triggered the request.
+This extension adds the `Triggering-Event` header to requests.  The value of
+the header is a JSON serialized version of the event that triggered the
+request.
 
 ### Usage
 

--- a/www/reference.md
+++ b/www/reference.md
@@ -71,8 +71,8 @@ title: </> htmx - Attributes
 | `HX-Active-Element-Value` | the `value` of the active element if it exists
 | `HX-Active-Element` | the `id` of the active element if it exists
 | `HX-Current-URL` | the current URL of the browser
-| `HX-Event-Target` | the `id` of the original event target 
-| `HX-Prompt` | the user response to an [ic-prompt](/attributes/hx-prompt)
+| `HX-Event-Target` | the `id` of the original event target
+| `HX-Prompt` | the user response to an [hx-prompt](/attributes/hx-prompt)
 | `HX-Request` | always `true`
 | `HX-Target` | the `id` of the target element if it exists
 | `HX-Trigger-Name` | the `name` of the triggered element if it exists


### PR DESCRIPTION
Fix some typos, and the location of the *event-header* extension as linked to in the latest release notes.