### PR TITLE
Docs: Reference guide readability. Essential attributes.

### DIFF
--- a/www/reference.md
+++ b/www/reference.md
@@ -6,52 +6,67 @@ title: </> htmx - Attributes
 
 ## Contents
 
-* [Htmx Attribute Reference](#attributes)
-* [Htmx CSS Class Reference](#classes)
-* [Htmx Request Headers Reference](#request_headers)
-* [Htmx Response Headers Reference](#response_headers)
-* [Htmx Event Reference](#events)
-* [Htmx Extensions Reference](/extensions#reference)
-* [JS API Reference](#api)
+* [Htmx Attributes (Essential)](#attributes-essential)
+* [Htmx Attributes](#attributes)
+* [Htmx CSS Classes](#classes)
+* [Htmx Request Headers](#request_headers)
+* [Htmx Response Headers](#response_headers)
+* [Htmx Events](#events)
+* [Htmx Extensions](/extensions#reference)
+* [Javascript API](#api)
 
-## <a name="attributes"></a> [Attribute Reference](#attributes)
+## <a name="attributes-essential"></a> [Attribute Reference (Essential)](#attributes-essential)
+
+The most significant attributes to use htmx.
 
 <div class="info-table">
 
 | Attribute                                      | Description |
 |------------------------------------------------|-------------|
-| [`hx-boost`](/attributes/hx-boost)             | progressively enhances anchors and forms to use AJAX requests
-| [`hx-confirm`](/attributes/hx-confirm)         | shows a confim() dialog before issuing a request
+| [`hx-boost`](/attributes/hx-boost)             | add or remove [progressive enhancement](https://en.wikipedia.org/wiki/Progressive_enhancement) for links and forms
+| [`hx-get`](/attributes/hx-get)                 | issues a `GET` to the specified URL
+| [`hx-post`](/attributes/hx-post)               | issues a `POST` to the specified URL
+| [`hx-push-url`](/attributes/hx-push-url)       | pushes the URL into the browser location bar, creating a new history entry
+| [`hx-select`](/attributes/hx-select)           | select content to swap in from a response
+| [`hx-select-oob`](/attributes/hx-select-oob)   | select content to swap in from a response, out of band (somewhere other than the target)
+| [`hx-swap`](/attributes/hx-swap)               | controls how content is swapped in (`outerHTML`, `beforeEnd`, `afterend`, ...)
+| [`hx-swap-oob`](/attributes/hx-swap-oob)       | marks content in a response to be out of band (should swap in somewhere other than the target)
+| [`hx-target`](/attributes/hx-target)           | specifies the target element to be swapped
+| [`hx-trigger`](/attributes/hx-trigger)         | specifies the event that triggers the request
+| [`hx-vals`](/attributes/hx-vals)               | adds values to the parameters to submit with the request (JSON-formatted)
+
+</div>
+
+## <a name="attributes"></a> [Attribute Reference](#attributes)
+
+All other attributes available.
+
+<div class="info-table">
+
+| Attribute                                      | Description |
+|------------------------------------------------|-------------|
+| [`hx-confirm`](/attributes/hx-confirm)         | shows a `confim()` dialog before issuing a request
 | [`hx-delete`](/attributes/hx-delete)           | issues a `DELETE` to the specified URL
 | [`hx-disable`](/attributes/hx-disable)         | disables htmx processing for the given node and any children nodes
 | [`hx-disinherit`](/attributes/hx-disinherit)   | control and disable automatic attribute inheritance for child nodes
 | [`hx-encoding`](/attributes/hx-encoding)       | changes the request encoding type
 | [`hx-ext`](/attributes/hx-ext)                 | extensions to use for this element
-| [`hx-get`](/attributes/hx-get)                 | issues a `GET` to the specified URL
 | [`hx-headers`](/attributes/hx-headers)         | adds to the headers that will be submitted with the request
 | [`hx-history-elt`](/attributes/hx-history-elt) | the element to snapshot and restore during history navigation
-| [`hx-include`](/attributes/hx-include)         | includes additional data in AJAX requests
-| [`hx-indicator`](/attributes/hx-indicator)     | the element to put the `htmx-request` class on during the AJAX request
+| [`hx-include`](/attributes/hx-include)         | include additional data in requests
+| [`hx-indicator`](/attributes/hx-indicator)     | the element to put the `htmx-request` class on during the request
 | [`hx-params`](/attributes/hx-params)           | filters the parameters that will be submitted with a request
 | [`hx-patch`](/attributes/hx-patch)             | issues a `PATCH` to the specified URL
-| [`hx-post`](/attributes/hx-post)               | issues a `POST` to the specified URL
-| [`hx-preserve`](/attributes/hx-preserve)       | preserves an element between requests
-| [`hx-prompt`](/attributes/hx-prompt)           | shows a prompt before submitting a request
-| [`hx-push-url`](/attributes/hx-push-url)       | pushes the URL into the location bar, creating a new history entry
+| [`hx-preserve`](/attributes/hx-preserve)       | specifies elements to keep unchanged between requests
+| [`hx-prompt`](/attributes/hx-prompt)           | shows a `prompt()` before submitting a request
 | [`hx-put`](/attributes/hx-put)                 | issues a `PUT` to the specified URL
-| [`hx-replace-url`](/attributes/hx-replace-url) | replace the URL in the location bar
+| [`hx-replace-url`](/attributes/hx-replace-url) | replace the URL in the browser location bar
 | [`hx-request`](/attributes/hx-request)         | configures various aspects of the request
-| [`hx-select`](/attributes/hx-select)           | selects a subset of the server response to process
-| [`hx-select-oob`](/attributes/hx-select-oob)   | selects one or more elements from a server response to swap in via an out of band swap
 | [`hx-sse`](/extensions/server-sent-events)     | has been moved to an extension.  [Documentation for older versions](/attributes/hx-sse)
-| [`hx-swap`](/attributes/hx-swap)               | controls how the response content is swapped into the DOM (e.g. 'outerHTML' or 'beforeEnd')
-| [`hx-swap-oob`](/attributes/hx-swap-oob)       | marks content in a response as being "Out of Band", i.e. swapped somewhere other than the target
-| [`hx-sync`](/attributes/hx-sync)               | controls requests made by different elements are synchronized with one another
-| [`hx-target`](/attributes/hx-target)           | specifies the target element to be swapped
-| [`hx-trigger`](/attributes/hx-trigger)         | specifies the event that triggers the request
-| [`hx-vals`](/attributes/hx-vals)               | adds JSON-formatted values to the parameters that will be submitted with the request
-| [`hx-vars`](/attributes/hx-vars)               | adds calculated values to the parameters that will be submitted with the request (deprecated)
+| [`hx-sync`](/attributes/hx-sync)               | control how requests made be different elements are synchronized
+| [`hx-vars`](/attributes/hx-vars)               | adds values dynamically to the parameters to submit with the request (deprecated, please use `hx-vals`)
 | [`hx-ws`](/extensions/web-sockets)             | has been moved to an extension.  [Documentation for older versions](/attributes/hx-ws)
+
 
 </div>
 
@@ -155,7 +170,7 @@ title: </> htmx - Attributes
 
 </div>
 
-## <a name="api"></a> [JS API Reference](#api)
+## <a name="api"></a> [Javascript API Reference](#api)
 
 <div class="info-table">
 

--- a/www/reference.md
+++ b/www/reference.md
@@ -6,8 +6,8 @@ title: </> htmx - Attributes
 
 ## Contents
 
-* [Htmx Attributes (Essential)](#attributes-essential)
 * [Htmx Attributes](#attributes)
+* [Htmx Additional Attributes](#attributes-additional)
 * [Htmx CSS Classes](#classes)
 * [Htmx Request Headers](#request_headers)
 * [Htmx Response Headers](#response_headers)
@@ -15,7 +15,7 @@ title: </> htmx - Attributes
 * [Htmx Extensions](/extensions#reference)
 * [Javascript API](#api)
 
-## <a name="attributes-essential"></a> [Attribute Reference (Essential)](#attributes-essential)
+## <a name="attributes"></a> [Attribute Reference](#attributes)
 
 The most significant attributes to use htmx.
 
@@ -37,7 +37,7 @@ The most significant attributes to use htmx.
 
 </div>
 
-## <a name="attributes"></a> [Attribute Reference](#attributes)
+## <a name="attributes-additional"></a> [Additional Attribute Reference](#attributes-additional)
 
 All other attributes available.
 


### PR DESCRIPTION
Removed words while improving overall descriptiveness, consistency.

Added Essential Attributes, to ensure important attributes are not lost in the supplementary ones. Important for newcomers to htmx.