### PR TITLE
Fix a typo in reference.md

### DIFF
--- a/www/reference.md
+++ b/www/reference.md
@@ -41,7 +41,7 @@ title: </> htmx - Attributes
 | [`hx-put`](/attributes/hx-put) | issues a `PUT` to the specified URL
 | [`hx-request`](/attributes/hx-request) | configures various aspects of the request
 | [`hx-select`](/attributes/hx-select) | selects a subset of the server response to process
-| [`hx-sse`](/extensions/server-sent-events) | has meen moved to an extension.  [Documentation for older versions](/attributes/hx-sse)
+| [`hx-sse`](/extensions/server-sent-events) | has been moved to an extension.  [Documentation for older versions](/attributes/hx-sse)
 | [`hx-swap`](/attributes/hx-swap) | controls how the response content is swapped into the DOM (e.g. 'outerHTML' or 'beforeEnd')
 | [`hx-swap-oob`](/attributes/hx-swap-oob) | marks content in a response as being "Out of Band", i.e. swapped somewhere other than the target 
 | [`hx-sync`](/attributes/hx-sync) | controls requests made by different elements are synchronized with one another


### PR DESCRIPTION
"has been moved to an extension"