### PR TITLE
More consistent parseInterval results

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -62,20 +62,8 @@ return (function () {
         //====================================================================
         // Utilities
         //====================================================================
-        /*function parseInterval(str) {
-            if (str == null || str === "null" || str === "false" || str === "") {
-                return null;
-            } else if (str.lastIndexOf("ms") === str.length - 2) {
-                return parseFloat(str.substr(0, str.length - 2));
-            } else if (str.lastIndexOf("s") === str.length - 1) {
-                return parseFloat(str.substr(0, str.length - 1)) * 1000;
-            } else {
-                return parseFloat(str);
-            }
-        }*/
 
 		function parseInterval(str) {
-
 			if (str == undefined)  {
 				return undefined
 			}
@@ -86,7 +74,7 @@ return (function () {
 				return (parseFloat(str.slice(0,-1)) * 1000) || undefined
 			}
 			return parseFloat(str) || undefined
-		}
+        }
 
         function getRawAttribute(elt, name) {
             return elt.getAttribute && elt.getAttribute(name);

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -62,7 +62,7 @@ return (function () {
         //====================================================================
         // Utilities
         //====================================================================
-        function parseInterval(str) {
+        /*function parseInterval(str) {
             if (str == null || str === "null" || str === "false" || str === "") {
                 return null;
             } else if (str.lastIndexOf("ms") === str.length - 2) {
@@ -72,7 +72,21 @@ return (function () {
             } else {
                 return parseFloat(str);
             }
-        }
+        }*/
+
+		function parseInterval(str) {
+
+			if (str == undefined)  {
+				return undefined
+			}
+			if (str.slice(-2) == "ms") {
+				return parseFloat(str.slice(0,-2)) || undefined
+			}			
+			if (str.slice(-1) == "s") {
+				return (parseFloat(str.slice(0,-1)) * 1000) || undefined
+			}
+			return parseFloat(str) || undefined
+		}
 
         function getRawAttribute(elt, name) {
             return elt.getAttribute && elt.getAttribute(name);

--- a/test/core/internals.js
+++ b/test/core/internals.js
@@ -1,5 +1,3 @@
-const { should } = require("chai");
-
 describe("Core htmx internals Tests", function() {
 
     it("makeFragment works with janky stuff", function(){
@@ -23,17 +21,17 @@ describe("Core htmx internals Tests", function() {
     })
 
     it("handles parseInterval correctly", function() {
-        htmx._("parseInterval")("1ms").should.equal(1);
-        htmx._("parseInterval")("300ms").should.equal(300);
-        htmx._("parseInterval")("1s").should.equal(1000)
-        htmx._("parseInterval")("1.5s").should.equal(1500)
-        htmx._("parseInterval")("2s").should.equal(2000)
+        chai.expect(htmx.parseInterval("1ms")).to.be.equal(1);
+        chai.expect(htmx.parseInterval("300ms")).to.be.equal(300);
+        chai.expect(htmx.parseInterval("1s")).to.be.equal(1000)
+        chai.expect(htmx.parseInterval("1.5s")).to.be.equal(1500)
+        chai.expect(htmx.parseInterval("2s")).to.be.equal(2000)
 
-/*        should(htmx.parseInterval(null)).be.undefined
-        should(htmx.parseInterval("")).be.undefined
-        should(htmx.parseInterval("false")).be.undefined
-        should(htmx.parseInterval("true")).be.undefined
-*/
+        chai.expect(htmx.parseInterval(null)).to.be.undefined
+        chai.expect(htmx.parseInterval("")).to.be.undefined
+        chai.expect(htmx.parseInterval("undefined")).to.be.undefined
+        chai.expect(htmx.parseInterval("true")).to.be.undefined
+        chai.expect(htmx.parseInterval("false")).to.be.undefined
     })
 
 });

--- a/test/core/internals.js
+++ b/test/core/internals.js
@@ -1,3 +1,5 @@
+const { should } = require("chai");
+
 describe("Core htmx internals Tests", function() {
 
     it("makeFragment works with janky stuff", function(){
@@ -18,6 +20,20 @@ describe("Core htmx internals Tests", function() {
         htmx._("safelySetHeaderValue")(xhr, "Example", "привет");
         // unfortunately I can't test the value :/
         // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest
+    })
+
+    it("handles parseInterval correctly", function() {
+        htmx._("parseInterval")("1ms").should.equal(1);
+        htmx._("parseInterval")("300ms").should.equal(300);
+        htmx._("parseInterval")("1s").should.equal(1000)
+        htmx._("parseInterval")("1.5s").should.equal(1500)
+        htmx._("parseInterval")("2s").should.equal(2000)
+
+/*        should(htmx.parseInterval(null)).be.undefined
+        should(htmx.parseInterval("")).be.undefined
+        should(htmx.parseInterval("false")).be.undefined
+        should(htmx.parseInterval("true")).be.undefined
+*/
     })
 
 });


### PR DESCRIPTION
I realized I'd duplicated the parseInterval function for another PR, then saw the the original function returns several kinds of values.  If the interval is parsed successfully, a floating point number is returned.  Otherwise, the original function may return a `null`, or `NaN`, depending on the particular circumstances.

This PR standardizes all errors to return `undefined` in event of any parsing errors, which should make it easier to inspect results.