### PR TITLE
WebSocket Reconnect

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -44,7 +44,8 @@ return (function () {
                 settlingClass:'htmx-settling',
                 swappingClass:'htmx-swapping',
                 allowEval:true,
-                attributesToSettle:["class", "style", "width", "height"]
+                attributesToSettle:["class", "style", "width", "height"],
+                wsReconnectInterval: 10000
             },
             parseInterval:parseInterval,
             _:internalEval,

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1044,7 +1044,7 @@ return (function () {
             for (var i = 0; i < values.length; i++) {
                 var value = values[i].split(/:(.+)/);
                 if (value[0] === "connect") {
-                    processWebSocketSource(elt, value[1], 0);
+                    ensureWebSocket(elt, value[1], 0);
                 }
                 if (value[0] === "send") {
                     processWebSocketSend(elt);
@@ -1052,7 +1052,11 @@ return (function () {
             }
         }
 
-        function processWebSocketSource(elt, wssSource, retryCount) {
+        function ensureWebSocket(elt, wssSource, retryCount) {
+            if (!bodyContains(elt)) {
+                return;  // stop ensuring websocket connection when socket bearing element ceases to exist
+            }
+
             if (wssSource.indexOf("/") == 0) {  // complete absolute paths only
                 var base_part = location.hostname + (location.port ? ':'+location.port: '');
                 if (location.protocol == 'https:') {
@@ -1071,7 +1075,7 @@ return (function () {
                 if ([1006, 1012, 1013].includes(e.code)) {  // Abnormal Closure/Service Restart/Try Again Later
                     var delay = getWebSocketReconnectDelay(retryCount);
                     setTimeout(function() {
-                        processWebSocketSource(elt, wssSource, retryCount+1);  // creates a websocket with a new timeout
+                        ensureWebSocket(elt, wssSource, retryCount+1);  // creates a websocket with a new timeout
                     }, delay);
                 }
             };

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1061,6 +1061,15 @@ return (function () {
                 triggerErrorEvent(elt, "htmx:wsError", {error:e, socket:socket});
                 maybeCloseWebSocketSource(elt);
             };
+
+            socket.onclose = function (e) {
+                if ([1006, 1012, 1013].includes(e.code)) {  // Abnormal Closure/Service Restart/Try Again Later
+                    setTimeout(function() {
+                        processWebSocketSource(elt, wssSource);  // creates a websocket with a new timeout
+                    }, htmx.config.wsReconnectInterval);
+                }
+            };
+
             getInternalData(elt).webSocket = socket;
             socket.addEventListener('message', function (event) {
                 if (maybeCloseWebSocketSource(elt)) {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1118,8 +1118,8 @@ return (function () {
                 return getInternalData(parent).webSocket != null;
             });
             if (webSocketSourceElt) {
-                var webSocket = getInternalData(webSocketSourceElt).webSocket;
                 elt.addEventListener(getTriggerSpecs(elt)[0].trigger, function (evt) {
+                    var webSocket = getInternalData(webSocketSourceElt).webSocket;
                     var headers = getHeaders(elt, webSocketSourceElt);
                     var results = getInputValues(elt, 'post');
                     var errors = results.errors;

--- a/test/manual/websocket-reconnect.html
+++ b/test/manual/websocket-reconnect.html
@@ -1,0 +1,22 @@
+<html>
+<head>
+    <script src="../../src/htmx.js"></script>
+    <title>WebSockets Test</title>
+</head>
+<body hx-ws="connect:wss://echo.websocket.org">
+
+    <form hx-ws="send">
+        Send Message to Echo Server...<br>
+        <textarea name="message" style="width:500px; height:300px;">&lt;div id="idMessage"&gt;This Is The Message&lt;div&gt;</textarea>
+        <br/><input type="submit"/>
+    </form>
+
+    <!--
+    Receive doesn't work with this `echo` server because of differences in the way HTMX formats
+    `send` messages vs. what it expects for replies.  It's has no bearing on the reconnect test.
+
+    <br><hr><br>
+    <div id="idMessage"></div>
+    -->
+</body>
+</html>

--- a/www/api.md
+++ b/www/api.md
@@ -96,6 +96,7 @@ Note that using a [meta tag](/docs/#config) is the preferred mechanism for setti
 * `settlingClass:'htmx-settling'` - string: the class to place on target elements when htmx is in the settling phase
 * `swappingClass:'htmx-swapping'` - string: the class to place on target elements when htmx is in the swapping phase
 * `allowEval:true` - boolean: allows the use of eval-like functionality in htmx, to enable `hx-vars`, trigger conditions & script tag evaluation.  Can be set to `false` for CSP compatibility
+* `wsReconnectInterval:10000` - int: the default interval of `hx-ws` for reconnecting after unexpected connection loss by the event code `Abnormal Closure`, `Service Restart` or `Try Again Later`
 
 ##### Example
 

--- a/www/api.md
+++ b/www/api.md
@@ -96,7 +96,7 @@ Note that using a [meta tag](/docs/#config) is the preferred mechanism for setti
 * `settlingClass:'htmx-settling'` - string: the class to place on target elements when htmx is in the settling phase
 * `swappingClass:'htmx-swapping'` - string: the class to place on target elements when htmx is in the swapping phase
 * `allowEval:true` - boolean: allows the use of eval-like functionality in htmx, to enable `hx-vars`, trigger conditions & script tag evaluation.  Can be set to `false` for CSP compatibility
-* `wsReconnectInterval:10000` - int: the default interval of `hx-ws` for reconnecting after unexpected connection loss by the event code `Abnormal Closure`, `Service Restart` or `Try Again Later`
+* `wsReconnectDelay:full-jitter` - string/function: the default implementation of `getWebSocketReconnectDelay` for reconnecting after unexpected connection loss by the event code `Abnormal Closure`, `Service Restart` or `Try Again Later`
 
 ##### Example
 

--- a/www/attributes/hx-ws.md
+++ b/www/attributes/hx-ws.md
@@ -35,7 +35,10 @@ The serialized values will include a field, `HEADERS`, that includes the headers
 request.
 
 After an unexpected connection loss due to `Abnormal Closure`, `Service Restart` or `Try Again Later`,
-reconnecting is done after `htmx.config.wsReconnectInterval` milliseconds until successful.
+reconnecting is tried until successful.
+The default reconnection interval is implemented with the full-jitter exponential-backoff algorithm.
+Own implementations can be provided by setting `htmx.config.wsReconnectDelay` to a function with
+`retryCount` as its only parameter.
 
 ### Notes
 

--- a/www/attributes/hx-ws.md
+++ b/www/attributes/hx-ws.md
@@ -34,6 +34,9 @@ and send to the nearest enclosing `WebSocket`.
 The serialized values will include a field, `HEADERS`, that includes the headers normally submitted with an htmx
 request.
 
+After an unexpected connection loss due to `Abnormal Closure`, `Service Restart` or `Try Again Later`,
+reconnecting is done after `htmx.config.wsReconnectInterval` milliseconds until successful.
+
 ### Notes
 
 * `hx-ws` is not inherited

--- a/www/docs.md
+++ b/www/docs.md
@@ -821,7 +821,7 @@ Htmx allows you to configure a few defaults:
 |  `htmx.config.settlingClass` | defaults to `htmx-settling`
 |  `htmx.config.swappingClass` | defaults to `htmx-swapping`
 |  `htmx.config.allowEval` | defaults to `true`
-|  `htmx.config.wsReconnectInterval` | defaults to 10000
+|  `htmx.config.wsReconnectDelay` | defaults to `full-jitter`
 
 </div>
 

--- a/www/docs.md
+++ b/www/docs.md
@@ -821,6 +821,7 @@ Htmx allows you to configure a few defaults:
 |  `htmx.config.settlingClass` | defaults to `htmx-settling`
 |  `htmx.config.swappingClass` | defaults to `htmx-swapping`
 |  `htmx.config.allowEval` | defaults to `true`
+|  `htmx.config.wsReconnectInterval` | defaults to 10000
 
 </div>
 


### PR DESCRIPTION
I noticed that htmx does not reconnect after the connection has been dropped for various reasons.

I added this functionality because during development/deployments, server restarts are quite common and page reloads add unnecessary delays to the feedback loop.

This patch also adds the possibility to configure the reconnect interval since different use-cases and stages requires different latencies, e.g. dev: 3sec, prod: 20-30sec (in my case). If you think of a chat-like web app, you might want even have 5-10 secs, whereas message boards/issue trackers could live with up to 60 secs or more.

So, I leave this here open for discussion.

EDIT:

As an addition, one could randomize the reconnect period (reduced server startup load). We then might need an additional config variable such as (wsReconnectMinInterval and wsReconnectMaxInterval). In the wild, a constant should work pretty well for smaller projects. If you think, that the scope of htmx is also for larger projects, we could add it easily if you are okay with the additional config var.

EDIT2:

Just to make you aware of it: https://github.com/joewalnes/reconnecting-websocket (if you prefer pulling a third-party). I would rather go with a simpler solution but especially this field has a lot of opinions on what resembles the perfect solution.

EDIT3:

OK, my fault. I didn't check on existing issues nor pull requests. So to link things up: #148 #150

EDIT4:
A well-described analysis can be found from AWS: https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/