### PR TITLE
Rename 'FastAPI' section in server examples docs

### DIFF
--- a/www/server-examples.md
+++ b/www/server-examples.md
@@ -38,6 +38,10 @@ These examples may make it a bit easier to get started using htmx with your plat
 
 - <https://github.com/adamchainz/django-htmx>
 
+### FastAPI
+
+- <https://github.com/renceInbox/fastapi-todo>
+
 ### Flask
 
 - <https://github.com/cscortes/htmxflask>
@@ -45,10 +49,6 @@ These examples may make it a bit easier to get started using htmx with your plat
 ### py4web
 
 - <https://github.com/jpsteil/py4web_htmx_demo>
-
-### jinja
-
-- <https://github.com/renceInbox/fastapi-todo>
 
 ## Java
 


### PR DESCRIPTION
The linked example is really a demonstration of use with the FastAPI framework rather than jinja. "jinja" is a templating language, which can also be used in Django, Flask, etc.