### PR TITLE
Handle preserved element that might not be existing

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -479,7 +479,9 @@ return (function () {
             forEach(findAll(fragment, '[hx-preserve], [data-hx-preserve]'), function (preservedElt) {
                 var id = getAttributeValue(preservedElt, "id");
                 var oldElt = getDocument().getElementById(id);
-                preservedElt.parentNode.replaceChild(oldElt, preservedElt);
+                if (oldElt != null) {
+                    preservedElt.parentNode.replaceChild(oldElt, preservedElt);
+                }
             });
         }
 

--- a/test/attributes/hx-preserve.js
+++ b/test/attributes/hx-preserve.js
@@ -17,5 +17,14 @@ describe("hx-preserve attribute", function () {
         byId("d2").innerHTML.should.equal("New Content");
     })
 
+    it('handles preserved element that might not be existing', function () {
+        this.server.respondWith("GET", "/test", "<div id='d1' hx-preserve>New Content</div><div id='d2'>New Content</div>");
+        var div = make("<div hx-get='/test'><div id='d2'>Old Content</div></div>");
+        div.click();
+        this.server.respond();
+        byId("d1").innerHTML.should.equal("New Content");
+        byId("d2").innerHTML.should.equal("New Content");
+    })
+
 });
 


### PR DESCRIPTION
In some cases that preserved element might not be existing in the document. It might be deleted by JavaScript or the element from server is first time to load into document.