### PR TITLE
fixes where dynamically adding hx-disable is not processed

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1791,18 +1791,26 @@ return (function () {
         }
 
         function initNode(elt) {
+            var nodeData = getInternalData(elt);
+
             if (elt.closest && elt.closest(htmx.config.disableSelector)) {
+                if (nodeData.initHash) {
+                  triggerEvent(elt, "htmx:beforeProcessNode")
+                  nodeData.initHash = null;
+                  deInitNode(elt);
+                  triggerEvent(elt, "htmx:afterProcessNode");
+                }
                 return;
             }
-            var nodeData = getInternalData(elt);
+
             if (nodeData.initHash !== attributeHash(elt)) {
+                triggerEvent(elt, "htmx:beforeProcessNode")
 
                 nodeData.initHash = attributeHash(elt);
 
                 // clean up any previously processed info
                 deInitNode(elt);
 
-                triggerEvent(elt, "htmx:beforeProcessNode")
 
                 if (elt.value) {
                     nodeData.lastValue = elt.value;


### PR DESCRIPTION
Fixes #1176 

Adding the `hx-disable` to an element and then running `htmx.process(...)` now de-registers the element.