### PR TITLE
fix content-type header for urlencoded form data

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2311,7 +2311,7 @@ return (function () {
             var filteredParameters = filterValues(allParameters, elt);
 
             if (verb !== 'get' && getClosestAttributeValue(elt, "hx-encoding") == null) {
-                headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=UTF-8';
+                headers['Content-Type'] = 'application/x-www-form-urlencoded';
             }
 
             // behavior of anchors w/ empty href is to use the current URL


### PR DESCRIPTION
This PR changes the content-type header for urlencoded form data
(hx-post) as proposed in #74 and #717.

From #74:
> Turns out, the parameter `charset` isn't allowed for mime type `application/x-www-form-urlencoded`. (For example, see discussion at [here](https://stackoverflow.com/questions/16819502/application-x-www-form-urlencoded-and-charset-utf-8) and [here](https://stackoverflow.com/questions/19694503/ajax-setrequestheader-content-type-application-x-www-form-urlencoded-and-ch).)