### PR TITLE
Use gzip level 9 compression

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "test": "mocha-chrome test/index.html",
     "test-types": "tsc --project ./jsconfig.json",
-    "dist": "cp -r src/* dist/ && npm run-script uglify && gzip -k -f dist/htmx.min.js > dist/htmx.min.js.gz && exit",
+    "dist": "cp -r src/* dist/ && npm run-script uglify && gzip -9 -k -f dist/htmx.min.js > dist/htmx.min.js.gz && exit",
     "www": "node scripts/www.js",
     "uglify": "uglifyjs -m eval -o dist/htmx.min.js dist/htmx.js"
   },


### PR DESCRIPTION
Level 9 is more compressed, and faster to decompress.

Before:

```
$ wc -c dist/htmx.min.js.gz
11615 dist/htmx.min.js.gz
```

After:

```
$ wc -c dist/htmx.min.js.gz
11596 dist/htmx.min.js.gz
```

Cor blimey, that's 19 bytes saved!