### PR TITLE
Fixes for `useTemplateFragments`

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -35,7 +35,6 @@ return (function () {
             removeExtension : removeExtension,
             logAll : logAll,
             logger : null,
-            useTemplateFragments: false,
             config : {
                 historyEnabled:true,
                 historyCacheSize:10,
@@ -53,6 +52,7 @@ return (function () {
                 withCredentials:false,
                 wsReconnectDelay: 'full-jitter',
                 disableSelector: "[hx-disable], [data-hx-disable]",
+                useTemplateFragments: false,
             },
             parseInterval:parseInterval,
             _:internalEval,

--- a/www/api.md
+++ b/www/api.md
@@ -98,7 +98,7 @@ Note that using a [meta tag](/docs/#config) is the preferred mechanism for setti
 * `settlingClass:'htmx-settling'` - string: the class to place on target elements when htmx is in the settling phase
 * `swappingClass:'htmx-swapping'` - string: the class to place on target elements when htmx is in the swapping phase
 * `allowEval:true` - boolean: allows the use of eval-like functionality in htmx, to enable `hx-vars`, trigger conditions & script tag evaluation.  Can be set to `false` for CSP compatibility
-* `htmx.config.useTemplateFraments:false` - boolean: use HTML template tags for parsing content from the server.  This allows you to use Out of Band content when returning things like table rows, but it is *not* IE11 compatible.
+* `useTemplateFragments:false` - boolean: use HTML template tags for parsing content from the server.  This allows you to use Out of Band content when returning things like table rows, but it is *not* IE11 compatible.
 * `withCredentials:false` - boolean: allow cross-site Access-Control requests using credentials such as cookies, authorization headers or TLS client certificates
 * `wsReconnectDelay:full-jitter` - string/function: the default implementation of `getWebSocketReconnectDelay` for reconnecting after unexpected connection loss by the event code `Abnormal Closure`, `Service Restart` or `Try Again Later`
 


### PR DESCRIPTION
useTemplateFragments is referenced as a property of the `config` object https://github.com/bigskysoftware/htmx/blob/master/src/htmx.js#L162

however it's initialized outside of the `config` object: https://github.com/bigskysoftware/htmx/blob/master/src/htmx.js#L38

Also updated the docs.