### PR TITLE
Preload Resources

### DIFF
--- a/src/ext/preload.js
+++ b/src/ext/preload.js
@@ -23,12 +23,11 @@ htmx.defineExtension("preload", {
 		// preloading an htmx resource (this sends the same HTTP headers as a regular htmx request)
 		var load = function(node) {
 
-			// This is used after a successful AJAX request, to mark the
+			// Called after a successful AJAX request, to mark the
 			// content as loaded (and prevent additional AJAX calls.)
-			var handleResponse = function(responseText) {
+			var done = function(html) {
 				node.preloadState = "DONE"
-				var ghost = document.createElement("div") // populate a "ghost" node
-				ghost.innerHTML = responseText            // to preload images, too.
+				document.createElement("div").innerHTML = html // create and populate a node to load linked resources, too.
 			}
 
 			return function() {
@@ -44,7 +43,7 @@ htmx.defineExtension("preload", {
 				// in the future
 				if (node.getAttribute("hx-get")) {
 					htmx.ajax("GET", node.getAttribute("hx-get"), {handler:function(elt, info) {
-						handleResponse(info.xhr.responseText);
+						done(info.xhr.responseText);
 					}});
 					return;
 				}
@@ -55,7 +54,7 @@ htmx.defineExtension("preload", {
 				if (node.getAttribute("href")) {
 					var r = new XMLHttpRequest();
 					r.open("GET", node.getAttribute("href"));
-					r.onload = function() {handleResponse(r.responseText);};
+					r.onload = function() {done(r.responseText);};
 					r.send();
 					return;
 				}

--- a/test/manual/preload-fragment.html
+++ b/test/manual/preload-fragment.html
@@ -6,5 +6,5 @@
 <style href="stylsheet-from-style.css"></style>
 <link rel="stylesheet" href="stylesheet-from-link.css">
 <script>
-alert("oops")
+alert("javascript executed")
 </script>

--- a/test/manual/preload-fragment.html
+++ b/test/manual/preload-fragment.html
@@ -1,1 +1,10 @@
 111
+<script src="script.js"></script>
+<img src="/images/image.gif">
+<img src="/images/image.png">
+<img src="/images/image.jpg">
+<style href="stylsheet-from-style.css"></style>
+<link rel="stylesheet" href="stylesheet-from-link.css">
+<script>
+alert("oops")
+</script>

--- a/test/manual/preload.html
+++ b/test/manual/preload.html
@@ -14,7 +14,7 @@
 
 <body hx-ext="preload">
 
-    <div class="container" preload="preload:init">
+    <div class="container" preload="preload:init" preload-images="true">
         <h4>Triggered by: preload:init</h4>
         <a href="preload-fragment.html?init=xhr1">Trigger on load (xhr)</a><br>
         <a href="preload-fragment.html?init=xhr2">Trigger on load (xhr)</a><br>

--- a/www/extensions/preload.md
+++ b/www/extensions/preload.md
@@ -38,6 +38,9 @@ You can add the `preload` attribute to the top-level element that contains sever
     </ul>
 ```
 
+### Preloading of Linked Resources
+
+After an HTML page (or page fragment) is preloaded, this extension parses it as a DOM element, but does not add the new DOM node into your document.  This is done so that any images included in the preloaded HTML via `<img>` tags are also preloaded.  This extension does not load or run linked Javascript or Cascading Stylesheet content, whether linked or embedded in the preloaded HTML.
 ### Configuration
 
 Defaults for this extension are chosen to balance users' perceived performance with potential load on your servers from unused requests.  As a developer, you can modify two settings to customize this behavior to your specific use cases.

--- a/www/extensions/preload.md
+++ b/www/extensions/preload.md
@@ -36,11 +36,18 @@ You can add the `preload` attribute to the top-level element that contains sever
         <li><a href="/server/2">This will also be preloaded for the same reason.</a>
         <li><a href="/server/3">This will be preloaded, too.  Lorem ipsum.</a>
     </ul>
+</body>
 ```
 
-### Preloading of Linked Resources
+### Preloading of Linked Images
 
-After an HTML page (or page fragment) is preloaded, this extension parses it as a DOM element, but does not add the new DOM node into your document.  This is done so that any images included in the preloaded HTML via `<img>` tags are also preloaded.  This extension does not load or run linked Javascript or Cascading Stylesheet content, whether linked or embedded in the preloaded HTML.
+After an HTML page (or page fragment) is preloaded, this extension can also preload linked image resources.  It will not load or run linked Javascript or Cascading Stylesheet content, whether linked or embedded in the preloaded HTML.  To preload images as well, use the following syntax.
+
+```html
+<div hx-ext="preload">
+    <a href="/my-next-page" preload="mouseover" preload-images="true">Next Page</a>
+</div>
+```
 
 ### Configuration
 

--- a/www/extensions/preload.md
+++ b/www/extensions/preload.md
@@ -41,6 +41,7 @@ You can add the `preload` attribute to the top-level element that contains sever
 ### Preloading of Linked Resources
 
 After an HTML page (or page fragment) is preloaded, this extension parses it as a DOM element, but does not add the new DOM node into your document.  This is done so that any images included in the preloaded HTML via `<img>` tags are also preloaded.  This extension does not load or run linked Javascript or Cascading Stylesheet content, whether linked or embedded in the preloaded HTML.
+
 ### Configuration
 
 Defaults for this extension are chosen to balance users' perceived performance with potential load on your servers from unused requests.  As a developer, you can modify two settings to customize this behavior to your specific use cases.


### PR DESCRIPTION
Updates to the preload extension that preload linked resources (images only, for now) included in the preloaded document (or HTML fragment).  Scripts and Stylesheets are not affected.  Tested on current versions of Firefox, Chrome, and Safari.