### PR TITLE
Alpine morph extension

### DIFF
--- a/src/ext/alpine-morph.js
+++ b/src/ext/alpine-morph.js
@@ -1,0 +1,16 @@
+htmx.defineExtension('alpine-morph', {
+    isInlineSwap: function (swapStyle) {
+        return swapStyle === 'morph';
+    },
+    handleSwap: function (swapStyle, target, fragment) {
+        if (swapStyle === 'morph') {
+            if (fragment.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
+                Alpine.morph(target, fragment.firstElementChild);
+                return [target];
+            } else {
+                Alpine.morph(target, fragment.outerHTML);
+                return [target];
+            }
+        }
+    }
+});

--- a/www/docs.md
+++ b/www/docs.md
@@ -750,6 +750,7 @@ Htmx includes some extensions that are tested against the htmx code base.  Here 
 |-----------|-------------
 | [`json-enc`](/extensions/json-enc) | use JSON encoding in the body of requests, rather than the default `x-www-form-urlencoded`
 | [`morphdom-swap`](/extensions/morphdom-swap) | an extension for using the [morphdom](https://github.com/patrick-steele-idem/morphdom) library as the swapping mechanism in htmx.
+| [`alpine-morph`](/extensions/alpine-morph) | an extension for using the [Alpine.js morph](https://alpinejs.dev/plugins/morph) plugin as the swapping mechanism in htmx.
 | [`client-side-templates`](/extensions/client-side-templates) | support for client side template processing of JSON responses
 | [`path-deps`](/extensions/path-deps) | an extension for expressing path-based dependencies [similar to intercoolerjs](http://intercoolerjs.org/docs.html#dependencies)
 | [`class-tools`](/extensions/class-tools) | an extension for manipulating timed addition and removal of classes on HTML elements

--- a/www/extensions.md
+++ b/www/extensions.md
@@ -59,6 +59,7 @@ against `htmx` in each distribution
 | [`json-enc`](/extensions/json-enc) | use JSON encoding in the body of requests, rather than the default `x-www-form-urlencoded`
 | [`method-override`](/extensions/method-override) | use the `X-HTTP-Method-Override` header for non-`GET` and `POST` requests
 | [`morphdom-swap`](/extensions/morphdom-swap) | an extension for using the [morphdom](https://github.com/patrick-steele-idem/morphdom) library as the swapping mechanism in htmx.
+| [`alpine-morph`](/extensions/alpine-morph) | an extension for using the [Alpine.js morph](https://alpinejs.dev/plugins/morph) plugin as the swapping mechanism in htmx.
 | [`client-side-templates`](/extensions/client-side-templates) | support for client side template processing of JSON responses
 | [`debug`](/extensions/debug) | an extension for debugging of a particular element using htmx
 | [`path-deps`](/extensions/path-deps) | an extension for expressing path-based dependencies [similar to intercoolerjs](http://intercoolerjs.org/docs.html#dependencies)

--- a/www/extensions/alpine-morph.md
+++ b/www/extensions/alpine-morph.md
@@ -5,7 +5,7 @@ title: </> htmx - high power tools for html
 
 ## The `alpine-morph` Extension
 
-Alpine.js now has a lightweight [morph plugin](https://alpinejs.dev/plugins/morph) and this extension allows you to use it as swapping mechanism in htmx which is necessary to retain Alpine state when you have entire Alpine components swapped by htmx.
+Alpine.js now has a lightweight [morph plugin](https://alpinejs.dev/plugins/morph) and this extension allows you to use it as the swapping mechanism in htmx which is necessary to retain Alpine state when you have entire Alpine components swapped by htmx.
 
 #### Usage
 

--- a/www/extensions/alpine-morph.md
+++ b/www/extensions/alpine-morph.md
@@ -1,0 +1,37 @@
+---
+layout: layout.njk
+title: </> htmx - high power tools for html
+---
+
+## The `alpine-morph` Extension
+
+Alpine.js now has a lightweight [morph plugin](https://alpinejs.dev/plugins/morph) and this extension allows you to use it as swapping mechanism in htmx which is necessary to retain Alpine state when you have entire Alpine components swapped by htmx.
+
+#### Usage
+
+```html
+<header>
+  <script src="https://unpkg.com/htmx.org@latest"></script>
+  <!-- Alpine Plugins -->
+  <script defer src="https://unpkg.com/@alpinejs/morph@3.x.x/dist/cdn.min.js"></script>
+  <!-- Alpine Core -->
+  <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+</header>
+
+<body>
+  <div hx-target="this" hx-ext="alpine-morph" hx-swap="morph">
+      <div x-data="{ count: 0, replaced: false, message: 'Change me, then press the button!' }">
+          <input type="text" x-model="message">
+          <div x-text="count"></div>
+          <button x-bind:style="replaced && {'backgroundColor': '#fecaca'}" x-on:click="replaced = true; count++" hx-get="/swap">Morph</button>
+      </div>
+  </div>
+</body>
+```
+
+In the above example, all the Alpine x-data states (count, replaced, and message) are preserved even the entire Alpine component is swapped.
+
+#### Source
+
+<https://unpkg.com/htmx.org/dist/ext/alpine-morph.js>
+


### PR DESCRIPTION
This PR adds a new `alpine-morph` extension to htmx, similar to the existing `morphdom-swap`, but specifically for projects using Alpine.js to take advantage of Alpine's new lightweight [morph plugin](https://alpinejs.dev/plugins/morph).