### PR TITLE
Fix logic of shoudCancel

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -937,7 +937,7 @@ return (function () {
         function shouldCancel(elt) {
             return elt.tagName === "FORM" ||
                 (matches(elt, 'input[type="submit"], button') && closest(elt, 'form') !== null) ||
-                (elt.tagName === "A" && elt.href && elt.getAttribute('href').indexOf('#') === 0);
+                (elt.tagName === "A" && elt.href && elt.getAttribute('href') === '#');
         }
 
         function ignoreBoostedAnchorCtrlClick(elt, evt) {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -937,7 +937,7 @@ return (function () {
         function shouldCancel(elt) {
             return elt.tagName === "FORM" ||
                 (matches(elt, 'input[type="submit"], button') && closest(elt, 'form') !== null) ||
-                (elt.tagName === "A" && elt.href && elt.getAttribute('href').indexOf('#') !== 0);
+                (elt.tagName === "A" && elt.href && elt.getAttribute('href').indexOf('#') === 0);
         }
 
         function ignoreBoostedAnchorCtrlClick(elt, evt) {


### PR DESCRIPTION
#413 

I double checked and I think the original PR (#385) fixed the use of`.href` but should have also changed `!==`to `===`. Using the latest version (1.3.1) when I click on `<a href='#'>` the page actually scroll to the top which is a big regression.