### PR TITLE
Actually pass original event on to `htmx:configRequest`

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1275,7 +1275,7 @@ return (function () {
                     path = getRawAttribute(elt, 'action');
                 }
                 triggerSpecs.forEach(function(triggerSpec) {
-                    addEventListener(elt, function(evt) {
+                    addEventListener(elt, function(elt, evt) {
                         issueAjaxRequest(verb, path, elt, evt)
                     }, nodeData, triggerSpec, true);
                 });

--- a/test/core/events.js
+++ b/test/core/events.js
@@ -115,6 +115,26 @@ describe("Core htmx Events", function() {
         }
     });
 
+    it("htmx:configRequest on form gives access to submit event", function () {
+        var submitterId;
+        var handler = htmx.on("htmx:configRequest", function (evt) {
+            evt.detail.headers['X-Submitter-Id'] = evt.detail.triggeringEvent.submitter.id;
+        });
+        try {
+            this.server.respondWith("POST", "/test", function (xhr) {
+                submitterId = xhr.requestHeaders['X-Submitter-Id']
+                xhr.respond(200, {}, "");
+            });
+            make('<div hx-target="this" hx-boost="true"><form action="/test" method="post"><button type="submit" id="b1">Submit</button><button type="submit" id="b2">Submit</button></form></div>');
+            var btn = byId('b1');
+            btn.click();
+            this.server.respond();
+            should.equal(submitterId, "b1")
+        } finally {
+            htmx.off("htmx:configRequest", handler);
+        }
+    });
+
     it("htmx:afterSwap is called when replacing outerHTML", function () {
         var called = false;
         var handler = htmx.on("htmx:afterSwap", function (evt) {


### PR DESCRIPTION
Previously, we passed the _element_ as the original event. I think this bug was introduced in https://github.com/bigskysoftware/htmx/commit/8bb0399052f5a52a49e9e4f0f9624d25f1c2e890.

We can easily fix this by actually using both arguments of the `handler` closure.

Let me know if there is a better way to write this test.