### PR TITLE
Support #anchor redirect refresh

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3051,16 +3051,17 @@ return (function () {
                 return;
             }
 
+            var shouldRefresh = hasHeader(xhr, /HX-Refresh:/i) && "true" === xhr.getResponseHeader("HX-Refresh");
+
             if (hasHeader(xhr, /HX-Redirect:/i)) {
                 location.href = xhr.getResponseHeader("HX-Redirect");
+                shouldRefresh && location.reload();
                 return;
             }
 
-            if (hasHeader(xhr,/HX-Refresh:/i)) {
-                if ("true" === xhr.getResponseHeader("HX-Refresh")) {
-                    location.reload();
-                    return;
-                }
+            if (shouldRefresh) {
+                location.reload();
+                return;
             }
 
             if (hasHeader(xhr,/HX-Retarget:/i)) {


### PR DESCRIPTION
Solves this problem:

Url is `/items-list` and it has a `hx-post` form on in to allow adding new items.

When form receives a response with `HX-Redirect: /items-list#item-10` header, the current location does not reload since it is the same url.

This pull request solves this by allowing user to combine `HX-Redirect` and `HX-Refresh` headers so the full page is reloaded, and it automaticaly scrolls to the newly added `#item-10`