### PR TITLE
Fix error message for responseError

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3180,7 +3180,7 @@ return (function () {
                 }
             }
             if (isError) {
-                triggerErrorEvent(elt, 'htmx:responseError', mergeObjects({error: "Response Status Error Code " + xhr.status + " from " + responseInfo.pathInfo.path}, responseInfo));
+                triggerErrorEvent(elt, 'htmx:responseError', mergeObjects({error: "Response Status Error Code " + xhr.status + " from " + responseInfo.pathInfo.requestPath}, responseInfo));
             }
         }
 


### PR DESCRIPTION
In my error tracking system, I was getting `Response Status Error Code 403 from undefined`. I tracked it down to this line. As far as I can tell, `responseInfo.pathInfo.path` is never defined. I assume this should be `responseInfo.pathInfo.requestPath`