### PR TITLE
Fix #demo-server-info's height

### DIFF
--- a/www/_includes/demo_ui.html.liquid
+++ b/www/_includes/demo_ui.html.liquid
@@ -5,7 +5,7 @@
         bottom: 0;
         right: 0;
         left: 0;
-        height: 50px;
+        height: 64px;
         width: 100vw;
         background-color: whitesmoke;
         border-top: 2px solid gray;


### PR DESCRIPTION
Fixed a little display annoyance where the bottom bar in examples is cropped:

![Screen Shot 2022-08-05 at 9 54 31 PM](https://user-images.githubusercontent.com/304450/183200889-7ef927d5-5241-41a6-9c40-12b7a0f8e45b.png)
