### PR TITLE
Properly set title during history cache miss

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1972,6 +1972,15 @@ return (function () {
                     fragment = fragment.querySelector('[hx-history-elt],[data-hx-history-elt]') || fragment;
                     var historyElement = getHistoryElement();
                     var settleInfo = makeSettleInfo(historyElement);
+		    var title = findTitle(this.response);
+                    if (title) {
+                        var titleElt = find("title");
+                        if (titleElt) {
+                            titleElt.innerHTML = title;
+                        } else {
+                            window.document.title = title;
+                        }
+                    }
                     // @ts-ignore
                     swapInnerHTML(historyElement, fragment, settleInfo)
                     settleImmediately(settleInfo.tasks);


### PR DESCRIPTION
I am running HTMX with hx-boost and the history cache disabled (it's important to not show stale content to my users unless my backend uses cache-control headers to do so, in which case I simply rely on the fetch being cached). However, during 'history cache misses', the page title is not properly set.

This fixes it (mirroring the logic in `handleAjaxResponse`).