### PR TITLE
Add `timeout` to configuration section in documentation

### DIFF
--- a/www/README.md
+++ b/www/README.md
@@ -6,3 +6,5 @@ The htmx.org website is built on [eleventy](https://www.11ty.dev/).  To run the 
 * `npx eleventy --serve`
 
 The site should then be available at <http://localhost:8080>
+
+**macOS 64-bit users may need to run `npm rebuild node-sass` to get the documentation site working.**

--- a/www/docs.md
+++ b/www/docs.md
@@ -966,6 +966,7 @@ listed below:
 |  `htmx.config.useTemplateFragments` | defaults to `false`, HTML template tags for parsing content from the server (not IE11 compatible!)
 |  `htmx.config.wsReconnectDelay` | defaults to `full-jitter`
 |  `htmx.config.disableSelector` | defaults to `[disable-htmx], [data-disable-htmx]`, htmx will not process elements with this attribute on it or a parent
+|  `htmx.config.timeout` | defaults to 0 in milliseconds
 
 </div>
 


### PR DESCRIPTION
Add `timeout` to the configuration section which was mentioned in the `1.5.0` release