### PR TITLE
Don't ignore button params if button is input element

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2120,8 +2120,14 @@ return (function () {
                 return false;
             }
             // ignore "submitter" types (see jQuery src/serialize.js)
-            if (elt.type === "button" || elt.type === "submit" || elt.tagName === "image" || elt.tagName === "reset" || elt.tagName === "file" ) {
-                return false;
+            if (elt.type === "button" || elt.type === "submit") {
+              // If is an input button (i.e. <input type="submit" name="..." value="..." />)
+              // then include the name & value if they exist.
+              // We know this input button already has a name from above logic.
+              if (elt.tagName !== "INPUT" || !elt.value) return false;
+            }
+            if (elt.tagName === "image" || elt.tagName === "reset" || elt.tagName === "file" ) {
+                  return false;
             }
             if (elt.type === "checkbox" || elt.type === "radio" ) {
                 return elt.checked;


### PR DESCRIPTION
Addresses the issue in #1132 

Currently, button parameters are never sent to the server. I believe that should still be the default but this PR allows users to be opt-in by using an input element instead of a button element. 

The input element must be type `button` or `submit`, and it must have a name and a value.

I think this makes sense since a user would expect an `<input ... />` element to send data to the server, whereas it makes sense why a button element wouldn't.