### PR TITLE
Add `delete` to docs.md swapping list

### DIFF
--- a/www/docs.md
+++ b/www/docs.md
@@ -399,6 +399,7 @@ with any of the following values:
 | `beforebegin` | prepends the content before the target in the targets parent element
 | `beforeend` | appends the content after the last child inside the target
 | `afterend` | appends the content after the target in the targets parent element
+| `delete` | deletes the target element regardless of the response
 | `none` | does not append content from response ([Out of Band Swaps](#oob_swaps) and [Response Headers](#response-headers) will still be processed)
 
 #### <a name="morphing"></a> [Morph Swaps](#morphing)


### PR DESCRIPTION
The `delete` value shows up on https://htmx.org/attributes/hx-swap/ but not on https://htmx.org/docs/#swapping... took me a little bit to realize it was a possibility.