### PR TITLE
<script> defer will cause friction for new people and breaks documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ By removing these arbitrary constraints htmx completes HTML as a
 ## quick start
 
 ```html
-  <script src="htmx.min.js" defer></script>
+  <script src="htmx.min.js"></script>
   <!-- have a button POST a click via AJAX -->
   <button hx-post="/clicked" hx-swap="outerHTML">
     Click Me

--- a/www/docs.md
+++ b/www/docs.md
@@ -113,7 +113,7 @@ Download `htmx.min.js` [from unpkg.com](https://unpkg.com/browse/htmx.org/dist/)
 Then, include it where necessary with a `<script>` tag:
 
 ```html
-<script src="/path/to/htmx.min.js" defer></script>
+<script src="/path/to/htmx.min.js"></script>
 ```
 
 You can also add extensions this way, by downloading them from the `ext/` directory.
@@ -137,7 +137,7 @@ Avoid using unpkg.com or other JavaScript CDN’s in production, for [many good 
 To use htmx from unpkg.com, use this `<script>` tag:
 
 ```html
-<script src="https://unpkg.com/htmx.org@1.7.0" integrity="sha384-EzBXYPt0/T6gxNp0nuPtLkmRpmDBbjg6WmCUZRLXBBwYYmwAUxzlSGej0ARHX0Bo" crossorigin="anonymous" defer></script>
+<script src="https://unpkg.com/htmx.org@1.7.0" integrity="sha384-EzBXYPt0/T6gxNp0nuPtLkmRpmDBbjg6WmCUZRLXBBwYYmwAUxzlSGej0ARHX0Bo" crossorigin="anonymous"></script>
 ```
 
 ### <a name="webpack">[Webpack](#webpack)
@@ -1078,7 +1078,7 @@ site that will install:
 Simply add the following script tag to your demo/fiddle/whatever:
 
 ```html
-<script src="https://demo.htmx.org" defer></script>
+<script src="https://demo.htmx.org"></script>
 ```
 
 This helper allows you to add mock responses by adding `template` tags with a `url` attribute to indicate which URL. 
@@ -1097,7 +1097,7 @@ Here is an example of the code in action:
 
 ```html
 <!-- load demo environment -->
-<script src="https://demo.htmx.org" defer></script>
+<script src="https://demo.htmx.org"></script>
 
 <!-- post to /foo -->
 <button hx-post="/foo" hx-target="#result">

--- a/www/extensions.md
+++ b/www/extensions.md
@@ -17,7 +17,7 @@ Using an extension involves two steps:
 Here is an example
 
 ```html
-  <script src="/path/to/ext/debug.js" defer></script>
+  <script src="/path/to/ext/debug.js"></script>
   <button hx-post="/example" hx-ext="debug">This Button Uses The Debug Extension</button>
 ```
 

--- a/www/index.md
+++ b/www/index.md
@@ -33,7 +33,7 @@ By removing these arbitrary constraints, htmx completes HTML as a [hypertext](ht
 ## quick start
 
 ```html
-  <script src="htmx.min.js" defer></script>
+  <script src="htmx.min.js"></script>
   <!-- have a button POST a click via AJAX -->
   <button hx-post="/clicked" hx-swap="outerHTML">
     Click Me


### PR DESCRIPTION
Was just added in: https://github.com/bigskysoftware/htmx/pull/851

Will cause any htmx calls in `<script>` to break javascript unless the page is fully loaded first.

Unnecessary added complexity and friction.

Will break examples such as: https://htmx.org/docs/#config_request_with_events

Will break inline `<script>`

