### PR TITLE
hx-include: Add `closest` and `find`, include descendants of non-form elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "htmx.org",
-  "version": "0.0.8",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1598,7 +1598,7 @@ return (function () {
                 }
             }
             if (matches(elt, 'form')) {
-                var inputs = elt.querySelectorAll('*');
+                var inputs = elt.elements;
                 forEach(inputs, function(input) {
                     processInputValue(processed, values, errors, input, validate);
                 });

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1598,7 +1598,7 @@ return (function () {
                 }
             }
             if (matches(elt, 'form')) {
-                var inputs = elt.elements;
+                var inputs = elt.querySelectorAll('*');
                 forEach(inputs, function(input) {
                     processInputValue(processed, values, errors, input, validate);
                 });
@@ -1613,7 +1613,19 @@ return (function () {
                     triggerEvent(element, "htmx:validation:failed", {message:element.validationMessage, validity:element.validity})
                 }
             }
-        }
+		}
+		
+		function descendantsToInclude(elt) {
+			var rv = [];
+			var descendants = elt.querySelectorAll('*')
+			forEach(descendants, function (descendant) {
+				if (shouldInclude(descendant)) {
+					rv.push(descendant);
+				}
+			})
+
+			return rv;
+		}
 
         function getInputValues(elt, verb) {
             var processed = [];
@@ -1640,7 +1652,13 @@ return (function () {
             if (includes) {
 				var nodes = querySelectorAllWithFeatures(elt, includes);
                 forEach(nodes, function(node) {
-                    processInputValue(processed, values.includes, errors, node, validate);
+					processInputValue(processed, values.includes, errors, node, validate);
+					if (!shouldInclude(node)) {
+						var descendants = descendantsToInclude(node);
+						forEach(descendants, function (descendant) {
+							processInputValue(processed, values.includes, errors, descendant, validate);
+						})
+					}
                 });
             }
 

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -337,33 +337,33 @@ return (function () {
             } else {
                 return arg2;
             }
-		}
-		
-		// Like querySelectorAll, but supports [closest] and [find]
-		// and other features that might have been added w/o updating this comment
-		// returns Array | NodeList
-		function querySelectorAllWithFeatures(eltOrSelector, selector) {
-			var elt;
-			if (selector === undefined) {
-				selector = eltOrSelector;
-				elt = getDocument();
-			} else {
-				elt = eltOrSelector;
-			}
+        }
 
-			if (selector.indexOf("closest ") === 0) {
-				return [closest(elt, selector.substr(8))];
-			} else if (selector.indexOf("find ") === 0) {
-				return [find(elt, selector.substr(5))];
-			} else {
-				return getDocument().querySelectorAll(selector);
-			}
-		}
+        // Like querySelectorAll, but supports [closest] and [find]
+        // and other features that might have been added w/o updating this comment
+        // returns Array | NodeList
+        function querySelectorAllWithFeatures(eltOrSelector, selector) {
+            var elt;
+            if (selector === undefined) {
+                selector = eltOrSelector;
+                elt = getDocument();
+            } else {
+                elt = eltOrSelector;
+            }
 
-		// See querySelectorAllWithFeatures
-		function querySelectorWithFeatures(eltOrSelector, selector) {
-			return querySelectorAllWithFeatures(eltOrSelector, selector)[0]
-		}
+            if (selector.indexOf("closest ") === 0) {
+                return [closest(elt, selector.substr(8))];
+            } else if (selector.indexOf("find ") === 0) {
+                return [find(elt, selector.substr(5))];
+            } else {
+                return getDocument().querySelectorAll(selector);
+            }
+        }
+
+        // See querySelectorAllWithFeatures
+        function querySelectorWithFeatures(eltOrSelector, selector) {
+            return querySelectorAllWithFeatures(eltOrSelector, selector)[0]
+        }
 
         function processEventArgs(arg1, arg2, arg3) {
             if (isFunction(arg2)) {
@@ -407,11 +407,11 @@ return (function () {
             var explicitTarget = getClosestMatch(elt, function(e){return getAttributeValue(e,"hx-target") !== null});
             if (explicitTarget) {
                 var targetStr = getAttributeValue(explicitTarget, "hx-target");
-				if (targetStr === "this") {
-					return explicitTarget;
-				} else {
-					return querySelectorWithFeatures(elt, targetStr)
-				}
+                if (targetStr === "this") {
+                    return explicitTarget;
+                } else {
+                    return querySelectorWithFeatures(elt, targetStr)
+                }
             } else {
                 var data = getInternalData(elt);
                 if (data.boosted) {
@@ -1613,19 +1613,19 @@ return (function () {
                     triggerEvent(element, "htmx:validation:failed", {message:element.validationMessage, validity:element.validity})
                 }
             }
-		}
-		
-		function descendantsToInclude(elt) {
-			var rv = [];
-			var descendants = elt.querySelectorAll('*')
-			forEach(descendants, function (descendant) {
-				if (shouldInclude(descendant)) {
-					rv.push(descendant);
-				}
-			})
+        }
 
-			return rv;
-		}
+        function descendantsToInclude(elt) {
+            var rv = [];
+            var descendants = elt.querySelectorAll('*')
+            forEach(descendants, function (descendant) {
+                if (shouldInclude(descendant)) {
+                   rv.push(descendant);
+                }
+            })
+
+            return rv;
+        }
 
         function getInputValues(elt, verb) {
             var processed = [];
@@ -1650,15 +1650,15 @@ return (function () {
             // include any explicit includes
             var includes = getClosestAttributeValue(elt, "hx-include");
             if (includes) {
-				var nodes = querySelectorAllWithFeatures(elt, includes);
+                var nodes = querySelectorAllWithFeatures(elt, includes);
                 forEach(nodes, function(node) {
-					processInputValue(processed, values.includes, errors, node, validate);
-					if (!shouldInclude(node)) {
-						var descendants = descendantsToInclude(node);
-						forEach(descendants, function (descendant) {
-							processInputValue(processed, values.includes, errors, descendant, validate);
-						})
-					}
+                    processInputValue(processed, values.includes, errors, node, validate);
+                    if (!shouldInclude(node)) {
+                        var descendants = descendantsToInclude(node);
+                        forEach(descendants, function (descendant) {
+                            processInputValue(processed, values.includes, errors, descendant, validate);
+                        })
+                    }
                 });
             }
 

--- a/test/attributes/hx-include.js
+++ b/test/attributes/hx-include.js
@@ -163,9 +163,9 @@ describe("hx-include attribute", function() {
         input.click();
         this.server.respond();
         div.innerHTML.should.equal("Clicked!");
-	});
-	
-	it('If the element is not includeable, its descendant inputs are included', function () {
+    });
+
+    it('If the element is not includeable, its descendant inputs are included', function () {
         this.server.respondWith("POST", "/include", function (xhr) {
             var params = getParameters(xhr);
             params['i1'].should.equal("test");
@@ -177,22 +177,22 @@ describe("hx-include attribute", function() {
         div.click();
         this.server.respond();
         div.innerHTML.should.equal("Clicked!");
-	})
-	
-	it('The `closest` modifier can be used in the hx-include selector', function () {
+    })
+
+    it('The `closest` modifier can be used in the hx-include selector', function () {
         this.server.respondWith("POST", "/include", function (xhr) {
             var params = getParameters(xhr);
             params['i1'].should.equal("test");
             params['i2'].should.equal("test");
             xhr.respond(200, {}, "Clicked!")
         });
-		make('<div id="i"><input name="i1" value="test"/><input name="i2" value="test"/>'+
-			'<button id="btn" hx-post="/include" hx-include="closest div"></button></div>');
+        make('<div id="i"><input name="i1" value="test"/><input name="i2" value="test"/>'+
+            '<button id="btn" hx-post="/include" hx-include="closest div"></button></div>');
         var btn = byId('btn')
         btn.click();
         this.server.respond();
         btn.innerHTML.should.equal("Clicked!");
-	})
+    })
 
 
 });

--- a/test/attributes/hx-include.js
+++ b/test/attributes/hx-include.js
@@ -163,7 +163,36 @@ describe("hx-include attribute", function() {
         input.click();
         this.server.respond();
         div.innerHTML.should.equal("Clicked!");
-    });
+	});
+	
+	it('If the element is not includeable, its descendant inputs are included', function () {
+        this.server.respondWith("POST", "/include", function (xhr) {
+            var params = getParameters(xhr);
+            params['i1'].should.equal("test");
+            params['i2'].should.equal("test");
+            xhr.respond(200, {}, "Clicked!")
+        });
+        make('<div id="i"><input name="i1" value="test"/><input name="i2" value="test"/></div>');
+        var div = make('<div hx-post="/include" hx-include="#i"></div>')
+        div.click();
+        this.server.respond();
+        div.innerHTML.should.equal("Clicked!");
+	})
+	
+	it('The `closest` modifier can be used in the hx-include selector', function () {
+        this.server.respondWith("POST", "/include", function (xhr) {
+            var params = getParameters(xhr);
+            params['i1'].should.equal("test");
+            params['i2'].should.equal("test");
+            xhr.respond(200, {}, "Clicked!")
+        });
+		make('<div id="i"><input name="i1" value="test"/><input name="i2" value="test"/>'+
+			'<button id="btn" hx-post="/include" hx-include="closest div"></button></div>');
+        var btn = byId('btn')
+        btn.click();
+        this.server.respond();
+        btn.innerHTML.should.equal("Clicked!");
+	})
 
 
 });

--- a/www/js/htmx.js
+++ b/www/js/htmx.js
@@ -1598,7 +1598,7 @@ return (function () {
                 }
             }
             if (matches(elt, 'form')) {
-                var inputs = elt.querySelectorAll('*');
+                var inputs = elt.elements;
                 forEach(inputs, function(input) {
                     processInputValue(processed, values, errors, input, validate);
                 });

--- a/www/js/htmx.js
+++ b/www/js/htmx.js
@@ -1598,7 +1598,7 @@ return (function () {
                 }
             }
             if (matches(elt, 'form')) {
-                var inputs = elt.elements;
+                var inputs = elt.querySelectorAll('*');
                 forEach(inputs, function(input) {
                     processInputValue(processed, values, errors, input, validate);
                 });
@@ -1613,7 +1613,19 @@ return (function () {
                     triggerEvent(element, "htmx:validation:failed", {message:element.validationMessage, validity:element.validity})
                 }
             }
-        }
+		}
+		
+		function descendantsToInclude(elt) {
+			var rv = [];
+			var descendants = elt.querySelectorAll('*')
+			forEach(descendants, function (descendant) {
+				if (shouldInclude(descendant)) {
+					rv.push(descendant);
+				}
+			})
+
+			return rv;
+		}
 
         function getInputValues(elt, verb) {
             var processed = [];
@@ -1640,7 +1652,13 @@ return (function () {
             if (includes) {
 				var nodes = querySelectorAllWithFeatures(elt, includes);
                 forEach(nodes, function(node) {
-                    processInputValue(processed, values.includes, errors, node, validate);
+					processInputValue(processed, values.includes, errors, node, validate);
+					if (!shouldInclude(node)) {
+						var descendants = descendantsToInclude(node);
+						forEach(descendants, function (descendant) {
+							processInputValue(processed, values.includes, errors, descendant, validate);
+						})
+					}
                 });
             }
 

--- a/www/js/htmx.js
+++ b/www/js/htmx.js
@@ -337,33 +337,33 @@ return (function () {
             } else {
                 return arg2;
             }
-		}
-		
-		// Like querySelectorAll, but supports [closest] and [find]
-		// and other features that might have been added w/o updating this comment
-		// returns Array | NodeList
-		function querySelectorAllWithFeatures(eltOrSelector, selector) {
-			var elt;
-			if (selector === undefined) {
-				selector = eltOrSelector;
-				elt = getDocument();
-			} else {
-				elt = eltOrSelector;
-			}
+        }
 
-			if (selector.indexOf("closest ") === 0) {
-				return [closest(elt, selector.substr(8))];
-			} else if (selector.indexOf("find ") === 0) {
-				return [find(elt, selector.substr(5))];
-			} else {
-				return getDocument().querySelectorAll(selector);
-			}
-		}
+        // Like querySelectorAll, but supports [closest] and [find]
+        // and other features that might have been added w/o updating this comment
+        // returns Array | NodeList
+        function querySelectorAllWithFeatures(eltOrSelector, selector) {
+            var elt;
+            if (selector === undefined) {
+                selector = eltOrSelector;
+                elt = getDocument();
+            } else {
+                elt = eltOrSelector;
+            }
 
-		// See querySelectorAllWithFeatures
-		function querySelectorWithFeatures(eltOrSelector, selector) {
-			return querySelectorAllWithFeatures(eltOrSelector, selector)[0]
-		}
+            if (selector.indexOf("closest ") === 0) {
+                return [closest(elt, selector.substr(8))];
+            } else if (selector.indexOf("find ") === 0) {
+                return [find(elt, selector.substr(5))];
+            } else {
+                return getDocument().querySelectorAll(selector);
+            }
+        }
+
+        // See querySelectorAllWithFeatures
+        function querySelectorWithFeatures(eltOrSelector, selector) {
+            return querySelectorAllWithFeatures(eltOrSelector, selector)[0]
+        }
 
         function processEventArgs(arg1, arg2, arg3) {
             if (isFunction(arg2)) {
@@ -407,11 +407,11 @@ return (function () {
             var explicitTarget = getClosestMatch(elt, function(e){return getAttributeValue(e,"hx-target") !== null});
             if (explicitTarget) {
                 var targetStr = getAttributeValue(explicitTarget, "hx-target");
-				if (targetStr === "this") {
-					return explicitTarget;
-				} else {
-					return querySelectorWithFeatures(elt, targetStr)
-				}
+                if (targetStr === "this") {
+                    return explicitTarget;
+                } else {
+                    return querySelectorWithFeatures(elt, targetStr)
+                }
             } else {
                 var data = getInternalData(elt);
                 if (data.boosted) {
@@ -1613,19 +1613,19 @@ return (function () {
                     triggerEvent(element, "htmx:validation:failed", {message:element.validationMessage, validity:element.validity})
                 }
             }
-		}
-		
-		function descendantsToInclude(elt) {
-			var rv = [];
-			var descendants = elt.querySelectorAll('*')
-			forEach(descendants, function (descendant) {
-				if (shouldInclude(descendant)) {
-					rv.push(descendant);
-				}
-			})
+        }
 
-			return rv;
-		}
+        function descendantsToInclude(elt) {
+            var rv = [];
+            var descendants = elt.querySelectorAll('*')
+            forEach(descendants, function (descendant) {
+                if (shouldInclude(descendant)) {
+                   rv.push(descendant);
+                }
+            })
+
+            return rv;
+        }
 
         function getInputValues(elt, verb) {
             var processed = [];
@@ -1650,15 +1650,15 @@ return (function () {
             // include any explicit includes
             var includes = getClosestAttributeValue(elt, "hx-include");
             if (includes) {
-				var nodes = querySelectorAllWithFeatures(elt, includes);
+                var nodes = querySelectorAllWithFeatures(elt, includes);
                 forEach(nodes, function(node) {
-					processInputValue(processed, values.includes, errors, node, validate);
-					if (!shouldInclude(node)) {
-						var descendants = descendantsToInclude(node);
-						forEach(descendants, function (descendant) {
-							processInputValue(processed, values.includes, errors, descendant, validate);
-						})
-					}
+                    processInputValue(processed, values.includes, errors, node, validate);
+                    if (!shouldInclude(node)) {
+                        var descendants = descendantsToInclude(node);
+                        forEach(descendants, function (descendant) {
+                            processInputValue(processed, values.includes, errors, descendant, validate);
+                        })
+                    }
                 });
             }
 

--- a/www/test/1.1.0/src/htmx.js
+++ b/www/test/1.1.0/src/htmx.js
@@ -1598,7 +1598,7 @@ return (function () {
                 }
             }
             if (matches(elt, 'form')) {
-                var inputs = elt.querySelectorAll('*');
+                var inputs = elt.elements;
                 forEach(inputs, function(input) {
                     processInputValue(processed, values, errors, input, validate);
                 });

--- a/www/test/1.1.0/src/htmx.js
+++ b/www/test/1.1.0/src/htmx.js
@@ -1598,7 +1598,7 @@ return (function () {
                 }
             }
             if (matches(elt, 'form')) {
-                var inputs = elt.elements;
+                var inputs = elt.querySelectorAll('*');
                 forEach(inputs, function(input) {
                     processInputValue(processed, values, errors, input, validate);
                 });
@@ -1613,7 +1613,19 @@ return (function () {
                     triggerEvent(element, "htmx:validation:failed", {message:element.validationMessage, validity:element.validity})
                 }
             }
-        }
+		}
+		
+		function descendantsToInclude(elt) {
+			var rv = [];
+			var descendants = elt.querySelectorAll('*')
+			forEach(descendants, function (descendant) {
+				if (shouldInclude(descendant)) {
+					rv.push(descendant);
+				}
+			})
+
+			return rv;
+		}
 
         function getInputValues(elt, verb) {
             var processed = [];
@@ -1640,7 +1652,13 @@ return (function () {
             if (includes) {
 				var nodes = querySelectorAllWithFeatures(elt, includes);
                 forEach(nodes, function(node) {
-                    processInputValue(processed, values.includes, errors, node, validate);
+					processInputValue(processed, values.includes, errors, node, validate);
+					if (!shouldInclude(node)) {
+						var descendants = descendantsToInclude(node);
+						forEach(descendants, function (descendant) {
+							processInputValue(processed, values.includes, errors, descendant, validate);
+						})
+					}
                 });
             }
 

--- a/www/test/1.1.0/src/htmx.js
+++ b/www/test/1.1.0/src/htmx.js
@@ -337,33 +337,33 @@ return (function () {
             } else {
                 return arg2;
             }
-		}
-		
-		// Like querySelectorAll, but supports [closest] and [find]
-		// and other features that might have been added w/o updating this comment
-		// returns Array | NodeList
-		function querySelectorAllWithFeatures(eltOrSelector, selector) {
-			var elt;
-			if (selector === undefined) {
-				selector = eltOrSelector;
-				elt = getDocument();
-			} else {
-				elt = eltOrSelector;
-			}
+        }
 
-			if (selector.indexOf("closest ") === 0) {
-				return [closest(elt, selector.substr(8))];
-			} else if (selector.indexOf("find ") === 0) {
-				return [find(elt, selector.substr(5))];
-			} else {
-				return getDocument().querySelectorAll(selector);
-			}
-		}
+        // Like querySelectorAll, but supports [closest] and [find]
+        // and other features that might have been added w/o updating this comment
+        // returns Array | NodeList
+        function querySelectorAllWithFeatures(eltOrSelector, selector) {
+            var elt;
+            if (selector === undefined) {
+                selector = eltOrSelector;
+                elt = getDocument();
+            } else {
+                elt = eltOrSelector;
+            }
 
-		// See querySelectorAllWithFeatures
-		function querySelectorWithFeatures(eltOrSelector, selector) {
-			return querySelectorAllWithFeatures(eltOrSelector, selector)[0]
-		}
+            if (selector.indexOf("closest ") === 0) {
+                return [closest(elt, selector.substr(8))];
+            } else if (selector.indexOf("find ") === 0) {
+                return [find(elt, selector.substr(5))];
+            } else {
+                return getDocument().querySelectorAll(selector);
+            }
+        }
+
+        // See querySelectorAllWithFeatures
+        function querySelectorWithFeatures(eltOrSelector, selector) {
+            return querySelectorAllWithFeatures(eltOrSelector, selector)[0]
+        }
 
         function processEventArgs(arg1, arg2, arg3) {
             if (isFunction(arg2)) {
@@ -407,11 +407,11 @@ return (function () {
             var explicitTarget = getClosestMatch(elt, function(e){return getAttributeValue(e,"hx-target") !== null});
             if (explicitTarget) {
                 var targetStr = getAttributeValue(explicitTarget, "hx-target");
-				if (targetStr === "this") {
-					return explicitTarget;
-				} else {
-					return querySelectorWithFeatures(elt, targetStr)
-				}
+                if (targetStr === "this") {
+                    return explicitTarget;
+                } else {
+                    return querySelectorWithFeatures(elt, targetStr)
+                }
             } else {
                 var data = getInternalData(elt);
                 if (data.boosted) {
@@ -1613,19 +1613,19 @@ return (function () {
                     triggerEvent(element, "htmx:validation:failed", {message:element.validationMessage, validity:element.validity})
                 }
             }
-		}
-		
-		function descendantsToInclude(elt) {
-			var rv = [];
-			var descendants = elt.querySelectorAll('*')
-			forEach(descendants, function (descendant) {
-				if (shouldInclude(descendant)) {
-					rv.push(descendant);
-				}
-			})
+        }
 
-			return rv;
-		}
+        function descendantsToInclude(elt) {
+            var rv = [];
+            var descendants = elt.querySelectorAll('*')
+            forEach(descendants, function (descendant) {
+                if (shouldInclude(descendant)) {
+                   rv.push(descendant);
+                }
+            })
+
+            return rv;
+        }
 
         function getInputValues(elt, verb) {
             var processed = [];
@@ -1650,15 +1650,15 @@ return (function () {
             // include any explicit includes
             var includes = getClosestAttributeValue(elt, "hx-include");
             if (includes) {
-				var nodes = querySelectorAllWithFeatures(elt, includes);
+                var nodes = querySelectorAllWithFeatures(elt, includes);
                 forEach(nodes, function(node) {
-					processInputValue(processed, values.includes, errors, node, validate);
-					if (!shouldInclude(node)) {
-						var descendants = descendantsToInclude(node);
-						forEach(descendants, function (descendant) {
-							processInputValue(processed, values.includes, errors, descendant, validate);
-						})
-					}
+                    processInputValue(processed, values.includes, errors, node, validate);
+                    if (!shouldInclude(node)) {
+                        var descendants = descendantsToInclude(node);
+                        forEach(descendants, function (descendant) {
+                            processInputValue(processed, values.includes, errors, descendant, validate);
+                        })
+                    }
                 });
             }
 

--- a/www/test/1.1.0/test/attributes/hx-include.js
+++ b/www/test/1.1.0/test/attributes/hx-include.js
@@ -163,9 +163,9 @@ describe("hx-include attribute", function() {
         input.click();
         this.server.respond();
         div.innerHTML.should.equal("Clicked!");
-	});
-	
-	it('If the element is not includeable, its descendant inputs are included', function () {
+    });
+
+    it('If the element is not includeable, its descendant inputs are included', function () {
         this.server.respondWith("POST", "/include", function (xhr) {
             var params = getParameters(xhr);
             params['i1'].should.equal("test");
@@ -177,22 +177,22 @@ describe("hx-include attribute", function() {
         div.click();
         this.server.respond();
         div.innerHTML.should.equal("Clicked!");
-	})
-	
-	it('The `closest` modifier can be used in the hx-include selector', function () {
+    })
+
+    it('The `closest` modifier can be used in the hx-include selector', function () {
         this.server.respondWith("POST", "/include", function (xhr) {
             var params = getParameters(xhr);
             params['i1'].should.equal("test");
             params['i2'].should.equal("test");
             xhr.respond(200, {}, "Clicked!")
         });
-		make('<div id="i"><input name="i1" value="test"/><input name="i2" value="test"/>'+
-			'<button id="btn" hx-post="/include" hx-include="closest div"></button></div>');
+        make('<div id="i"><input name="i1" value="test"/><input name="i2" value="test"/>'+
+            '<button id="btn" hx-post="/include" hx-include="closest div"></button></div>');
         var btn = byId('btn')
         btn.click();
         this.server.respond();
         btn.innerHTML.should.equal("Clicked!");
-	})
+    })
 
 
 });

--- a/www/test/1.1.0/test/attributes/hx-include.js
+++ b/www/test/1.1.0/test/attributes/hx-include.js
@@ -163,7 +163,36 @@ describe("hx-include attribute", function() {
         input.click();
         this.server.respond();
         div.innerHTML.should.equal("Clicked!");
-    });
+	});
+	
+	it('If the element is not includeable, its descendant inputs are included', function () {
+        this.server.respondWith("POST", "/include", function (xhr) {
+            var params = getParameters(xhr);
+            params['i1'].should.equal("test");
+            params['i2'].should.equal("test");
+            xhr.respond(200, {}, "Clicked!")
+        });
+        make('<div id="i"><input name="i1" value="test"/><input name="i2" value="test"/></div>');
+        var div = make('<div hx-post="/include" hx-include="#i"></div>')
+        div.click();
+        this.server.respond();
+        div.innerHTML.should.equal("Clicked!");
+	})
+	
+	it('The `closest` modifier can be used in the hx-include selector', function () {
+        this.server.respondWith("POST", "/include", function (xhr) {
+            var params = getParameters(xhr);
+            params['i1'].should.equal("test");
+            params['i2'].should.equal("test");
+            xhr.respond(200, {}, "Clicked!")
+        });
+		make('<div id="i"><input name="i1" value="test"/><input name="i2" value="test"/>'+
+			'<button id="btn" hx-post="/include" hx-include="closest div"></button></div>');
+        var btn = byId('btn')
+        btn.click();
+        this.server.respond();
+        btn.innerHTML.should.equal("Clicked!");
+	})
 
 
 });

--- a/www/test/index.html
+++ b/www/test/index.html
@@ -6,9 +6,7 @@
 <li><a href='/test/0.4.1/test'>0.4.1</a>
 <li><a href='/test/0.4.0/test'>0.4.0</a>
 <li><a href='/test/0.3.0/test'>0.3.0</a>
-<li><a href='/test/0.2.1/test'>0.2.1</a>
 <li><a href='/test/0.2.0/test'>0.2.0</a>
-<li><a href='/test/0.1.3/test'>0.1.3</a>
 <li><a href='/test/0.1.2/test'>0.1.2</a>
 <li><a href='/test/0.1.1/test'>0.1.1</a>
 <li><a href='/test/0.1.0/test'>0.1.0</a>


### PR DESCRIPTION
- The `closest` and `find` features of `hx-target` have been factored out, and added to `hx-include`.
- When using `hx-include`, if we include a non-form element (`shouldInclude` returns false e.g. div) then we look through its descendants for elements which should be included.