### PR TITLE
Allow 'unset' directive for hx-vals and hx-vars

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2418,7 +2418,7 @@ return (function () {
             if (attributeValue) {
                 var str = attributeValue.trim();
                 var evaluateValue = evalAsDefault;
-                if (str.indexOf("unset") === 0 && str.length === 5) {
+                if (str === "unset") {
                     return null;
                 }
                 if (str.indexOf("javascript:") === 0) {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2418,6 +2418,9 @@ return (function () {
             if (attributeValue) {
                 var str = attributeValue.trim();
                 var evaluateValue = evalAsDefault;
+                if (str.indexOf("unset") === 0 && str.length === 5) {
+                    return null;
+                }
                 if (str.indexOf("javascript:") === 0) {
                     str = str.substr(11);
                     evaluateValue = true;
@@ -3293,4 +3296,3 @@ return (function () {
     }
 )()
 }));
-

--- a/test/attributes/hx-vals.js
+++ b/test/attributes/hx-vals.js
@@ -184,5 +184,72 @@ describe("hx-vals attribute", function() {
         div.innerHTML.should.equal("Clicked!");
     });
 
+    it('basic hx-vals can be unset', function () {
+        this.server.respondWith("POST", "/vars", function (xhr) {
+            var params = getParameters(xhr);
+            params.should.be.empty;
+            xhr.respond(200, {}, "Clicked!")
+        });
+        make(
+            "<div hx-vals='\"i1\":\"test\"'>\
+                <div id='d1' hx-post='/vars' hx-vals='unset'></div>\
+            </div>"
+        );
+        var div = byId("d1");
+        div.click();
+        this.server.respond();
+        div.innerHTML.should.equal("Clicked!");
+    });
+
+    it('basic hx-vals with braces can be unset', function () {
+        this.server.respondWith("POST", "/vars", function (xhr) {
+            var params = getParameters(xhr);
+            params.should.be.empty;
+            xhr.respond(200, {}, "Clicked!")
+        });
+        make(
+            "<div hx-vals='{\"i1\":\"test\"}'>\
+                <div id='d1' hx-post='/vars' hx-vals='unset'></div>\
+            </div>"
+        );
+        var div = byId("d1");
+        div.click();
+        this.server.respond();
+        div.innerHTML.should.equal("Clicked!");
+    });
+
+    it('multiple hx-vals can be unset', function () {
+        this.server.respondWith("POST", "/vars", function (xhr) {
+            var params = getParameters(xhr);
+            params.should.be.empty;
+            xhr.respond(200, {}, "Clicked!")
+        });
+        make(
+            "<div hx-vals='\"v1\":\"test\", \"v2\":42'>\
+                <div id='d1' hx-post='/vars' hx-vals='unset'></div>\
+            </div>"
+        );
+        var div = byId("d1");
+        div.click();
+        this.server.respond();
+        div.innerHTML.should.equal("Clicked!");
+    });
+
+    it('unsetting hx-vals maintains input values', function () {
+        this.server.respondWith("POST", "/include", function (xhr) {
+            var params = getParameters(xhr);
+            params['i1'].should.equal("test");
+            xhr.respond(200, {}, "Clicked!")
+        });
+        var div = make(
+            "<div hx-target='this' hx-vals='\"i1\":\"best\"'>\
+                <input hx-post='/include' hx-vals='unset' hx-trigger='click' id='i1' name='i1' value='test'/>\
+            </div>"
+        )
+        var input = byId("i1")
+        input.click();
+        this.server.respond();
+        div.innerHTML.should.equal("Clicked!");
+    });
 
 });

--- a/test/attributes/hx-vars.js
+++ b/test/attributes/hx-vars.js
@@ -84,4 +84,72 @@ describe("hx-vars attribute", function() {
         div.innerHTML.should.equal("Clicked!");
     });
 
+    it('basic hx-vars can be unset', function () {
+        this.server.respondWith("POST", "/vars", function (xhr) {
+            var params = getParameters(xhr);
+            params.should.be.empty;
+            xhr.respond(200, {}, "Clicked!")
+        });
+        make(
+            "<div hx-vars='i1:\"test\"'>\
+                <div id='d1' hx-post='/vars' hx-vars='unset'></div>\
+            </div>"
+        );
+        var div = byId("d1");
+        div.click();
+        this.server.respond();
+        div.innerHTML.should.equal("Clicked!");
+    });
+
+    it('basic hx-vars with braces can be unset', function () {
+        this.server.respondWith("POST", "/vars", function (xhr) {
+            var params = getParameters(xhr);
+            params.should.be.empty;
+            xhr.respond(200, {}, "Clicked!")
+        });
+        make(
+            "<div hx-vars='{i1:\"test\"}'>\
+                <div id='d1' hx-post='/vars' hx-vars='unset'></div>\
+            </div>"
+        );
+        var div = byId("d1");
+        div.click();
+        this.server.respond();
+        div.innerHTML.should.equal("Clicked!");
+    });
+
+    it('multiple hx-vars can be unset', function () {
+        this.server.respondWith("POST", "/vars", function (xhr) {
+            var params = getParameters(xhr);
+            params.should.be.empty;
+            xhr.respond(200, {}, "Clicked!")
+        });
+        make(
+            "<div hx-vars='v1:\"test\", v2:42'>\
+                <div id='d1' hx-post='/vars' hx-vars='unset'></div>\
+            </div>"
+        );
+        var div = byId("d1");
+        div.click();
+        this.server.respond();
+        div.innerHTML.should.equal("Clicked!");
+    });
+
+    it('unsetting hx-vars maintains input values', function () {
+        this.server.respondWith("POST", "/include", function (xhr) {
+            var params = getParameters(xhr);
+            params['i1'].should.equal("test");
+            xhr.respond(200, {}, "Clicked!")
+        });
+        var div = make(
+            "<div hx-target='this' hx-vars='i1:\"best\"'>\
+                <input hx-post='/include' hx-vars='unset' hx-trigger='click' id='i1' name='i1' value='test'/>\
+            </div>"
+        )
+        var input = byId("i1")
+        input.click();
+        this.server.respond();
+        div.innerHTML.should.equal("Clicked!");
+    });
+
 });


### PR DESCRIPTION
This PR aims to fix the issue of the "unset" directive not working for `hx-vals` or `hx-vars` due to it being parsed as JSON.

See [this codepen](https://codepen.io/b-lenton/pen/NWYoQMo) for an example of `hx-vals="unset"` both causing an error and not unsetting the inherited values.