### PR TITLE
[#1115] Client-side-templates fix - support arrays

### DIFF
--- a/src/ext/client-side-templates.js
+++ b/src/ext/client-side-templates.js
@@ -7,7 +7,7 @@ htmx.defineExtension('client-side-templates', {
             var templateId = mustacheTemplate.getAttribute('mustache-template');
             var template = htmx.find("#" + templateId);
             if (template) {
-                return Mustache.render(template.innerHTML, data);
+                return Mustache.render(template.innerHTML, {"data": data});
             } else {
                 throw "Unknown mustache template: " + templateId;
             }
@@ -17,7 +17,7 @@ htmx.defineExtension('client-side-templates', {
         if (handlebarsTemplate) {
             var data = JSON.parse(text);
             var templateName = handlebarsTemplate.getAttribute('handlebars-template');
-            return Handlebars.partials[templateName](data);
+            return Handlebars.partials[templateName]({"data": data});
         }
 
         var nunjucksTemplate = htmx.closest(elt, "[nunjucks-template]");
@@ -26,9 +26,9 @@ htmx.defineExtension('client-side-templates', {
             var templateName = nunjucksTemplate.getAttribute('nunjucks-template');
             var template = htmx.find('#' + templateName);
             if (template) {
-                return nunjucks.renderString(template.innerHTML, data);
+                return nunjucks.renderString(template.innerHTML, {"data": data});
             } else {
-                return nunjucks.render(templateName, data);
+                return nunjucks.render(templateName, {"data": data});
             }
           }
 

--- a/test/ext/client-side-templates.js
+++ b/test/ext/client-side-templates.js
@@ -11,7 +11,7 @@ describe("client-side-templates extension", function() {
     it('works on basic mustache template', function () {
         this.server.respondWith("GET", "/test", '{"foo":"bar"}');
         var btn = make('<button hx-get="/test" hx-ext="client-side-templates" mustache-template="mt1">Click Me!</button>')
-        make('<script id="mt1" type="x-tmpl-mustache">*{{foo}}*</script>')
+        make('<script id="mt1" type="x-tmpl-mustache">*{{data.foo}}*</script>')
         btn.click();
         this.server.respond();
         btn.innerHTML.should.equal("*bar*");
@@ -20,7 +20,7 @@ describe("client-side-templates extension", function() {
     it('works on basic handlebars template', function () {
         this.server.respondWith("GET", "/test", '{"foo":"bar"}');
         var btn = make('<button hx-get="/test" hx-ext="client-side-templates" handlebars-template="hb1">Click Me!</button>')
-        Handlebars.partials["hb1"] = Handlebars.compile("*{{foo}}*");
+        Handlebars.partials["hb1"] = Handlebars.compile("*{{data.foo}}*");
         btn.click();
         this.server.respond();
         btn.innerHTML.should.equal("*bar*");

--- a/www/extensions/client-side-templates.md
+++ b/www/extensions/client-side-templates.md
@@ -21,20 +21,23 @@ the template the standard way for that template engine:
 * `nunjucks` - resolves the template by name via `nunjucks.render(<template-name>)
 
 The AJAX response body will be parsed as JSON and passed into the template rendering.
+The JSON data will be passed as the value of `data` property.
+You will access the server data as `data.my_server_field`.
+This allows you to return and render arrays and collections.
 
 ### Usage
 
 ```html
 <div hx-ext="client-side-templates">
-  <button hx-get="/some_json" 
+  <button hx-get="/some_json"
           mustache-template="my-mustache-template">
      Handle with mustache
   </button>
-  <button hx-get="/some_json" 
+  <button hx-get="/some_json"
           handlebars-template="my-handlebars-template">
      Handle with handlebars
   </button>
-  <button hx-get="/some_json" 
+  <button hx-get="/some_json"
           nunjucks-template="my-nunjucks-template">
      Handle with nunjucks
   </button>
@@ -48,7 +51,7 @@ The AJAX response body will be parsed as JSON and passed into the template rende
 ### Full HTML Example
 
 To use the client side template, you will need to include htmx, the extension, and the rendering engine.
-Here is an example of this setup for Mustache using 
+Here is an example of this setup for Mustache using
 a [`<template>` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template).
 
 If you wish to put a template into another file, you can use a directive such as
@@ -67,7 +70,7 @@ If you wish to put a template into another file, you can use a directive such as
 </head>
 <body>
   <div hx-ext="client-side-templates">
-    <button hx-get="https://jsonplaceholder.typicode.com/todos/1" 
+    <button hx-get="https://jsonplaceholder.typicode.com/todos/1"
             hx-swap="innerHTML"
             hx-target="#content"
             mustache-template="foo">
@@ -75,9 +78,9 @@ If you wish to put a template into another file, you can use a directive such as
     </button>
 
     <p id="content">Start</p>
-    
+
     <template id="foo">
-      <p>{{userID}} and {{id}} and {{title}} and {{completed}}</p>
+      <p>{{data.userID}} and {{data.id}} and {{data.title}} and {{data.completed}}</p>
     </template>
   </div>
 </body>
@@ -92,7 +95,7 @@ As a warning, many web services use CORS protection and/or other protection sche
 REST/JSON request from a web browser - for example, GitHub will issue a CORS error if you try to
 use the above snippet to access public APIs. This can be frustrating, as a dedicated REST development
 client may work fine, but the CORS error will appear when running JavaScript. This doesn't really
-have anything to do with HTMX (as you'd have the same issues with any JavaScript code), but can be 
+have anything to do with HTMX (as you'd have the same issues with any JavaScript code), but can be
 a frustrating surprise.
 
 Unfortunately, the solution will vary depending on the provider of the web service. Depending on


### PR DESCRIPTION
* Provide data as property named `data` so we can render arrays

Fixes #1115 (closed before I had a chance to make this PR). 