### PR TITLE
[DRAFT] Don't overwrite Content-Type header if it has been set

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2684,7 +2684,7 @@ return (function () {
             var allParameters = mergeObjects(rawParameters, expressionVars);
             var filteredParameters = filterValues(allParameters, elt);
 
-            if (verb !== 'get' && !usesFormData(elt)) {
+            if (!headers['Content-Type'] && verb !== 'get' && !usesFormData(elt)) {
                 headers['Content-Type'] = 'application/x-www-form-urlencoded';
             }
 
@@ -3294,4 +3294,3 @@ return (function () {
     }
 )()
 }));
-


### PR DESCRIPTION
This allows the `Content-Type` to be set via headers in the case of `htmx.ajax`

NOTE: I have not tested this yet. This is a proof-of-concept.