### PR TITLE
Escape curly braces in the example

### DIFF
--- a/www/extensions/client-side-templates.md
+++ b/www/extensions/client-side-templates.md
@@ -77,7 +77,7 @@ If you wish to put a template into another file, you can use a directive such as
     <p id="content">Start</p>
     
     <template id="foo">
-      <p>{{userID}} and {{id}} and {{title}} and {{completed}}</p>
+      <p> {% raw %}{{userID}}{% endraw %} and {% raw %}{{id}}{% endraw %} and {% raw %}{{title}}{% endraw %} and {% raw %}{{completed}}{% endraw %}</p>
     </template>
   </div>
 </body>


### PR DESCRIPTION
Docs on the website for this page are currently rendering incorrectly because of faulty escaping of curly braces (line 80 is rendered has `<p> and  and </> htmx - high power tools for html and </p>`). Unfortunately, this fix breaks the rendering of the file on github (there are extra `{% raw %}` directives), but I think it's better than the other way around.