### PR TITLE
Allow docs navigation to scroll on shorter screens

### DIFF
--- a/www/css/site.scss
+++ b/www/css/site.scss
@@ -196,7 +196,6 @@ h4 {
         display: none !important;
     }
     .hamburger {
-        // display: inline-block;
         float: right;
     }
     .nav {

--- a/www/css/site.scss
+++ b/www/css/site.scss
@@ -101,11 +101,11 @@ p {
 pre[class*="language-"] {
     font-size: 16px;
     margin-top: 24px !important;
-    margin-bottom: 24px !important;    
+    margin-bottom: 24px !important;
 }
 
 @media(min-width:45rem) {
-    pre[class*="language-"] {       
+    pre[class*="language-"] {
         margin-left: 48px !important;
         margin-right: 48px !important;
     }
@@ -143,6 +143,7 @@ a {
         list-style: none;
         padding-left: 12px;
     }
+    margin-bottom: 1em;
 }
 
 .hamburger {
@@ -195,7 +196,7 @@ h4 {
         display: none !important;
     }
     .hamburger {
-        display: inline-block;
+        // display: inline-block;
         float: right;
     }
     .nav {
@@ -329,25 +330,25 @@ h1,h2,h3,h4{
 .nav ul{
     padding-left: 0;
     li ul {
-        padding-left:12px;       
+        padding-left:12px;
     }
 }
 
 
 @media(min-width:45em) {
 
-    // Menu 
+    // Menu
     .menu,
     .navigation > div{
         display:flex;
         align-items:center;
-    }    
+    }
     .navigation{
        flex:1;
        display:flex;
        justify-content: space-between;
        padding-left: calc(1em + 1.5vw);
-    }    
+    }
     .navigation-items > *:not(:last-child){
         margin-right: calc(.5em + .7vw);
     }
@@ -357,9 +358,9 @@ h1,h2,h3,h4{
         a{
             margin:0 calc(.5em + .7vw);
         }
-        
+
     }
-    
+
     // Content
     .content .col:not(.nav) {
         padding-left: calc(1em + 1.5vw);
@@ -367,18 +368,23 @@ h1,h2,h3,h4{
     .content .nav > p,
     .content .nav #contents{
         position: sticky;
-       
+
     }
-   
+
     .content .nav #contents{
         top: 3.5em;
     }
+    .content .nav #contents > ul {
+        max-height: calc(100vh - 5rem);
+        overflow-y: scroll;
+    }
+
     .content .nav > p
     {
         position: sticky;
         top: 2vh;
     }
-    
+
 }
 
 @media(max-width:45rem) {


### PR DESCRIPTION
The menu for the docs is rather long, and on Firefox the last few items are cut off. I added an overflow to the list and a max-height to it to scroll on smaller desktop viewports. Also added a margin to the bottom to allow set some space between it and the rest of the content on mobile screens. 

![Screenshot 2021-06-05 at 15 25 47](https://user-images.githubusercontent.com/3392638/120894863-7899fa00-c612-11eb-919a-c9b580093c2d.png)

