### PR TITLE
Extension Point: transformRequest

### DIFF
--- a/src/ext/authentication-header.js
+++ b/src/ext/authentication-header.js
@@ -1,0 +1,25 @@
+htmx.defineExtension('authentication-header', {
+
+	transformRequest: function(xhr) {
+		
+		if (window.sessionStorage) {
+			let auth = window.sessionStorage.getItem("Authentication")
+			if (auth != "") {
+				xhr.setRequestHeader("Authentication", auth)
+			}
+		}
+		return xhr
+	},
+
+	transformResponse: function(message, xhr, elt) {
+
+		if (window.sessionStorage) {
+			let auth = xhr.getResponseHeader("Authentication")
+			if (auth != "") {
+				window.sessionStorage.setItem("Authentication", auth)
+			}
+		}
+
+		return message
+	}
+});

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2097,6 +2097,11 @@ return (function () {
                     })
                 });
             });
+
+            withExtensions(elt, function(extension) {
+                xhr = extension.transformRequest(xhr)
+            })
+
             xhr.send(verb === 'get' ? null : encodeParamsForBody(xhr, elt, filteredParameters));
         }
 
@@ -2107,6 +2112,7 @@ return (function () {
         function extensionBase() {
             return {
                 onEvent : function(name, evt) {return true;},
+                transformRequest : function(xhr) {return xhr;},
                 transformResponse : function(text, xhr, elt) {return text;},
                 isInlineSwap : function(swapStyle) {return false;},
                 handleSwap : function(swapStyle, target, fragment, settleInfo) {return false;},

--- a/test/core/ajax.js
+++ b/test/core/ajax.js
@@ -818,5 +818,28 @@ describe("Core htmx AJAX Tests", function(){
         window.document.title.should.equal("</> htmx rocks!");
     });
 
+    it('should use transformRequest extensions properly', function()
+    {
+        this.server.respondWith("GET", "/success", function (xhr) {
+            xhr.respond(200, {}, "SUCCESS");
+        });
+
+        htmx.defineExtension("transformRequest", {
+            transformRequest: function(xhr) {
+
+                if (xhr.url == "/failure") {
+                    xhr.url = "/success"
+                }
+                return xhr
+            }
+        })
+
+        var btn = make('<button hx-ext="transformRequest" hx-get="/failure">Click Me!</button>')
+        btn.click();
+        this.server.respond();
+        btn.innerText.should.equal("SUCCESS");
+
+        htmx.removeExtension("transformRequest")
+    });
 
 })

--- a/www/extensions.md
+++ b/www/extensions.md
@@ -55,6 +55,7 @@ against `htmx` in each distribution
 | [`remove-me`](/extensions/remove-me) | allows you to remove an element after a given amount of time
 | [`include-vals`](/extensions/include-vals) | allows you to include additional values in a request
 | [`ajax-header`](/extensions/ajax-header) | includes the commonly-used `X-Requested-With` header that identifies ajax requests in many backend frameworks
+| [`authentication-header`](/extensions/authentication-header) | automates use of `Authentication` header 
 | [`event-header`](/extensions/event-header) | includes a JSON serialized version of the triggering event, if any
 
 </div>
@@ -82,6 +83,7 @@ Extensions can override the following default extension points to add or change 
 ```javascript
 {
     onEvent : function(name, evt) {return true;},
+    transformRequest : function(xhr) {return xhr;},
     transformResponse : function(text, xhr, elt) {return text;},
     isInlineSwap : function(swapStyle) {return false;},
     handleSwap : function(swapStyle, target, fragment, settleInfo) {return false;},

--- a/www/extensions/authentication-header.md
+++ b/www/extensions/authentication-header.md
@@ -1,0 +1,22 @@
+---
+layout: layout.njk
+title: </> htmx - high power tools for html
+---
+
+## The `authentication-header` Extension
+
+This extension listens for `Authentication` headers in HTTP responses, then stores this value in `sessionStorage` and injects it back in to outgoing HTTP requests.
+
+This demonstrates how to use extensions to sign in to remote servers without using cookies.
+
+### Usage
+
+```html
+<body hx-ext="authentication-header">
+ ...
+</body>
+```
+
+### Source
+
+<https://unpkg.com/htmx.org/dist/ext/authentication-header.js>


### PR DESCRIPTION
This PR addresses #254 by adding a `transformRequest` function to extensions.  

I'm also including a simple extension that demonstrates this feature by listening for an "Authorization" header in any XHR responses and storing the value in sessionStorage.  If we have an "Authorization" token in sessionStorage, then this value is included in the headers of any subsequent XHR requests.