### PR TITLE
Added selector for input of type button

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -952,6 +952,8 @@ return (function () {
                 return triggerSpecs;
             } else if (matches(elt, 'form')) {
                 return [{trigger: 'submit'}];
+            } else if (matches(elt, 'input[type="button"]')){
+                return [{trigger: 'click'}];
             } else if (matches(elt, INPUT_SELECTOR)) {
                 return [{trigger: 'change'}];
             } else {


### PR DESCRIPTION
Added a selector for the case where event listeners are to be added to inputs of type="button". In which case the "natural" event would be the "click" event instead of the "change" event.