### PR TITLE
Add test for path-deps outerHTML case

### DIFF
--- a/test/ext/path-deps.js
+++ b/test/ext/path-deps.js
@@ -158,4 +158,16 @@ describe("path-deps extension", function() {
         div2.innerHTML.should.equal("Path deps 2 fired!");
     });
 
+    it('path-deps replacing containing element fires event', function () {
+        this.server.respondWith("POST", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test2", "Deps fired!");
+        var div1 = make('<div><button id="buttonSubmit" hx-post="/test" hx-swap="outerHTML" hx-ext="path-deps" >Click Me!</button></div>')
+        var div2 = make('<div hx-get="/test2" hx-trigger="path-deps" path-deps="/test">FOO</div>')
+        byId("buttonSubmit").click();
+        this.server.respond();
+        div1.innerHTML.should.equal('Clicked!');
+        div2.innerHTML.should.equal("FOO");
+        this.server.respond();
+        div2.innerHTML.should.equal("Deps fired!");
+    });
 });


### PR DESCRIPTION
This test reproduces issue #323

Test output:
```
       path-deps replacing containing element fires event:

      AssertionError: expected 'FOO' to equal 'Deps fired!'
      + expected - actual

      -FOO
      +Deps fired!
      
      at Context.<anonymous> (ext/path-deps.js:171:31)

npm ERR! Test failed.  See above for more details.
```

---

For some reason, with this line the test passes, even though this is the similar issue I am seeing. Maybe I am mistaken...

```
var div1 = make('<div id="outer"><button id="buttonSubmit" hx-post="/test" hx-target="#outer" hx-ext="path-deps" >Click Me!</button></div>')
```