### PR TITLE
Add `hx-swap-title` to prevent title change

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1003,7 +1003,10 @@ return (function () {
         }
 
         function selectAndSwap(swapStyle, target, elt, responseText, settleInfo) {
-            settleInfo.title = findTitle(responseText);
+            var shouldSwapTitle = getClosestAttributeValue(elt, 'hx-swap-title');
+            if (shouldSwapTitle !== "no") {
+                settleInfo.title = findTitle(responseText);
+            }
             var fragment = makeFragment(responseText);
             if (fragment) {
                 handleOutOfBandSwaps(elt, fragment, settleInfo);

--- a/test/core/ajax.js
+++ b/test/core/ajax.js
@@ -845,6 +845,18 @@ describe("Core htmx AJAX Tests", function(){
         window.document.title.should.equal("</> htmx rocks!");
     });
 
+    it('hx-swap-title value of "no" prevents title update', function () {
+        var originalTitle = window.document.title
+        this.server.respondWith("GET", "/test", function (xhr) {
+            xhr.respond(200, {}, "<title class=''>htmx rocks!</title>Clicked!");
+        });
+        var btn = make('<button hx-get="/test" hx-swap-title="no">Click Me!</button>')
+        btn.click();
+        this.server.respond();
+        btn.innerText.should.equal("Clicked!");
+        window.document.title.should.equal(originalTitle);
+    });
+
     it('by default 400 content is not swapped', function()
     {
         this.server.respondWith("GET", "/test", function (xhr) {


### PR DESCRIPTION
Simpler than I thought. If `hx-swap-title` has a value of "no" then don't swap the page title. This attribute can be inherited.

Let me know if this makes sense, and I will add/edit docs