### PR TITLE
Updated to note that change in format and add info about optional prefix

### DIFF
--- a/www/attributes/hx-ws.md
+++ b/www/attributes/hx-ws.md
@@ -8,7 +8,7 @@ title: </> htmx - hx-ws
 The `hx-ws` allows you to work with [Web Sockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_client_applications)
 directly from HTML.  The value of the attribute can be one or more of the following, separated by commas:
 
-* `connect:<url>` - A URL to establish an `WebSocket` connection against
+* `connect:<url>` or `connect:<prefix>:<url>` - A URL to establish an `WebSocket` connection against. Prefixes `ws` or `wss` can optionally be specified. If not specified, HTMX defaults to add the `wss` prefix to the url.
 * `send` - Sends a message to the nearest websocket based on the trigger value for the element (either the natural event
 of the event specified by [`hx-trigger`])
 
@@ -25,7 +25,7 @@ Here is an example:
   </div>
 ```
 
-This example establishes a WebSocket to the `chatroom` end point.  Content that is send down from the websocket will
+This example establishes a WebSocket to the `chatroom` end point.  Content that is sent down from the websocket will
 be parsed as HTML and swapped in by the `id` property, using the same logic as [Out of Band Swaps](/attributes/hx-swap-oob).
 
 The form uses the `send` syntax to indicate that when it is submitted, the form values should be serialized as JSON

--- a/www/docs.md
+++ b/www/docs.md
@@ -481,7 +481,7 @@ These features are under active development, so please let us know if you are wi
 If you wish to establish a `WebSocket` connection in htmx, you use the [hx-ws](/attributes/hx-ws) attribute:
 
 ```html
-  <div hx-ws="connect wss:/chatroom">
+  <div hx-ws="connect:wss:/chatroom">
     <div id="chat_room">
       ...
     </div>


### PR DESCRIPTION
When connecting to websockets, the previous format using optional prefix was:

`hx-ws="connect ws:/chatroom"`

If has been changed to:

`hx-ws="connect:ws:/chatroom"` or `hx-ws="connect:wss:/chatroom"`

Made this fix in the docs.