### PR TITLE
Allow execusion of scripts of type module

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1431,7 +1431,7 @@ return (function () {
         }
 
         function evalScript(script) {
-            if (script.type === "text/javascript" || script.type === "") {
+            if (script.type === "text/javascript" || script.type === "module" || script.type === "") {
                 var newScript = getDocument().createElement("script");
                 forEach(script.attributes, function (attr) {
                     newScript.setAttribute(attr.name, attr.value);


### PR DESCRIPTION
#787 

This PR allows the execution of scripts of type `module`, and therefore the sequencial execution of

```html
<script src='URL'></script>
<script type="module">
function_from_module();
</script>
```
when the `<script>`s are dynamically executed by htmx.