### PR TITLE
[Fixes #1128] submit button child elements not sending name or value of parent attributes in form request

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1781,6 +1781,12 @@ return (function () {
                 if (matches(evt.target, "button, input[type='submit']")) {
                     var internalData = getInternalData(form);
                     internalData.lastButtonClicked = evt.target;
+                } else { // in case clicked element is nested within a button
+                    var elt = closest(evt.target, "button");
+                    if (elt !== null) {
+                        var internalData = getInternalData(form);
+                        internalData.lastButtonClicked = elt;
+                    }
                 }
             };
 

--- a/test/core/parameters.js
+++ b/test/core/parameters.js
@@ -169,5 +169,12 @@ describe("Core htmx Parameter Handling", function() {
         should.equal(vals['s1'], undefined);
     })
 
+    it('form includes button name and value if button has nested elements when clicked', function () {
+        var form = make('<form hx-get="/foo"><input id="i1" name="foo" value="bar"/><button type="submit" id="btn1" name="do" value="rey"><div id="div1"><span id="span1"></span></div></button></form>');
+        var nestedElt = byId('span1');
+        nestedElt.click();
+        var vals = htmx._('getInputValues')(form).values;
+        vals['do'].should.equal('rey');
+    })
 });
 

--- a/test/index.html
+++ b/test/index.html
@@ -9,7 +9,8 @@
     <meta http-equiv="expires" content="0" />
     <meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
     <meta http-equiv="pragma" content="no-cache" />
-    <meta name="htmx-config" content='{"historyEnabled":false,"defaultSettleDelay":0}'>
+    <!-- <meta name="htmx-config" content='{"historyEnabled":false,"defaultSettleDelay":0}'> -->
+    <meta name="htmx-config" content="history-enabled=false, default-settle-delay=0">
 </head>
 <body style="padding:20px;font-family: sans-serif">
 


### PR DESCRIPTION
Fixes #1128 

This fixes child elements nested within a submit button not sending the appropriate attributes on a form request.
For example, the following code would submit `{ "foo": "bar" }`:
```
<form>
    <input/>
    <input/>
    <button type="submit" name="foo" value="bar">Submit</button>
</form>
```
whereas prior to the change, the following code would **not** send those same attributes (when the `span` was clicked):
```
<form>
    <input/>
    <input/>
    <button type="submit" name="foo" value="bar">
        <span>Submit</span>
    </button>
</form>
```
This change allows for more complex button styling while keeping form functionality simpler.