### PR TITLE
Fix main websockets example attribute in docs

### DIFF
--- a/www/extensions/web-sockets.md
+++ b/www/extensions/web-sockets.md
@@ -21,7 +21,7 @@ of the event specified by [`hx-trigger`])
     <div id="chat_room">
       ...
     </div>
-    <form ws-send="send">
+    <form ws-send>
         <input name="chat_message">
     </form>
   </div>

--- a/www/extensions/web-sockets.md
+++ b/www/extensions/web-sockets.md
@@ -21,7 +21,7 @@ of the event specified by [`hx-trigger`])
     <div id="chat_room">
       ...
     </div>
-    <form hx-ws="send">
+    <form ws-send="send">
         <input name="chat_message">
     </form>
   </div>


### PR DESCRIPTION
Tiny change, it was still using hx rather than ws
@benpate does this look good to you?
