### PR TITLE
search example typo

### DIFF
--- a/www/attributes/hx-trigger.md
+++ b/www/attributes/hx-trigger.md
@@ -82,7 +82,7 @@ and the user hasn't typed anything new for 1 second:
        hx-target="#search-results"/>
 ```
 
-The response from the `/register` url will be appended to the `div` with the id `response-div`.
+The response from the `/search` url will be appended to the `div` with the id `search-results`.
 
 There are two special events that are non-standard that htmx supports:
 


### PR DESCRIPTION
Typo in the description of the search example. The target id and the url didn't match betewwn text and example.