### PR TITLE
Allow inline scripts to have a nonce added

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -51,6 +51,7 @@ return (function () {
                 settlingClass:'htmx-settling',
                 swappingClass:'htmx-swapping',
                 allowEval:true,
+                inlineScriptNonce:'',
                 attributesToSettle:["class", "style", "width", "height"],
                 withCredentials:false,
                 timeout:0,
@@ -1415,6 +1416,9 @@ return (function () {
                 });
                 newScript.textContent = script.textContent;
                 newScript.async = false;
+                if (htmx.config.inlineScriptNonce) {
+                    newScript.nonce = htmx.config.inlineScriptNonce;
+                }
                 var parent = script.parentElement;
 
                 try {

--- a/www/docs.md
+++ b/www/docs.md
@@ -1036,7 +1036,7 @@ content into your site without any sort of HTML escaping discipline.
 
 You should, of course, escape all 3rd party untrusted content that is injected into your site to prevent, among other issues, [XSS attacks](https://en.wikipedia.org/wiki/Cross-site_scripting). Attributes starting with `hx-` and `data-hx`, as well as inline `<script>` tags should be filtered.
 
-It is important to understand that htmx does *not* require inline scripts or `eval()` for most of its features. You (or your security team) may use a [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) that intentionally disallows inline scripts and the use of `eval()`. This, however, will have *no effect* on htmx functionality, which will still be able to execute JavaScript code placed in htmx attributes and may be a security concern.
+It is important to understand that htmx does *not* require inline scripts or `eval()` for most of its features. You (or your security team) may use a [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) that intentionally disallows inline scripts and the use of `eval()`. This, however, will have *no effect* on htmx functionality, which will still be able to execute JavaScript code placed in htmx attributes and may be a security concern. With that said, if your site relies on inline scripts that you do wish to allow and have a CSP in place, you may need to define [htmx.config.inlineScriptNonce](#config)--however, HTMX will add this nonce to *all* inline script tags it encounters, meaning a nonce-based CSP will no longer be effective for HTMX-loaded content.
 
 To address this, if you don't want a particular part of the DOM to allow for htmx functionality, you can place the
 `hx-disable` or `data-hx-disable` attribute on the enclosing element of that area.  
@@ -1074,6 +1074,7 @@ listed below:
 |  `htmx.config.settlingClass` | defaults to `htmx-settling`
 |  `htmx.config.swappingClass` | defaults to `htmx-swapping`
 |  `htmx.config.allowEval` | defaults to `true`
+|  `htmx.config.inlineScriptNonce` | default to '', no nonce will be added to inline scripts
 |  `htmx.config.useTemplateFragments` | defaults to `false`, HTML template tags for parsing content from the server (not IE11 compatible!)
 |  `htmx.config.wsReconnectDelay` | defaults to `full-jitter`
 |  `htmx.config.disableSelector` | defaults to `[disable-htmx], [data-disable-htmx]`, htmx will not process elements with this attribute on it or a parent


### PR DESCRIPTION
The script insertion method introduced in 1.6.0 is very clean and avoids using `eval()`, which is great. However, it breaks when using CSPs that require a nonce for inline scripts. While `evalScript` does try to copy all the incoming script's attributes, this doesn't work for nonce because a) it appears to be [filtered from the attributes](https://github.com/whatwg/html/issues/2369) and b) wouldn't actually match the nonce for the original page anyway, since each request's nonce is different in most setups.

The CSP `script-src 'self' 'nonce-9190f323fb54b166d23a0ad59387dabf' 'unsafe-eval'` used to work with HTMX, but no longer does if you were relying on inline scripts. Changing it to add 'unsafe-inline' would work, but at that point there feels like almost no point to having the CSP.

This PR adds an `inlineScriptNonce` configuration setting to allow nonce-based CSPs to still work with the new script insertion method. It's not flawless from a security standpoint--it essentially just allows all inline scripts in HTMX requests to work, but at least then you can still have a stronger CSP for non-HTMX pages/requests. This also still isn't ideal since now an attacker could grab the nonce from the HTML.

Usage-wise, it's working for me using this in my base HTML:
```
  <meta name="htmx-config" content='{"inlineScriptNonce":"{% csp_nonce %}"}'>
```
Which renders to include the original page's nonce:
```
  <meta name="htmx-config" content='{"inlineScriptNonce":"9190f323fb54b166d23a0ad59387dabf"}'>
```

Again, not flawless but at least you put a slight barrier up! Truly security conscious people should probably just put the dang script in a file and not inline.