### PR TITLE
Skip validation if form submit button has formnovalidate attribute

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2068,9 +2068,13 @@ return (function () {
             var values = {};
             var formValues = {};
             var errors = [];
+            var internalData = getInternalData(elt);
 
-            // only validate when form is directly submitted and novalidate is not set
+            // only validate when form is directly submitted and novalidate or formnovalidate are not set
             var validate = matches(elt, 'form') && elt.noValidate !== true;
+            if (internalData.lastButtonClicked) {
+                validate = validate && internalData.lastButtonClicked.formNoValidate !== true;
+            }
 
             // for a non-GET include the closest form
             if (verb !== 'get') {
@@ -2081,7 +2085,6 @@ return (function () {
             processInputValue(processed, values, errors, elt, validate);
 
             // if a button or submit was clicked last, include its value
-            var internalData = getInternalData(elt);
             if (internalData.lastButtonClicked) {
                 var name = getRawAttribute(internalData.lastButtonClicked,"name");
                 if (name) {

--- a/test/core/validation.js
+++ b/test/core/validation.js
@@ -55,6 +55,21 @@ describe("Core htmx client side validation tests", function(){
         form.textContent.should.equal("Clicked!");
     });
 
+    it('Formnovalidate skips form validation', function()
+    {
+        this.server.respondWith("POST", "/test", "Clicked!");
+
+        var form = make('<form hx-post="/test">' +
+            'No Request' +
+            '<input id="i1" name="i1" required>' +
+            '<button id="button" type="submit" formnovalidate></button>' +
+            '</form>');
+        form.textContent.should.equal("No Request");
+        byId("button").click();
+        this.server.respond();
+        form.textContent.should.equal("Clicked!");
+    });
+
     it('HTML5 pattern validation error prevents request', function()
     {
         this.server.respondWith("POST", "/test", "Clicked!");


### PR DESCRIPTION
Building on the changes in https://github.com/bigskysoftware/htmx/pull/288, submitting a form using a button containing the [`formnovalidate`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/submit#formnovalidate) attribute should also cause the form to skip validation.