### PR TITLE
fix a typo in test-ws example

### DIFF
--- a/test/servers/ws/README.md
+++ b/test/servers/ws/README.md
@@ -8,7 +8,7 @@ This server listens for incoming WebSocket connections coming in to ws://localho
 
 ## How to Use This Server
 
-1. If you do not already have Go (version 1.17 or higher) installed on your machine, you can download an installation for your machine from [https://golang.org](the Go website)
+1. If you do not already have Go (version 1.17 or higher) installed on your machine, you can download an installation for your machine from [the Go website](https://golang.org)
 
 2. Open up a terminal window and navigate to this directory.  Start up the WebSocket server by typing `go run server.go`
 


### PR DESCRIPTION
fixing a link mismatch error in the readme for the go lang example for websocket extension