### PR TITLE
Fix the <title> of markdown docs

### DIFF
--- a/www/_includes/layout.njk
+++ b/www/_includes/layout.njk
@@ -1,6 +1,6 @@
 <html lang="en">
 <head>
-    <title>&lt;/> htmx - high power tools for html</title>
+    <title>{{ title | default("&lt;/> htmx - high power tools for html") }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="/css/site.css"/>
     <link rel="stylesheet" href="/css/prism-htmx.css"/>


### PR DESCRIPTION
I noticed all the markdown doc files declare their own page title, but on the live website all have the same title of "</> htmx - high power tools for html". It appears the title var wasn't getting used in the base layout template