### PR TITLE
Added reinit method to public API

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -822,7 +822,7 @@ return (function () {
             }
         }
 
-        function cleanUpElement(element) {
+        function cleanUpElement(element, withInitialized) {
             var internalData = getInternalData(element);
             if (internalData.webSocket) {
                 internalData.webSocket.close();
@@ -833,6 +833,9 @@ return (function () {
 
             triggerEvent(element, "htmx:beforeCleanupElement")
 
+            if (withInitialized)
+                internalData.initialized = false;
+
             if (internalData.listenerInfos) {
                 forEach(internalData.listenerInfos, function(info) {
                     if (element !== info.on) {
@@ -841,7 +844,7 @@ return (function () {
                 });
             }
             if (element.children) { // IE
-                forEach(element.children, function(child) { cleanUpElement(child) });
+                forEach(element.children, function(child) { cleanUpElement(child, withInitialized) });
             }
         }
 
@@ -1797,13 +1800,8 @@ return (function () {
 
         function reinitNode(elt) {
             elt = resolveTarget(elt);
-            var nodeData = getInternalData(elt);
-            nodeData.initialized = false;
-            forEach(findElementsToProcess(elt), function(child) {
-                var childData = getInternalData(child);
-                childData.initialized = false;
-            });
-            initNode(elt);
+            cleanUpElement(elt, true);
+            processNode(elt);
         }
 
         //====================================================================

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -19,6 +19,7 @@ return (function () {
         var htmx = {
             onLoad: onLoadHelper,
             process: processNode,
+            reinit: reinitNode,
             on: addEventListenerImpl,
             off: removeEventListenerImpl,
             trigger : triggerEvent,
@@ -1792,6 +1793,17 @@ return (function () {
             elt = resolveTarget(elt);
             initNode(elt);
             forEach(findElementsToProcess(elt), function(child) { initNode(child) });
+        }
+
+        function reinitNode(elt) {
+            elt = resolveTarget(elt);
+            var nodeData = getInternalData(elt);
+            nodeData.initialized = false;
+            forEach(findElementsToProcess(elt), function(child) {
+                var childData = getInternalData(child);
+                childData.initialized = false;
+            });
+            initNode(elt);
         }
 
         //====================================================================

--- a/www/docs.md
+++ b/www/docs.md
@@ -1288,6 +1288,26 @@ example uses Alpine's `$watch` function to look for a change of value that would
 </div>
 ```
 
+If elements are _modified_ rather than added to the DOM at runtime (which can happen when morphing responses
+with an extension such as [`morphdom-swap`](/extensions/morphdom-swap), or through JS that modifies attributes)
+and the node has already been initialised by htmx you need to call `htmx.reinit()` once the changes are complete.
+
+The following example shows how Alpine may alter a property that htmx has already initialised in a similar way to above:
+
+```html
+<div x-data="{selectedId:null}"
+     x-init="$watch('selectedId', value => {
+        htmx.reinit(document.querySelector('#loadbtn'));
+    })">
+    <select x-model.number="selectedId">
+        <option selected disabled>Choose an item</option>
+        <option value="1">Item 1</option>
+        <option value="2">Item 2</option>
+    </select>
+    <button :hx-get="'/server/item/' + selectedId" id="loadbtn">Load item</button>
+</div>
+```
+
 ## <a name="security"></a>[Security](#security)
 
 htmx allows you to define logic directly in your DOM.  This has a number of advantages, the


### PR DESCRIPTION
In reference to #425 (and subsequent PRs #943) this adds a `reinit` method to clean up elements and then reprocess.

`cleanUpElement` was extended to have a parameter that resets the `initialized` flag too (to allow `initNode` to reactivate).

Documentation updated with an Alpine sample that would reinitialise when a `hx-get` has changed on an element.