### PR TITLE
swap into all elements matching the out-of-band css selector

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -512,15 +512,22 @@ return (function () {
                 swapStyle = oobValue;
             }
 
-            var target = getDocument().querySelector(selector);
-            if (target) {
-                var fragment;
-                fragment = getDocument().createDocumentFragment();
-                fragment.appendChild(oobElement); // pulls the child out of the existing fragment
-                if (!isInlineSwap(swapStyle, target)) {
-                    fragment = oobElement; // if this is not an inline swap, we use the content of the node, not the node itself
-                }
-                swap(swapStyle, target, target, fragment, settleInfo);
+            var targets = getDocument().querySelectorAll(selector);
+            if (targets) {
+                forEach(
+                    targets,
+                    function (target) {
+                        var fragment;
+                        var oobElementClone = oobElement.cloneNode(true);
+                        fragment = getDocument().createDocumentFragment();
+                        fragment.appendChild(oobElementClone);
+                        if (!isInlineSwap(swapStyle, target)) {
+                            fragment = oobElementClone; // if this is not an inline swap, we use the content of the node, not the node itself
+                        }
+                        swap(swapStyle, target, target, fragment, settleInfo);
+                    }
+                );
+                oobElement.parentNode.removeChild(oobElement);
             } else {
                 oobElement.parentNode.removeChild(oobElement);
                 triggerErrorEvent(getDocument().body, "htmx:oobErrorNoTarget", {content: oobElement})

--- a/test/attributes/hx-swap-oob.js
+++ b/test/attributes/hx-swap-oob.js
@@ -92,5 +92,31 @@ describe("hx-swap-oob attribute", function () {
         byId("d1").innerHTML.should.equal("Swapped");
     })
 
+    it('swaps into all targets that match the selector (innerHTML)', function () {
+        this.server.respondWith("GET", "/test", "<div>Clicked</div><div class='target' hx-swap-oob='innerHTML:.target'>Swapped</div>");
+        var div = make('<div hx-get="/test">click me</div>');
+        make('<div id="d1">No swap</div>');
+        make('<div id="d2" class="target">Not swapped</div>');
+        make('<div id="d3" class="target">Not swapped</div>');
+        div.click();
+        this.server.respond();
+        byId("d1").innerHTML.should.equal("No swap");
+        byId("d2").innerHTML.should.equal("Swapped");
+        byId("d3").innerHTML.should.equal("Swapped");
+    })
+
+    it('swaps into all targets that match the selector (outerHTML)', function () {
+        var oobSwapContent = '<div class="new-target" hx-swap-oob="outerHTML:.target">Swapped</div>';
+        this.server.respondWith("GET", "/test", "<div>Clicked</div>" + oobSwapContent);
+        var div = make('<div hx-get="/test">click me</div>');
+        make('<div id="d1"><div>No swap</div></div>');
+        make('<div id="d2"><div class="target">Not swapped</div></div>');
+        make('<div id="d3"><div class="target">Not swapped</div></div>');
+        div.click();
+        this.server.respond();
+        byId("d1").innerHTML.should.equal("<div>No swap</div>");
+        byId("d2").innerHTML.should.equal(oobSwapContent);
+        byId("d3").innerHTML.should.equal(oobSwapContent);
+    })
 });
 

--- a/www/attributes/hx-swap-oob.md
+++ b/www/attributes/hx-swap-oob.md
@@ -32,7 +32,7 @@ If the value is `true` or `outerHTML` (which are equivalent) the element will be
 
 If a swap value is given, that swap strategy will be used.
 
-If a selector is given, the first element matching that selector will be swapped.  If not, the element with an ID matching the new content will be swapped.
+If a selector is given, all elements matched by that that selector will be swapped.  If not, the element with an ID matching the new content will be swapped.
 
 ### Notes
 


### PR DESCRIPTION
resolves #634
Motivation for these change is described in more detail in the referenced issue.

### Summary

The [`hx-swap-oob`](https://htmx.org/attributes/hx-swap-oob/) attribute can use a css selector to find its target in the document.
In the current implementation, it only swaps into *the first* element found matching that selector.
It would be useful to be able to target *every* matching element, for example when the request leads to an update of some value displayed in multiple places in the page (such as nickname, tags, ...).

### Solution

Use `querySelectorAll` instead of plain `querySelector`.
Loop over the results and swap a copy of the supplied fragment into each of them.

### Notes on this MR

I'm not very familiar with js and the structure/conventions of this repo so I'm not sure if I made the right changes in all the right files etc., I'd be happy to fix it up if something is not in order.
Also, if there are any more scenarios that I should write tests for, I'd be happy to contribute.