### PR TITLE
Explore a possible action attribute

### DIFF
--- a/src/ext/actions.js
+++ b/src/ext/actions.js
@@ -1,0 +1,35 @@
+(function () {
+  function processAction(elt, action) {}
+
+  function maybeProcessActions(elt) {
+    if (elt.getAttribute) {
+      var action =
+        elt.getAttribute("hx-action") || elt.getAttribute("data-hx-action");
+      var triggers =
+        elt.getAttribute("hx-trigger") || elt.getAttribute("data-hx-trigger");
+      if (action && triggers) {
+        var triggerSpecs = htmx.getTriggerSpecs(elt);
+        var nodeData = htmx.getInternalData(elt);
+        var triggerAction = function(evt){
+          eval(action);
+        }
+        htmx.addEventListenerFn(elt, triggerAction, nodeData, triggerSpecs[0], false)
+      }
+    }
+  }
+
+  htmx.defineExtension("actions", {
+    onEvent: function (name, evt) {
+      if (name === "htmx:afterProcessNode") {
+        var elt = evt.detail.elt;
+        maybeProcessActions(elt);
+        if (elt.querySelectorAll) {
+          var children = elt.querySelectorAll("[hx-action], [data-hx-action]");
+          for (var i = 0; i < children.length; i++) {
+            maybeProcessActions(children[i]);
+          }
+        }
+      }
+    },
+  });
+})();

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -54,6 +54,9 @@ return (function () {
                 wsReconnectDelay: 'full-jitter',
                 disableSelector: "[hx-disable], [data-hx-disable]",
             },
+            getTriggerSpecs: getTriggerSpecs,
+            addEventListenerFn: addEventListenerFn,
+            getInternalData: getInternalData,
             parseInterval:parseInterval,
             _:internalEval,
             createEventSource: function(url){
@@ -977,8 +980,16 @@ return (function () {
             }
             return false;
         }
+        
 
         function addEventListener(elt, verb, path, nodeData, triggerSpec, explicitCancel) {
+          var fn = function(evt){
+            issueAjaxRequest(verb, path, elt, evt);
+          };
+          return addEventListenerFn(elt, fn, nodeData, triggerSpec, explicitCancel);
+        }
+
+        function addEventListenerFn(elt, fn, nodeData, triggerSpec, explicitCancel){
             var eltToListenOn = elt;
             if (triggerSpec.from) {
                 eltToListenOn = find(triggerSpec.from);
@@ -1035,17 +1046,17 @@ return (function () {
 
                     if (triggerSpec.throttle) {
                         if(!elementData.throttle) {
-                            issueAjaxRequest(verb, path, elt, evt);
+                            fn(evt);
                             elementData.throttle = setTimeout(function(){
                                 elementData.throttle = null;
                             }, triggerSpec.throttle);
                         }
                     } else if (triggerSpec.delay) {
                         elementData.delayed = setTimeout(function(){
-                            issueAjaxRequest(verb, path, elt, evt);
+                          fn(evt);
                         }, triggerSpec.delay);
                     } else {
-                        issueAjaxRequest(verb, path, elt, evt);
+                      fn(evt);
                     }
                 }
             };

--- a/test/scratch.html
+++ b/test/scratch.html
@@ -20,6 +20,7 @@
 <body style="padding:20px;font-family: sans-serif">
 <script src="../node_modules/sinon/pkg/sinon.js"></script>
 <script src="../src/htmx.js"></script>
+<script src="../src/ext/actions.js"></script>
 <script src="util/util.js"></script>
 <script src="util/scratch_server.js"></script>
 
@@ -31,11 +32,16 @@
 
     htmx.logAll();
 
+    function logAction(){
+      console.log("Hello World")
+    }
+
     this.server.respondWith("GET", "/test", function(xhr){
         xhr.respond(201, {}, '<form><input hx-trigger="keyup delay:1s changed" hx-swap="outerHTML" hx-get="/test" id="i1" value="blahblah"/></form>')
     });
 
-    make('<form hx-target="this"><input hx-trigger="keyup delay:1s changed" hx-swap="outerHTML" hx-get="/test" id="i1"/></form>');
+    //make('<form hx-target="this"><input hx-trigger="keyup delay:1s changed" hx-swap="outerHTML" hx-get="/test" id="i1"/></form>');
+  make('<form hx-ext="actions"><input hx-trigger="keyup delay:1s changed" hx-swap="outerHTML" hx-action="logAction()" id="i1"/></form>');
 </script>
 
 


### PR DESCRIPTION
This pr is an extension of issue: https://github.com/bigskysoftware/htmx/issues/472

Like I mentioned in the issue, hx-trigger is very expressive and powerful, and just like with HTML, sometimes we just want to trigger a function or action, instead of a HTTP request. This opens a new set of possibilities. I believe this should be simple, and work like the regular HTML onEvent [eg onClick] attributes, and simply execute the attribute value as javascript. 

What this looks like in practice?
```html
<script>
    function doAction(value){
      document.getElementById("btnID").innerHTML = value;
    }
</script>
<button 
              hx-trigger="click[metaKey&&shiftKey] delay:1s" 
              hx-action="doAction(12345)" id="btnID"
>original string</button>
```
This example will replace original string with the numbers passed as argument to the doAction function, when the user clicks the button while holding down CMD+Shift, and after a 1 second delay. This is really non-trivial to implement with HTML and javascript, especially when compared to how easily it was achieved in the example above, and this is also currently not trivial(or I don't know how to), in hyperscript.


This can be combined quite powerfully with hyperscript, especially using an interop function between hyperscript and javascript like `_hyperscript.evaluate()`. 

```html
<button 
        hx-trigger="click[metaKey&&shiftKey] delay:1s" 
        hx-action="_hyperscript.evaluate(put '1234' into #btnID.innerHTML)" id="btnID"
>original string</button>
```
The line above leverages hyperscript to do the same thing as the previous code example. This opens the door for really powerful expressions not possible before.