### PR TITLE
Fix root: option of the intersect event

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1361,7 +1361,7 @@ return (function () {
                         } else if (triggerSpec.trigger === "intersect") {
                             var observerOptions = {};
                             if (triggerSpec.root) {
-                                observerOptions.root = querySelectorExt(triggerSpec.root)
+                                observerOptions.root = querySelectorExt(elt, triggerSpec.root)
                             }
                             if (triggerSpec.threshold) {
                                 observerOptions.threshold = parseFloat(triggerSpec.threshold);

--- a/test/manual/intersect-test-eventHandler.html
+++ b/test/manual/intersect-test-eventHandler.html
@@ -19,6 +19,12 @@
 			margin-bottom:20px;
 			padding:20px;
 		}
+		.container {
+			height:200px;
+			padding:20px;
+			border:1px solid black;
+			overflow:auto;
+		}
 	</style>
 
 </head>
@@ -35,6 +41,18 @@
 <div class="panel" hx-get="/more_content" hx-trigger="intersect"></div>
 <div class="panel" hx-get="/more_content" hx-trigger="intersect"></div>
 <div class="panel" hx-get="/more_content" hx-trigger="intersect"></div>
+
+<h1>Root</h1>
+
+<div class="container" id="wrapper">
+<div class="panel" hx-get="/more_content" hx-trigger="intersect root:#wrapper"></div>
+<div class="panel" hx-get="/more_content" hx-trigger="intersect root:#wrapper"></div>
+<div class="panel" hx-get="/more_content" hx-trigger="intersect root:#wrapper"></div>
+<div class="panel" hx-get="/more_content" hx-trigger="intersect root:#wrapper"></div>
+<div class="panel" hx-get="/more_content" hx-trigger="intersect root:#wrapper"></div>
+<div class="panel" hx-get="/more_content" hx-trigger="intersect root:#wrapper"></div>
+<div class="panel" hx-get="/more_content" hx-trigger="intersect root:#wrapper"></div>
+</div>
 
 <h1>Threshold .5</h1>
 


### PR DESCRIPTION
This PR fixes the root: option of the intersect special event which is currently broken and adds a manual test to demonstrate the issue.