### PR TITLE
Fix typo in hx-swap.md

### DIFF
--- a/www/attributes/hx-swap.md
+++ b/www/attributes/hx-swap.md
@@ -79,7 +79,7 @@ of which take the values `top` and `bottom`:
 ```
 
 If you wish to target a different element for scrolling or showing, you may place a CSS selector after the `scroll:`
-or `swap:`, followed by `:top` or ':bottom':
+or `show:`, followed by `:top` or `:bottom`:
 
 ```html
   <!-- this will get some content and swap it into the current div, then ensure that the top of #another-div is visible in the 


### PR DESCRIPTION
Instead of `swap:` I think you meant `show:`. Also changed the single quotes surrounding `:bottom` into backticks so it renders properly as inline code.