### PR TITLE
Create disable-element.js

### DIFF
--- a/dist/ext/disable-element.js
+++ b/dist/ext/disable-element.js
@@ -1,0 +1,16 @@
+"use strict";
+
+// Disable Submit Button
+htmx.defineExtension('disable-element', {
+    onEvent: function (name, evt) {
+        let elt = evt.detail.elt;
+        let target = elt.getAttribute("hx-disable-element");
+        let targetElement = (target == "this") ? elt : elt.querySelector(target);
+
+        if (name === "htmx:beforeRequest" && targetElement) {
+            targetElement.disabled = true;
+        } else if (name == "htmx:afterRequest" && targetElement) {
+            targetElement.disabled = false;
+        }
+    }
+});


### PR DESCRIPTION
Extension to disable an element (e.g. a button) for the duration of a request. Can either target the current element with the keyword "this" or any other element by specifying a CSS selector. It works by disabling said element and can be further enhanced in combination with the :disabled CSS pseudo-class to style it. Example:

```
<button hx-post="/example" hx-ext="disable-element" hx-disable-element="this" class="button">Submit</button>

<style>
    button:disabled {
        background-color: red;
    }        
</style>
```