### PR TITLE
Rewrite scheme-relative URL’s to https

### DIFF
--- a/www/examples/confirm.md
+++ b/www/examples/confirm.md
@@ -9,7 +9,7 @@ htmx supports the [`hx-confirm`](/attributes/hx-confirm) attribute to provide a 
 In this example we will see how to use [sweetalert2](https://sweetalert2.github.io) to implement a custom confirmation dialog.
 
 ```html
-<script src="//cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+<script src="https://cdn.jsdelivr.net/npm/sweetalert2@11" defer></script>
 <button hx-trigger='confirmed'
         hx-get="/confirmed"
         _="on click
@@ -31,7 +31,7 @@ A VanillaJS implementation is left as an exercise for the reader.  :)
 
 {% include demo_ui.html.liquid %}
 
-<script src="//cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+<script src="https://cdn.jsdelivr.net/npm/sweetalert2@11" defer></script>
 
 <script>
 

--- a/www/examples/edit-row.md
+++ b/www/examples/edit-row.md
@@ -91,7 +91,7 @@ this makes things a bit nicer to deal with.
 
 {% include demo_ui.html.liquid %}
 
-<script src="//cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+<script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 <script>
     //=========================================================================
     // Fake Server Side Code


### PR DESCRIPTION
Scheme-relative URL’s were invented when HTTPS was slow, so HTTP pages could load resources insecurely, but a little faster. There’s no need to use them now as HTTPS is fast, and everything should be secure.