### PR TITLE
Document required node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,20 +74,25 @@ keep the core htmx code tidy
 
 ### hacking guide
 
-to develop htmx locally, you will need to install the development dependencies:
+To develop htmx locally, you will need to install the development dependencies.
+Use node 15 and run:
 
-* `npm install`
+```
+npm install
+```
 
-and then run a web server in the root (easiest with python):
+Then, run a web server in the root.
+This is easiest with Python:
 
-* `python3 -m http.server
-`
+```
+python3 -m http.server
+```
 
-you can then run the test suite by navigating to:
+You can then run the test suite by navigating to:
 
 <http://0.0.0.0:8000/test/>
 
-at this point you can modify `/src/htmx.js` to add features, and then add tests in the appropriate area under `/test`
+At this point you can modify `/src/htmx.js` to add features, and then add tests in the appropriate area under `/test`.
 
 * `/test/index.html` - the root test page from which all other tests are included
 * `/test/attributres` - attribute specific tests

--- a/www/README.md
+++ b/www/README.md
@@ -1,9 +1,12 @@
 ## Running The Website Locally
 
-The htmx.org website is built on [eleventy](https://www.11ty.dev/).  To run the site, run
+The htmx.org website is built on [eleventy](https://www.11ty.dev/).
+To run the site, use node 15 and run:
 
-* `npm install`
-* `npx eleventy --serve`
+```
+npm install
+npx eleventy --serve
+```
 
 The site should then be available at <http://localhost:8080>
 


### PR DESCRIPTION
After trying to set up the project, I found that Node 16 is incompatible with the pinned version of node-sass, and node 15 must be used. This PR documents the requirement - perhaps an upgrade to Node 16 can be done after.