### PR TITLE
[RFC] Always use latest `href`/`hx-*` in `hx-boost`

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1221,23 +1221,29 @@ return (function () {
                 getRawAttribute(elt,'href').indexOf("#") !== 0;
         }
 
+        function shouldBoost(elt) {
+          return (elt.tagName === "A" && isLocalLink(elt) && (elt.target === "" || elt.target === "_self")) || elt.tagName === "FORM";
+        }
+
         function boostElement(elt, nodeData, triggerSpecs) {
-            if ((elt.tagName === "A" && isLocalLink(elt) && (elt.target === "" || elt.target === "_self")) || elt.tagName === "FORM") {
+            if (shouldBoost(elt)) {
                 nodeData.boosted = true;
-                var verb, path;
-                if (elt.tagName === "A") {
-                    verb = "get";
-                    path = getRawAttribute(elt, 'href');
-                } else {
-                    var rawAttribute = getRawAttribute(elt, "method");
-                    verb = rawAttribute ? rawAttribute.toLowerCase() : "get";
-                    if (verb === "get") {
-                    }
-                    path = getRawAttribute(elt, 'action');
-                }
                 triggerSpecs.forEach(function(triggerSpec) {
                     addEventListener(elt, function(evt) {
-                        issueAjaxRequest(verb, path, elt, evt)
+                        // Revalidate that element should be boosted
+                        if (shouldBoost(evt)) {
+                          // Use latest path/verb (rather than when the element was boosted) 
+                          var verb, path;
+                          if (elt.tagName === "A") {
+                              verb = "get";
+                              path = getRawAttribute(elt, 'href');
+                          } else {
+                              var rawAttribute = getRawAttribute(elt, "method");
+                              verb = rawAttribute ? rawAttribute.toLowerCase() : "get";
+                              path = getRawAttribute(elt, 'action');
+                          }
+                          issueAjaxRequest(verb, path, elt, evt)
+                        }
                     }, nodeData, triggerSpec, true);
                 });
             }


### PR DESCRIPTION
hx-boost seems to capture the href/hx-get/etc of an element when the boosting logic is setup. 

But if the element changes its `href` since it was created, `hx-boost` will cause it to redirect to the wrong location. While opening that link in a new tab/window (bypassing hx-boost) will sent to the correct URL.

This proposed change would -- when performing an AJAX request -- revalidate that the element should be boosted and compute the verb/path at that time.

Thanks for your consideration! :)