### PR TITLE
docs: document the use of htmx in a CORS context

### DIFF
--- a/www/docs.md
+++ b/www/docs.md
@@ -628,6 +628,17 @@ event, which you can handle.
 
 In the event of a connection error, the `htmx:sendError` event will be triggered.
 
+### <a name="cors"></a> [CORS](#cors)
+
+When using htmx in a cross origin context, remember to configure your web
+server to set Access-Control headers in order for htmx headers to be visible
+on the client side.
+
+- [Access-Control-Allow-Headers (for request headers)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers)
+- [Access-Control-Expose-Headers (for response headers)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers)
+
+[See all the request and response headers that htmx implements.](/reference/#request_headers)
+
 ### <a name="request-header"></a> [Request Headers](#request-headers)
 
 htmx includes a number of useful headers in requests:


### PR DESCRIPTION
This just adds a small reminder to set Access-Control headers. I had some pain with this today, because when this doesn't work, there is absolutely no indication in the browser developer tools. The headers just appear in the network tab of the browser, but do not exist in javascript. Very confusing if it strikes you for the first time!

I'm sure there is more that could go into this section about caveats associated with CORS. I can add more if anyone wants to recommend things to add.