### PR TITLE
Docs: Code element readability.

### DIFF
--- a/www/css/site.scss
+++ b/www/css/site.scss
@@ -59,7 +59,7 @@ body .content code {
     font-size: 0.9em;
 }
 
-body .content code:not(code[class*="language-"]) {
+code:not(code[class*="language-"]) {
     background: #3465a426;
     border-radius: 2px;
     padding: 2px 5px;
@@ -395,7 +395,7 @@ h1,h2,h3,h4{
             display:block;
         }
     }
-}
+}table td:first-child code
 
 
 .logo-wrapper {
@@ -404,6 +404,7 @@ h1,h2,h3,h4{
 
 table td:first-child code {
   display: block;
+  background: none;
 }
 
 

--- a/www/css/site.scss
+++ b/www/css/site.scss
@@ -57,6 +57,9 @@ table {
 
 body .content code {
     font-size: 0.9em;
+}
+
+body .content code:not(code[class*="language-"]) {
     background: #3465a426;
     border-radius: 2px;
     padding: 2px 5px;

--- a/www/css/site.scss
+++ b/www/css/site.scss
@@ -395,7 +395,7 @@ h1,h2,h3,h4{
             display:block;
         }
     }
-}table td:first-child code
+}
 
 
 .logo-wrapper {

--- a/www/css/site.scss
+++ b/www/css/site.scss
@@ -57,6 +57,9 @@ table {
 
 body .content code {
     font-size: 0.9em;
+    background: #3465a426;
+    border-radius: 2px;
+    padding: 2px 5px;
 }
 
 .dark-hero {

--- a/www/css/site.scss
+++ b/www/css/site.scss
@@ -60,7 +60,7 @@ body .content code {
 }
 
 code:not(code[class*="language-"]) {
-    background: #3465a422;
+    background: #3465a424;
     border-radius: 2px;
     padding: 2px 5px;
 }

--- a/www/css/site.scss
+++ b/www/css/site.scss
@@ -60,7 +60,7 @@ body .content code {
 }
 
 code:not(code[class*="language-"]) {
-    background: #3465a426;
+    background: #3465a422;
     border-radius: 2px;
     padding: 2px 5px;
 }


### PR DESCRIPTION
Before / After, so code elements don't blend in so much with the background.

Hotwire does this in their own documentation for clarity, example: https://turbo.hotwired.dev/handbook/frames

![image](https://user-images.githubusercontent.com/24665/179698310-98002ec3-3711-4ce7-bf5f-3141d35fddb8.png)
