### PR TITLE
Introduce hx-allow-error-codes

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2435,8 +2435,9 @@ return (function () {
             }
 
             var shouldSaveHistory = shouldPush(elt) || pushedUrl;
+            var shouldAllowErrorCodes = getAllowErrorCodes(elt);
 
-            if (xhr.status >= 200 && xhr.status < 400) {
+            if (xhr.status >= 200 && xhr.status < 400 || shouldAllowErrorCodes) {
                 if (xhr.status === 286) {
                     cancelPolling(elt);
                 }
@@ -2553,6 +2554,10 @@ return (function () {
             } else {
                 triggerErrorEvent(elt, 'htmx:responseError', mergeObjects({error: "Response Status Error Code " + xhr.status + " from " + responseInfo.pathInfo.path}, responseInfo));
             }
+        }
+
+        function getAllowErrorCodes(elt) {
+            return getClosestAttributeValue(elt, "hx-allow-error-codes") === 'true';
         }
 
         //====================================================================

--- a/test/core/ajax.js
+++ b/test/core/ajax.js
@@ -841,5 +841,15 @@ describe("Core htmx AJAX Tests", function(){
         window.document.title.should.equal("</> htmx rocks!");
     });
 
-
+    it('allows error codes to be handled like a success', function()
+    {
+        this.server.respondWith("GET", "/test", function (xhr) {
+            xhr.respond(404, {}, "Could not be found");
+        });
+        make('<div hx-allow-error-codes="true"><button id="btn1" hx-get="/test">Click Me!</button></div>')
+        var btn = byId('btn1')
+        btn.click();
+        this.server.respond();
+        btn.innerText.should.equal("Could not be found");
+    });
 })

--- a/www/attributes/hx-allow-error-codes.md
+++ b/www/attributes/hx-allow-error-codes.md
@@ -1,0 +1,22 @@
+---
+layout: layout.njk
+title: </> htmx - hx-allow-error-codes
+---
+
+## `hx-allow-error-codes`
+
+The `hx-allow-error-codes` attribute allows error codes to be accepted from AJAX requests. This means that meaningful status codes can be used from ajax requests for errors and still use the same rendering behaviour as requests with success codes.
+
+Here is an example:
+
+```html
+<div hx-allow-error-codes="true">
+  <button hx-get="/login">
+    Login
+  </button>
+</div>
+```
+
+### Notes
+
+* `hx-allow-error-codes` is inherited and can be placed on a parent element

--- a/www/reference.md
+++ b/www/reference.md
@@ -20,6 +20,7 @@ title: </> htmx - Attributes
 
 | Attribute | Description |
 |-----------|-------------|
+| [`hx-allow-error-codes`](/attributes/hx-allow-error-codes) | allow error codes to be accepted from AJAX requests
 | [`hx-boost`](/attributes/hx-boost) | progressively enhances anchors and forms to use AJAX requests
 | [`hx-confirm`](/attributes/hx-confirm) | shows a confim() dialog before issuing a request
 | [`hx-delete`](/attributes/hx-delete) | issues a `DELETE` to the specified URL


### PR DESCRIPTION
Hopefully this change makes sense 😅 I'd like to be able to show messages when requests fail and it seems incorrect to use a success error code. I'd argue this behaviour is more aligned with typical web semantics as when you return a 404 page, it's normally accompanied with the html you'd like to show the user. It's not obvious to me why this behaviour should change when only rendering a portion of the page. I'm also not particularly eager to use the `htmx:responseError` error and write javascript error handling logic, seems to break the preference for locality that motivates this library.