### PR TITLE
Make explicit that AlpineJS should register events in Kebab case

### DIFF
--- a/www/docs.md
+++ b/www/docs.md
@@ -716,7 +716,9 @@ Note that all events are fired with two different names
 * Kebab Case
 
 So, for example, you can listen for `htmx:afterSwap` or for `htmx:after-swap`.  This facilitates interoperability
-with libraries like [Alpine.js](https://github.com/alpinejs/alpine/).
+with other libraries.
+ 
+⚠️ for [Alpine.js](https://github.com/alpinejs/alpine/) you **should** use Kebab case.
 
 ### Logging
 


### PR DESCRIPTION
AlpineJS needs Kebab case registrations of HTMX events to work properly.