### PR TITLE
settle on SSE Swap event

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1169,6 +1169,7 @@ return (function () {
                     var settleInfo = makeSettleInfo(elt);
 
                     selectAndSwap(swapSpec.swapStyle, elt, target, response, settleInfo)
+                    settleImmediately(settleInfo.tasks)
                     triggerEvent(elt, "htmx:sseMessage", event)
                 };
 


### PR DESCRIPTION
Small PR to make SSE consistent with Websockets.  On htmx.js#L1082 we settleImmediately after oob swapping a websocket event.  For SSE events we also swap in content, but settling is missing which means that the node does not get processed properly.