### PR TITLE
Handle <form novalidate> correctly

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1565,7 +1565,9 @@ return (function () {
 
             // for a non-GET include the closest form
             if (verb !== 'get') {
-                processInputValue(processed, values, errors, closest(elt, 'form'), validate);
+                var parentForm = closest(elt, 'form');
+                validate = parentForm ? parentForm.noValidate !== true : validate;
+                processInputValue(processed, values, errors, parentForm, validate);
             }
 
             // include the element itself

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1561,13 +1561,12 @@ return (function () {
             var values = {};
             var errors = [];
 
-            var validate = matches(elt, 'form') ? elt.noValidate !== true : true;
+            var parentForm  = closest(elt, 'form');
+            var validate = parentForm ? parentForm.noValidate !== true : true;
 
             // for a non-GET include the closest form
             if (verb !== 'get') {
-                var parentForm = closest(elt, 'form');
-                validate = parentForm ? parentForm.noValidate !== true : validate;
-                processInputValue(processed, values, errors, parentForm, validate);
+                processInputValue(processed, values, errors, closest(elt, 'form'), validate);
             }
 
             // include the element itself

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1569,14 +1569,14 @@ return (function () {
             }
 
             // include the element itself
-            processInputValue(processed, values, errors, elt, true, validate);
+            processInputValue(processed, values, errors, elt, validate);
 
             // include any explicit includes
             var includes = getClosestAttributeValue(elt, "hx-include");
             if (includes) {
                 var nodes = getDocument().querySelectorAll(includes);
                 forEach(nodes, function(node) {
-                    processInputValue(processed, values, errors, node, true, validate);
+                    processInputValue(processed, values, errors, node, validate);
                 });
             }
 

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1561,8 +1561,7 @@ return (function () {
             var values = {};
             var errors = [];
 
-            var parentForm  = closest(elt, 'form');
-            var validate = parentForm ? parentForm.noValidate !== true : true;
+            var validate = matches(elt, 'form') && elt.noValidate !== true;
 
             // for a non-GET include the closest form
             if (verb !== 'get') {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1496,7 +1496,7 @@ return (function () {
             return true;
         }
 
-        function processInputValue(processed, values, errors, elt) {
+        function processInputValue(processed, values, errors, elt, validate) {
             if (elt == null || haveSeenNode(processed, elt)) {
                 return;
             } else {
@@ -1534,12 +1534,14 @@ return (function () {
                         values[name] = value;
                     }
                 }
-                validateElement(elt, errors);
+                if (validate) {
+                    validateElement(elt, errors);
+                }
             }
             if (matches(elt, 'form')) {
                 var inputs = elt.elements;
                 forEach(inputs, function(input) {
-                    processInputValue(processed, values, errors, input);
+                    processInputValue(processed, values, errors, input, validate);
                 });
             }
         }
@@ -1559,20 +1561,22 @@ return (function () {
             var values = {};
             var errors = [];
 
+            var validate = matches(elt, 'form') ? elt.noValidate !== true : true;
+
             // for a non-GET include the closest form
             if (verb !== 'get') {
-                processInputValue(processed, values, errors, closest(elt, 'form'));
+                processInputValue(processed, values, errors, closest(elt, 'form'), validate);
             }
 
             // include the element itself
-            processInputValue(processed, values, errors, elt);
+            processInputValue(processed, values, errors, elt, true, validate);
 
             // include any explicit includes
             var includes = getClosestAttributeValue(elt, "hx-include");
             if (includes) {
                 var nodes = getDocument().querySelectorAll(includes);
                 forEach(nodes, function(node) {
-                    processInputValue(processed, values, errors, node);
+                    processInputValue(processed, values, errors, node, true, validate);
                 });
             }
 


### PR DESCRIPTION
Thanks for the great library!  When we have

```
<form novalidate...>
```

The browser does not show validation errors, however htmx still silently validates which is confusing.  This PR will prevent htmx from validating to be consistent with the browser.