### PR TITLE
Stop re-locating hx-swap-oob oobElement by ID which might not exist

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -446,7 +446,7 @@ return (function () {
             } else if (oobValue.indexOf(":") > 0) {
                 swapStyle = oobValue.substr(0, oobValue.indexOf(":"));
                 selector  = oobValue.substr(oobValue.indexOf(":") + 1, oobValue.length);
-                var target = getDocument().querySelector(selector);
+                target = getDocument().querySelector(selector);
             } else {
                 swapStyle = oobValue;
             }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -70,7 +70,7 @@ return (function () {
 			}
 			if (str.slice(-2) == "ms") {
 				return parseFloat(str.slice(0,-2)) || undefined
-			}			
+			}
 			if (str.slice(-1) == "s") {
 				return (parseFloat(str.slice(0,-1)) * 1000) || undefined
 			}
@@ -439,18 +439,18 @@ return (function () {
         }
 
         function oobSwap(oobValue, oobElement, settleInfo) {
-            var selector = "#" + oobElement.id;
+            var target = oobElement;
             var swapStyle = "outerHTML";
             if (oobValue === "true") {
                 // do nothing
             } else if (oobValue.indexOf(":") > 0) {
                 swapStyle = oobValue.substr(0, oobValue.indexOf(":"));
                 selector  = oobValue.substr(oobValue.indexOf(":") + 1, oobValue.length);
+                var target = getDocument().querySelector(selector);
             } else {
                 swapStyle = oobValue;
             }
 
-            var target = getDocument().querySelector(selector);
             if (target) {
                 var fragment;
                 fragment = getDocument().createDocumentFragment();

--- a/test/attributes/hx-swap-oob.js
+++ b/test/attributes/hx-swap-oob.js
@@ -92,5 +92,32 @@ describe("hx-swap-oob attribute", function () {
         byId("d1").innerHTML.should.equal("Swapped");
     })
 
-});
+    it('oob swaps can swap elements without id', function () {
+        this.server.respondWith("GET", "/test", "<div>Clicked<div hx-swap-oob='innerHTML:.c1'>Swapped</div></div>");
+        var div = make('<div hx-get="/test">click me</div>');
+        make('<div class="c1" foo="bar"></div>');
+        div.click();
+        this.server.respond();
+        let elems = getWorkArea().getElementsByClassName("c1")
+        elems.length.should.equal(1);
+        should.equal(elems[0].getAttribute("foo"), "bar");
+        elems[0].innerHTML.should.equal("<div>Clicked</div>");
+        elems[0].innerHTML.should.equal("Swapped");
+    })
 
+    it('oob swaps can swap multiple elements without id', function () {
+        this.server.respondWith("GET", "/test", "<div>Clicked<div hx-swap-oob='innerHTML:.c1'>Swapped</div></div>");
+        var div = make('<div hx-get="/test">click me</div>');
+        make('<div class="c1" foo="bar"></div><div class="c1" foo="bar2"></div>');
+        div.click();
+        this.server.respond();
+        let elems = getWorkArea().getElementsByClassName("c1");
+        elems.length.should.equal(2);
+        should.equal(elems[0].getAttribute("foo"), "bar");
+        elems[0].innerHTML.should.equal("<div>Clicked</div>");
+        elems[0].innerHTML.should.equal("Swapped");
+        should.equal(elems[1].getAttribute("foo"), "bar2");
+        elems[1].innerHTML.should.equal("<div>Clicked</div>");
+        elems[1].innerHTML.should.equal("Swapped");
+    })
+});


### PR DESCRIPTION
#363 

This allows `hx-swap-oob` for element without an ID, such as

```
<div class="someclass"  hx-swap-oob="true:.someclass">
</div>
```
The code is also slightly more performant because the original code calls `querySelect(oobElement.id)` to re-locate the `target` in most cases.