### PR TITLE
docs: fix links to web-sockets extension page

### DIFF
--- a/www/attributes/hx-ws.md
+++ b/www/attributes/hx-ws.md
@@ -6,7 +6,7 @@ title: </> htmx - hx-ws
 ## `hx-ws`
 
 *Note: This attribute will be migrated to an extension in htmx 2.0, which is available now.  Please visit the 
-[WebSockets extension page](../extensions/web-sockets) to learn about the new implementation of Web Sockets as an extension.*
+[WebSockets extension page](/extensions/web-sockets) to learn about the new implementation of Web Sockets as an extension.*
 
 The `hx-ws` allows you to work with [Web Sockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_client_applications)
 directly from HTML.  The value of the attribute can be one or more of the following, separated by commas:

--- a/www/reference.md
+++ b/www/reference.md
@@ -49,7 +49,7 @@ title: </> htmx - Attributes
 | [`hx-trigger`](/attributes/hx-trigger) | specifies the event that triggers the request
 | [`hx-vals`](/attributes/hx-vals) | adds JSON-formatted values to the parameters that will be submitted with the request
 | [`hx-vars`](/attributes/hx-vals) | adds calculated values to the parameters that will be submitted with the request
-| [`hx-ws`](/extensions/websockets) | has been moved to an extension.  [Documentation for older versions](/attributes/hx-ws)
+| [`hx-ws`](/extensions/web-sockets) | has been moved to an extension.  [Documentation for older versions](/attributes/hx-ws)
 
 </div>
 


### PR DESCRIPTION
Link in the documentation index is pointing to `/extensions/websockets` and link from the legacy `hx-ws` page is pointing to `/attributes/extensions/web-sockets`.
They should both be pointing to `/extensions/web-sockets`