### PR TITLE
[RFC] Trigger preload module on htmx:load

### DIFF
--- a/dist/ext/preload.js
+++ b/dist/ext/preload.js
@@ -7,7 +7,7 @@ htmx.defineExtension("preload", {
 	onEvent: function(name, event) {
 
 		// Only take actions on "htmx:afterProcessNode"
-		if (name !== "htmx:afterProcessNode") {
+		if (name !== "htmx:afterProcessNode" && name !== "htmx:load") {
 			return;
 		}
 


### PR DESCRIPTION
I was having some trouble getting preloading working on a fresh page load until making this tweak. But it worked fine after doing a single boosted navigation. This led me to believe there was an issue with how preloading was initialized on links. This may not be the right fix, but it seems to be working for me.

For context, the JS bundle (which contains HTMX) on my site (in an `<script async="true" ...` tag) usually arrives after the DOM is finished loading  , which probably has something to do with why this wasn't working. HTMX otherwise works fine.