### PR TITLE
Adding swap argument for ajax calls

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1967,9 +1967,9 @@ return (function () {
                 "swapStyle" : getInternalData(elt).boosted ? 'innerHTML' : htmx.config.defaultSwapStyle,
                 "swapDelay" : htmx.config.defaultSwapDelay,
                 "settleDelay" : htmx.config.defaultSettleDelay
-            };
+            }
             if (getInternalData(elt).boosted && !isAnchorLink(elt)) {
-                swapSpec["show"] = "top";
+              swapSpec["show"] = "top"
             }
             if (swapInfo) {
                 var split = splitOnWhitespace(swapInfo);
@@ -2318,7 +2318,7 @@ return (function () {
                     var queuedRequest = eltData.queuedRequests.shift();
                     queuedRequest();
                 }
-            };
+            }
             var promptQuestion = getClosestAttributeValue(elt, "hx-prompt");
             if (promptQuestion) {
                 var promptResponse = prompt(promptQuestion);
@@ -2335,7 +2335,7 @@ return (function () {
             if (confirmQuestion) {
                 if(!confirm(confirmQuestion)) {
                     maybeCall(resolve);
-                    endRequestLock();
+                    endRequestLock()
                     return promise;
                 }
             }
@@ -2393,7 +2393,7 @@ return (function () {
             errors = requestConfig.errors;
 
             if(errors && errors.length > 0){
-                triggerEvent(elt, 'htmx:validation:halted', requestConfig);
+                triggerEvent(elt, 'htmx:validation:halted', requestConfig)
                 maybeCall(resolve);
                 endRequestLock();
                 return promise;
@@ -2470,33 +2470,33 @@ return (function () {
                     triggerErrorEvent(elt, 'htmx:onLoadError', mergeObjects({error:e}, responseInfo));
                     throw e;
                 }
-            };
+            }
             xhr.onerror = function () {
                 removeRequestIndicatorClasses(indicators);
                 triggerErrorEvent(elt, 'htmx:afterRequest', responseInfo);
                 triggerErrorEvent(elt, 'htmx:sendError', responseInfo);
                 maybeCall(reject);
                 endRequestLock();
-            };
+            }
             xhr.onabort = function() {
                 removeRequestIndicatorClasses(indicators);
                 triggerErrorEvent(elt, 'htmx:afterRequest', responseInfo);
                 triggerErrorEvent(elt, 'htmx:sendAbort', responseInfo);
                 maybeCall(reject);
                 endRequestLock();
-            };
+            }
             xhr.ontimeout = function() {
                 removeRequestIndicatorClasses(indicators);
                 triggerErrorEvent(elt, 'htmx:afterRequest', responseInfo);
                 triggerErrorEvent(elt, 'htmx:timeout', responseInfo);
                 maybeCall(reject);
                 endRequestLock();
-            };
+            }
             if(!triggerEvent(elt, 'htmx:beforeRequest', responseInfo)){
                 maybeCall(resolve);
-                endRequestLock();
+                endRequestLock()
                 return promise
-            };
+            }
             var indicators = addRequestIndicatorClasses(elt);
 
             forEach(['loadstart', 'loadend', 'progress', 'abort'], function(eventName) {
@@ -2507,13 +2507,13 @@ return (function () {
                             loaded:event.loaded,
                             total:event.total
                         });
-                    });
+                    })
                 });
             });
             triggerEvent(elt, 'htmx:beforeSend', responseInfo);
             xhr.send(verb === 'get' ? null : encodeParamsForBody(xhr, elt, filteredParameters));
             return promise;
-        };
+        }
 
         function handleAjaxResponse(elt, responseInfo) {
             var xhr = responseInfo.xhr;

--- a/test/core/api.js
+++ b/test/core/api.js
@@ -279,6 +279,15 @@ describe("Core htmx API test", function(){
         div.innerHTML.should.equal("foo!");
     });
 
+    it('ajax api works with swapSpec', function()
+    {
+        this.server.respondWith("GET", "/test", "<p class='test'>foo!</p>");
+        var div = make("<div><div id='target'></div></div>");
+        htmx.ajax("GET", "/test", {target: "#target", swap:"outerHTML"});
+        this.server.respond();
+        div.innerHTML.should.equal('<p class="test">foo!</p>');
+    });
+
     it('ajax returns a promise', function(done)
     {
         // in IE we do not return a promise

--- a/www/api.md
+++ b/www/api.md
@@ -51,22 +51,26 @@ or
     * `event` - an event that "triggered" the request
     * `handler` - a callback that will handle the response HTML
     * `target` - the target to swap the response into
+    * `swap` - how the response will be swapped in relative to the target
     * `values` - values to submit with the request
     * `headers` - headers to submit with the request
-
 
 ##### Example
 
 ```js
     // issue a GET to /example and put the response HTML into #myDiv
     htmx.ajax('GET', '/example', '#myDiv')
-    
+
+    // issue a GET to /example and replace #myDiv with the repsonse
+    htmx.ajax('GET', '/example', {target:'#myDiv', swap:'outerHTML'})
+
     // execute some code after the content has been inserted into the DOM
     htmx.ajax('GET', '/example', '#myDiv').then(() => {
       // this code will be executed after the 'htmx:afterOnLoad' event,
       // and before the 'htmx:xhr:loadend' event
       console.log('Content inserted successfully!');
-    }); 
+    });
+
 ```
 
 ### <a name="closest"></a> Method -  [`htmx.closest()`](#closest)
@@ -329,7 +333,7 @@ Caution: Accepts an int followed by either `s` or `ms`. All other values use `pa
 ```js
     // returns 3000
     var milliseconds = htmx.parseInterval("3s");
-    
+
     // returns 3 - Caution
     var milliseconds = htmx.parseInterval("3m");
 ```


### PR DESCRIPTION
Gives ajax calls the ability to pass a swap string to control swapping behavior