### PR TITLE
Completing websocket URLs

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1052,8 +1052,13 @@ return (function () {
         }
 
         function processWebSocketSource(elt, wssSource) {
-            if (wssSource.indexOf("ws:") !== 0 && wssSource.indexOf("wss:") !== 0) {
-                wssSource = "wss:" + wssSource;
+            if (wssSource.indexOf("/") == 0) {  // complete absolute paths only
+                var base_part = location.hostname + (location.port ? ':'+location.port: '');
+                if (location.protocol == 'https:') {
+                    wssSource = "wss://" + base_part + wssSource;
+                } else if (location.protocol == 'http:') {
+                    wssSource = "ws://" + base_part + wssSource;
+                }
             }
             var socket = htmx.createWebSocket(wssSource);
             socket.onerror = function (e) {

--- a/www/attributes/hx-ws.md
+++ b/www/attributes/hx-ws.md
@@ -8,7 +8,8 @@ title: </> htmx - hx-ws
 The `hx-ws` allows you to work with [Web Sockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_client_applications)
 directly from HTML.  The value of the attribute can be one or more of the following, separated by commas:
 
-* `connect:<url>` or `connect:<prefix>:<url>` - A URL to establish an `WebSocket` connection against. Prefixes `ws` or `wss` can optionally be specified. If not specified, HTMX defaults to add the `wss` prefix to the url.
+* `connect:<url>` or `connect:<prefix>:<url>` - A URL to establish an `WebSocket` connection against.
+* Prefixes `ws` or `wss` can optionally be specified. If not specified, HTMX defaults to add the location's scheme-type, host and port to have browsers send cookies via websockets.
 * `send` - Sends a message to the nearest websocket based on the trigger value for the element (either the natural event
 of the event specified by [`hx-trigger`])
 


### PR DESCRIPTION
I leave this here for discussion. Please, let me know what you think about this.

- use the current host and port
- use ws for http and wss for https
- these changes allow sending cookies of the current site

Another benefit is ease of use during development (usually without TLS).

