### PR TITLE
Fix focus scroll page jumps using new `htmx config.scrollOnFocus` setting.

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -60,6 +60,7 @@ return (function () {
                 disableSelector: "[hx-disable], [data-hx-disable]",
                 useTemplateFragments: false,
                 scrollBehavior: 'smooth',
+                scrollOnFocus: false,
             },
             parseInterval:parseInterval,
             _:internalEval,
@@ -2640,7 +2641,7 @@ return (function () {
                                     // @ts-ignore
                                     newActiveElt.setSelectionRange(selectionInfo.start, selectionInfo.end);
                                 }
-                                newActiveElt.focus();
+                                newActiveElt.focus({preventScroll: ! htmx.config.scrollOnFocus});
                             }
                         }
 


### PR DESCRIPTION
This fixes #781 . It adds a global `htmx.config.scrollOnFocus` which is disabled by default to avoid page jumps on longer responses if the user has already scroll away from an input before the response is swapped. I am not sure it makes sense to add a new attribute or swap modifier for this type of (undesired) behavior. When using a swap scroll modifier, a user may want to scroll to the top if using pagination, and maintain focus (without auto scrolling) when using filters within the same target area, so multiple scroll modifiers would be needed in this case.