### PR TITLE
Add handleHistorySwap extension function

### DIFF
--- a/www/extensions.md
+++ b/www/extensions.md
@@ -97,6 +97,7 @@ Extensions can override the following default extension points to add or change 
     transformResponse : function(text, xhr, elt) {return text;},
     isInlineSwap : function(swapStyle) {return false;},
     handleSwap : function(swapStyle, target, fragment, settleInfo) {return false;},
+    handleHistorySwap: function(target, fragment, settleInfo) {return false;},
     encodeParameters : function(xhr, parameters, elt) {return null;}
 }
 ```


### PR DESCRIPTION
Closes #749.

This adds `handleHistorySwap` as a method for extensions to allow them to control the HTML swapping of browser history behavior. I considered just adding a new `swapType` of `history` and keep using `handleSwap`, but my concern was that older extensions wouldn't necessarily know to check for that and might start behaving incorrectly.

I didn't add any tests since history didn't have any, but I saw there were manual tests for it. If this is an acceptable change, I could add some manual test pages for it too.