### PR TITLE
445 - Add hx-target="this" example

### DIFF
--- a/www/attributes/hx-target.md
+++ b/www/attributes/hx-target.md
@@ -28,6 +28,11 @@ Here is an example that targets a div:
 
 The response from the `/register` url will be appended to the `div` with the id `response-div`.
 
+This example uses `hx-target="this"` to make a link that updates itself when clicked:
+```html
+<a hx-post="/new-link" hx-target="this" hx-swap="outerHTML">New link</a>
+```
+
 ### Notes
 
 * `hx-target` is inherited and can be placed on a parent element


### PR DESCRIPTION
Added quick example for a link that can update itself using hx-target="this".

Issue #445 