### PR TITLE
Add missing header

### DIFF
--- a/www/docs.md
+++ b/www/docs.md
@@ -23,6 +23,7 @@ title: </> htmx - Documentation
   * [swapping](#swapping)
   * [synchronization](#synchronization)
   * [css transitions](#css_transitions)
+  * [Out of Band Swaps](#oob_swaps)
   * [parameters](#parameters)
   * [confirming](#confirming)
 * [inheritance](#inheritance)


### PR DESCRIPTION
oob-swap wasn't in the headers, making it hard to find, and incidentally a pretty important feature.