### PR TITLE
Typing with jsdoc (incomplete atm)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "unpkg": "dist/htmx.min.js",
   "scripts": {
     "test": "mocha-chrome test/index.html",
+      "test-types": "tsc -w --project ./tsconfig.json",
     "dist": "cp -r src/* dist/ && npm run-script uglify && gzip -k -f dist/htmx.min.js > dist/htmx.min.js.gz && exit",
     "www": "node scripts/www.js",
     "uglify": "uglifyjs -m eval -o dist/htmx.min.js dist/htmx.js"

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -22,6 +22,9 @@ return (function () {
             find : find,
             findAll : findAll,
             closest : closest,
+            /**
+             * @param {HTMLElement} elt
+             */
             values : function(elt, type){
                 var inputValues = getInputValues(elt, type || "post");
                 return inputValues.values;
@@ -55,9 +58,16 @@ return (function () {
             },
             parseInterval:parseInterval,
             _:internalEval,
+            /**
+             * @param {string} url
+             * @returns {EventSource}
+             */
             createEventSource: function(url){
                 return new EventSource(url, {withCredentials:true})
             },
+            /**
+             * @param {string} url
+             */
             createWebSocket: function(url){
                 return new WebSocket(url, []);
             }
@@ -71,7 +81,10 @@ return (function () {
         //====================================================================
         // Utilities
         //====================================================================
-
+    /**
+       @param {string} str
+       @returns {{undefined|number}}
+       */
 		function parseInterval(str) {
 			if (str == undefined)  {
 				return undefined
@@ -82,9 +95,13 @@ return (function () {
 			if (str.slice(-1) == "s") {
 				return (parseFloat(str.slice(0,-1)) * 1000) || undefined
 			}
+
 			return parseFloat(str) || undefined
         }
-
+    /**
+     * @param {HTMLElement} elt
+     * @param {string} name
+     */
         function getRawAttribute(elt, name) {
             return elt.getAttribute && elt.getAttribute(name);
         }
@@ -94,15 +111,22 @@ return (function () {
             return elt.hasAttribute && (elt.hasAttribute(qualifiedName) ||
                 elt.hasAttribute("data-" + qualifiedName));
         }
-
+    /**
+     * @param {HTMLElement}  elt
+     * @param {string} qualifiedName
+     */
         function getAttributeValue(elt, qualifiedName) {
             return getRawAttribute(elt, qualifiedName) || getRawAttribute(elt, "data-" + qualifiedName);
         }
-
+    /**
+     * @param {HTMLElement}  elt
+     */
         function parentElt(elt) {
             return elt.parentElement;
         }
-
+    /**
+     * @return {HTMLDocument}
+     */
         function getDocument() {
             return document;
         }
@@ -2013,7 +2037,10 @@ return (function () {
                 return issueAjaxRequest(verb, path);
             }
         }
-
+    /**
+     * @param {string}  verb
+     * @param {string} path 
+     */
         function issueAjaxRequest(verb, path, elt, event, etc) {
             var resolve = null;
             var reject = null;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "target": "es3",
+        "module": "amd",
+        "allowJs": true,
+        "checkJs": true,
+        "noEmit": true,
+        "baseUrl": "./src"
+    },
+    "include": ["./src/**/*"],
+    "verbose": true
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,16 @@
 {
     "compilerOptions": {
-        "target": "es3",
+        "target": "es5",
         "module": "amd",
         "allowJs": true,
         "checkJs": true,
         "noEmit": true,
-        "baseUrl": "./src"
+        "baseUrl": "./src",
+        "lib": [
+            "ES6",
+            "dom"
+        ]
     },
-    "include": ["./src/**/*"],
+    "include": ["./src/htmx.js"],
     "verbose": true
 }


### PR DESCRIPTION
Hi,

I'm submitting a proof of concept of what it would be like to use jsdoc to add typings to htmx rather than converting the whole thing to typescript.

Some thoughts on this. It would definitely be a bit tedious to complete this and it would necessitate updating build process to strip these comments.

Alternatively, what about converting to typescript? Something like https://github.com/developit/microbundle could be used to build for multiple targets easily.

EDIT: Happy to help explore different avenues.