### PR TITLE
hx-ws-send-on-open & htmx:wsOnOpen

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1177,6 +1177,11 @@ return (function () {
             };
             socket.onopen = function (e) {
                 retryCount = 0;
+                var init = getAttributeValue(elt, "hx-ws-send-on-open")
+                if (init !== null) {
+                    socket.send(init)
+                }
+                triggerEvent(elt, "htmx:wsOnOpen", e)
             }
 
             getInternalData(elt).webSocket = socket;


### PR DESCRIPTION
This adds `hx-ws-send-on-open`, my personal use case is making a `send` to the websocket which subscribes to an event once the websocket is open.
I've also included `htmx:wsOnOpen` which may cater to different preferences and use cases outside of my own.

Happy to add accompanying documentation - just wanted to see whether I've missed an existing way to do this stuff & whether it's something that belongs in the lib.

Thanks for the great work on this project.