### PR TITLE
Change active search example to be case insensitive

### DIFF
--- a/www/examples/active-search.md
+++ b/www/examples/active-search.md
@@ -209,9 +209,9 @@ Search Contacts
           return {
             findContactsMatching : function(str) {
               var result = [];
+              var s = str.toLowerCase();
               for (var i = 0; i < data.length; i++) {
                 var c = data[i];
-                var s = str.toLowerCase()
                 if(c['FirstName'].toLowerCase().indexOf(s) >= 0 || c['LastName'].toLowerCase().indexOf(s) >= 0 || c['Email'].toLowerCase().indexOf(s) >= 0) {
                   result.push(c)
                 }

--- a/www/examples/active-search.md
+++ b/www/examples/active-search.md
@@ -211,7 +211,8 @@ Search Contacts
               var result = [];
               for (var i = 0; i < data.length; i++) {
                 var c = data[i];
-                if(c['FirstName'].indexOf(str) >= 0 || c['LastName'].indexOf(str) >= 0 || c['Email'].indexOf(str) >= 0) {
+                var s = str.toLowerCase()
+                if(c['FirstName'].toLowerCase().indexOf(s) >= 0 || c['LastName'].toLowerCase().indexOf(s) >= 0 || c['Email'].toLowerCase().indexOf(s) >= 0) {
                   result.push(c)
                 }
               }


### PR DESCRIPTION
Closes #715 

Hi,

This is my first pull request on this repository. I hope I am abiding by the repository's collaboration guidelines, please let me know if I should've proceded differently.

Following up on issue #715, I took the liberty to make the changes to the [active search example on the website](https://htmx.org/examples/active-search/), so as to have a case-insensitive search when searching for contacts. The idea is to convert both the search term and all the contact information (_First name_, _Last name_ and _Email_) to lowercase, before checking if the search term is part of any of the contact fields.

Here a screenshot of the changes when running the `eleventy` server locally:
![image](https://user-images.githubusercontent.com/55711215/147503392-9f0d120d-ef6c-4c22-ba4a-f9d58d54126c.png)
As you can see, searching for `venus` also yields the contact with `Venus` as their first name (example mentioned on the issue #715)

I've also run the tests with the python http server, but since I haven't seen any tests for the website examples, I have not changed anything on that side.

Please let me know if you would change anything.

Thanks and looking forward to continue contributing to this awesome library! 