### PR TITLE
Use getAttribute("href") instead of .href in shouldCancel

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -922,7 +922,7 @@ return (function () {
         function shouldCancel(elt) {
             return elt.tagName === "FORM" ||
                 (matches(elt, 'input[type="submit"], button') && closest(elt, 'form') !== null) ||
-                (elt.tagName === "A" && elt.href && elt.href.indexOf('#') !== 0);
+                (elt.tagName === "A" && elt.href && elt.getAttribute('href').indexOf('#') !== 0);
         }
 
         function ignoreBoostedAnchorCtrlClick(elt, evt) {


### PR DESCRIPTION
#385

Using
```
elt.getAttribute('href').indexOf('#') !== 0
```
instead of
```
elf.href.indexOf('#') !== 0
```
seems to be the right thing to do because the latter always returns true. The PR does not fix any bug but it does not break any existing tests either.