### PR TITLE
fix indicator styles flash

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3337,9 +3337,9 @@ return (function () {
             if (htmx.config.includeIndicatorStyles !== false) {
                 getDocument().head.insertAdjacentHTML("beforeend",
                     "<style>\
-                      ." + htmx.config.indicatorClass + "{opacity:0;transition: opacity 200ms ease-in;}\
-                      ." + htmx.config.requestClass + " ." + htmx.config.indicatorClass + "{opacity:1}\
-                      ." + htmx.config.requestClass + "." + htmx.config.indicatorClass + "{opacity:1}\
+                      ." + htmx.config.indicatorClass + "{opacity:0}\
+                      ." + htmx.config.requestClass + " ." + htmx.config.indicatorClass + "{opacity:1; transition: opacity 200ms ease-in;}\
+                      ." + htmx.config.requestClass + "." + htmx.config.indicatorClass + "{opacity:1; transition: opacity 200ms ease-in;}\
                     </style>");
             }
         }


### PR DESCRIPTION
In a SPA I am writing, I noticed that when adding an element with an indicator to the DOM, the indicator will "flash" (display for a brief moment). Specifically, in my case this is when content for a page is loaded via the "HX-Location" header.

I am not a CSS expert, but it appears as though the CSS transition is on the wrong element. Instead, the transition should be placed on the elements with opacity: 1 (when the request class is added).

I made that change locally in my app, and the "flashing" behavior went away. Here is a PR for that change.