### PR TITLE
add withCredentials config option

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -49,6 +49,7 @@ return (function () {
                 swappingClass:'htmx-swapping',
                 allowEval:true,
                 attributesToSettle:["class", "style", "width", "height"],
+                withCredentials:false,
                 wsReconnectDelay: 'full-jitter',
                 disableSelector: "[hx-disable], [data-hx-disable]",
             },
@@ -2145,6 +2146,7 @@ return (function () {
             }
 
             xhr.overrideMimeType("text/html");
+            xhr.withCredentials = htmx.config.withCredentials;
 
             // request headers
             for (var header in headers) {

--- a/www/api.md
+++ b/www/api.md
@@ -98,6 +98,7 @@ Note that using a [meta tag](/docs/#config) is the preferred mechanism for setti
 * `settlingClass:'htmx-settling'` - string: the class to place on target elements when htmx is in the settling phase
 * `swappingClass:'htmx-swapping'` - string: the class to place on target elements when htmx is in the swapping phase
 * `allowEval:true` - boolean: allows the use of eval-like functionality in htmx, to enable `hx-vars`, trigger conditions & script tag evaluation.  Can be set to `false` for CSP compatibility
+* `withCredentials:false` - boolean: allow cross-site Access-Control requests using credentials such as cookies, authorization headers or TLS client certificates
 * `wsReconnectDelay:full-jitter` - string/function: the default implementation of `getWebSocketReconnectDelay` for reconnecting after unexpected connection loss by the event code `Abnormal Closure`, `Service Restart` or `Try Again Later`
 
 ##### Example


### PR DESCRIPTION
Hi!
I ran into an issue today while HTMX to breath new life into a Jekyll site.
In development mode Jekyll HTML is served on `127.0.0.1:4000` while HTMX partials are coming from `127.0.0.1:9000`. I noticed that cookies were not sent to `127.0.0.1:9000`. Initially I suspected some problem with CSP, but it turned out that `XMLHttpRequest` objects need to have `withCredentials` set to `true`. After patching `htmx.js` locally cookies were sent as expected.
Since this might be useful for others also, I decided to submit this pull request.
Hope this is useful!