### PR TITLE
Avoid: "Element.querySelector: '...' is not a valid selector"

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -779,7 +779,7 @@ return (function () {
         function handleAttributes(parentNode, fragment, settleInfo) {
             forEach(fragment.querySelectorAll("[id]"), function (newNode) {
                 if (newNode.id && newNode.id.length > 0) {
-                    var oldNode = parentNode.querySelector(newNode.tagName + "[id='" + newNode.id + "']");
+                    var oldNode = parentNode.querySelector((newNode.tagName.split(':')[1] || newNode.tagName) + "[id='" + newNode.id + "']");
                     if (oldNode && oldNode !== parentNode) {
                         var newAttributes = newNode.cloneNode();
                         cloneAttributes(newNode, oldNode);

--- a/test/attributes/hx-get.js
+++ b/test/attributes/hx-get.js
@@ -73,4 +73,14 @@ describe("hx-get attribute", function() {
         this.server.respond();
         btn.innerHTML.should.equal("Clicked!");
     });
+
+    it('GET on page with namespaces (ie inkscape\'s svg) works', function () {
+        var svg_response = '<?xml version="1.0" ?><svg xmlns="http://www.w3.org/2000/svg" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"><g inkscape:groupmode="layer"></g></svg>';
+        this.server.respondWith("GET", "/test", svg_response);
+
+        var div = make('<div hx-get="/test"></div>');
+        div.click();
+        this.server.respond();
+        div.innerHTML.should.equal(svg_response);
+    });
 });


### PR DESCRIPTION
When hx-get swap for an xml page (inkscape svg for exemple) with namespaces on elements, htmx failed.
This trick avoid the error raised.