### PR TITLE
Fix throttling to avoid delaying

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1016,10 +1016,12 @@ return (function () {
                     }
 
                     if (triggerSpec.throttle) {
-                        elementData.throttle = setTimeout(function(){
+                        if(!elementData.throttle) {
                             issueAjaxRequest(verb, path, elt, evt);
-                            elementData.throttle = null;
-                        }, triggerSpec.throttle);
+                            elementData.throttle = setTimeout(function(){
+                                elementData.throttle = null;
+                            }, triggerSpec.throttle);
+                        }
                     } else if (triggerSpec.delay) {
                         elementData.delayed = setTimeout(function(){
                             issueAjaxRequest(verb, path, elt, evt);


### PR DESCRIPTION
This changes throttling so it doesn't wait to be fired when the event happens, _unless_ it has already been fired and a timeout is waiting to be executed to clean itself.

Please note this is a bit of a shoot in the dark as I'm editing this directly in GitHub and haven't tested it, and of course I'm not adding/fixing any automated tests. So it's just an idea. :P