### PR TITLE
Fix issue 724

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2028,7 +2028,13 @@ return (function () {
             var request = new XMLHttpRequest();
             var details = {path: path, xhr:request};
             triggerEvent(getDocument().body, "htmx:historyCacheMiss", details);
-            request.open('GET', path, true);
+            var finalPathForGet = path;
+            if (finalPathForGet.includes("?")) {
+                finalPathForGet.replace(/\?/, "?htmx-request=1&")
+            } else {
+                finalPathForGet += "?htmx-request=1"
+            }
+            request.open('GET', finalPathForGet, true);
             request.setRequestHeader("HX-History-Restore-Request", "true");
             request.onload = function () {
                 if (this.status >= 200 && this.status < 400) {
@@ -2832,17 +2838,15 @@ return (function () {
             var finalPathForGet = null;
             if (verb === 'get') {
                 finalPathForGet = pathNoAnchor;
-                var values = Object.keys(filteredParameters).length !== 0;
-                if (values) {
-                    if (finalPathForGet.indexOf("?") < 0) {
-                        finalPathForGet += "?";
-                    } else {
-                        finalPathForGet += "&";
-                    }
-                    finalPathForGet += urlEncode(filteredParameters);
-                    if (anchor) {
-                        finalPathForGet += "#" + anchor;
-                    }
+                filteredParameters["htmx-request"] = 1;
+                if (finalPathForGet.indexOf("?") < 0) {
+                    finalPathForGet += "?";
+                } else {
+                    finalPathForGet += "&";
+                }
+                finalPathForGet += urlEncode(filteredParameters);
+                if (anchor) {
+                    finalPathForGet += "#" + anchor;
                 }
                 xhr.open('GET', finalPathForGet, true);
             } else {
@@ -3020,6 +3024,8 @@ return (function () {
                     path.indexOf("#") === -1) {
                     path = path + "#" + responseInfo.pathInfo.anchor;
                 }
+
+                path = path.replace(/[?&]?htmx-request=1&?/i, "")
 
                 return {
                     type:saveType,

--- a/test/attributes/hx-boost.js
+++ b/test/attributes/hx-boost.js
@@ -10,7 +10,7 @@ describe("hx-boost attribute", function() {
     });
 
     it('handles basic anchor properly', function () {
-        this.server.respondWith("GET", "/test", "Boosted");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Boosted");
         var div = make('<div hx-target="this" hx-boost="true"><a id="a1" href="/test">Foo</a></div>');
         var a = byId('a1');
         a.click();
@@ -30,7 +30,7 @@ describe("hx-boost attribute", function() {
     })
 
     it('handles basic form get properly', function () {
-        this.server.respondWith("GET", "/test", "Boosted");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Boosted");
         var div = make('<div hx-target="this" hx-boost="true"><form id="f1" action="/test" method="get"><button id="b1">Submit</button></form></div>');
         var btn = byId('b1');
         btn.click();
@@ -39,7 +39,7 @@ describe("hx-boost attribute", function() {
     })
 
     it('handles basic form with no explicit method property', function () {
-        this.server.respondWith("GET", "/test", "Boosted");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Boosted");
         var div = make('<div hx-target="this" hx-boost="true"><form id="f1" action="/test"><button id="b1">Submit</button></form></div>');
         var btn = byId('b1');
         btn.click();
@@ -48,7 +48,7 @@ describe("hx-boost attribute", function() {
     })
 
     it('handles basic anchor properly w/ data-* prefix', function () {
-        this.server.respondWith("GET", "/test", "Boosted");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Boosted");
         var div = make('<div data-hx-target="this" data-hx-boost="true"><a id="a1" href="/test">Foo</a></div>');
         var a = byId('a1');
         a.click();
@@ -60,7 +60,7 @@ describe("hx-boost attribute", function() {
     it('overriding default swap style does not effect boosting', function () {
         htmx.config.defaultSwapStyle = "afterend";
         try {
-            this.server.respondWith("GET", "/test", "Boosted");
+            this.server.respondWith("GET", "/test?htmx-request=1", "Boosted");
             var a = make('<a hx-target="this" hx-boost="true" id="a1" href="/test">Foo</a>');
             a.click();
             this.server.respond();
@@ -78,7 +78,7 @@ describe("hx-boost attribute", function() {
 
     it('includes an HX-Boosted Header', function()
     {
-        this.server.respondWith("GET", "/test", function(xhr){
+        this.server.respondWith("GET", "/test?htmx-request=1", function(xhr){
             should.equal(xhr.requestHeaders['HX-Boosted'], "true");
             xhr.respond(200, {}, "Boosted!");
         });

--- a/test/attributes/hx-disinherit.js
+++ b/test/attributes/hx-disinherit.js
@@ -12,7 +12,7 @@ describe("hx-disinherit attribute", function() {
     it('basic inheritance sanity-check', function () {
         var response_inner = '<div id="snowflake" class="">Hello world</div>'
         var response = '<div id="unique" class="">' + response_inner + '</div>'
-        this.server.respondWith("GET", "/test", response);
+        this.server.respondWith("GET", "/test?htmx-request=1", response);
 
         var div = make('<div hx-select="#snowflake" hx-target="#cta" hx-swap="outerHTML"><button id="bx1" hx-get="/test"><span id="cta">Click Me!</span></button></div>')
         var btn = byId("bx1");
@@ -25,7 +25,7 @@ describe("hx-disinherit attribute", function() {
     it('disinherit exclude single attribute', function () {
         var response_inner = '<div id="snowflake" class="">Hello world</div>'
         var response = '<div id="unique">' + response_inner + '</div>'
-        this.server.respondWith("GET", "/test", response);
+        this.server.respondWith("GET", "/test?htmx-request=1", response);
 
         var div = make('<div hx-select="#snowflake" hx-target="#cta" hx-swap="beforebegin" hx-disinherit="hx-select"><button id="bx1" hx-get="/test"><span id="cta">Click Me!</span></button></div>')
         var btn = byId("bx1");
@@ -37,7 +37,7 @@ describe("hx-disinherit attribute", function() {
     it('disinherit exclude multiple attributes', function () {
         var response_inner = '<div id="snowflake">Hello world</div>'
         var response = '<div id="unique">' + response_inner + '</div>'
-        this.server.respondWith("GET", "/test", response);
+        this.server.respondWith("GET", "/test?htmx-request=1", response);
 
         var div = make('<div hx-select="#snowflake" hx-target="#cta" hx-swap="beforebegin" hx-disinherit="hx-select hx-swap">' +
             '  <button id="bx1" hx-get="/test"><span id="cta">Click Me!</span></button>' +
@@ -53,7 +53,7 @@ describe("hx-disinherit attribute", function() {
     it('disinherit exclude all attributes', function () {
         var response_inner = '<div id="snowflake">Hello world</div>'
         var response = '<div id="unique">' + response_inner + '</div>'
-        this.server.respondWith("GET", "/test", response);
+        this.server.respondWith("GET", "/test?htmx-request=1", response);
         var div = make('<div hx-select="#snowflake" hx-target="#cta" hx-swap="beforebegin" hx-disinherit="*">' +
             '  <button id="bx1" hx-get="/test">' +
             '    <span id="cta">Click Me!</span>' +
@@ -68,7 +68,7 @@ describe("hx-disinherit attribute", function() {
     it('same-element inheritance disable', function () {
         var response_inner = '<div id="snowflake" class="">Hello world</div>'
         var response = '<div id="unique">' + response_inner + '</div>'
-        this.server.respondWith("GET", "/test", response);
+        this.server.respondWith("GET", "/test?htmx-request=1", response);
 
         var btn = make('<button hx-select="#snowflake" hx-target="#container" hx-trigger="click" hx-get="/test" hx-swap="outerHTML" hx-disinherit="*"><div id="container"></div></button>')
         btn.click();
@@ -79,8 +79,8 @@ describe("hx-disinherit attribute", function() {
     it('same-element inheritance disable with child nodes', function () {
         var response_inner = '<div id="snowflake" class="">Hello world</div>'
         var response = '<div id="unique">' + response_inner + '</div>'
-        this.server.respondWith("GET", "/test", response);
-        this.server.respondWith("GET", "/test2", 'unique-snowflake');
+        this.server.respondWith("GET", "/test?htmx-request=1", response);
+        this.server.respondWith("GET", "/test2?htmx-request=1", 'unique-snowflake');
 
         var div = make('<div hx-select="#snowflake" hx-target="#container" hx-get="/test" hx-swap="outerHTML" hx-trigger="keyup" hx-disinherit="*"><div id="container"><button id="bx1" hx-get="/test2" hx-trigger="click" hx-target="#target"><div id="target"></div></button></div></div>')
         var btn = byId("bx1");

--- a/test/attributes/hx-ext.js
+++ b/test/attributes/hx-ext.js
@@ -45,7 +45,7 @@ describe("hx-ext attribute", function() {
     });
 
     it('A simple extension is invoked properly', function () {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
 
         var btn = make('<button hx-get="/test" hx-ext="ext-1">Click Me!</button>')
         btn.click();
@@ -56,7 +56,7 @@ describe("hx-ext attribute", function() {
     });
 
     it('Extensions are merged properly', function () {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
 
         make('<div hx-ext="ext-1"><button id="btn-1" hx-get="/test" hx-ext="ext-2">Click Me!</button>' +
             '<button id="btn-2"  hx-get="/test" hx-ext="ext-3">Click Me!</button></div>')
@@ -77,7 +77,7 @@ describe("hx-ext attribute", function() {
     });
 
     it('supports comma separated lists', function () {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
 
         make('<div hx-ext="ext-1"><button id="btn-1" hx-get="/test" hx-ext="ext-2,  ext-3 ">Click Me!</button></div>')
         var btn1 = byId("btn-1");
@@ -91,7 +91,7 @@ describe("hx-ext attribute", function() {
     });
 
     it('A simple extension is invoked properly  w/ data-* prefix', function () {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
 
         var btn = make('<button data-hx-get="/test" data-hx-ext="ext-1">Click Me!</button>')
         btn.click();
@@ -102,7 +102,7 @@ describe("hx-ext attribute", function() {
     });
 
     it('A simple extension is invoked properly when an HX-Trigger event w/ a namespace fires', function () {
-        this.server.respondWith("GET", "/test", [200, {"HX-Trigger":"namespace:example"}, ""]);
+        this.server.respondWith("GET", "/test?htmx-request=1", [200, {"HX-Trigger":"namespace:example"}, ""]);
         var btn = make('<button data-hx-get="/test" data-hx-ext="ext-4">Click Me!</button>')
         btn.click();
         this.server.respond();
@@ -114,7 +114,7 @@ describe("hx-ext attribute", function() {
     });
 
     it('Extensions are ignored properly', function () {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
 
         make('<div id="div-AA" hx-ext="ext-1, ext-2"><button id="btn-AA" hx-get="/test">Click Me!</button>' +
             '<div id="div-BB" hx-ext="ignore:ext-1"><button id="btn-BB" hx-get="/test"></div></div>')

--- a/test/attributes/hx-get.js
+++ b/test/attributes/hx-get.js
@@ -9,7 +9,7 @@ describe("hx-get attribute", function() {
     });
 
     it('issues a GET request on click and swaps content', function () {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
 
         var btn = make('<button hx-get="/test">Click Me!</button>')
         btn.click();
@@ -18,7 +18,7 @@ describe("hx-get attribute", function() {
     });
 
     it('GET does not include surrounding data by default', function () {
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             should.equal(getParameters(xhr)["i1"], undefined);
             xhr.respond(200, {}, "Clicked!");
         });
@@ -66,7 +66,7 @@ describe("hx-get attribute", function() {
 
 
     it('issues a GET request on click and swaps content w/ data-* prefix', function () {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
 
         var btn = make('<button data-hx-get="/test">Click Me!</button>')
         btn.click();

--- a/test/attributes/hx-history.js
+++ b/test/attributes/hx-history.js
@@ -14,9 +14,9 @@ describe("hx-history attribute", function() {
     });
 
     it("history cache should not contain embargoed content", function () {
-        this.server.respondWith("GET", "/test1", '<div id="d2" hx-push-url="true" hx-get="/test2" hx-swap="outerHTML settle:0" hx-history="true">test1</div>');
-        this.server.respondWith("GET", "/test2", '<div id="d3" hx-push-url="true" hx-get="/test3" hx-swap="outerHTML settle:0" hx-history="false">test2</div>');
-        this.server.respondWith("GET", "/test3", '<div id="d4" hx-push-url="true" hx-get="/test3" hx-swap="outerHTML settle:0" hx-history="true">test3</div>');
+        this.server.respondWith("GET", "/test1?htmx-request=1", '<div id="d2" hx-push-url="true" hx-get="/test2" hx-swap="outerHTML settle:0" hx-history="true">test1</div>');
+        this.server.respondWith("GET", "/test2?htmx-request=1", '<div id="d3" hx-push-url="true" hx-get="/test3" hx-swap="outerHTML settle:0" hx-history="false">test2</div>');
+        this.server.respondWith("GET", "/test3?htmx-request=1", '<div id="d4" hx-push-url="true" hx-get="/test3" hx-swap="outerHTML settle:0" hx-history="true">test3</div>');
 
         make('<div id="d1" hx-push-url="true" hx-get="/test1" hx-swap="outerHTML settle:0">init</div>');
 

--- a/test/attributes/hx-include.js
+++ b/test/attributes/hx-include.js
@@ -51,7 +51,7 @@ describe("hx-include attribute", function() {
     });
 
     it('GET does not include closest form by default', function () {
-        this.server.respondWith("GET", "/include", function (xhr) {
+        this.server.respondWith("GET", "/include?htmx-request=1", function (xhr) {
             var params = getParameters(xhr);
             should.equal(params['i1'], undefined);
             xhr.respond(200, {}, "Clicked!")

--- a/test/attributes/hx-indicator.js
+++ b/test/attributes/hx-indicator.js
@@ -10,7 +10,7 @@ describe("hx-indicator attribute", function(){
 
     it('Indicator classes are properly put on element with no explicit indicator', function()
     {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var btn = make('<button hx-get="/test">Click Me!</button>')
         btn.click();
         btn.classList.contains("htmx-request").should.equal(true);
@@ -20,7 +20,7 @@ describe("hx-indicator attribute", function(){
 
     it('Indicator classes are properly put on element with explicit indicator', function()
     {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var btn = make('<button hx-get="/test" hx-indicator="#a1, #a2">Click Me!</button>')
         var a1 = make('<a id="a1"></a>')
         var a2 = make('<a id="a2"></a>')
@@ -36,7 +36,7 @@ describe("hx-indicator attribute", function(){
 
     it('Indicator classes are properly put on element with explicit indicator w/ data-* prefix', function()
     {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var btn = make('<button hx-get="/test" data-hx-indicator="#a1, #a2">Click Me!</button>')
         var a1 = make('<a id="a1"></a>')
         var a2 = make('<a id="a2"></a>')
@@ -52,7 +52,7 @@ describe("hx-indicator attribute", function(){
 
     it('allows closest syntax in hx-indicator', function()
     {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var div = make('<div id="d1"><button id="b1" hx-get="/test" hx-indicator="closest div">Click Me!</button></div>')
         var btn = byId("b1");
         btn.click();
@@ -65,7 +65,7 @@ describe("hx-indicator attribute", function(){
 
     it('is removed when initiating element is removed from the DOM', function()
     {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var indicator = make('<div id="ind1">Indicator</div>')
         var div = make('<div id="d1" hx-target="this" hx-indicator="#ind1"><button id="b1" hx-get="/test">Click Me!</button></div>')
         var btn = byId("b1");
@@ -77,7 +77,7 @@ describe("hx-indicator attribute", function(){
 
     it('allows this syntax in hx-indicator', function()
     {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var div = make('<div id="d1" hx-indicator="this"><button id="b1" hx-get="/test">Click Me!</button></div>')
         var btn = byId("b1");
         btn.click();
@@ -90,7 +90,7 @@ describe("hx-indicator attribute", function(){
 
     it('multiple requests with same indicator are handled properly', function()
     {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var b1 = make('<button hx-get="/test" hx-indicator=".a1">Click Me!</button>')
         var b2 = make('<button hx-get="/test" hx-indicator=".a1">Click Me!</button>')
         var a1 = make('<a class="a1"></a>')

--- a/test/attributes/hx-preserve.js
+++ b/test/attributes/hx-preserve.js
@@ -9,7 +9,7 @@ describe("hx-preserve attribute", function () {
     });
 
     it('handles basic response properly', function () {
-        this.server.respondWith("GET", "/test", "<div id='d1' hx-preserve>New Content</div><div id='d2'>New Content</div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<div id='d1' hx-preserve>New Content</div><div id='d2'>New Content</div>");
         var div = make("<div hx-get='/test'><div id='d1' hx-preserve>Old Content</div><div id='d2'>Old Content</div></div>");
         div.click();
         this.server.respond();
@@ -18,7 +18,7 @@ describe("hx-preserve attribute", function () {
     })
 
     it('handles preserved element that might not be existing', function () {
-        this.server.respondWith("GET", "/test", "<div id='d1' hx-preserve>New Content</div><div id='d2'>New Content</div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<div id='d1' hx-preserve>New Content</div><div id='d2'>New Content</div>");
         var div = make("<div hx-get='/test'><div id='d2'>Old Content</div></div>");
         div.click();
         this.server.respond();
@@ -27,7 +27,7 @@ describe("hx-preserve attribute", function () {
     })
 
     it('preserved element should not be swapped if it lies outside of hx-select', function () {
-        this.server.respondWith("GET", "/test", "<div id='d1' hx-preserve>New Content</div><div id='d2'>New Content</div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<div id='d1' hx-preserve>New Content</div><div id='d2'>New Content</div>");
         var div = make("<div hx-get='/test' hx-target='#d2' hx-select='#d2' hx-swap='outerHTML'><div id='d1' hx-preserve>Old Content</div><div id='d2'>Old Content</div></div>");
         div.click();
         this.server.respond();

--- a/test/attributes/hx-push-url.js
+++ b/test/attributes/hx-push-url.js
@@ -14,7 +14,7 @@ describe("hx-push-url attribute", function() {
     });
 
     it("navigation should push an element into the cache when true", function () {
-        this.server.respondWith("GET", "/test", "second");
+        this.server.respondWith("GET", "/test?htmx-request=1", "second");
         getWorkArea().innerHTML.should.be.equal("");
         var div = make('<div hx-push-url="true" hx-get="/test">first</div>');
         div.click();
@@ -28,7 +28,7 @@ describe("hx-push-url attribute", function() {
     });
 
     it("navigation should push an element into the cache when string", function () {
-        this.server.respondWith("GET", "/test", "second");
+        this.server.respondWith("GET", "/test?htmx-request=1", "second");
         getWorkArea().innerHTML.should.be.equal("");
         var div = make('<div hx-push-url="/abc123" hx-get="/test">first</div>');
         div.click();
@@ -42,8 +42,8 @@ describe("hx-push-url attribute", function() {
     });
 
     it("restore should return old value", function () {
-        this.server.respondWith("GET", "/test1", '<div id="d2" hx-push-url="true" hx-get="/test2" hx-swap="outerHTML settle:0">test1</div>');
-        this.server.respondWith("GET", "/test2", '<div id="d3" hx-push-url="true" hx-get="/test3" hx-swap="outerHTML settle:0">test2</div>');
+        this.server.respondWith("GET", "/test1?htmx-request=1", '<div id="d2" hx-push-url="true" hx-get="/test2" hx-swap="outerHTML settle:0">test1</div>');
+        this.server.respondWith("GET", "/test2?htmx-request=1", '<div id="d3" hx-push-url="true" hx-get="/test3" hx-swap="outerHTML settle:0">test2</div>');
 
         make('<div id="d1" hx-push-url="true" hx-get="/test1" hx-swap="outerHTML settle:0">init</div>');
 
@@ -64,8 +64,8 @@ describe("hx-push-url attribute", function() {
     });
 
     it("history restore should not have htmx support classes in content", function () {
-        this.server.respondWith("GET", "/test1", '<div id="d2" hx-push-url="true" hx-get="/test2" hx-swap="outerHTML settle:0">test1</div>');
-        this.server.respondWith("GET", "/test2", '<div id="d3" hx-push-url="true" hx-get="/test3" hx-swap="outerHTML settle:0">test2</div>');
+        this.server.respondWith("GET", "/test1?htmx-request=1", '<div id="d2" hx-push-url="true" hx-get="/test2" hx-swap="outerHTML settle:0">test1</div>');
+        this.server.respondWith("GET", "/test2?htmx-request=1", '<div id="d3" hx-push-url="true" hx-get="/test3" hx-swap="outerHTML settle:0">test2</div>');
 
         make('<div id="d1" hx-push-url="true" hx-get="/test1" hx-swap="outerHTML settle:0">init</div>');
 
@@ -99,8 +99,8 @@ describe("hx-push-url attribute", function() {
     });
 
     it("cache miss should issue another GET", function () {
-        this.server.respondWith("GET", "/test1", '<div id="d2" hx-push-url="true" hx-get="/test2" hx-swap="outerHTML settle:0">test1</div>');
-        this.server.respondWith("GET", "/test2", '<div id="d3" hx-push-url="true" hx-get="/test3" hx-swap="outerHTML settle:0">test2</div>');
+        this.server.respondWith("GET", "/test1?htmx-request=1", '<div id="d2" hx-push-url="true" hx-get="/test2" hx-swap="outerHTML settle:0">test1</div>');
+        this.server.respondWith("GET", "/test2?htmx-request=1", '<div id="d3" hx-push-url="true" hx-get="/test3" hx-swap="outerHTML settle:0">test2</div>');
 
         make('<div id="d1" hx-push-url="true" hx-get="/test1" hx-swap="outerHTML settle:0">init</div>');
 
@@ -123,7 +123,7 @@ describe("hx-push-url attribute", function() {
     });
 
     it("navigation should push an element into the cache  w/ data-* prefix", function () {
-        this.server.respondWith("GET", "/test", "second");
+        this.server.respondWith("GET", "/test?htmx-request=1", "second");
         getWorkArea().innerHTML.should.be.equal("");
         var div = make('<div data-hx-push-url="true" data-hx-get="/test">first</div>');
         div.click();

--- a/test/attributes/hx-request.js
+++ b/test/attributes/hx-request.js
@@ -10,7 +10,7 @@ describe("hx-request attribute", function() {
 
     it('basic hx-request timeout works', function (done) {
         var timedOut = false;
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var div = make("<div hx-post='/vars' hx-request='\"timeout\":1'></div>")
         htmx.on(div, 'htmx:timeout', function(){
             timedOut = true;

--- a/test/attributes/hx-select-oob.js
+++ b/test/attributes/hx-select-oob.js
@@ -10,7 +10,7 @@ describe("hx-select-oob attribute", function () {
 
     it('basic hx-select-oob works', function()
     {
-        this.server.respondWith("GET", "/test", "<div id='d1'>foo</div><div id='d2'>bar</div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<div id='d1'>foo</div><div id='d2'>bar</div>");
         var div = make('<div hx-get="/test" hx-select="#d1" hx-select-oob="#d2"></div>');
         make('<div id="d2"></div>');
         div.click();
@@ -22,7 +22,7 @@ describe("hx-select-oob attribute", function () {
 
     it('basic hx-select-oob ignores bad selector', function()
     {
-        this.server.respondWith("GET", "/test", "<div id='d1'>foo</div><div id='d2'>bar</div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<div id='d1'>foo</div><div id='d2'>bar</div>");
         var div = make('<div hx-get="/test" hx-select="#d1" hx-select-oob="#bad"></div>');
         make('<div id="d2"></div>');
         div.click();

--- a/test/attributes/hx-select.js
+++ b/test/attributes/hx-select.js
@@ -11,7 +11,7 @@ describe("BOOTSTRAP - htmx AJAX Tests", function(){
     it('properly handles a partial of HTML', function()
     {
         var i = 1;
-        this.server.respondWith("GET", "/test", "<div id='d1'>foo</div><div id='d2'>bar</div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<div id='d1'>foo</div><div id='d2'>bar</div>");
         var div = make('<div hx-get="/test" hx-select="#d1"></div>');
         div.click();
         this.server.respond();
@@ -21,7 +21,7 @@ describe("BOOTSTRAP - htmx AJAX Tests", function(){
     it('properly handles a full HTML document', function()
     {
         var i = 1;
-        this.server.respondWith("GET", "/test", "<html><body><div id='d1'>foo</div><div id='d2'>bar</div></body></html>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<html><body><div id='d1'>foo</div><div id='d2'>bar</div></body></html>");
         var div = make('<div hx-get="/test" hx-select="#d1"></div>');
         div.click();
         this.server.respond();
@@ -31,7 +31,7 @@ describe("BOOTSTRAP - htmx AJAX Tests", function(){
     it('properly handles a full HTML document  w/ data-* prefix', function()
     {
         var i = 1;
-        this.server.respondWith("GET", "/test", "<html><body><div id='d1'>foo</div><div id='d2'>bar</div></body></html>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<html><body><div id='d1'>foo</div><div id='d2'>bar</div></body></html>");
         var div = make('<div hx-get="/test" data-hx-select="#d1"></div>');
         div.click();
         this.server.respond();

--- a/test/attributes/hx-sse.js
+++ b/test/attributes/hx-sse.js
@@ -42,8 +42,8 @@ describe("hx-sse attribute", function() {
 
     it('handles basic sse triggering', function () {
 
-        this.server.respondWith("GET", "/d1", "div1 updated");
-        this.server.respondWith("GET", "/d2", "div2 updated");
+        this.server.respondWith("GET", "/d1?htmx-request=1", "div1 updated");
+        this.server.respondWith("GET", "/d2?htmx-request=1", "div2 updated");
 
         var div = make('<div hx-sse="connect:/foo">' +
             '<div id="d1" hx-trigger="sse:e1" hx-get="/d1">div1</div>' +
@@ -63,7 +63,7 @@ describe("hx-sse attribute", function() {
 
     it('does not trigger events that arent named', function () {
 
-        this.server.respondWith("GET", "/d1", "div1 updated");
+        this.server.respondWith("GET", "/d1?htmx-request=1", "div1 updated");
 
         var div = make('<div hx-sse="connect:/foo">' +
             '<div id="d1" hx-trigger="sse:e1" hx-get="/d1">div1</div>' +
@@ -84,7 +84,7 @@ describe("hx-sse attribute", function() {
 
     it('does not trigger events not on decendents', function () {
 
-        this.server.respondWith("GET", "/d1", "div1 updated");
+        this.server.respondWith("GET", "/d1?htmx-request=1", "div1 updated");
 
         var div = make('<div hx-sse="connect:/foo"></div>' +
             '<div id="d1" hx-trigger="sse:e1" hx-get="/d1">div1</div>');
@@ -103,7 +103,7 @@ describe("hx-sse attribute", function() {
     })
 
     it('is closed after removal', function () {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var div = make('<div hx-get="/test" hx-swap="outerHTML" hx-sse="connect:/foo">' +
             '<div id="d1" hx-trigger="sse:e1" hx-get="/d1">div1</div>' +
             '</div>');

--- a/test/attributes/hx-swap-oob.js
+++ b/test/attributes/hx-swap-oob.js
@@ -9,7 +9,7 @@ describe("hx-swap-oob attribute", function () {
     });
 
     it('handles basic response properly', function () {
-        this.server.respondWith("GET", "/test", "Clicked<div id='d1' hx-swap-oob='true'>Swapped0</div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked<div id='d1' hx-swap-oob='true'>Swapped0</div>");
         var div = make('<div hx-get="/test">click me</div>');
         make('<div id="d1"></div>');
         div.click();
@@ -19,7 +19,7 @@ describe("hx-swap-oob attribute", function () {
     })
 
     it('handles more than one oob swap properly', function () {
-        this.server.respondWith("GET", "/test", "Clicked<div id='d1' hx-swap-oob='true'>Swapped1</div><div id='d2' hx-swap-oob='true'>Swapped2</div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked<div id='d1' hx-swap-oob='true'>Swapped1</div><div id='d2' hx-swap-oob='true'>Swapped2</div>");
         var div = make('<div hx-get="/test">click me</div>');
         make('<div id="d1"></div>');
         make('<div id="d2"></div>');
@@ -31,7 +31,7 @@ describe("hx-swap-oob attribute", function () {
     })
 
     it('handles no id match properly', function () {
-        this.server.respondWith("GET", "/test", "Clicked<div id='d1' hx-swap-oob='true'>Swapped2</div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked<div id='d1' hx-swap-oob='true'>Swapped2</div>");
         var div = make('<div hx-get="/test">click me</div>');
         div.click();
         this.server.respond();
@@ -39,7 +39,7 @@ describe("hx-swap-oob attribute", function () {
     })
 
     it('handles basic response properly w/ data-* prefix', function () {
-        this.server.respondWith("GET", "/test", "Clicked<div id='d1' data-hx-swap-oob='true'>Swapped3</div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked<div id='d1' data-hx-swap-oob='true'>Swapped3</div>");
         var div = make('<div data-hx-get="/test">click me</div>');
         make('<div id="d1"></div>');
         div.click();
@@ -49,7 +49,7 @@ describe("hx-swap-oob attribute", function () {
     })
 
     it('handles outerHTML response properly', function () {
-        this.server.respondWith("GET", "/test", "Clicked<div id='d1' foo='bar' hx-swap-oob='outerHTML'>Swapped4</div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked<div id='d1' foo='bar' hx-swap-oob='outerHTML'>Swapped4</div>");
         var div = make('<div hx-get="/test">click me</div>');
         make('<div id="d1"></div>');
         div.click();
@@ -60,7 +60,7 @@ describe("hx-swap-oob attribute", function () {
     })
 
     it('handles innerHTML response properly', function () {
-        this.server.respondWith("GET", "/test", "Clicked<div id='d1' foo='bar' hx-swap-oob='innerHTML'>Swapped5</div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked<div id='d1' foo='bar' hx-swap-oob='innerHTML'>Swapped5</div>");
         var div = make('<div hx-get="/test">click me</div>');
         make('<div id="d1"></div>');
         div.click();
@@ -71,7 +71,7 @@ describe("hx-swap-oob attribute", function () {
     })
 
     it('oob swaps can be nested in content', function () {
-        this.server.respondWith("GET", "/test", "<div>Clicked<div id='d1' foo='bar' hx-swap-oob='innerHTML'>Swapped6</div></div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<div>Clicked<div id='d1' foo='bar' hx-swap-oob='innerHTML'>Swapped6</div></div>");
         var div = make('<div hx-get="/test">click me</div>');
         make('<div id="d1"></div>');
         div.click();
@@ -82,7 +82,7 @@ describe("hx-swap-oob attribute", function () {
     })
 
     it('oob swaps can use selectors to match up', function () {
-        this.server.respondWith("GET", "/test", "<div>Clicked<div hx-swap-oob='innerHTML:[oob-foo]'>Swapped7</div></div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<div>Clicked<div hx-swap-oob='innerHTML:[oob-foo]'>Swapped7</div></div>");
         var div = make('<div hx-get="/test">click me</div>');
         make('<div id="d1" oob-foo="bar"></div>');
         div.click();
@@ -93,7 +93,7 @@ describe("hx-swap-oob attribute", function () {
     })
 
     it('swaps into all targets that match the selector (innerHTML)', function () {
-        this.server.respondWith("GET", "/test", "<div>Clicked</div><div class='target' hx-swap-oob='innerHTML:.target'>Swapped8</div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<div>Clicked</div><div class='target' hx-swap-oob='innerHTML:.target'>Swapped8</div>");
         var div = make('<div hx-get="/test">click me</div>');
         make('<div id="d1">No swap</div>');
         make('<div id="d2" class="target">Not swapped</div>');
@@ -107,7 +107,7 @@ describe("hx-swap-oob attribute", function () {
 
     it('swaps into all targets that match the selector (outerHTML)', function () {
         var oobSwapContent = '<div class="new-target" hx-swap-oob="outerHTML:.target">Swapped9</div>';
-        this.server.respondWith("GET", "/test", "<div>Clicked</div>" + oobSwapContent);
+        this.server.respondWith("GET", "/test?htmx-request=1", "<div>Clicked</div>" + oobSwapContent);
         var div = make('<div hx-get="/test">click me</div>');
         make('<div id="d1"><div>No swap</div></div>');
         make('<div id="d2"><div class="target">Not swapped</div></div>');
@@ -121,7 +121,7 @@ describe("hx-swap-oob attribute", function () {
 
     it('oob swap delete works properly', function()
     {
-        this.server.respondWith("GET", "/test", '<div hx-swap-oob="delete" id="d1"></div>');
+        this.server.respondWith("GET", "/test?htmx-request=1", '<div hx-swap-oob="delete" id="d1"></div>');
 
         var div = make('<div id="d1" hx-get="/test">Foo</div>')
         div.click();

--- a/test/attributes/hx-swap.js
+++ b/test/attributes/hx-swap.js
@@ -10,8 +10,8 @@ describe("hx-swap attribute", function(){
 
     it('swap innerHTML properly', function()
     {
-        this.server.respondWith("GET", "/test", '<a hx-get="/test2">Click Me</a>');
-        this.server.respondWith("GET", "/test2", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", '<a hx-get="/test2">Click Me</a>');
+        this.server.respondWith("GET", "/test2?htmx-request=1", "Clicked!");
 
         var div = make('<div hx-get="/test"></div>')
         div.click();
@@ -25,8 +25,8 @@ describe("hx-swap attribute", function(){
 
     it('swap outerHTML properly', function()
     {
-        this.server.respondWith("GET", "/test", '<a id="a1" hx-get="/test2">Click Me</a>');
-        this.server.respondWith("GET", "/test2", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", '<a id="a1" hx-get="/test2">Click Me</a>');
+        this.server.respondWith("GET", "/test2?htmx-request=1", "Clicked!");
 
         var div = make('<div id="d1" hx-get="/test" hx-swap="outerHTML"></div>')
         div.click();
@@ -41,11 +41,11 @@ describe("hx-swap attribute", function(){
     it('swap beforebegin properly', function()
     {
         var i = 0;
-        this.server.respondWith("GET", "/test", function(xhr){
+        this.server.respondWith("GET", "/test?htmx-request=1", function(xhr){
             i++;
             xhr.respond(200, {}, '<a id="a' + i + '" hx-get="/test2" hx-swap="innerHTML">' + i + '</a>');
         });
-        this.server.respondWith("GET", "/test2", "*");
+        this.server.respondWith("GET", "/test2?htmx-request=1", "*");
 
         var div = make('<div hx-get="/test" hx-swap="beforebegin">*</div>')
         var parent = div.parentElement;
@@ -71,7 +71,7 @@ describe("hx-swap attribute", function(){
     it('swap afterbegin properly', function()
     {
         var i = 0;
-        this.server.respondWith("GET", "/test", function(xhr){
+        this.server.respondWith("GET", "/test?htmx-request=1", function(xhr){
             i++;
             xhr.respond(200, {}, "" + i);
         });
@@ -94,7 +94,7 @@ describe("hx-swap attribute", function(){
     it('swap afterbegin properly with no initial content', function()
     {
         var i = 0;
-        this.server.respondWith("GET", "/test", function(xhr){
+        this.server.respondWith("GET", "/test?htmx-request=1", function(xhr){
             i++;
             xhr.respond(200, {}, "" + i);
         });
@@ -117,11 +117,11 @@ describe("hx-swap attribute", function(){
     it('swap afterend properly', function()
     {
         var i = 0;
-        this.server.respondWith("GET", "/test", function(xhr){
+        this.server.respondWith("GET", "/test?htmx-request=1", function(xhr){
             i++;
             xhr.respond(200, {}, '<a id="a' + i + '" hx-get="/test2" hx-swap="innerHTML">' + i + '</a>');
         });
-        this.server.respondWith("GET", "/test2", "*");
+        this.server.respondWith("GET", "/test2?htmx-request=1", "*");
 
         var div = make('<div hx-get="/test" hx-swap="afterend">*</div>')
         var parent = div.parentElement;
@@ -147,7 +147,7 @@ describe("hx-swap attribute", function(){
     it('handles beforeend properly', function()
     {
         var i = 0;
-        this.server.respondWith("GET", "/test", function(xhr){
+        this.server.respondWith("GET", "/test?htmx-request=1", function(xhr){
             i++;
             xhr.respond(200, {}, "" + i);
         });
@@ -170,7 +170,7 @@ describe("hx-swap attribute", function(){
     it('handles beforeend properly with no initial content', function()
     {
         var i = 0;
-        this.server.respondWith("GET", "/test", function(xhr){
+        this.server.respondWith("GET", "/test?htmx-request=1", function(xhr){
             i++;
             xhr.respond(200, {}, "" + i);
         });
@@ -207,7 +207,7 @@ describe("hx-swap attribute", function(){
     })
 
     it('works with a swap delay', function(done) {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var div = make("<div hx-get='/test' hx-swap='innerHTML swap:10ms'></div>");
         div.click();
         this.server.respond();
@@ -219,7 +219,7 @@ describe("hx-swap attribute", function(){
     });
 
     it('works with a settle delay', function(done) {
-        this.server.respondWith("GET", "/test", "<div id='d1' class='foo' hx-get='/test' hx-swap='outerHTML settle:10ms'></div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<div id='d1' class='foo' hx-get='/test' hx-swap='outerHTML settle:10ms'></div>");
         var div = make("<div id='d1' hx-get='/test' hx-swap='outerHTML settle:10ms'></div>");
         div.click();
         this.server.respond();
@@ -232,8 +232,8 @@ describe("hx-swap attribute", function(){
 
     it('swap outerHTML properly  w/ data-* prefix', function()
     {
-        this.server.respondWith("GET", "/test", '<a id="a1" data-hx-get="/test2">Click Me</a>');
-        this.server.respondWith("GET", "/test2", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", '<a id="a1" data-hx-get="/test2">Click Me</a>');
+        this.server.respondWith("GET", "/test2?htmx-request=1", "Clicked!");
 
         var div = make('<div id="d1" data-hx-get="/test" data-hx-swap="outerHTML"></div>')
         div.click();
@@ -247,7 +247,7 @@ describe("hx-swap attribute", function(){
 
     it('swap none works properly', function()
     {
-        this.server.respondWith("GET", "/test", 'Ooops, swapped');
+        this.server.respondWith("GET", "/test?htmx-request=1", 'Ooops, swapped');
 
         var div = make('<div hx-swap="none" hx-get="/test">Foo</div>')
         div.click();
@@ -258,7 +258,7 @@ describe("hx-swap attribute", function(){
 
     it('swap outerHTML does not trigger htmx:afterSwap on original element', function()
     {
-        this.server.respondWith("GET", "/test", 'Clicked!');
+        this.server.respondWith("GET", "/test?htmx-request=1", 'Clicked!');
         var div = make('<div id="d1" hx-get="/test" hx-swap="outerHTML"></div>')
         div.addEventListener("htmx:afterSwap", function(){
             count++;
@@ -272,7 +272,7 @@ describe("hx-swap attribute", function(){
     });
     it('swap delete works properly', function()
     {
-        this.server.respondWith("GET", "/test", 'Oops, deleted!');
+        this.server.respondWith("GET", "/test?htmx-request=1", 'Oops, deleted!');
 
         var div = make('<div id="d1" hx-swap="delete" hx-get="/test">Foo</div>')
         div.click();
@@ -285,7 +285,7 @@ describe("hx-swap attribute", function(){
         var initialSwapStyle = htmx.config.defaultSwapStyle;
         htmx.config.defaultSwapStyle = "outerHTML";
         try {
-            this.server.respondWith("GET", "/test", "Clicked!");
+            this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
 
             var div = make('<div><button id="b1" hx-swap="foo" hx-get="/test">Initial</button></div>')
             var b1 = byId("b1");

--- a/test/attributes/hx-sync.js
+++ b/test/attributes/hx-sync.js
@@ -11,7 +11,7 @@ describe("hx-sync attribute", function(){
     it('can use drop strategy', function()
     {
         var count = 0;
-        this.server.respondWith("GET", "/test", function(xhr){
+        this.server.respondWith("GET", "/test?htmx-request=1", function(xhr){
             xhr.respond(200, {}, "Click " + count++);
         });
         make('<div hx-sync="this:drop"><button id="b1" hx-get="/test">Initial</button>' +
@@ -29,7 +29,7 @@ describe("hx-sync attribute", function(){
     it('defaults to the drop strategy', function()
     {
         var count = 0;
-        this.server.respondWith("GET", "/test", function(xhr){
+        this.server.respondWith("GET", "/test?htmx-request=1", function(xhr){
             xhr.respond(200, {}, "Click " + count++);
         });
         make('<div hx-sync="this"><button id="b1" hx-get="/test">Initial</button>' +
@@ -47,7 +47,7 @@ describe("hx-sync attribute", function(){
     it('can use replace strategy', function()
     {
         var count = 0;
-        this.server.respondWith("GET", "/test", function(xhr){
+        this.server.respondWith("GET", "/test?htmx-request=1", function(xhr){
             xhr.respond(200, {}, "Click " + count++);
         });
         make('<div hx-sync="this:replace"><button id="b1" hx-get="/test">Initial</button>' +
@@ -65,7 +65,7 @@ describe("hx-sync attribute", function(){
     it('can use queue all strategy', function()
     {
         var count = 0;
-        this.server.respondWith("GET", "/test", function(xhr){
+        this.server.respondWith("GET", "/test?htmx-request=1", function(xhr){
             xhr.respond(200, {}, "Click " + count++);
         });
         make('<div hx-sync="this:queue all"><button id="b1" hx-get="/test">Initial</button>' +
@@ -99,7 +99,7 @@ describe("hx-sync attribute", function(){
     it('can use queue last strategy', function()
     {
         var count = 0;
-        this.server.respondWith("GET", "/test", function(xhr){
+        this.server.respondWith("GET", "/test?htmx-request=1", function(xhr){
             xhr.respond(200, {}, "Click " + count++);
         });
         make('<div hx-sync="this:queue last"><button id="b1" hx-get="/test">Initial</button>' +
@@ -133,7 +133,7 @@ describe("hx-sync attribute", function(){
     it('can use queue first strategy', function()
     {
         var count = 0;
-        this.server.respondWith("GET", "/test", function(xhr){
+        this.server.respondWith("GET", "/test?htmx-request=1", function(xhr){
             xhr.respond(200, {}, "Click " + count++);
         });
         make('<div hx-sync="this:queue first"><button id="b1" hx-get="/test">Initial</button>' +
@@ -167,7 +167,7 @@ describe("hx-sync attribute", function(){
     it('can use abort strategy to end existing abortable request', function()
     {
         var count = 0;
-        this.server.respondWith("GET", "/test", function(xhr){
+        this.server.respondWith("GET", "/test?htmx-request=1", function(xhr){
             xhr.respond(200, {}, "Click " + count++);
         });
         make('<div hx-sync="this"><button hx-sync="closest div:abort" id="b1" hx-get="/test">Initial</button>' +
@@ -185,7 +185,7 @@ describe("hx-sync attribute", function(){
     it('can use abort strategy to drop abortable request when one is in flight', function()
     {
         var count = 0;
-        this.server.respondWith("GET", "/test", function(xhr){
+        this.server.respondWith("GET", "/test?htmx-request=1", function(xhr){
             xhr.respond(200, {}, "Click " + count++);
         });
         make('<div hx-sync="this"><button hx-sync="closest div:abort" id="b1" hx-get="/test">Initial</button>' +
@@ -203,7 +203,7 @@ describe("hx-sync attribute", function(){
     it('can abort a request programmatically', function()
     {
         var count = 0;
-        this.server.respondWith("GET", "/test", function(xhr){
+        this.server.respondWith("GET", "/test?htmx-request=1", function(xhr){
             xhr.respond(200, {}, "Click " + count++);
         });
         make('<div><button id="b1" hx-get="/test">Initial</button>' +

--- a/test/attributes/hx-target.js
+++ b/test/attributes/hx-target.js
@@ -10,7 +10,7 @@ describe("hx-target attribute", function(){
 
     it('targets an adjacent element properly', function()
     {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var btn = make('<button hx-target="#d1" hx-get="/test">Click Me!</button>')
         var div1 = make('<div id="d1"></div>')
         btn.click();
@@ -20,7 +20,7 @@ describe("hx-target attribute", function(){
 
     it('targets a parent element properly', function()
     {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var div1 = make('<div id="d1"><button id="b1" hx-target="#d1" hx-get="/test">Click Me!</button></div>')
         var btn = byId("b1")
         btn.click();
@@ -30,7 +30,7 @@ describe("hx-target attribute", function(){
 
     it('targets a `this` element properly', function()
     {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var div1 = make('<div hx-target="this"><button id="b1" hx-get="/test">Click Me!</button></div>')
         var btn = byId("b1")
         btn.click();
@@ -40,7 +40,7 @@ describe("hx-target attribute", function(){
 
     it('targets a `closest` element properly', function()
     {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var div1 = make('<div><p><i><button id="b1" hx-target="closest div" hx-get="/test">Click Me!</button></i></p></div>')
         var btn = byId("b1")
         btn.click();
@@ -50,7 +50,7 @@ describe("hx-target attribute", function(){
     
     it('targets a `find` element properly', function()
     {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var div1 = make('<div hx-target="find span" hx-get="/test">Click Me! <div><span id="s1"></span><span id="s2"></span></div></div>')
         div1.click();
         this.server.respond();
@@ -62,7 +62,7 @@ describe("hx-target attribute", function(){
 
     it('targets an inner element properly', function()
     {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var btn = make('<button hx-target="#d1" hx-get="/test">Click Me!<div id="d1"></div></button>')
         var div1 = byId("d1")
         btn.click();
@@ -73,7 +73,7 @@ describe("hx-target attribute", function(){
 
     it('handles bad target gracefully', function()
     {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var btn = make('<button hx-target="bad" hx-get="/test">Click Me!</button>')
         btn.click();
         this.server.respond();
@@ -83,7 +83,7 @@ describe("hx-target attribute", function(){
 
     it('targets an adjacent element properly w/ data-* prefix', function()
     {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var btn = make('<button data-hx-target="#d1" data-hx-get="/test">Click Me!</button>')
         var div1 = make('<div id="d1"></div>')
         btn.click();
@@ -93,7 +93,7 @@ describe("hx-target attribute", function(){
 
     it('targets a `next` element properly', function()
     {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         make('<div>' +
             '  <div id="d3"></div>' +
             '  <button id="b1" hx-target="next div" hx-get="/test">Click Me!</button>' +
@@ -113,7 +113,7 @@ describe("hx-target attribute", function(){
 
     it('targets a `previous` element properly', function()
     {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         make('<div>' +
             '  <div id="d3"></div>' +
             '  <button id="b1" hx-target="previous div" hx-get="/test">Click Me!</button>' +

--- a/test/attributes/hx-trigger.js
+++ b/test/attributes/hx-trigger.js
@@ -10,7 +10,7 @@ describe("hx-trigger attribute", function(){
 
     it('non-default value works', function()
     {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
 
         var form = make('<form hx-get="/test" hx-trigger="click">Click Me!</form>');
         form.click();
@@ -22,7 +22,7 @@ describe("hx-trigger attribute", function(){
     it('changed modifier works', function()
     {
         var requests = 0;
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             requests++;
             xhr.respond(200, {}, "Requests: " + requests);
         });
@@ -46,7 +46,7 @@ describe("hx-trigger attribute", function(){
     it('once modifier works', function()
     {
         var requests = 0;
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             requests++;
             xhr.respond(200, {}, "Requests: " + requests);
         });
@@ -70,7 +70,7 @@ describe("hx-trigger attribute", function(){
     it('once modifier works with multiple triggers', function()
     {
         var requests = 0;
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             requests++;
             xhr.respond(200, {}, "Requests: " + requests);
         });
@@ -97,7 +97,7 @@ describe("hx-trigger attribute", function(){
     it('polling works', function(complete)
     {
         var requests = 0;
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             requests++;
             if (requests > 5) {
                 complete();
@@ -115,7 +115,7 @@ describe("hx-trigger attribute", function(){
 
     it('non-default value works w/ data-* prefix', function()
     {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var form = make('<form data-hx-get="/test" data-hx-trigger="click">Click Me!</form>');
         form.click();
         form.innerHTML.should.equal("Click Me!");
@@ -126,7 +126,7 @@ describe("hx-trigger attribute", function(){
     it('works with multiple events', function()
     {
         var requests = 0;
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             requests++;
             xhr.respond(200, {}, "Requests: " + requests);
         });
@@ -182,7 +182,7 @@ describe("hx-trigger attribute", function(){
     })
 
     it('filters properly with false filter spec', function(){
-        this.server.respondWith("GET", "/test", "Called!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Called!");
         var form = make('<form hx-get="/test" hx-trigger="evt[foo]">Not Called</form>');
         form.click();
         form.innerHTML.should.equal("Not Called");
@@ -193,7 +193,7 @@ describe("hx-trigger attribute", function(){
     })
 
     it('filters properly with true filter spec', function(){
-        this.server.respondWith("GET", "/test", "Called!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Called!");
         var form = make('<form hx-get="/test" hx-trigger="evt[foo]">Not Called</form>');
         form.click();
         form.innerHTML.should.equal("Not Called");
@@ -205,7 +205,7 @@ describe("hx-trigger attribute", function(){
     })
 
     it('filters properly compound filter spec', function(){
-        this.server.respondWith("GET", "/test", "Called!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Called!");
         var div = make('<div hx-get="/test" hx-trigger="evt[foo&&bar]">Not Called</div>');
         var event = htmx._("makeEvent")('evt');
         event.foo = true;
@@ -219,7 +219,7 @@ describe("hx-trigger attribute", function(){
     })
 
     it('can refer to target element in condition', function(){
-        this.server.respondWith("GET", "/test", "Called!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Called!");
         var div = make('<div hx-get="/test" hx-trigger="evt[target.classList.contains(\'doIt\')]">Not Called</div>');
         var event = htmx._("makeEvent")('evt');
         div.dispatchEvent(event);
@@ -232,7 +232,7 @@ describe("hx-trigger attribute", function(){
     })
 
     it('can refer to target element in condition w/ equality', function(){
-        this.server.respondWith("GET", "/test", "Called!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Called!");
         var div = make('<div hx-get="/test" hx-trigger="evt[target.id==\'foo\']">Not Called</div>');
         var event = htmx._("makeEvent")('evt');
         div.dispatchEvent(event);
@@ -245,7 +245,7 @@ describe("hx-trigger attribute", function(){
     })
 
     it('negative condition', function(){
-        this.server.respondWith("GET", "/test", "Called!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Called!");
         var div = make('<div hx-get="/test" hx-trigger="evt[!target.classList.contains(\'disabled\')]">Not Called</div>');
         div.classList.add("disabled");
         var event = htmx._("makeEvent")('evt');
@@ -263,7 +263,7 @@ describe("hx-trigger attribute", function(){
             return evt.bar;
         }
         try {
-            this.server.respondWith("GET", "/test", "Called!");
+            this.server.respondWith("GET", "/test?htmx-request=1", "Called!");
             var div = make('<div hx-get="/test" hx-trigger="evt[globalFun(event)]">Not Called</div>');
             var event = htmx._("makeEvent")('evt');
             event.bar = false;
@@ -284,7 +284,7 @@ describe("hx-trigger attribute", function(){
             bar:false
         }
         try {
-            this.server.respondWith("GET", "/test", "Called!");
+            this.server.respondWith("GET", "/test?htmx-request=1", "Called!");
             var div = make('<div hx-get="/test" hx-trigger="evt[foo.bar]">Not Called</div>');
             var event = htmx._("makeEvent")('evt');
             div.dispatchEvent(event);
@@ -301,7 +301,7 @@ describe("hx-trigger attribute", function(){
 
     it('global variable filter works', function(){
         try {
-            this.server.respondWith("GET", "/test", "Called!");
+            this.server.respondWith("GET", "/test?htmx-request=1", "Called!");
             var div = make('<div hx-get="/test" hx-trigger="evt[foo]">Not Called</div>');
             var event = htmx._("makeEvent")('evt');
             div.dispatchEvent(event);
@@ -317,7 +317,7 @@ describe("hx-trigger attribute", function(){
     })
 
     it('can filter polling', function(complete){
-        this.server.respondWith("GET", "/test", "Called!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Called!");
         window.foo = false;
         var div = make('<div hx-get="/test" hx-trigger="every 5ms[foo]">Not Called</div>');
         var div2 = make('<div hx-get="/test" hx-trigger="every 5ms">Not Called</div>');
@@ -332,7 +332,7 @@ describe("hx-trigger attribute", function(){
     })
 
     it('bad condition issues error', function(){
-        this.server.respondWith("GET", "/test", "Called!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Called!");
         var div = make('<div hx-get="/test" hx-trigger="evt[a.b]">Not Called</div>');
         var errorEvent = null;
         var handler = htmx.on("htmx:eventFilter:error", function (event) {
@@ -352,7 +352,7 @@ describe("hx-trigger attribute", function(){
     it('from clause works', function()
     {
         var requests = 0;
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             requests++;
             xhr.respond(200, {}, "Requests: " + requests);
         });
@@ -370,7 +370,7 @@ describe("hx-trigger attribute", function(){
     it('from clause works with body selector', function()
     {
         var requests = 0;
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             requests++;
             xhr.respond(200, {}, "Requests: " + requests);
         });
@@ -384,7 +384,7 @@ describe("hx-trigger attribute", function(){
     it('from clause works with document selector', function()
     {
         var requests = 0;
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             requests++;
             xhr.respond(200, {}, "Requests: " + requests);
         });
@@ -398,7 +398,7 @@ describe("hx-trigger attribute", function(){
     it('from clause works with window selector', function()
     {
         var requests = 0;
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             requests++;
             xhr.respond(200, {}, "Requests: " + requests);
         });
@@ -412,7 +412,7 @@ describe("hx-trigger attribute", function(){
     it('from clause works with closest clause', function()
     {
         var requests = 0;
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             requests++;
             xhr.respond(200, {}, "Requests: " + requests);
         });
@@ -427,7 +427,7 @@ describe("hx-trigger attribute", function(){
     it('from clause works with find clause', function()
     {
         var requests = 0;
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             requests++;
             xhr.respond(200, {}, "Requests: " + requests);
         });
@@ -442,11 +442,11 @@ describe("hx-trigger attribute", function(){
     it('event listeners on other elements are removed when an element is swapped out', function()
     {
         var requests = 0;
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             requests++;
             xhr.respond(200, {}, "Requests: " + requests);
         });
-        this.server.respondWith("GET", "/test2", "Clicked");
+        this.server.respondWith("GET", "/test2?htmx-request=1", "Clicked");
 
         var div1 = make('<div hx-get="/test2">' +
             '<div id="d2" hx-trigger="click from:body" hx-get="/test">Requests: 0</div>' +
@@ -475,7 +475,7 @@ describe("hx-trigger attribute", function(){
     it('multiple triggers with from clauses mixed in work', function()
     {
         var requests = 0;
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             requests++;
             xhr.respond(200, {}, "Requests: " + requests);
         });
@@ -493,7 +493,7 @@ describe("hx-trigger attribute", function(){
     it('event listeners can filter on target', function()
     {
         var requests = 0;
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             requests++;
             xhr.respond(200, {}, "Requests: " + requests);
         });
@@ -528,8 +528,8 @@ describe("hx-trigger attribute", function(){
 
     it('consume prevents event propogation', function()
     {
-        this.server.respondWith("GET", "/foo", "foo");
-        this.server.respondWith("GET", "/bar", "bar");
+        this.server.respondWith("GET", "/foo?htmx-request=1", "foo");
+        this.server.respondWith("GET", "/bar?htmx-request=1", "bar");
         var div = make("<div hx-trigger='click' hx-get='/foo'>" +
             "   <div id='d1' hx-trigger='click consume' hx-get='/bar'></div>" +
             "</div>");
@@ -546,11 +546,11 @@ describe("hx-trigger attribute", function(){
     {
         var requests = 0;
         var server = this.server;
-        server.respondWith("GET", "/test", function (xhr) {
+        server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             requests++;
             xhr.respond(200, {}, "Requests: " + requests);
         });
-        server.respondWith("GET", "/bar", "bar");
+        server.respondWith("GET", "/bar?htmx-request=1", "bar");
         var div = make("<div hx-trigger='click throttle:10ms' hx-get='/test'></div>");
 
         div.click();
@@ -585,11 +585,11 @@ describe("hx-trigger attribute", function(){
     {
         var requests = 0;
         var server = this.server;
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             requests++;
             xhr.respond(200, {}, "Requests: " + requests);
         });
-        this.server.respondWith("GET", "/bar", "bar");
+        this.server.respondWith("GET", "/bar?htmx-request=1", "bar");
         var div = make("<div hx-trigger='click delay:10ms' hx-get='/test'></div>");
 
         div.click();
@@ -621,11 +621,11 @@ describe("hx-trigger attribute", function(){
     {
         var requests = 0;
         var server = this.server;
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             requests++;
             xhr.respond(200, {}, "Requests: " + requests);
         });
-        this.server.respondWith("GET", "/bar", "bar");
+        this.server.respondWith("GET", "/bar?htmx-request=1", "bar");
         var div = make("<div hx-trigger='click' hx-get='/test'></div>");
 
         div.click();
@@ -645,11 +645,11 @@ describe("hx-trigger attribute", function(){
     {
         var requests = 0;
         var server = this.server;
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             requests++;
             xhr.respond(200, {}, "Requests: " + requests);
         });
-        this.server.respondWith("GET", "/bar", "bar");
+        this.server.respondWith("GET", "/bar?htmx-request=1", "bar");
         var div = make("<div hx-trigger='click queue:all' hx-get='/test'></div>");
 
         div.click();
@@ -670,11 +670,11 @@ describe("hx-trigger attribute", function(){
     {
         var requests = 0;
         var server = this.server;
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             requests++;
             xhr.respond(200, {}, "Requests: " + requests);
         });
-        this.server.respondWith("GET", "/bar", "bar");
+        this.server.respondWith("GET", "/bar?htmx-request=1", "bar");
         var div = make("<div hx-trigger='click queue:first' hx-get='/test'></div>");
 
         div.click();
@@ -694,11 +694,11 @@ describe("hx-trigger attribute", function(){
     {
         var requests = 0;
         var server = this.server;
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             requests++;
             xhr.respond(200, {}, "Requests: " + requests);
         });
-        this.server.respondWith("GET", "/bar", "bar");
+        this.server.respondWith("GET", "/bar?htmx-request=1", "bar");
         var div = make("<div hx-trigger='click queue:none' hx-get='/test'></div>");
 
         div.click();
@@ -716,7 +716,7 @@ describe("hx-trigger attribute", function(){
 
     it('load event works w/ positive filters', function()
     {
-        this.server.respondWith("GET", "/test", "Loaded!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Loaded!");
         var div = make('<div hx-get="/test" hx-trigger="load[true]">Load Me!</div>');
         div.innerHTML.should.equal("Load Me!");
         this.server.respond();
@@ -725,7 +725,7 @@ describe("hx-trigger attribute", function(){
 
     it('load event works w/ negative filters', function()
     {
-        this.server.respondWith("GET", "/test", "Loaded!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Loaded!");
         var div = make('<div hx-get="/test" hx-trigger="load[false]">Load Me!</div>');
         div.innerHTML.should.equal("Load Me!");
         this.server.respond();
@@ -734,8 +734,8 @@ describe("hx-trigger attribute", function(){
 
     it('reveal event works on two elements', function()
     {
-        this.server.respondWith("GET", "/test1", "test 1");
-        this.server.respondWith("GET", "/test2", "test 2");
+        this.server.respondWith("GET", "/test1?htmx-request=1", "test 1");
+        this.server.respondWith("GET", "/test2?htmx-request=1", "test 2");
         var div = make('<div hx-get="/test1" hx-trigger="revealed"></div>');
         var div2 = make('<div hx-get="/test2" hx-trigger="revealed"></div>');
         div.innerHTML.should.equal("");
@@ -749,7 +749,7 @@ describe("hx-trigger attribute", function(){
 
     it('reveal event works when triggered by window', function()
     {
-        this.server.respondWith("GET", "/test1", "test 1");
+        this.server.respondWith("GET", "/test1?htmx-request=1", "test 1");
         var div = make('<div hx-get="/test1" hx-trigger="revealed" style="position: fixed; top: 1px; left: 1px; border: 3px solid red">foo</div>');
         div.innerHTML.should.equal("foo");
         this.server.respondAll();

--- a/test/attributes/hx-ws.js
+++ b/test/attributes/hx-ws.js
@@ -59,7 +59,7 @@ describe("hx-ws attribute", function() {
     })
 
     it('is closed after removal', function () {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var div = make('<div hx-get="/test" hx-swap="outerHTML" hx-ws="connect:wss:/foo"></div>');
         div.click();
         this.server.respond();

--- a/test/core/ajax.js
+++ b/test/core/ajax.js
@@ -11,7 +11,7 @@ describe("Core htmx AJAX Tests", function(){
     // bootstrap test
     it('issues a GET request on click and swaps content', function()
     {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
 
         var btn = make('<button hx-get="/test">Click Me!</button>')
         btn.click();
@@ -21,8 +21,8 @@ describe("Core htmx AJAX Tests", function(){
 
     it('processes inner content properly', function()
     {
-        this.server.respondWith("GET", "/test", '<a hx-get="/test2">Click Me</a>');
-        this.server.respondWith("GET", "/test2", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", '<a hx-get="/test2">Click Me</a>');
+        this.server.respondWith("GET", "/test2?htmx-request=1", "Clicked!");
 
         var div = make('<div hx-get="/test"></div>')
         div.click();
@@ -36,8 +36,8 @@ describe("Core htmx AJAX Tests", function(){
 
     it('handles swap outerHTML properly', function()
     {
-        this.server.respondWith("GET", "/test", '<a id="a1" hx-get="/test2">Click Me</a>');
-        this.server.respondWith("GET", "/test2", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", '<a id="a1" hx-get="/test2">Click Me</a>');
+        this.server.respondWith("GET", "/test2?htmx-request=1", "Clicked!");
 
         var div = make('<div id="d1" hx-get="/test" hx-swap="outerHTML"></div>')
         div.click();
@@ -52,11 +52,11 @@ describe("Core htmx AJAX Tests", function(){
     it('handles beforebegin properly', function()
     {
         var i = 0;
-        this.server.respondWith("GET", "/test", function(xhr){
+        this.server.respondWith("GET", "/test?htmx-request=1", function(xhr){
             i++;
             xhr.respond(200, {}, '<a id="a' + i + '" hx-get="/test2" hx-swap="innerHTML">' + i + '</a>');
         });
-        this.server.respondWith("GET", "/test2", "*");
+        this.server.respondWith("GET", "/test2?htmx-request=1", "*");
 
         var div = make('<div hx-get="/test" hx-swap="beforebegin">*</div>')
         var parent = div.parentElement;
@@ -82,7 +82,7 @@ describe("Core htmx AJAX Tests", function(){
     it('handles afterbegin properly', function()
     {
         var i = 0;
-        this.server.respondWith("GET", "/test", function(xhr){
+        this.server.respondWith("GET", "/test?htmx-request=1", function(xhr){
             i++;
             xhr.respond(200, {}, "" + i);
         });
@@ -105,7 +105,7 @@ describe("Core htmx AJAX Tests", function(){
     it('handles afterbegin properly with no initial content', function()
     {
         var i = 0;
-        this.server.respondWith("GET", "/test", function(xhr){
+        this.server.respondWith("GET", "/test?htmx-request=1", function(xhr){
             i++;
             xhr.respond(200, {}, "" + i);
         });
@@ -128,11 +128,11 @@ describe("Core htmx AJAX Tests", function(){
     it('handles afterend properly', function()
     {
         var i = 0;
-        this.server.respondWith("GET", "/test", function(xhr){
+        this.server.respondWith("GET", "/test?htmx-request=1", function(xhr){
             i++;
             xhr.respond(200, {}, '<a id="a' + i + '" hx-get="/test2" hx-swap="innerHTML">' + i + '</a>');
         });
-        this.server.respondWith("GET", "/test2", "*");
+        this.server.respondWith("GET", "/test2?htmx-request=1", "*");
 
         var div = make('<div hx-get="/test" hx-swap="afterend">*</div>')
         var parent = div.parentElement;
@@ -158,7 +158,7 @@ describe("Core htmx AJAX Tests", function(){
     it('handles beforeend properly', function()
     {
         var i = 0;
-        this.server.respondWith("GET", "/test", function(xhr){
+        this.server.respondWith("GET", "/test?htmx-request=1", function(xhr){
             i++;
             xhr.respond(200, {}, "" + i);
         });
@@ -181,7 +181,7 @@ describe("Core htmx AJAX Tests", function(){
     it('handles beforeend properly with no initial content', function()
     {
         var i = 0;
-        this.server.respondWith("GET", "/test", function(xhr){
+        this.server.respondWith("GET", "/test?htmx-request=1", function(xhr){
             i++;
             xhr.respond(200, {}, "" + i);
         });
@@ -203,7 +203,7 @@ describe("Core htmx AJAX Tests", function(){
 
     it('handles hx-target properly', function()
     {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
 
         var btn = make('<button hx-get="/test" hx-target="#s1">Click Me!</button>');
         var target = make('<span id="s1">Initial</span>');
@@ -215,7 +215,7 @@ describe("Core htmx AJAX Tests", function(){
 
     it('handles 204 NO CONTENT responses properly', function()
     {
-        this.server.respondWith("GET", "/test", [204, {}, "No Content!"]);
+        this.server.respondWith("GET", "/test?htmx-request=1", [204, {}, "No Content!"]);
 
         var btn = make('<button hx-get="/test">Click Me!</button>');
         btn.click();
@@ -226,8 +226,8 @@ describe("Core htmx AJAX Tests", function(){
 
     it('handles 304 NOT MODIFIED responses properly', function()
     {
-        this.server.respondWith("GET", "/test-1", [200, {}, "Content for Tab 1"]);
-        this.server.respondWith("GET", "/test-2", [200, {}, "Content for Tab 2"]);
+        this.server.respondWith("GET", "/test-1?htmx-request=1", [200, {}, "Content for Tab 1"]);
+        this.server.respondWith("GET", "/test-2?htmx-request=1", [200, {}, "Content for Tab 2"]);
 
         var target = make('<div id="target"></div>')
         var btn1 = make('<button hx-get="/test-1" hx-target="#target">Tab 1</button>');
@@ -242,8 +242,8 @@ describe("Core htmx AJAX Tests", function(){
         this.server.respond();
         target.innerHTML.should.equal("Content for Tab 2");
 
-        this.server.respondWith("GET", "/test-1", [304, {}, "Content for Tab 1"]);
-        this.server.respondWith("GET", "/test-2", [304, {}, "Content for Tab 2"]);
+        this.server.respondWith("GET", "/test-1?htmx-request=1", [304, {}, "Content for Tab 1"]);
+        this.server.respondWith("GET", "/test-2?htmx-request=1", [304, {}, "Content for Tab 2"]);
 
         btn1.click();
         this.server.respond();
@@ -256,7 +256,7 @@ describe("Core htmx AJAX Tests", function(){
 
     it('handles hx-trigger with non-default value', function()
     {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
 
         var form = make('<form hx-get="/test" hx-trigger="click">Click Me!</form>');
         form.click();
@@ -267,7 +267,7 @@ describe("Core htmx AJAX Tests", function(){
 
     it('handles hx-trigger with load event', function()
     {
-        this.server.respondWith("GET", "/test", "Loaded!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Loaded!");
         var div = make('<div hx-get="/test" hx-trigger="load">Load Me!</div>');
         div.innerHTML.should.equal("Load Me!");
         this.server.respond();
@@ -275,7 +275,7 @@ describe("Core htmx AJAX Tests", function(){
     });
 
     it('sets the content type of the request properly', function (done) {
-        this.server.respondWith("GET", "/test", function(xhr){
+        this.server.respondWith("GET", "/test?htmx-request=1", function(xhr){
             xhr.respond(200, {}, "done");
             xhr.overriddenMimeType.should.equal("text/html");
             done();
@@ -288,7 +288,7 @@ describe("Core htmx AJAX Tests", function(){
     it('issues two requests when clicked twice before response', function()
     {
         var i = 1;
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             xhr.respond(200, {}, "click " + i);
             i++
         });
@@ -304,7 +304,7 @@ describe("Core htmx AJAX Tests", function(){
     it('issues two requests when clicked three times before response', function()
     {
         var i = 1;
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             xhr.respond(200, {}, "click " + i);
             i++
         });
@@ -319,7 +319,7 @@ describe("Core htmx AJAX Tests", function(){
     it('properly handles hx-select for basic situation', function()
     {
         var i = 1;
-        this.server.respondWith("GET", "/test", "<div id='d1'>foo</div><div id='d2'>bar</div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<div id='d1'>foo</div><div id='d2'>bar</div>");
         var div = make('<div hx-get="/test" hx-select="#d1"></div>');
         div.click();
         this.server.respond();
@@ -328,7 +328,7 @@ describe("Core htmx AJAX Tests", function(){
 
     it('properly handles hx-select for full html document situation', function()
     {
-        this.server.respondWith("GET", "/test", "<html><body><div id='d1'>foo</div><div id='d2'>bar</div></body></html>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<html><body><div id='d1'>foo</div><div id='d2'>bar</div></body></html>");
         var div = make('<div hx-get="/test" hx-select="#d1"></div>');
         div.click();
         this.server.respond();
@@ -337,7 +337,7 @@ describe("Core htmx AJAX Tests", function(){
 
     it('properly settles attributes on interior elements', function(done)
     {
-        this.server.respondWith("GET", "/test", "<div hx-get='/test'><div width='bar' id='d1'></div></div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<div hx-get='/test'><div width='bar' id='d1'></div></div>");
         var div = make("<div hx-get='/test' hx-swap='outerHTML settle:10ms'><div id='d1'></div></div>");
         div.click();
         this.server.respond();
@@ -535,8 +535,8 @@ describe("Core htmx AJAX Tests", function(){
 
     it('text nodes dont screw up settling via variable capture', function()
     {
-        this.server.respondWith("GET", "/test", "<div id='d1' hx-trigger='click consume' hx-get='/test2'></div>fooo");
-        this.server.respondWith("GET", "/test2", "clicked");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<div id='d1' hx-trigger='click consume' hx-get='/test2'></div>fooo");
+        this.server.respondWith("GET", "/test2?htmx-request=1", "clicked");
         var div = make("<div hx-get='/test'/>");
         div.click();
         this.server.respond();
@@ -552,7 +552,7 @@ describe("Core htmx AJAX Tests", function(){
             globalWasCalled = true;
         }
         try {
-            this.server.respondWith("GET", "/test", "<div></div><script type='text/javascript'>callGlobal()</script>");
+            this.server.respondWith("GET", "/test?htmx-request=1", "<div></div><script type='text/javascript'>callGlobal()</script>");
             var div = make("<div hx-get='/test'></div>");
             div.click();
             this.server.respond();
@@ -569,7 +569,7 @@ describe("Core htmx AJAX Tests", function(){
             globalWasCalled = true;
         }
         try {
-            this.server.respondWith("GET", "/test", "<script type='text/javascript'>callGlobal()</script>");
+            this.server.respondWith("GET", "/test?htmx-request=1", "<script type='text/javascript'>callGlobal()</script>");
             var div = make("<div hx-get='/test'></div>");
             div.click();
             this.server.respond();
@@ -583,7 +583,7 @@ describe("Core htmx AJAX Tests", function(){
     {
         try {
             window.foo = {}
-            this.server.respondWith("GET", "/test", "<script type='text/javascript'>foo.bar = function() { return 42 }</script>");
+            this.server.respondWith("GET", "/test?htmx-request=1", "<script type='text/javascript'>foo.bar = function() { return 42 }</script>");
             var div = make("<div hx-get='/test'></div>");
             div.click();
             this.server.respond();
@@ -600,7 +600,7 @@ describe("Core htmx AJAX Tests", function(){
             globalWasCalled = true;
         }
         try {
-            this.server.respondWith("GET", "/test", "<div><script type='text/javascript'>callGlobal()</script></div>");
+            this.server.respondWith("GET", "/test?htmx-request=1", "<div><script type='text/javascript'>callGlobal()</script></div>");
             var div = make("<div hx-get='/test'></div>");
             div.click();
             this.server.respond();
@@ -617,7 +617,7 @@ describe("Core htmx AJAX Tests", function(){
             globalWasCalled = true;
         }
         try {
-            this.server.respondWith("GET", "/test", "<script type='text/javascript'>callGlobal()</script><div></div>");
+            this.server.respondWith("GET", "/test?htmx-request=1", "<script type='text/javascript'>callGlobal()</script><div></div>");
             var div = make("<div hx-get='/test'></div>");
             div.click();
             this.server.respond();
@@ -634,7 +634,7 @@ describe("Core htmx AJAX Tests", function(){
             globalWasCalled = true;
         }
         try {
-            this.server.respondWith("GET", "/test", "<div><script>callGlobal()</script></div>");
+            this.server.respondWith("GET", "/test?htmx-request=1", "<div><script>callGlobal()</script></div>");
             var div = make("<div hx-get='/test'></div>");
             div.click();
             this.server.respond();
@@ -651,7 +651,7 @@ describe("Core htmx AJAX Tests", function(){
             globalWasCalled = true;
         }
         try {
-            this.server.respondWith("GET", "/test", "<div><script type='text/samplescript'>callGlobal()</script></div>");
+            this.server.respondWith("GET", "/test?htmx-request=1", "<div><script type='text/samplescript'>callGlobal()</script></div>");
             var div = make("<div hx-get='/test'></div>");
             div.click();
             this.server.respond();
@@ -668,7 +668,7 @@ describe("Core htmx AJAX Tests", function(){
             window.tempVal = byId("d1").innerText
         }
         try {
-            this.server.respondWith("GET", "/test", "<div><script>callGlobal()</script><div id='d1'>After settle...</div> </div>");
+            this.server.respondWith("GET", "/test?htmx-request=1", "<div><script>callGlobal()</script><div id='d1'>After settle...</div> </div>");
             var div = make("<div hx-get='/test'></div>");
             div.click();
             this.server.respond();
@@ -682,7 +682,7 @@ describe("Core htmx AJAX Tests", function(){
     it('script node exceptions do not break rendering', function()
     {
         this.skip("Rendering does not break, but the exception bubbles up and mocha reports it");
-        this.server.respondWith("GET", "/test", "clicked<script type='text/javascript'>throw 'foo';</script>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "clicked<script type='text/javascript'>throw 'foo';</script>");
         var div = make("<div hx-get='/test'></div>");
         div.click();
         this.server.respond();
@@ -719,7 +719,7 @@ describe("Core htmx AJAX Tests", function(){
 
     it('input values are not settle swapped (causes flicker)', function()
     {
-        this.server.respondWith("GET", "/test", "<input id='i1' value='bar'/>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<input id='i1' value='bar'/>");
         var input = make("<input id='i1' hx-get='/test' value='foo' hx-swap='outerHTML settle:50' hx-trigger='click'/>");
         input.click();
         this.server.respond();
@@ -729,7 +729,7 @@ describe("Core htmx AJAX Tests", function(){
 
     it('autofocus attribute works properly', function()
     {
-        this.server.respondWith("GET", "/test", "<input id='i2' value='bar' autofocus/>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<input id='i2' value='bar' autofocus/>");
         var input = make("<input id='i1' hx-get='/test' value='foo' hx-swap='afterend' hx-trigger='click'/>");
         input.focus();
         input.click();
@@ -741,7 +741,7 @@ describe("Core htmx AJAX Tests", function(){
 
     it('autofocus attribute works properly w/ child', function()
     {
-        this.server.respondWith("GET", "/test", "<div><input id='i2' value='bar' autofocus/></div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<div><input id='i2' value='bar' autofocus/></div>");
         var input = make("<input id='i1' hx-get='/test' value='foo' hx-swap='afterend' hx-trigger='click'/>");
         input.focus();
         input.click();
@@ -753,7 +753,7 @@ describe("Core htmx AJAX Tests", function(){
 
     it('autofocus attribute works properly w/ true value', function()
     {
-        this.server.respondWith("GET", "/test", "<div><input id='i2' value='bar' autofocus='true'/></div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<div><input id='i2' value='bar' autofocus='true'/></div>");
         var input = make("<input id='i1' hx-get='/test' value='foo' hx-swap='afterend' hx-trigger='click'/>");
         input.focus();
         input.click();
@@ -783,7 +783,7 @@ describe("Core htmx AJAX Tests", function(){
     it('removed elements do not issue requests', function()
     {
         var count = 0;
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             count++;
             xhr.respond(200, {}, "");
         });
@@ -796,7 +796,7 @@ describe("Core htmx AJAX Tests", function(){
 
     it('title tags update title', function()
     {
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             xhr.respond(200, {}, "<title class=''>htmx rocks!</title>Clicked!");
         });
         var btn = make('<button hx-get="/test">Click Me!</button>')
@@ -809,7 +809,7 @@ describe("Core htmx AJAX Tests", function(){
     it('svg title tags do not update title', function()
     {
         var originalTitle = window.document.title
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             xhr.respond(200, {}, "<svg class=''><title>" + originalTitle + "UPDATE" + "</title></svg>Clicked!");
         });
         var btn = make('<button hx-get="/test">Click Me!</button>')
@@ -823,7 +823,7 @@ describe("Core htmx AJAX Tests", function(){
     {
         var originalTitle = window.document.title
         var newTitle = originalTitle + "!!!";
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             xhr.respond(200, {}, "<title class=''>" + newTitle + "</title><svg class=''><title>foo</title></svg>Clicked!<title class=''>x</title>");
         });
         var btn = make('<button hx-get="/test">Click Me!</button>')
@@ -835,7 +835,7 @@ describe("Core htmx AJAX Tests", function(){
 
     it('title update does not URL escape', function()
     {
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             xhr.respond(200, {}, "<title>&lt;/> htmx rocks!</title>Clicked!");
         });
         var btn = make('<button hx-get="/test">Click Me!</button>')
@@ -847,7 +847,7 @@ describe("Core htmx AJAX Tests", function(){
 
     it('by default 400 content is not swapped', function()
     {
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             xhr.respond(400, {}, "Clicked!");
         });
         var btn = make('<button hx-get="/test">Click Me!</button>')
@@ -864,7 +864,7 @@ describe("Core htmx AJAX Tests", function(){
             }
         });
 
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             xhr.respond(400, {}, "Clicked!");
         });
         var btn = make('<button hx-get="/test">Click Me!</button>')
@@ -883,7 +883,7 @@ describe("Core htmx AJAX Tests", function(){
             }
         });
 
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             xhr.respond(400, {}, "Clicked!");
         });
         var btn = make('<button hx-get="/test">Click Me!</button>')
@@ -900,10 +900,10 @@ describe("Core htmx AJAX Tests", function(){
         var handler = htmx.on("htmx:responseError", function(){
             errors++;
         })
-        this.server.respondWith("GET", "/test1", function (xhr) {
+        this.server.respondWith("GET", "/test1?htmx-request=1", function (xhr) {
             xhr.respond(204, {}, "Clicked!");
         });
-        this.server.respondWith("GET", "/test2", function (xhr) {
+        this.server.respondWith("GET", "/test2?htmx-request=1", function (xhr) {
             xhr.respond(400, {}, "Clicked!");
         });
         var btn1 = make('<button hx-get="/test1">Click Me!</button>')
@@ -926,7 +926,7 @@ describe("Core htmx AJAX Tests", function(){
             }
         });
 
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             xhr.respond(400, {}, "Clicked!");
         });
         var btn = make('<button hx-get="/test">Click Me!</button>')
@@ -939,7 +939,7 @@ describe("Core htmx AJAX Tests", function(){
     it('scripts w/ src attribute are properly loaded', function(done)
     {
         try {
-            this.server.respondWith("GET", "/test", "<script src='setGlobal.js'></script>");
+            this.server.respondWith("GET", "/test?htmx-request=1", "<script src='setGlobal.js'></script>");
             var div = make("<div hx-get='/test'></div>");
             div.click();
             this.server.respond();
@@ -953,4 +953,12 @@ describe("Core htmx AJAX Tests", function(){
         }
     });
 
+    it('adds an internal querystring param to trick browser cache', function () {
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
+
+        var btn = make('<button hx-get="/test">Click Me!</button>')
+        btn.click();
+        this.server.respond();
+        btn.innerHTML.should.equal("Clicked!");
+    })
 })

--- a/test/core/api.js
+++ b/test/core/api.js
@@ -10,7 +10,7 @@ describe("Core htmx API test", function(){
 
     it('onLoad is called... onLoad', function(done){
         // also tests on/off
-        this.server.respondWith("GET", "/test", "<div id='d1' hx-get='/test'></div>")
+        this.server.respondWith("GET", "/test?htmx-request=1", "<div id='d1' hx-get='/test'></div>")
         var helper = htmx.onLoad(function (elt) {
             elt.setAttribute("foo", "bar");
         });
@@ -267,7 +267,7 @@ describe("Core htmx API test", function(){
 
     it('ajax api works', function()
     {
-        this.server.respondWith("GET", "/test", "foo!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "foo!");
         var div = make("<div></div>");
         htmx.ajax("GET", "/test", div)
         this.server.respond();
@@ -276,7 +276,7 @@ describe("Core htmx API test", function(){
 
     it('ajax api works by ID', function()
     {
-        this.server.respondWith("GET", "/test", "foo!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "foo!");
         var div = make("<div id='d1'></div>");
         htmx.ajax("GET", "/test", "#d1")
         this.server.respond();
@@ -285,7 +285,7 @@ describe("Core htmx API test", function(){
 
     it('ajax api works with swapSpec', function()
     {
-        this.server.respondWith("GET", "/test", "<p class='test'>foo!</p>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<p class='test'>foo!</p>");
         var div = make("<div><div id='target'></div></div>");
         htmx.ajax("GET", "/test", {target: "#target", swap:"outerHTML"});
         this.server.respond();
@@ -296,7 +296,7 @@ describe("Core htmx API test", function(){
     {
         // in IE we do not return a promise
         if (typeof Promise !== "undefined") {
-            this.server.respondWith("GET", "/test", "foo!");
+            this.server.respondWith("GET", "/test?htmx-request=1", "foo!");
             var div = make("<div id='d1'></div>");
             var promise = htmx.ajax("GET", "/test", "#d1");
             this.server.respond();

--- a/test/core/events.js
+++ b/test/core/events.js
@@ -14,8 +14,8 @@ describe("Core htmx Events", function() {
             called = true;
         });
         try {
-            this.server.respondWith("GET", "/test", "");
-            this.server.respondWith("GET", "/test", "<div></div>");
+            this.server.respondWith("GET", "/test?htmx-request=1", "");
+            this.server.respondWith("GET", "/test?htmx-request=1", "<div></div>");
             var div = make("<div hx-get='/test'></div>");
             div.click();
             this.server.respond();
@@ -614,7 +614,7 @@ describe("Core htmx Events", function() {
         });
 
         try {
-            this.server.respondWith("GET", "/test", "updated");
+            this.server.respondWith("GET", "/test?htmx-request=1", "updated");
             var div = make("<div hx-get='/test'></div>");
             div.click();
             this.server.respond();

--- a/test/core/headers.js
+++ b/test/core/headers.js
@@ -9,7 +9,7 @@ describe("Core htmx AJAX headers", function () {
     });
 
     it("should include the HX-Request header", function () {
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             xhr.requestHeaders['HX-Request'].should.be.equal('true');
             xhr.respond(200, {}, "");
         });
@@ -19,7 +19,7 @@ describe("Core htmx AJAX headers", function () {
     })
 
     it("should include the HX-Trigger header", function () {
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             xhr.requestHeaders['HX-Trigger'].should.equal('d1');
             xhr.respond(200, {}, "");
         });
@@ -29,7 +29,7 @@ describe("Core htmx AJAX headers", function () {
     })
 
     it("should include the HX-Trigger-Name header", function () {
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             xhr.requestHeaders['HX-Trigger-Name'].should.equal('n1');
             xhr.respond(200, {}, "");
         });
@@ -39,7 +39,7 @@ describe("Core htmx AJAX headers", function () {
     })
 
     it("should include the HX-Target header", function () {
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             xhr.requestHeaders['HX-Target'].should.equal('d1');
             xhr.respond(200, {}, "");
         });
@@ -49,7 +49,7 @@ describe("Core htmx AJAX headers", function () {
     })
 
     it("should handle simple string HX-Trigger response header properly", function () {
-        this.server.respondWith("GET", "/test", [200, {"HX-Trigger": "foo"}, ""]);
+        this.server.respondWith("GET", "/test?htmx-request=1", [200, {"HX-Trigger": "foo"}, ""]);
 
         var div = make('<div hx-get="/test"></div>');
         var invokedEvent = false;
@@ -62,7 +62,7 @@ describe("Core htmx AJAX headers", function () {
     })
 
     it("should handle dot path HX-Trigger response header properly", function () {
-        this.server.respondWith("GET", "/test", [200, {"HX-Trigger": "foo.bar"}, ""]);
+        this.server.respondWith("GET", "/test?htmx-request=1", [200, {"HX-Trigger": "foo.bar"}, ""]);
 
         var div = make('<div hx-get="/test"></div>');
         var invokedEvent = false;
@@ -75,7 +75,7 @@ describe("Core htmx AJAX headers", function () {
     })
 
     it("should handle simple string HX-Trigger response header in different case properly", function () {
-        this.server.respondWith("GET", "/test", [200, {"hx-trigger": "foo"}, ""]);
+        this.server.respondWith("GET", "/test?htmx-request=1", [200, {"hx-trigger": "foo"}, ""]);
 
         var div = make('<div hx-get="/test"></div>');
         var invokedEvent = false;
@@ -88,7 +88,7 @@ describe("Core htmx AJAX headers", function () {
     })
 
     it("should handle a namespaced HX-Trigger response header properly", function () {
-        this.server.respondWith("GET", "/test", [200, {"HX-Trigger": "namespace:foo"}, ""]);
+        this.server.respondWith("GET", "/test?htmx-request=1", [200, {"HX-Trigger": "namespace:foo"}, ""]);
 
         var div = make('<div hx-get="/test"></div>');
         var invokedEvent = false;
@@ -101,7 +101,7 @@ describe("Core htmx AJAX headers", function () {
     })
 
     it("should handle basic JSON HX-Trigger response header properly", function () {
-        this.server.respondWith("GET", "/test", [200, {"HX-Trigger": "{\"foo\":null}"}, ""]);
+        this.server.respondWith("GET", "/test?htmx-request=1", [200, {"HX-Trigger": "{\"foo\":null}"}, ""]);
 
         var div = make('<div hx-get="/test"></div>');
         var invokedEvent = false;
@@ -116,7 +116,7 @@ describe("Core htmx AJAX headers", function () {
     })
 
     it("should handle JSON with array arg HX-Trigger response header properly", function () {
-        this.server.respondWith("GET", "/test", [200, {"HX-Trigger": "{\"foo\":[1, 2, 3]}"}, ""]);
+        this.server.respondWith("GET", "/test?htmx-request=1", [200, {"HX-Trigger": "{\"foo\":[1, 2, 3]}"}, ""]);
 
         var div = make('<div hx-get="/test"></div>');
         var invokedEvent = false;
@@ -131,7 +131,7 @@ describe("Core htmx AJAX headers", function () {
     })
 
     it("should handle JSON with array arg HX-Trigger response header properly", function () {
-        this.server.respondWith("GET", "/test", [200, {"HX-Trigger": "{\"foo\":{\"a\":1, \"b\":2}}"}, ""]);
+        this.server.respondWith("GET", "/test?htmx-request=1", [200, {"HX-Trigger": "{\"foo\":{\"a\":1, \"b\":2}}"}, ""]);
 
         var div = make('<div hx-get="/test"></div>');
         var invokedEvent = false;
@@ -147,7 +147,7 @@ describe("Core htmx AJAX headers", function () {
     })
 
     it("should survive malformed JSON in HX-Trigger response header", function () {
-        this.server.respondWith("GET", "/test", [200, {"HX-Trigger": "{not: valid}"}, ""]);
+        this.server.respondWith("GET", "/test?htmx-request=1", [200, {"HX-Trigger": "{not: valid}"}, ""]);
 
         var div = make('<div hx-get="/test"></div>');
         div.click();
@@ -155,7 +155,7 @@ describe("Core htmx AJAX headers", function () {
     })
 
     it("should handle simple string HX-Trigger response header properly w/ outerHTML swap", function () {
-        this.server.respondWith("GET", "/test", [200, {"HX-Trigger": "foo"}, ""]);
+        this.server.respondWith("GET", "/test?htmx-request=1", [200, {"HX-Trigger": "foo"}, ""]);
 
         var div = make('<div hx-swap="outerHTML" hx-get="/test"></div>');
         var invokedEvent = false;
@@ -169,7 +169,7 @@ describe("Core htmx AJAX headers", function () {
     })
 
     it("should handle HX-Retarget", function () {
-        this.server.respondWith("GET", "/test", [200, {"HX-Retarget": "#d2"}, "Result"]);
+        this.server.respondWith("GET", "/test?htmx-request=1", [200, {"HX-Retarget": "#d2"}, "Result"]);
 
         var div1 = make('<div id="d1" hx-get="/test"></div>');
         var div2 = make('<div id="d2"></div>');
@@ -180,7 +180,7 @@ describe("Core htmx AJAX headers", function () {
     })
 
     it("should handle HX-Reswap", function () {
-        this.server.respondWith("GET", "/test", [200, {"HX-Reswap": "innerHTML"}, "Result"]);
+        this.server.respondWith("GET", "/test?htmx-request=1", [200, {"HX-Reswap": "innerHTML"}, "Result"]);
 
         var div1 = make('<div id="d1" hx-get="/test" hx-swap="outerHTML"></div>');
         div1.click();
@@ -189,7 +189,7 @@ describe("Core htmx AJAX headers", function () {
     })
 
     it("should handle simple string HX-Trigger-After-Swap response header properly w/ outerHTML swap", function () {
-        this.server.respondWith("GET", "/test", [200, {"HX-Trigger-After-Swap": "foo"}, ""]);
+        this.server.respondWith("GET", "/test?htmx-request=1", [200, {"HX-Trigger-After-Swap": "foo"}, ""]);
 
         var div = make('<div hx-swap="outerHTML" hx-get="/test"></div>');
         var invokedEvent = false;
@@ -203,7 +203,7 @@ describe("Core htmx AJAX headers", function () {
     })
 
     it("should handle simple string HX-Trigger-After-Settle response header properly w/ outerHTML swap", function () {
-        this.server.respondWith("GET", "/test", [200, {"HX-Trigger-After-Settle": "foo"}, ""]);
+        this.server.respondWith("GET", "/test?htmx-request=1", [200, {"HX-Trigger-After-Settle": "foo"}, ""]);
 
         var div = make('<div hx-swap="outerHTML" hx-get="/test"></div>');
         var invokedEvent = false;
@@ -218,8 +218,8 @@ describe("Core htmx AJAX headers", function () {
 
 
     it("should change body content on HX-Location", function () {
-        this.server.respondWith("GET", "/test", [200, {"HX-Location": '{"path":"/test2", "target":"#testdiv"}'}, ""]);
-        this.server.respondWith("GET", "/test2", [200, {}, "<div>Yay! Welcome</div>"]);
+        this.server.respondWith("GET", "/test?htmx-request=1", [200, {"HX-Location": '{"path":"/test2", "target":"#testdiv"}'}, ""]);
+        this.server.respondWith("GET", "/test2?htmx-request=1", [200, {}, "<div>Yay! Welcome</div>"]);
         var div = make('<div id="testdiv" hx-trigger="click" hx-get="/test"></div>');
         div.click();
         this.server.respond();

--- a/test/core/regressions.js
+++ b/test/core/regressions.js
@@ -19,7 +19,7 @@ describe("Core htmx Regression Tests", function(){
     });
 
     it ('Handles https://github.com/bigskysoftware/htmx/issues/4 properly', function() {
-        this.server.respondWith("GET", "/index2a.php",
+        this.server.respondWith("GET", "/index2a.php?htmx-request=1",
             "<div id='message' hx-swap-oob='true'>I came from message oob swap I should be second</div>" +
             "<div id='message2' hx-swap-oob='true'>I came from a message2 oob swap I should be third  but I am in the wrong spot</div>" +
             "I'm page2 content (non-swap) I should be first")
@@ -51,7 +51,7 @@ describe("Core htmx Regression Tests", function(){
     });
 
     it ('name=id doesnt cause an error', function(){
-        this.server.respondWith("GET", "/test", "Foo<form><input name=\"id\"/></form>")
+        this.server.respondWith("GET", "/test?htmx-request=1", "Foo<form><input name=\"id\"/></form>")
         var div = make('<div hx-get="/test">Get It</div>')
         div.click();
         this.server.respond();
@@ -59,7 +59,7 @@ describe("Core htmx Regression Tests", function(){
     });
 
     it ('empty id doesnt cause an error', function(){
-        this.server.respondWith("GET", "/test", "Foo\n<div id=''></div>")
+        this.server.respondWith("GET", "/test?htmx-request=1", "Foo\n<div id=''></div>")
         var div = make('<div hx-get="/test">Get It</div>')
         div.click();
         this.server.respond();
@@ -67,7 +67,7 @@ describe("Core htmx Regression Tests", function(){
     });
     
     it ('id with dot in value doesnt cause an error', function(){
-        this.server.respondWith("GET", "/test", "Foo <div id='ViewModel.Test'></div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Foo <div id='ViewModel.Test'></div>");
         var div = make('<div hx-get="/test">Get It</div>');
         div.click();
         this.server.respond();
@@ -75,7 +75,7 @@ describe("Core htmx Regression Tests", function(){
     });
 
     it ('@ symbol in attributes does not break requests', function(){
-        this.server.respondWith("GET", "/test", "<div id='d1' @foo='bar'>Foo</div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<div id='d1' @foo='bar'>Foo</div>");
         var div = make('<div hx-get="/test">Get It</div>');
         div.click();
         this.server.respond();
@@ -83,7 +83,7 @@ describe("Core htmx Regression Tests", function(){
     });
 
     it ('@ symbol in attributes does not break attribute settling requests', function(){
-        this.server.respondWith("GET", "/test", "<div id='d1' @foo='bar'>Foo</div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<div id='d1' @foo='bar'>Foo</div>");
         var div = make('<div hx-get="/test"><div id="d1">Foo</div></div>');
         div.click();
         this.server.respond();
@@ -91,7 +91,7 @@ describe("Core htmx Regression Tests", function(){
     });
 
     it ('selected element with ID does not cause NPE when it disappears', function(){
-        this.server.respondWith("GET", "/test", "<div id='d1'>Replaced</div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<div id='d1'>Replaced</div>");
         var input = make('<input hx-trigger="click" hx-get="/test" id="i1" hx-swap="outerHTML">');
         input.focus();
         input.click();
@@ -112,7 +112,7 @@ describe("Core htmx Regression Tests", function(){
     })
 
     it('two elements can listen for the same event on another element', function() {
-        this.server.respondWith("GET", "/test", "triggered");
+        this.server.respondWith("GET", "/test?htmx-request=1", "triggered");
 
         make('<div id="d1" hx-trigger="click from:body" hx-get="/test"></div>' +
             '        <div id="d2" hx-trigger="click from:body" hx-get="/test"></div>');
@@ -152,7 +152,7 @@ describe("Core htmx Regression Tests", function(){
     })
 
     it('supports image maps', function() {
-        this.server.respondWith("GET", "/test", "triggered");
+        this.server.respondWith("GET", "/test?htmx-request=1", "triggered");
 
         make('<div>' +
             '    <div id="d1"></div>' +
@@ -173,7 +173,7 @@ describe("Core htmx Regression Tests", function(){
     })
 
     it("supports unset on hx-select", function(){
-        this.server.respondWith("GET", "/test", "Foo<span id='example'>Bar</span>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Foo<span id='example'>Bar</span>");
         htmx.logAll();
         make('<form hx-select="#example">\n' +
             '      <button id="b1" hx-select="unset" hx-get="/test">Initial</button>\n' +

--- a/test/core/security.js
+++ b/test/core/security.js
@@ -10,7 +10,7 @@ describe("security options", function() {
     });
 
     it("can disable a single elt", function(){
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
 
         var btn = make('<button hx-disable hx-get="/test">Initial</button>')
         btn.click();
@@ -19,7 +19,7 @@ describe("security options", function() {
     })
 
     it("can disable a parent  elt", function(){
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
 
         var div = make('<div hx-disable><button id="b1" hx-get="/test">Initial</button></div>')
         var btn = byId("b1");

--- a/test/ext/ajax-header.js
+++ b/test/ext/ajax-header.js
@@ -9,7 +9,7 @@ describe("ajax-header extension", function() {
     });
 
     it('Sends the X-Requested-With header', function () {
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             xhr.respond(200, {}, xhr.requestHeaders['X-Requested-With'])
         });
         var btn = make('<button hx-get="/test" hx-ext="ajax-header">Click Me!</button>')

--- a/test/ext/bad-extension.js
+++ b/test/ext/bad-extension.js
@@ -17,7 +17,7 @@ describe("bad extension", function() {
     });
 
     it('does not blow up rendering', function () {
-        this.server.respondWith("GET", "/test", "clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "clicked!");
         var div = make('<div hx-get="/test" hx-ext="bad-extension">Click Me!</div>')
         div.click();
         this.server.respond();

--- a/test/ext/client-side-templates.js
+++ b/test/ext/client-side-templates.js
@@ -9,7 +9,7 @@ describe("client-side-templates extension", function() {
     });
 
     it('works on basic mustache template', function () {
-        this.server.respondWith("GET", "/test", '{"foo":"bar"}');
+        this.server.respondWith("GET", "/test?htmx-request=1", '{"foo":"bar"}');
         var btn = make('<button hx-get="/test" hx-ext="client-side-templates" mustache-template="mt1">Click Me!</button>')
         make('<script id="mt1" type="x-tmpl-mustache">*{{foo}}*</script>')
         btn.click();
@@ -18,7 +18,7 @@ describe("client-side-templates extension", function() {
     });
 
     it('works on basic handlebars template', function () {
-        this.server.respondWith("GET", "/test", '{"foo":"bar"}');
+        this.server.respondWith("GET", "/test?htmx-request=1", '{"foo":"bar"}');
         var btn = make('<button hx-get="/test" hx-ext="client-side-templates" handlebars-template="hb1">Click Me!</button>')
         Handlebars.partials["hb1"] = Handlebars.compile("*{{foo}}*");
         btn.click();

--- a/test/ext/debug.js
+++ b/test/ext/debug.js
@@ -9,7 +9,7 @@ describe("debug extension", function() {
     });
 
     it('works on basic request', function () {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var btn = make('<button hx-get="/test" hx-ext="debug">Click Me!</button>')
         btn.click();
         this.server.respond();

--- a/test/ext/disable-element.js
+++ b/test/ext/disable-element.js
@@ -12,7 +12,7 @@ describe("disable-element extension", function() {
         // GIVEN:
         // - A button triggering an htmx request with disable-element extension
         // - The button is enabled
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             xhr.respond(200, {})
         });
         var btn = make('<button hx-get="/test" hx-ext="disable-element" hx-disable-element="self">Click Me!</button>')
@@ -36,7 +36,7 @@ describe("disable-element extension", function() {
         // - A button triggering an htmx request with disable-element extension
         // - Another button that needs to be disabled during the htmx request
         // - Both buttons are enabled
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             xhr.respond(200, {})
         });
         var btn = make('<button hx-get="/test" hx-ext="disable-element" hx-disable-element="#should-be-disabled">Click Me!</button>')

--- a/test/ext/event-header.js
+++ b/test/ext/event-header.js
@@ -9,7 +9,7 @@ describe("event-header extension", function() {
     });
 
     it('Sends the Triggering-Event header', function () {
-        this.server.respondWith("GET", "/test", function (xhr) {
+        this.server.respondWith("GET", "/test?htmx-request=1", function (xhr) {
             xhr.respond(200, {}, xhr.requestHeaders['Triggering-Event'])
         });
         var btn = make('<button hx-get="/test" hx-ext="event-header">Click Me!</button>')

--- a/test/ext/extension-swap.js
+++ b/test/ext/extension-swap.js
@@ -31,7 +31,7 @@ describe("default extensions behavior", function() {
     });
 
     it('handleSwap: afterSwap and afterSettle triggered if extension defined on parent', function () {
-        this.server.respondWith("GET", "/test", '<button>Clicked!</button>');
+        this.server.respondWith("GET", "/test?htmx-request=1", '<button>Clicked!</button>');
         var div = make('<div hx-ext="ext-testswap"><button hx-get="/test" hx-swap="testswap">Click Me!</button></div>');
         var btn = div.firstChild;
         btn.click()
@@ -41,8 +41,8 @@ describe("default extensions behavior", function() {
     });
 
     it('handleSwap: new content is handled by htmx', function() {
-        this.server.respondWith("GET", "/test", '<button id="test-ext-testswap">Clicked!<span hx-get="/test-inner" hx-trigger="load"></span></button>');
-        this.server.respondWith("GET", "/test-inner", 'Loaded!');
+        this.server.respondWith("GET", "/test?htmx-request=1", '<button id="test-ext-testswap">Clicked!<span hx-get="/test-inner" hx-trigger="load"></span></button>');
+        this.server.respondWith("GET", "/test-inner?htmx-request=1", 'Loaded!');
         make('<div hx-ext="ext-testswap"><button hx-get="/test" hx-swap="testswap">Click Me!</button></div>').querySelector('button').click();
 
         this.server.respond(); // call /test via button trigger=click

--- a/test/ext/hyperscript.js
+++ b/test/ext/hyperscript.js
@@ -9,7 +9,7 @@ describe("hyperscript integration", function() {
     });
 
     it('can trigger with a custom event', function () {
-        this.server.respondWith("GET", "/test", "Custom Event Sent!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Custom Event Sent!");
         var btn = make('<button _="on click send customEvent" hx-trigger="customEvent" hx-get="/test">Click Me!</button>')
         htmx.trigger(btn, "htmx:load"); // have to manually trigger the load event for non-AJAX dynamic content
         btn.click();
@@ -18,7 +18,7 @@ describe("hyperscript integration", function() {
     });
 
     it('can handle htmx driven events', function () {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var btn = make('<button _="on htmx:afterSettle add .afterSettle" hx-get="/test">Click Me!</button>')
         htmx.trigger(btn, "htmx:load");
         btn.classList.contains("afterSettle").should.equal(false);
@@ -28,7 +28,7 @@ describe("hyperscript integration", function() {
     });
 
     it('can handle htmx error events', function () {
-        this.server.respondWith("GET", "/test", [404, {}, "Bad request"]);
+        this.server.respondWith("GET", "/test?htmx-request=1", [404, {}, "Bad request"]);
         var div = make('<div id="d1"></div>')
         var btn = make('<button _="on htmx:error(errorInfo) put errorInfo.error into #d1.innerHTML" hx-get="/test">Click Me!</button>')
         htmx.trigger(btn, "htmx:load");
@@ -38,7 +38,7 @@ describe("hyperscript integration", function() {
     });
 
     it('hyperscript in non-htmx annotated nodes is evaluated', function () {
-        this.server.respondWith("GET", "/test", "<div><div><div id='d1' _='on click put \"Clicked...\" into my.innerHTML'></div></div></div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<div><div><div id='d1' _='on click put \"Clicked...\" into my.innerHTML'></div></div></div>");
         var btn = make('<button hx-get="/test">Click Me!</button>')
         btn.click();
         this.server.respond();
@@ -48,7 +48,7 @@ describe("hyperscript integration", function() {
     });
 
     it('hyperscript removal example works', function (done) {
-        this.server.respondWith("GET", "/test", "<div id='d1' _='on load wait 20ms then remove me'>To Remove</div>");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<div id='d1' _='on load wait 20ms then remove me'>To Remove</div>");
         var btn = make('<button hx-get="/test">Click Me!</button>')
         btn.click();
         this.server.respond();

--- a/test/ext/loading-states.js
+++ b/test/ext/loading-states.js
@@ -11,7 +11,7 @@ describe("loading states extension", function () {
     });
 
     it('works on basic setup', function () {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var btn = make('<button hx-get="/test" hx-ext="loading-states">Click Me!</button>');
         var element = make('<div data-loading>');
         btn.click();
@@ -22,7 +22,7 @@ describe("loading states extension", function () {
     });
 
     it('works with custom display', function () {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var btn = make('<button hx-get="/test" hx-ext="loading-states">Click Me!</button>');
         var element = make('<div data-loading="flex">');
         btn.click();
@@ -33,7 +33,7 @@ describe("loading states extension", function () {
     });
 
     it('works with classes', function () {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var btn = make('<button hx-get="/test" hx-ext="loading-states">Click Me!</button>');
         var element = make('<div data-loading-class="test">');
         btn.click();
@@ -44,7 +44,7 @@ describe("loading states extension", function () {
     });
 
     it('works with classes removal', function () {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var btn = make('<button hx-get="/test" hx-ext="loading-states">Click Me!</button>');
         var element = make('<div data-loading-class-remove="test" class="test">');
         btn.click();
@@ -55,7 +55,7 @@ describe("loading states extension", function () {
     });
 
     it('works with disabling', function () {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var btn = make('<button hx-get="/test" hx-ext="loading-states">Click Me!</button>');
         var element = make('<button data-loading-disable>');
         btn.click();
@@ -66,7 +66,7 @@ describe("loading states extension", function () {
     });
 
     it('works with aria-busy', function () {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var btn = make('<button hx-get="/test" hx-ext="loading-states">Click Me!</button>');
         var element = make('<button data-loading-aria-busy>');
         btn.click();
@@ -77,7 +77,7 @@ describe("loading states extension", function () {
     });
 
     it('works with multiple directives', function () {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var btn = make('<button hx-get="/test" hx-ext="loading-states">Click Me!</button>');
         var element = make('<button data-loading-aria-busy data-loading-class="loading" data-loading-class-remove="not-loading" class="not-loading">');
         btn.click();
@@ -92,7 +92,7 @@ describe("loading states extension", function () {
     });
 
     it('works with delay', function () {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var btn = make('<button hx-get="/test" hx-ext="loading-states">Click Me!</button>');
         var element = make('<div data-loading-class-remove="test" data-loading-delay="1s" class="test">');
         btn.click();
@@ -105,7 +105,7 @@ describe("loading states extension", function () {
     });
 
     it('works with custom targets', function () {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var btn = make('<button hx-get="/test" hx-ext="loading-states" data-loading-target="#loader" data-loading-class="test">Click Me!</button>');
         var element = make('<div id="loader">');
         btn.click();
@@ -116,7 +116,7 @@ describe("loading states extension", function () {
     });
 
     it('works with path filters', function () {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var btn = make('<button hx-get="/test" hx-ext="loading-states" >Click Me!</button>');
         var matchingRequestElement = make('<div data-loading-class="test" data-loading-path="/test">');
         var nonMatchingPathElement = make('<div data-loading-class="test" data-loading-path="/test1">');
@@ -130,7 +130,7 @@ describe("loading states extension", function () {
     });
 
     it('works with scopes', function () {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
         var btn = make('<div data-loading-states><button hx-get="/test" hx-ext="loading-states" >Click Me!</button></div>');
         var element = make('<div data-loading-class="test">');
         btn.getElementsByTagName("button")[0].click();
@@ -142,8 +142,8 @@ describe("loading states extension", function () {
 
     it('history restore should not have loading states in content', function () {
         // this test is based on test from test/attributes/hx-push-url.js:65
-        this.server.respondWith("GET", "/test1", '<button id="d2" hx-push-url="true" hx-get="/test2" hx-swap="outerHTML settle:0" data-loading-disable>test1</button>');
-        this.server.respondWith("GET", "/test2", '<button id="d3" hx-push-url="true" hx-get="/test3" hx-swap="outerHTML settle:0" data-loading-disable>test2</button>');
+        this.server.respondWith("GET", "/test1?htmx-request=1", '<button id="d2" hx-push-url="true" hx-get="/test2" hx-swap="outerHTML settle:0" data-loading-disable>test1</button>');
+        this.server.respondWith("GET", "/test2?htmx-request=1", '<button id="d3" hx-push-url="true" hx-get="/test3" hx-swap="outerHTML settle:0" data-loading-disable>test2</button>');
 
         make('<div hx-ext="loading-states"><button id="d1" hx-push-url="true" hx-get="/test1" hx-swap="outerHTML settle:0" data-loading-disable>init</button></div>');
 

--- a/test/ext/morphdom-swap.js
+++ b/test/ext/morphdom-swap.js
@@ -9,7 +9,7 @@ describe("morphdom-swap extension", function() {
     });
 
     it('works on basic request', function () {
-        this.server.respondWith("GET", "/test", "<button>Clicked!</button>!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<button>Clicked!</button>!");
         var btn = make('<button hx-get="/test" hx-ext="morphdom-swap" hx-swap="morphdom" >Click Me!</button>')
         btn.click();
         should.equal(btn.getAttribute("hx-get"), "/test");
@@ -19,8 +19,8 @@ describe("morphdom-swap extension", function() {
     });
 
     it('works with htmx elements in new content', function () {
-        this.server.respondWith("GET", "/test", '<button>Clicked!<span hx-get="/test-inner" hx-trigger="load" hx-swap="morphdom"></span></button>');
-        this.server.respondWith("GET", "/test-inner", 'Loaded!');
+        this.server.respondWith("GET", "/test?htmx-request=1", '<button>Clicked!<span hx-get="/test-inner" hx-trigger="load" hx-swap="morphdom"></span></button>');
+        this.server.respondWith("GET", "/test-inner?htmx-request=1", 'Loaded!');
         var btn = make('<div hx-ext="morphdom-swap"><button hx-get="/test" hx-swap="morphdom">Click Me!</button></div>').querySelector('button');
         btn.click();
         this.server.respond(); // call /test via button trigger=click
@@ -29,7 +29,7 @@ describe("morphdom-swap extension", function() {
     });
 
     it('works with hx-select', function () {
-        this.server.respondWith("GET", "/test", "<button>Clicked!</button>!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "<button>Clicked!</button>!");
         var btn = make('<button hx-get="/test" hx-ext="morphdom-swap" hx-swap="morphdom" hx-select="button" >Click Me!</button>')
         btn.click();
         should.equal(btn.getAttribute("hx-get"), "/test");

--- a/test/ext/multi-swap.js
+++ b/test/ext/multi-swap.js
@@ -9,7 +9,7 @@ describe("multi-swap extension", function() {
     });
 
     it('swap only one element with default innerHTML', function () {
-        this.server.respondWith("GET", "/test", '<html><body><div class="dummy"><div id="a">New A</div></div></html>');
+        this.server.respondWith("GET", "/test?htmx-request=1", '<html><body><div class="dummy"><div id="a">New A</div></div></html>');
         var content = make('<div>Foo <div id="a">Old A</div></div>');
         var btn = make('<button hx-get="/test" hx-ext="multi-swap" hx-swap="multi:#a">Click Me!</button>');
         btn.click();
@@ -18,7 +18,7 @@ describe("multi-swap extension", function() {
     });
 
     it('swap multiple elements with outerHTML, beforeend, afterend, beforebegin and delete methods', function () {
-        this.server.respondWith("GET", "/test",
+        this.server.respondWith("GET", "/test?htmx-request=1",
             '<html><body><div class="abc">' +
             '<div id="a">New A</div> foo ' +
             '<div id="b"><b>New B</b></div> bar ' +

--- a/test/ext/path-deps.js
+++ b/test/ext/path-deps.js
@@ -10,7 +10,7 @@ describe("path-deps extension", function() {
 
     it('path-deps basic case works', function () {
         this.server.respondWith("POST", "/test", "Clicked!");
-        this.server.respondWith("GET", "/test2", "Deps fired!");
+        this.server.respondWith("GET", "/test2?htmx-request=1", "Deps fired!");
         var btn = make('<button hx-post="/test" hx-ext="path-deps">Click Me!</button>')
         var div = make('<div hx-get="/test2" hx-trigger="path-deps" path-deps="/test">FOO</div>')
         btn.click();
@@ -23,7 +23,7 @@ describe("path-deps extension", function() {
 
     it('path-deps works with trailing slash', function () {
         this.server.respondWith("POST", "/test", "Clicked!");
-        this.server.respondWith("GET", "/test2", "Deps fired!");
+        this.server.respondWith("GET", "/test2?htmx-request=1", "Deps fired!");
         var btn = make('<button hx-post="/test" hx-ext="path-deps">Click Me!</button>')
         var div = make('<div hx-get="/test2" hx-trigger="path-deps" path-deps="/test/">FOO</div>')
         btn.click();
@@ -35,8 +35,8 @@ describe("path-deps extension", function() {
     });
 
     it('path-deps GET does not trigger', function () {
-        this.server.respondWith("GET", "/test", "Clicked!");
-        this.server.respondWith("GET", "/test2", "Deps fired!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
+        this.server.respondWith("GET", "/test2?htmx-request=1", "Deps fired!");
         var btn = make('<button hx-get="/test" hx-ext="path-deps">Click Me!</button>')
         var div = make('<div hx-get="/test2" hx-trigger="path-deps" path-deps="/test">FOO</div>')
         btn.click();
@@ -49,7 +49,7 @@ describe("path-deps extension", function() {
 
     it('path-deps dont trigger on path mismatch', function () {
         this.server.respondWith("POST", "/test", "Clicked!");
-        this.server.respondWith("GET", "/test2", "Deps fired!");
+        this.server.respondWith("GET", "/test2?htmx-request=1", "Deps fired!");
         var btn = make('<button hx-post="/test" hx-ext="path-deps">Click Me!</button>')
         var div = make('<div hx-get="/test2" hx-trigger="path-deps" path-deps="/test2">FOO</div>')
         btn.click();
@@ -62,7 +62,7 @@ describe("path-deps extension", function() {
 
     it('path-deps dont trigger on path longer than request', function () {
         this.server.respondWith("POST", "/test", "Clicked!");
-        this.server.respondWith("GET", "/test2", "Deps fired!");
+        this.server.respondWith("GET", "/test2?htmx-request=1", "Deps fired!");
         var btn = make('<button hx-post="/test" hx-ext="path-deps">Click Me!</button>')
         var div = make('<div hx-get="/test2" hx-trigger="path-deps" path-deps="/test/child">FOO</div>')
         btn.click();
@@ -75,7 +75,7 @@ describe("path-deps extension", function() {
 
     it('path-deps trigger on path shorter than request', function () {
         this.server.respondWith("POST", "/test/child", "Clicked!");
-        this.server.respondWith("GET", "/test2", "Deps fired!");
+        this.server.respondWith("GET", "/test2?htmx-request=1", "Deps fired!");
         var btn = make('<button hx-post="/test/child" hx-ext="path-deps">Click Me!</button>')
         var div = make('<div hx-get="/test2" hx-trigger="path-deps" path-deps="/test">FOO</div>')
         btn.click();
@@ -88,7 +88,7 @@ describe("path-deps extension", function() {
 
     it('path-deps trigger on *-at-start path', function () {
         this.server.respondWith("POST", "/test/child/test", "Clicked!");
-        this.server.respondWith("GET", "/test2", "Deps fired!");
+        this.server.respondWith("GET", "/test2?htmx-request=1", "Deps fired!");
         var btn = make('<button hx-post="/test/child/test" hx-ext="path-deps">Click Me!</button>')
         var div = make('<div hx-get="/test2" hx-trigger="path-deps" path-deps="/*/child/test">FOO</div>')
         btn.click();
@@ -101,7 +101,7 @@ describe("path-deps extension", function() {
 
     it('path-deps trigger on *-in-middle path', function () {
         this.server.respondWith("POST", "/test/child/test", "Clicked!");
-        this.server.respondWith("GET", "/test2", "Deps fired!");
+        this.server.respondWith("GET", "/test2?htmx-request=1", "Deps fired!");
         var btn = make('<button hx-post="/test/child/test" hx-ext="path-deps">Click Me!</button>')
         var div = make('<div hx-get="/test2" hx-trigger="path-deps" path-deps="/test/*/test">FOO</div>')
         btn.click();
@@ -114,7 +114,7 @@ describe("path-deps extension", function() {
 
     it('path-deps trigger on *-at-end path', function () {
         this.server.respondWith("POST", "/test/child/test", "Clicked!");
-        this.server.respondWith("GET", "/test2", "Deps fired!");
+        this.server.respondWith("GET", "/test2?htmx-request=1", "Deps fired!");
         var btn = make('<button hx-post="/test/child/test" hx-ext="path-deps">Click Me!</button>')
         var div = make('<div hx-get="/test2" hx-trigger="path-deps" path-deps="/test/child/*">FOO</div>')
         btn.click();
@@ -127,7 +127,7 @@ describe("path-deps extension", function() {
 
     it('path-deps trigger all *s path', function () {
         this.server.respondWith("POST", "/test/child/test", "Clicked!");
-        this.server.respondWith("GET", "/test2", "Deps fired!");
+        this.server.respondWith("GET", "/test2?htmx-request=1", "Deps fired!");
         var btn = make('<button hx-post="/test/child/test" hx-ext="path-deps">Click Me!</button>')
         var div = make('<div hx-get="/test2" hx-trigger="path-deps" path-deps="/*/*/*">FOO</div>')
         btn.click();
@@ -139,7 +139,7 @@ describe("path-deps extension", function() {
     });
 
     it('path-deps api basic refresh case works', function () {
-        this.server.respondWith("GET", "/test", "Path deps fired!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Path deps fired!");
         var div = make('<div hx-get="/test" hx-trigger="path-deps" path-deps="/test">FOO</div>')
         PathDeps.refresh("/test");
         this.server.respond();
@@ -147,8 +147,8 @@ describe("path-deps extension", function() {
     });
 
     it('path-deps api parent path case works', function () {
-        this.server.respondWith("GET", "/test1", "Path deps 1 fired!");
-        this.server.respondWith("GET", "/test2", "Path deps 2 fired!");
+        this.server.respondWith("GET", "/test1?htmx-request=1", "Path deps 1 fired!");
+        this.server.respondWith("GET", "/test2?htmx-request=1", "Path deps 2 fired!");
         var div = make('<div hx-get="/test1" hx-trigger="path-deps" path-deps="/test/child">FOO</div>')
         var div2 = make('<div hx-get="/test2" hx-trigger="path-deps" path-deps="/test">BAR</div>')
         PathDeps.refresh("/test/child");
@@ -160,7 +160,7 @@ describe("path-deps extension", function() {
 
     it('path-deps replacing containing element fires event', function () {
         this.server.respondWith("POST", "/test", "Clicked!");
-        this.server.respondWith("GET", "/test2", "Deps fired!");
+        this.server.respondWith("GET", "/test2?htmx-request=1", "Deps fired!");
         var div1 = make('<div><button id="buttonSubmit" hx-post="/test" hx-swap="outerHTML" hx-ext="path-deps" >Click Me!</button></div>')
         var div2 = make('<div hx-get="/test2" hx-trigger="path-deps" path-deps="/test">FOO</div>')
         byId("buttonSubmit").click();

--- a/test/ext/ws.js
+++ b/test/ext/ws.js
@@ -36,7 +36,7 @@ describe("web-sockets extension", function () {
     })
 
     it('is closed after removal by swap', function () {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
 
         var div = make('<div hx-get="/test" hx-swap="outerHTML" hx-ext="ws" ws-connect="ws://localhost:8080">');
         this.tickMock();
@@ -52,7 +52,7 @@ describe("web-sockets extension", function () {
     })
 
     it('is closed after removal by js when message is received', function () {
-        this.server.respondWith("GET", "/test", "Clicked!");
+        this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
 
         var div = make('<div hx-get="/test" hx-swap="outerHTML" hx-ext="ws" ws-connect="ws://localhost:8080">');
         this.tickMock();

--- a/test/manual/confirm-and-prompt.html
+++ b/test/manual/confirm-and-prompt.html
@@ -11,10 +11,10 @@
 <script>
     server = makeServer();
     server.autoRespond = true;
-    server.respondWith("GET", "/prompt", function(xhr){
+    server.respondWith("GET", "/prompt?htmx-request=1", function(xhr){
         xhr.respond(200, {}, "You entered: " + xhr.requestHeaders["HX-Prompt"]);
     })
-    server.respondWith("GET", "/confirm", function(xhr){
+    server.respondWith("GET", "/confirm?htmx-request=1", function(xhr){
         xhr.respond(200, {}, "Confirmed")
     })
 </script>

--- a/test/manual/intersect-test-eventHandler.html
+++ b/test/manual/intersect-test-eventHandler.html
@@ -9,7 +9,7 @@
 	<script>
 		server = makeServer();
 		server.autoRespond = true;
-		server.respondWith("GET", "/more_content", "Here is more content for this page, loaded 'remotely'.");
+		server.respondWith("GET", "/more_content?htmx-request=1", "Here is more content for this page, loaded 'remotely'.");
 	</script>
 
 	<style>

--- a/test/manual/manual-perf.html
+++ b/test/manual/manual-perf.html
@@ -47,7 +47,7 @@
         }
 
         it("DOM processing should be fast", function(){
-            this.server.respondWith("GET", "/test", "Clicked!");
+            this.server.respondWith("GET", "/test?htmx-request=1", "Clicked!");
 
             // create an entry with a large content string (256k) and see how fast we can write and read it
             // to local storage as a single entry

--- a/test/manual/poll-condition-test.html
+++ b/test/manual/poll-condition-test.html
@@ -11,7 +11,7 @@
 <script>
     server = makeServer();
     server.autoRespond = true;
-    server.respondWith("GET", "/more_divs", "<div>More Content</div>");
+    server.respondWith("GET", "/more_divs?htmx-request=1", "<div>More Content</div>");
 </script>
 <h1>Should Not Add Any Content Due To False Condition</h1>
 <div hx-trigger="every 3s [false]" hx-get="/more_divs" hx-swap="beforeend" style="height: 100px; overflow: scroll">

--- a/test/manual/scroll-test-eventHandler.html
+++ b/test/manual/scroll-test-eventHandler.html
@@ -9,7 +9,7 @@
 	<script>
 		server = makeServer();
 		server.autoRespond = true;
-		server.respondWith("GET", "/more_content", "Here is more content for this page, loaded 'remotely'.");
+		server.respondWith("GET", "/more_content?htmx-request=1", "Here is more content for this page, loaded 'remotely'.");
 	</script>
 
 	<style>

--- a/test/manual/scroll-test-startEnd.html
+++ b/test/manual/scroll-test-startEnd.html
@@ -11,7 +11,7 @@
 <script>
     server = makeServer();
     server.autoRespond = true;
-    server.respondWith("GET", "/more_divs", "<div>More Content</div>");
+    server.respondWith("GET", "/more_divs?htmx-request=1", "<div>More Content</div>");
 </script>
 <h1>Scrolling Start/End Tests</h1>
 

--- a/test/manual/scroll-test-targets.html
+++ b/test/manual/scroll-test-targets.html
@@ -11,7 +11,7 @@
 <script>
     server = makeServer();
     server.autoRespond = true;
-    server.respondWith("GET", "/demo", "Clicked...");
+    server.respondWith("GET", "/demo?htmx-request=1", "Clicked...");
     htmx.config.scrollBehavior = 'auto';
 </script>
 <h1>Scrolling Start/End Tests</h1>

--- a/test/scratch.html
+++ b/test/scratch.html
@@ -25,14 +25,14 @@
 
 <script>
 
-    // this.server.respondWith("GET", "/test2", "Clicked!");
+    // this.server.respondWith("GET", "/test2?htmx-request=1", "Clicked!");
     //
     // make('<div hx-get="/test">dd</div>')
 
 //    htmx.logAll();
 
     // var i = 1;
-    // this.server.respondWith("GET", "/test", function(xhr){
+    // this.server.respondWith("GET", "/test?htmx-request=1", function(xhr){
     //     xhr.respond(201, {}, "" + i++);
     // });
     //
@@ -62,7 +62,7 @@ Autorespond: <input id="autorespond" type="checkbox" onclick="toggleAutoRespond(
 </div>
 
 <script>
-    this.server.respondWith("GET", "/preserve", 'foo');
+    this.server.respondWith("GET", "/preserve?htmx-request=1", 'foo');
 </script>
 
 <div hx-post="/preserve" hx-trigger="every 1s">


### PR DESCRIPTION
Fixes #724 

* Both `issueAjaxRequest()` and `loadHistoryFromServer()` now add `htmx-request=1` queryparam to all GET XHR requests
* This queryparam is eliminated before saving URL to history
* Many tests are changed to make the mock server respond to these new URLs