### PR TITLE
Remove ASP.NET Core from list

### DIFF
--- a/www/essays/template-fragments.md
+++ b/www/essays/template-fragments.md
@@ -132,8 +132,6 @@ hypermedia-oriented libraries.
 
 Here are some known implementations of the fragment concept:
 
-* ASP.NET Core
-  * [ASP.NET Core MVC Partial Views (Razor markup)](https://docs.microsoft.com/en-us/aspnet/core/mvc/views/partial)
 * Go
   * [Standard Library (use block actions)](https://pkg.go.dev/text/template) [[demo]](https://gist.github.com/benpate/f92b77ea9b3a8503541eb4b9eb515d8a)
 * Java


### PR DESCRIPTION
As clarified in #1023, ASP.NET Core doesn't have the concept similar to fragments.