### PR TITLE
This solves the mystery of the missing types file re npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "files": [
     "LICENSE",
     "README.md",
+    "src/htmx.d.ts",
     "dist/*.js",
     "dist/ext/*.js",
     "dist/*.js.gz"


### PR DESCRIPTION
> This still seems an open issue, right? NPM shows the TS badge, `package.json` mentions it, but the downloaded package doesn't contain the typings file.

_Originally posted by @qqilihq in https://github.com/bigskysoftware/htmx/issues/545#issuecomment-962667918_



This PR is a direct response to @qqilihq's comment for PR #545