### PR TITLE
Expand focus-scroll usage info

### DIFF
--- a/www/attributes/hx-swap.md
+++ b/www/attributes/hx-swap.md
@@ -103,11 +103,19 @@ You may also use `window:top` and `window:bottom` to scroll to the top and botto
   </div>
 ```
 
-Finally, htmx attempts to preserve focus between requests.  This will cause the focused element to scroll into view
-which can be unwanted behavior in some cases.  To disable this, you can use `focus-scroll:false`:
+#### <a name="focus-scroll"></a>Focus scroll
+
+htmx preserves focus between requests for inputs that have a defined id attribute. By default htmx prevents auto-scrolling to focused inputs between requests which can be unwanted behavior on longer requests when the user has already scrolled away. To enable focus scroll you can use `focus-scroll:true`.
 
 ```html
-  <input hx-get="/validation" 
+  <input id="name" hx-get="/validation" 
+       hx-swap="outerHTML focus-scroll:true"/>
+```
+
+Alternatively, if you want the page to automatically scroll to the focused element after each request you can change the htmx global configuration value `htxm.config.defaultFocusScroll` to true. Then disable it for specific requests using `focus-scroll:false`.
+
+```html
+  <input id="name" hx-get="/validation" 
        hx-swap="outerHTML focus-scroll:false"/>
 ```
 

--- a/www/docs.md
+++ b/www/docs.md
@@ -1256,7 +1256,7 @@ listed below:
 |  `htmx.config.wsReconnectDelay` | defaults to `full-jitter`
 |  `htmx.config.disableSelector` | defaults to `[disable-htmx], [data-disable-htmx]`, htmx will not process elements with this attribute on it or a parent
 |  `htmx.config.timeout` | defaults to 0 in milliseconds
-|  `htmx.config.defaultFocusScroll` | if the focused element should be scrolled into view, defaults to false
+|  `htmx.config.defaultFocusScroll` | if the focused element should be scrolled into view, defaults to false and can be overriden using the [focus-scroll](/attributes/hx-swap/#focus-scroll) swap modifier.
 
 </div>
 


### PR DESCRIPTION
Added a bit more info on the swap page to make it clear the focus scroll behavior is disabled by default so it should be enabled with the modifier, or changed globally and then disabled via the modifier.