### PR TITLE
Added Quarkus Qute fragments as one of the implementations

### DIFF
--- a/www/essays/template-fragments.md
+++ b/www/essays/template-fragments.md
@@ -137,6 +137,7 @@ Here are some known implementations of the fragment concept:
 * Java
   * [Thymeleaf](https://www.thymeleaf.org/doc/tutorials/3.0/usingthymeleaf.html#fragment-specification-syntax)
   * [Chill Templates (currently in early alpha)](https://github.com/bigskysoftware/chill/tree/master/chill-script)
+  * [Quarkus Qute](https://quarkus.io/guides/qute-reference#fragments)
 * PHP
   * [Latte](https://latte.nette.org/en/template-inheritance#toc-blocks) - Use the 3rd parameter to only render 1 block from the template -  `$Latte_Engine->render('path/to/template.latte', [ 'foo' => 'bar' ], 'content');`
 * Python


### PR DESCRIPTION
Quarkus Qute now supports Template Fragments. Added link under `Known Template Fragment Implementations`.
