### PR TITLE
Improve `getInputValues` function

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1619,7 +1619,7 @@ return (function () {
                 });
             }
 
-            // values in closest form take precedence
+            // form values take precedence, overriding the regular values
             values = mergeObjects(values, formValues);
 
             return {errors:errors, values:values};

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1597,8 +1597,7 @@ return (function () {
             var processed = [];
             var values = {
                 form: {},
-                element: {},
-                includes: {},
+                other: {},
             };
             var errors = [];
 
@@ -1611,19 +1610,19 @@ return (function () {
             }
 
             // include the element itself
-            processInputValue(processed, values.element, errors, elt, validate);
+            processInputValue(processed, values.other, errors, elt, validate);
 
             // include any explicit includes
             var includes = getClosestAttributeValue(elt, "hx-include");
             if (includes) {
                 var nodes = getDocument().querySelectorAll(includes);
                 forEach(nodes, function(node) {
-                    processInputValue(processed, values.includes, errors, node, validate);
+                    processInputValue(processed, values.other, errors, node, validate);
                 });
             }
 
-            var mergedValues = mergeObjects(values.includes, values.element);
-            mergedValues = mergeObjects(mergedValues, values.form);
+            // values in closest form take precedence
+            var mergedValues = mergeObjects(values.other, values.form);
 
             return {errors:errors, values:mergedValues};
         }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1596,7 +1596,7 @@ return (function () {
         function getInputValues(elt, verb) {
             var processed = [];
             var values = {};
-	    var formValues = {};
+            var formValues = {};
             var errors = [];
 
             // only validate when form is directly submitted and novalidate is not set

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1595,10 +1595,8 @@ return (function () {
 
         function getInputValues(elt, verb) {
             var processed = [];
-            var values = {
-                form: {},
-                other: {},
-            };
+            var values = {};
+	    var formValues = {};
             var errors = [];
 
             // only validate when form is directly submitted and novalidate is not set
@@ -1606,25 +1604,25 @@ return (function () {
 
             // for a non-GET include the closest form
             if (verb !== 'get') {
-                processInputValue(processed, values.form, errors, closest(elt, 'form'), validate);
+                processInputValue(processed, formValues, errors, closest(elt, 'form'), validate);
             }
 
             // include the element itself
-            processInputValue(processed, values.other, errors, elt, validate);
+            processInputValue(processed, values, errors, elt, validate);
 
             // include any explicit includes
             var includes = getClosestAttributeValue(elt, "hx-include");
             if (includes) {
                 var nodes = getDocument().querySelectorAll(includes);
                 forEach(nodes, function(node) {
-                    processInputValue(processed, values.other, errors, node, validate);
+                    processInputValue(processed, values, errors, node, validate);
                 });
             }
 
             // values in closest form take precedence
-            var mergedValues = mergeObjects(values.other, values.form);
+            values = mergeObjects(values, formValues);
 
-            return {errors:errors, values:mergedValues};
+            return {errors:errors, values};
         }
 
         function appendParam(returnStr, name, realValue) {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1622,7 +1622,7 @@ return (function () {
             // values in closest form take precedence
             values = mergeObjects(values, formValues);
 
-            return {errors:errors, values};
+            return {errors:errors, values:values};
         }
 
         function appendParam(returnStr, name, realValue) {


### PR DESCRIPTION
This improves the `getInputValues` method by non overriding included element values with the main element's value.
This should make the `Two inputs are included twice when they have the same name` test, added in https://github.com/bigskysoftware/htmx/commit/10e068fcaa4bdcf3190a9eb818064dc08ba8f7a4, pass.