### PR TITLE
Prevent errors from being thrown on 204 status messages

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2600,7 +2600,7 @@ return (function () {
                 } else {
                     doSwap();
                 }
-            } else {
+            } else if (xhr.status != 204) {
                 triggerErrorEvent(elt, 'htmx:responseError', mergeObjects({error: "Response Status Error Code " + xhr.status + " from " + responseInfo.pathInfo.path}, responseInfo));
             }
         }


### PR DESCRIPTION
When the server returns a status code 204 (No Content), the library currently adds an error into the browser's error log.  This little hack prevents this from happening.