### PR TITLE
Add Pushup to template fragments implementation

### DIFF
--- a/www/essays/template-fragments.md
+++ b/www/essays/template-fragments.md
@@ -134,6 +134,7 @@ Here are some known implementations of the fragment concept:
 
 * Go
   * [Standard Library (use block actions)](https://pkg.go.dev/text/template) [[demo]](https://gist.github.com/benpate/f92b77ea9b3a8503541eb4b9eb515d8a)
+  * [Pushup (currently unreleased but coming soon)](https://github.com/paulsmith/pushup-template-fragments-demo/) [[demo]](https://pushup-htmx-template-fragments.fly.dev/demo)
 * Java
   * [Thymeleaf](https://www.thymeleaf.org/doc/tutorials/3.0/usingthymeleaf.html#fragment-specification-syntax)
   * [Chill Templates (currently in early alpha)](https://github.com/bigskysoftware/chill/tree/master/chill-script)


### PR DESCRIPTION
Pushup is a Go web framework (unreleased but coming soon) that has an "inline partials" feature which is the same as template fragments.