### PR TITLE
Update docs for OOB swaps must be specified in the top level of the response

### DIFF
--- a/www/attributes/hx-swap-oob.md
+++ b/www/attributes/hx-swap-oob.md
@@ -37,3 +37,4 @@ If a selector is given, the elements matching that selector will be swapped.  If
 ### Notes
 
 * `hx-swap-oob` is not inherited
+* Out of band elements must be in the top level of the response, and not children of the top level elements.


### PR DESCRIPTION
The docs for OOB swaps notes that the attribute must be on a top level element, however this note is missing from the reference docs. 