### PR TITLE
Ignore meta key for boosted links.

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -944,7 +944,7 @@ return (function () {
         }
 
         function ignoreBoostedAnchorCtrlClick(elt, evt) {
-            return getInternalData(elt).boosted && elt.tagName === "A" && evt.type === "click" && evt.ctrlKey;
+            return getInternalData(elt).boosted && elt.tagName === "A" && evt.type === "click" && (evt.ctrlKey || evt.metaKey);
         }
 
         function maybeFilterEvent(triggerSpec, evt) {


### PR DESCRIPTION
metaKey is the Cmd key in MacOS, which is used for the same purpose of opening
a link in another tab.

So it should be also used to ignore clicks on boosted links.