### PR TITLE
Fix link to template fragments essay

### DIFF
--- a/www/essays.md
+++ b/www/essays.md
@@ -14,7 +14,7 @@ title: </> htmx - Essays
 * [Complexity Budget](/essays/complexity-budget)
 * [SPA Alternative](/essays/spa-alternative)
 * [A Response To "Have SPA's Ruined The Web"](/essays/a-response-to-rich-harris)
-* [Template Fragments](essays/template-fragments/)
+* [Template Fragments](/essays/template-fragments/)
 
 
 ### Older [intercooler.js](https://intercoolerjs.org) Essays


### PR DESCRIPTION
Fix link from https://htmx.org/essays/essays/template-fragments/ to https://htmx.org/essays/template-fragments/