### PR TITLE
Fixed :closest and :find extended css selectors on hx-trigger

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -907,7 +907,17 @@ return (function () {
                                     triggerSpec.delay = parseInterval(consumeUntil(tokens, WHITESPACE_OR_COMMA));
                                 } else if (token === "from" && tokens[0] === ":") {
                                     tokens.shift();
-                                    triggerSpec.from = consumeUntil(tokens, WHITESPACE_OR_COMMA);
+                                    let from_arg = consumeUntil(tokens, WHITESPACE_OR_COMMA);
+                                    if (from_arg === "closest" || from_arg === "find") {
+                                        tokens.shift();
+                                        from_arg +=
+                                            " " +
+                                            consumeUntil(
+                                                tokens,
+                                                WHITESPACE_OR_COMMA
+                                            );
+                                    }
+                                    triggerSpec.from = from_arg;
                                 } else if (token === "target" && tokens[0] === ":") {
                                     tokens.shift();
                                     triggerSpec.target = consumeUntil(tokens, WHITESPACE_OR_COMMA);


### PR DESCRIPTION
In the [the docs](https://htmx.org/attributes/hx-trigger/) about hx-trigger, it is mentioned that you can use extended CSS selectors such as `from:closest <CSS selector>` and `from:find <CSS selector>`. This however leads to a syntax error and does not seem to be implemented in the `getTriggerSpecs` method for 'from'.
I have added this parsing to this section and in our demo it works as described.
