### PR TITLE
Change how getInputValues() works

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1569,7 +1569,7 @@ return (function () {
             }
 
             // include the element itself
-            processInputValue(processed, values, errors, elt);
+            processInputValue(processed, values.element, errors, elt);
 
             // include any explicit includes
             var includes = getClosestAttributeValue(elt, "hx-include");

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1556,12 +1556,16 @@ return (function () {
 
         function getInputValues(elt, verb) {
             var processed = [];
-            var values = {};
+            var values = {
+                form: {},
+                element: {},
+                includes: {},
+            };
             var errors = [];
 
             // for a non-GET include the closest form
             if (verb !== 'get') {
-                processInputValue(processed, values, errors, closest(elt, 'form'));
+                processInputValue(processed, values.form, errors, closest(elt, 'form'));
             }
 
             // include the element itself
@@ -1572,12 +1576,14 @@ return (function () {
             if (includes) {
                 var nodes = getDocument().querySelectorAll(includes);
                 forEach(nodes, function(node) {
-                    processInputValue(processed, values, errors, node);
+                    processInputValue(processed, values.includes, errors, node);
                 });
             }
 
+            var mergedValues = mergeObjects(values.includes, values.form);
+            mergedValues = mergeObjects(mergedValues, values.element);
 
-            return {errors:errors, values:values};
+            return {errors:errors, values:mergedValues};
         }
 
         function appendParam(returnStr, name, realValue) {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1580,8 +1580,8 @@ return (function () {
                 });
             }
 
-            var mergedValues = mergeObjects(values.includes, values.form);
-            mergedValues = mergeObjects(mergedValues, values.element);
+            var mergedValues = mergeObjects(values.includes, values.element);
+            mergedValues = mergeObjects(mergedValues, values.form);
 
             return {errors:errors, values:mergedValues};
         }

--- a/test/attributes/hx-include.js
+++ b/test/attributes/hx-include.js
@@ -34,6 +34,22 @@ describe("hx-include attribute", function() {
         div.innerHTML.should.equal("Clicked!");
     });
 
+    it('non-GET includes closest form and overrides values included that exist outside the form', function () {
+        this.server.respondWith("POST", "/include", function (xhr) {
+            var params = getParameters(xhr);
+            params['i1'].should.equal("test");
+            xhr.respond(200, {}, "Clicked!")
+        });
+        var div = make('<div hx-include="*" hx-target="this">' +
+            '<input name="i1" value="before"/>' +
+            '<form><div id="d1" hx-post="/include"></div><input name="i1" value="test"/></form>' +
+            '<input name="i1" value="after"/>')
+        var input = byId("d1")
+        input.click();
+        this.server.respond();
+        div.innerHTML.should.equal("Clicked!");
+    });
+
     it('GET does not include closest form by default', function () {
         this.server.respondWith("GET", "/include", function (xhr) {
             var params = getParameters(xhr);


### PR DESCRIPTION
This PR changes how `getInputValues()` works.

### Before

1. If a non-GET request, collect all input values from the enclosing form.
2. Concatenate the current element's value.
3. Concatenate all remaining values from explicit includes.

### After

1. If a non-GET request, collect all input values from the enclosing form.
2. Collect the current element's value.
3. Collect all remaining values from explicit includes.
4. Merge values from step 3 with values from step 2 with values from step 1.

The key difference is that in a non-GET request, if an element is inside a form then that form's input field values will _override_ input fields that exist outside the form.

### Example

```html
<div hx-include="*">
  <input hx-get="/" type="text" name="secret" value="abc">
  <form hx-post="/" id="form-1">
    <input type="text" name="id" value="1">
    <input type="submit" value="Submit">
  </form>
  <form hx-post="/" id="form-2">
    <input type="text" name="id" value="2">
    <input type="submit" value="Submit">
  </form>
</div>
```

### Before

Changing `secret` results in the following request params:
```
secret=abc
id=1
id=2
```

Submitting `form-1` results in the following request params:
```
secret=abc
id=1
id=2
```
*** **The `id` above will be evaluated to `2` by most servers since it comes last.** ***

Submitting `form-2` results in the following request params:
```
secret=abc
id=1
id=2
```

### After

Changing `secret` results in the following request params:
```
secret=abc
id=1
id=2
```

Submitting `form-1` results in the following request params:
```
secret=abc
id=1
```

Submitting `form-2` results in the following request params:
```
secret=abc
id=2
```

Let me know what you think and whether I should proceed to writing this up as a test.