### PR TITLE
Correct documentation to reflect removal of some request headers

### DIFF
--- a/www/reference.md
+++ b/www/reference.md
@@ -69,11 +69,7 @@ title: </> htmx - Attributes
 | Header | Description |
 |-------|-------------|
 | `X-HTTP-Method-Override` | the HTTP verb for non-`GET` and `POST` requests
-| `HX-Active-Element-Name` | the `name` of the active element if it exists
-| `HX-Active-Element-Value` | the `value` of the active element if it exists
-| `HX-Active-Element` | the `id` of the active element if it exists
 | `HX-Current-URL` | the current URL of the browser
-| `HX-Event-Target` | the `id` of the original event target
 | `HX-Prompt` | the user response to an [hx-prompt](/attributes/hx-prompt)
 | `HX-Request` | always `true`
 | `HX-Target` | the `id` of the target element if it exists


### PR DESCRIPTION
As part of the htmx 1.1.0 release, the following headers were removed:

- HX-Event-Target
- HX-Active-Element
- HX-Active-Element-Name
- HX-Active-Element-Value

This removes them from the documentation as well