### PR TITLE
Extend path-deps extension to handle explicit path refreshes

### DIFF
--- a/src/ext/path-deps.js
+++ b/src/ext/path-deps.js
@@ -35,6 +35,9 @@
                 }
             } else if (name === "htmx:refreshPath") {
                 refreshPath(evt.path);
+            } else if (name === "htmx:refreshElement") {
+                var elt = evt.detail.elt;
+                htmx.trigger(elt, "path-deps");
             }
         }
     });

--- a/src/ext/path-deps.js
+++ b/src/ext/path-deps.js
@@ -35,7 +35,7 @@
                 }
             } else if (name === "htmx:refreshPath") {
                 refreshPath(evt.path);
-            } else if (name === "htmx:refreshElement") {
+            } else if (name === "htmx:refresh") {
                 var elt = evt.detail.elt;
                 htmx.trigger(elt, "path-deps");
             }

--- a/src/ext/path-deps.js
+++ b/src/ext/path-deps.js
@@ -35,10 +35,7 @@
                 }
             } else if (name === "htmx:refreshPath") {
                 refreshPath(evt.path);
-            } else if (name === "htmx:refresh") {
-                var elt = evt.detail.elt;
-                htmx.trigger(elt, "path-deps");
-            }
+            } 
         }
     });
 })();

--- a/src/ext/path-deps.js
+++ b/src/ext/path-deps.js
@@ -15,20 +15,26 @@
         return false;
     }
 
+    function refreshPath(path) {
+        var eltsWithDeps = htmx.findAll("[path-deps]");
+        for (var i = 0; i < eltsWithDeps.length; i++) {
+            var elt = eltsWithDeps[i];
+            if (dependsOn(elt.getAttribute('path-deps'), path)) {
+                htmx.trigger(elt, "path-deps");
+            }
+        }      
+    }
+
     htmx.defineExtension('path-deps', {
         onEvent: function (name, evt) {
             if (name === "htmx:afterRequest") {
                 var config = evt.detail.requestConfig;
                 // mutating call
                 if (config.verb !== "get") {
-                    var eltsWithDeps = htmx.findAll("[path-deps]");
-                    for (var i = 0; i < eltsWithDeps.length; i++) {
-                        var elt = eltsWithDeps[i];
-                        if (dependsOn(elt.getAttribute('path-deps'), config.path)) {
-                            htmx.trigger(elt, "path-deps");
-                        }
-                    }
+                    refreshPath(config.path);
                 }
+            } else if (name === "htmx:refreshPath") {
+                refreshPath(evt.path);
             }
         }
     });

--- a/src/ext/path-deps.js
+++ b/src/ext/path-deps.js
@@ -1,4 +1,9 @@
-(function(){
+(function(undefined){
+    'use strict';
+
+    // Save a reference to the global object (window in the browser)
+    var _root = this;
+  
     function dependsOn(pathSpec, url) {
         var dependencyPath = pathSpec.split("/");
         var urlPath = url.split("/");
@@ -23,7 +28,7 @@
                 htmx.trigger(elt, "path-deps");
             }
         }      
-    }
+    }    
 
     htmx.defineExtension('path-deps', {
         onEvent: function (name, evt) {
@@ -33,9 +38,21 @@
                 if (config.verb !== "get") {
                     refreshPath(config.path);
                 }
-            } else if (name === "htmx:refreshPath") {
-                refreshPath(evt.detail.path);
             } 
         }
     });
-})();
+
+    /**
+     *  ********************
+     *  Expose functionality
+     *  ********************
+     */    
+
+    _root.PathDeps = {
+            
+        PathDeps.refresh: function(path) {
+            refreshPath(path);
+        }
+    };
+            
+}).call(this);

--- a/src/ext/path-deps.js
+++ b/src/ext/path-deps.js
@@ -34,7 +34,7 @@
                     refreshPath(config.path);
                 }
             } else if (name === "htmx:refreshPath") {
-                refreshPath(evt.path);
+                refreshPath(evt.detail.path);
             } 
         }
     });

--- a/test/ext/path-deps.js
+++ b/test/ext/path-deps.js
@@ -138,5 +138,24 @@ describe("path-deps extension", function() {
         div.innerHTML.should.equal("Deps fired!");
     });
 
+    it('path-deps api basic refresh case works', function () {
+        this.server.respondWith("GET", "/test", "Path deps fired!");
+        var div = make('<div hx-get="/test" hx-trigger="path-deps" path-deps="/test">FOO</div>')
+        PathDeps.refresh("/test");
+        this.server.respond();
+        div.innerHTML.should.equal("Path deps fired!");
+    });
+
+    it('path-deps api parent path case works', function () {
+        this.server.respondWith("GET", "/test1", "Path deps 1 fired!");
+        this.server.respondWith("GET", "/test2", "Path deps 2 fired!");
+        var div = make('<div hx-get="/test1" hx-trigger="path-deps" path-deps="/test/child">FOO</div>')
+        var div2 = make('<div hx-get="/test2" hx-trigger="path-deps" path-deps="/test">BAR</div>')
+        PathDeps.refresh("/test/child");
+        this.server.respond();
+        div.innerHTML.should.equal("Path deps 1 fired!");
+        this.server.respond();
+        div2.innerHTML.should.equal("Path deps 2 fired!");
+    });
 
 });

--- a/www/extensions/path-deps.md
+++ b/www/extensions/path-deps.md
@@ -5,14 +5,14 @@ title: </> htmx - high power tools for html
 
 ## The `path-deps` Extension
 
-This extension supports expressing inter-element dependencies based on paths, inspired by the 
+This extension supports expressing inter-element dependencies based on paths, inspired by the
 [intercooler.js dependencies mechanism.](http://intercoolerjs.org/docs.html#dependencies).  When this
 extension is installed an element can express a dependency on another path by using the `path-deps` property
 and then setting `hx-trigger` to `path-deps`:
 
 ```html
-  <div hx-get="/example" 
-       hx-trigger="path-deps" 
+  <div hx-get="/example"
+       hx-trigger="path-deps"
        path-deps="/foo/bar">...</div>
 ```
 
@@ -22,8 +22,8 @@ request like a `POST`) to `/foo/bar` or any sub-paths of that path.
 You can use a `*` to match any path component:
 
 ```html
-  <div hx-get="/example" 
-       hx-trigger="path-deps" 
+  <div hx-get="/example"
+       hx-trigger="path-deps"
        path-deps="/contacts/*">...</div>
 ```
 
@@ -37,6 +37,23 @@ You can use a `*` to match any path component:
      Post To List
   </button>
 </div>
+```
+
+#### Javascript API
+
+### <a name="refresh"></a> Method -  [`PathDeps.refresh()`](#refresh)
+
+This method manually triggers a refresh for the given path.
+
+##### Parameters
+
+* `path` - the path to refresh
+
+##### Example
+
+```js
+  // Trigger a refresh on all elements with the path-deps attribute '/path/to/refresh', including elements with a parent path, e.g. '/path'
+  PathDeps.refresh('/path/to/refresh');
 ```
 
 #### Source


### PR DESCRIPTION
This is to implement #286.

**TLDR**: Went with `PathDeps.refresh("/path/to/refresh");` in the end.
Keeping the rest here for historical purposes.

-----

By catering for a new custom event called `htmx:refreshPath`, we should be able to trigger the refresh of a specific path, e.g. 

- `htmx.trigger(document, "htmx:refreshPath", {path:"path/to/refresh"});`
- `htmx.trigger(document, "htmx:refreshPath", {path:"path/to/refresh/*"});`

I have not added any tests or documentation yet, happy to do so if this idea is deemed to be ok in principle.

**Note**: Since we're interested in triggering updates on all elements with the given path (or dependent paths), the element to trigger on is irrelevant, I just went with "document" in the example. Not sure if there's a better way

