### PR TITLE
Fix swap error when using hx-boost or swapping the body tag

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -581,7 +581,7 @@ return (function () {
 
         function swapOuterHTML(target, fragment, settleInfo) {
             if (target.tagName === "BODY") {
-                return swapInnerHTML(target, fragment);
+                return swapInnerHTML(target, fragment, settleInfo);
             } else {
                 var eltBeforeNewContent = target.previousSibling;
                 insertNodesBefore(parentElt(target), target, fragment, settleInfo);


### PR DESCRIPTION
When hx-boost is swapping the body, in some cases it fails with:

```
htmx:swapError
TypeError: Cannot read property 'tasks' of undefined
    at htmx-1.3.3.js:526
    at forEach (htmx-1.3.3.js:222)
    at handleAttributes (htmx-1.3.3.js:520)
    at insertNodesBefore (htmx-1.3.3.js:552)
    at swapInnerHTML (htmx-1.3.3.js:624)
    at swapOuterHTML (htmx-1.3.3.js:584)
    at swap (htmx-1.3.3.js:652)
    at selectAndSwap (htmx-1.3.3.js:715)
    at doSwap (htmx-1.3.3.js:2284)
    at handleAjaxResponse (htmx-1.3.3.js:2358)
```

because `swapOuterHTML` is not passing `settleInfo` to `swapInnerHTML`