### PR TITLE
Add file inputs to hx-ws=send either inline or out of band

### DIFF
--- a/www/attributes/hx-encoding.md
+++ b/www/attributes/hx-encoding.md
@@ -15,3 +15,4 @@ The `hx-encoding` tag may be placed on parent elements.
 ### Notes
 
 * `hx-encoding` is inherited and can be placed on a parent element
+* The `hx-encoding` attribute has a different interpretation and set of values when used with [`hx-ws`](/attributes/hx-ws)

--- a/www/attributes/hx-ws.md
+++ b/www/attributes/hx-ws.md
@@ -41,6 +41,96 @@ The default reconnection interval is implemented with the full-jitter exponentia
 Own implementations can be provided by setting `htmx.config.wsReconnectDelay` to a function with
 `retryCount` as its only parameter.
 
+### File inputs
+
+The JSON websocket request will include any file inputs. There are multiple
+ways files can be encoded into websocket requests. Whichever way, the part of
+the JSON request corresponding the file will be object, with the field
+`serialization` indicating to the websocket server how the file has been
+serialized as well fields with the metadata about the file: `name`,
+`lastModified`, `size` and `type`.
+
+The mode for serialization can be modified using `hx-encoding`. The default
+mode for value if no `hx-encoding` is specified is `multipart/json-files-oob`.
+In this case, for each request, multiple websocket messages will be sent from
+the client: one for the initial request, and subsequently one for each file
+which is part of the request. In this case, the object corresponding to the
+file have `serialization` set to `file/oob` and it will also contain an
+`offset` field containing a 0-based offset into the following messages. The
+server program must then gather these offsets and use them to determine how
+many extra packets to read and include in the initial message.
+
+The other mode available from `hx-encoding` is `multipart/json-files-inline`.
+This mode sends a single request containing the contents of the files inline.
+This mode is easier to handle server-side, but it is only appropriate for usage
+with small files, since it will load the whole file into memory when
+constructing the request. In this case files with mime types beginning with
+`text/` have a `serialization` set to `file/inline-text` and contain a `body`
+field with the contents of the file as text. For other types of files,
+`serialization` will be set to `file/inline-base64` and `body` field will be
+base64 encoded.
+
+To clarify, consider the following example:
+
+```html
+<div hx-ws="connect:/session">
+  <form hx-ws="send" hx-encoding="multipart/json-files-oob">
+    <input type="file" name="photo">
+    <input type="file" name="markdown_bio">
+    <input type="submit">
+  </form>
+</div>
+```
+
+In this case, 3 websocket messages would be sent, the first of which would be:
+
+```json
+{
+  "photo": {
+    "serialization": "multipart/json-files-oob",
+    "offset": 0,
+    "name": "photo.jpg",
+    "lastModified": 1485903600000,
+    "size": 8192,
+    "type": "image/jpeg"
+  },
+  "markdown_bio": {
+    "serialization": "multipart/json-files-oob",
+    "offset": 1,
+    "name": "bio.md",
+    "lastModified": 1485903600000,
+    "size": 13,
+    "type": "text/markdown"
+  }
+}
+```
+
+The next two message would then contain the contents of photo and markdown bio respectively as binary websocket messages.
+
+Now consider if `hx-encoding` was set to `multipart/json-files-inline`. In this
+case the request would be the following:
+
+```json
+{
+  "photo": {
+    "serialization": "file/inline-base64",
+    "body": "TG9yZW0gaXBzdW0gZG9sciBzaXI=",
+    "name": "photo.jpg",
+    "lastModified": 1485903600000,
+    "size": 8192,
+    "type": "image/jpeg"
+  },
+  "markdown_bio": {
+    "serialization": "file/inline-text",
+    "body": "*Lorem ipsum*",
+    "name": "bio.md",
+    "lastModified": 1485903600000,
+    "size": 13,
+    "type": "text/markdown"
+  }
+}
+```
+
 ### Notes
 
 * `hx-ws` is not inherited


### PR DESCRIPTION
This patch adds files to websocket sends. By default it does the more efficient thing, sending each file afterwards in a separate message and adding pointer to this. This is more efficient since it relies on primitives inside the browser. The other encoding possibility requires hx-encoding to be set to multipart/json-files-inline. In this case, the files are included inline either as text or base64 depending on the mimetype.

How does this approach seem? If it suits I will add short additional documentation to the effect of the above.