### PR TITLE
Docs: Move extension script URL to the start of the page

### DIFF
--- a/www/extensions.md
+++ b/www/extensions.md
@@ -52,7 +52,7 @@ against `htmx` in each distribution.
 
 ### <a name="installing"></a> [Installing Extensions](#installing)
 
-You can find the source for the bundled extensions at https://unpkg.com/browse/htmx.org/dist/ext/.  You will need
+You can find the source for the bundled extensions at `https://unpkg.com/browse/htmx.org/dist/ext/`.  You will need
 to include the javascript file for the extension and then install it using the [hx-ext](/attributes/hx-ext) attributes.
 
 See the individual extension documentation for more details.

--- a/www/extensions/ajax-header.md
+++ b/www/extensions/ajax-header.md
@@ -9,6 +9,12 @@ This extension adds the `X-Requested-With` header to requests with the value "XM
 
 This header is commonly used by javascript frameworks to differentiate ajax requests from normal http requests.
 
+### Install
+
+```html
+<script src="https://unpkg.com/htmx.org/dist/ext/ajax-header.js">
+```
+
 ### Usage
 
 ```html
@@ -16,7 +22,3 @@ This header is commonly used by javascript frameworks to differentiate ajax requ
  ...
 </body>
 ```
-
-### Source
-
-<https://unpkg.com/htmx.org/dist/ext/ajax-header.js>

--- a/www/extensions/alpine-morph.md
+++ b/www/extensions/alpine-morph.md
@@ -7,7 +7,13 @@ title: </> htmx - high power tools for html
 
 Alpine.js now has a lightweight [morph plugin](https://alpinejs.dev/plugins/morph) and this extension allows you to use it as the swapping mechanism in htmx which is necessary to retain Alpine state when you have entire Alpine components swapped by htmx.
 
-#### Usage
+### Install
+
+```html
+<script src="https://unpkg.com/htmx.org/dist/ext/alpine-morph.js">
+```
+
+### Usage
 
 ```html
 <header>
@@ -21,12 +27,12 @@ Alpine.js now has a lightweight [morph plugin](https://alpinejs.dev/plugins/morp
 
 <body>
   <div hx-target="this" hx-ext="alpine-morph" hx-swap="morph">
-      <div x-data="{ count: 0, replaced: false, 
+      <div x-data="{ count: 0, replaced: false,
                      message: 'Change me, then press the button!' }">
           <input type="text" x-model="message">
           <div x-text="count"></div>
-          <button x-bind:style="replaced && {'backgroundColor': '#fecaca'}" 
-                  x-on:click="replaced = true; count++" 
+          <button x-bind:style="replaced && {'backgroundColor': '#fecaca'}"
+                  x-on:click="replaced = true; count++"
                   hx-get="/swap">
             Morph
           </button>
@@ -38,8 +44,3 @@ Alpine.js now has a lightweight [morph plugin](https://alpinejs.dev/plugins/morp
 In the above example, all the Alpine x-data states (count, replaced, and message) are preserved even the entire Alpine component is swapped.
 
 NOTE: `/swap` response from the example above should return actual element that is being replaced (this is `<div hx-target="this"...` element).
-
-#### Source
-
-<https://unpkg.com/htmx.org/dist/ext/alpine-morph.js>
-

--- a/www/extensions/class-tools.md
+++ b/www/extensions/class-tools.md
@@ -6,7 +6,7 @@ title: </> htmx - high power tools for html
 ## The `class-tools` Extension
 
 The `class-tools` extension  allows you to specify CSS classes that will be swapped onto or off of the elements by using
-a `classes` or `data-classes` attribute.  This functionality allows you to apply 
+a `classes` or `data-classes` attribute.  This functionality allows you to apply
 [CSS Transitions](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions)
 to your HTML without resorting to javascript.
 
@@ -18,6 +18,12 @@ Within a run, a `,` character separates distinct class operations.
 A class operation is an operation name `add`, `remove`, or `toggle`, followed by a CSS class name,
 optionally followed by a colon `:` and a time delay.
 
+### Install
+
+```html
+<script src="https://unpkg.com/htmx.org/dist/ext/class-tools.js">
+```
+
 ### Usage
 
 ```html
@@ -26,12 +32,8 @@ optionally followed by a colon `:` and a time delay.
     <div class="bar" classes="remove bar:1s"/> <!-- removes the class "bar" after 1s -->
     <div class="bar" classes="remove bar:1s, add foo:1s"/> <!-- removes the class "bar" after 1s
                                                                 then adds the class "foo" 1s after that -->
-    <div class="bar" classes="remove bar:1s & add foo:1s"/> <!-- removes the class "bar" and adds 
+    <div class="bar" classes="remove bar:1s & add foo:1s"/> <!-- removes the class "bar" and adds
                                                                  class "foo" after 1s  -->
     <div classes="toggle foo:1s"/> <!-- toggles the class "foo" every 1s -->
-</div> 
+</div>
 ```
-
-### Source
-
-<https://unpkg.com/htmx.org/dist/ext/class-tools.js>

--- a/www/extensions/client-side-templates.md
+++ b/www/extensions/client-side-templates.md
@@ -22,33 +22,35 @@ the template the standard way for that template engine:
 
 The AJAX response body will be parsed as JSON and passed into the template rendering.
 
+### Install
+
+```html
+<script src="https://unpkg.com/htmx.org/dist/ext/client-side-templates.js">
+```
+
 ### Usage
 
 ```html
 <div hx-ext="client-side-templates">
-  <button hx-get="/some_json" 
+  <button hx-get="/some_json"
           mustache-template="my-mustache-template">
      Handle with mustache
   </button>
-  <button hx-get="/some_json" 
+  <button hx-get="/some_json"
           handlebars-template="my-handlebars-template">
      Handle with handlebars
   </button>
-  <button hx-get="/some_json" 
+  <button hx-get="/some_json"
           nunjucks-template="my-nunjucks-template">
      Handle with nunjucks
   </button>
 </div>
 ```
 
-### Source
-
-<https://unpkg.com/htmx.org/dist/ext/client-side-templates.js>
-
 ### Full HTML Example
 
 To use the client side template, you will need to include htmx, the extension, and the rendering engine.
-Here is an example of this setup for Mustache using 
+Here is an example of this setup for Mustache using
 a [`<template>` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template).
 
 If you wish to put a template into another file, you can use a directive such as
@@ -67,7 +69,7 @@ If you wish to put a template into another file, you can use a directive such as
 </head>
 <body>
   <div hx-ext="client-side-templates">
-    <button hx-get="https://jsonplaceholder.typicode.com/todos/1" 
+    <button hx-get="https://jsonplaceholder.typicode.com/todos/1"
             hx-swap="innerHTML"
             hx-target="#content"
             mustache-template="foo">
@@ -75,7 +77,7 @@ If you wish to put a template into another file, you can use a directive such as
     </button>
 
     <p id="content">Start</p>
-    
+
     <template id="foo">
       <p> {% raw %}{{userID}}{% endraw %} and {% raw %}{{id}}{% endraw %} and {% raw %}{{title}}{% endraw %} and {% raw %}{{completed}}{% endraw %}</p>
     </template>
@@ -92,7 +94,7 @@ As a warning, many web services use CORS protection and/or other protection sche
 REST/JSON request from a web browser - for example, GitHub will issue a CORS error if you try to
 use the above snippet to access public APIs. This can be frustrating, as a dedicated REST development
 client may work fine, but the CORS error will appear when running JavaScript. This doesn't really
-have anything to do with HTMX (as you'd have the same issues with any JavaScript code), but can be 
+have anything to do with HTMX (as you'd have the same issues with any JavaScript code), but can be
 a frustrating surprise.
 
 Unfortunately, the solution will vary depending on the provider of the web service. Depending on

--- a/www/extensions/debug.md
+++ b/www/extensions/debug.md
@@ -8,12 +8,14 @@ title: </> htmx - high power tools for html
 This extension includes log all htmx events for the element it is on, either through the `console.debug` function
 or through the `console.log` function with a `DEBUG:` prefix.
 
+### Install
+
+```html
+<script src="https://unpkg.com/htmx.org/dist/ext/debug.js">
+```
+
 ### Usage
 
 ```html
 <button hx-ext="debug">Debug Me...</button>
 ```
-
-### Source
-
-<https://unpkg.com/htmx.org/dist/ext/debug.js>

--- a/www/extensions/disable-element.md
+++ b/www/extensions/disable-element.md
@@ -7,6 +7,12 @@ title: </> htmx - high power tools for html
 
 This extension disables an element during an htmx request, when configured on the element triggering the request.
 
+### Install
+
+```html
+<script src="https://unpkg.com/htmx.org/dist/ext/disable-element.js">
+```
+
 ### Usage
 
 #### Nominal case: disabling the element triggering the request
@@ -19,7 +25,3 @@ This extension disables an element during an htmx request, when configured on th
 <button hx-get="/whatever" hx-ext="disable-element" hx-disable-element="#to-disable">Click me</button>
 <button id="to-disable">Watch me being disabled</button>
 ```
-
-### Source
-
-<https://unpkg.com/htmx.org/dist/ext/disable-element.js>

--- a/www/extensions/event-header.md
+++ b/www/extensions/event-header.md
@@ -9,6 +9,12 @@ This extension adds the `Triggering-Event` header to requests.  The value of
 the header is a JSON serialized version of the event that triggered the
 request.
 
+### Install
+
+```html
+<script src="https://unpkg.com/htmx.org/dist/ext/event-header.js">
+```
+
 ### Usage
 
 ```html
@@ -20,7 +26,3 @@ Sends something like this:
 ```text
 Triggering-Event: '{ "isTrusted": false, "htmx-internal-data": { "handled": true }, "screenX": 0, "screenY": 0, "clientX": 0, "clientY": 0, "ctrlKey": false, "shiftKey": false, "altKey": false, "metaKey": false, "button": 0, "buttons": 0, "relatedTarget": null, "pageX": 0, "pageY": 0, "x": 0, "y": 0, "offsetX": 0, "offsetY": 0, "movementX": 0, "movementY": 0, "fromElement": null, "toElement": "button", "layerX": 0, "layerY": 0, "view": "Window", "detail": 0, "sourceCapabilities": null, "which": 1, "NONE": 0, "CAPTURING_PHASE": 1, "AT_TARGET": 2, "BUBBLING_PHASE": 3, "type": "click", "target": "button", "currentTarget": "button", "eventPhase": 2, "bubbles": true, "cancelable": true, "defaultPrevented": true, "composed": true, "timeStamp": 188.86999995447695, "srcElement": "button", "returnValue": false, "cancelBubble": false, "path": [ "button", "div#work-area", "body", "html", "Node", "Window" ] }'
 ```
-
-### Source
-
-<https://unpkg.com/htmx.org/dist/ext/event-header.js>

--- a/www/extensions/head-support.md
+++ b/www/extensions/head-support.md
@@ -16,12 +16,15 @@ The [`hx-boost`](/attributes/hx-boost) attribute moved htmx closer to this world
 support for extracting the `title` tag out of head elements was eventually added, but full head tag support has never been
 a feature of the library.
 
-This extension addresses that shortcoming & will likely be integrated into htmx for the 2.0 release.  
+This extension addresses that shortcoming & will likely be integrated into htmx for the 2.0 release.
+
+### Install
+
+```html
+<script src="https://unpkg.com/htmx.org/dist/ext/head-support.js">
+```
 
 ### Usage
-
-The `head-support` extension is simple to install.  Simply add the `/ext/head-support.js` file to your head tag and
-install the extension using the `hx-ext` attribute:
 
 ```html
 <body hx-ext="head-support">
@@ -103,9 +106,9 @@ The final head element will look like this:
 
 This extension triggers the following events:
 
-* `htmx:removingHeadElement` - triggered when a head element is about to be removed, with the element being removed 
+* `htmx:removingHeadElement` - triggered when a head element is about to be removed, with the element being removed
    available in `event.detail.headElement`.  If `preventDefault()` is invoked on the event, the element will not be removed.
-* `htmx:addingHeadElement` - triggered when a head element is about to be added, with the element being added 
+* `htmx:addingHeadElement` - triggered when a head element is about to be added, with the element being added
    available in `event.detail.headElement`.  If `preventDefault()` is invoked on the event, the element will not be added.
 * `htmx:afterHeadMerge` - triggered after a head tag merge has occurred, with the following values available in the event `detail`:
   * `added` - added head elements

--- a/www/extensions/include-vals.md
+++ b/www/extensions/include-vals.md
@@ -9,6 +9,12 @@ The `include-vals` extension allows you to programatically include values in a r
 a `include-vals` attribute.  The value of this attribute is one or more name/value pairs, which
 will be evaluated as the fields in a javascript object literal.
 
+### Install
+
+```html
+<script src="https://unpkg.com/htmx.org/dist/ext/include-vals.js">
+```
+
 ### Usage
 
 ```html
@@ -16,9 +22,5 @@ will be evaluated as the fields in a javascript object literal.
     <div hx-get="/test" include-vals="included:true, computed: computeValue()">
       Will Include Additional Values
     </div>
-</div> 
+</div>
 ```
-
-### Source
-
-<https://unpkg.com/htmx.org/dist/ext/include-vals.js>

--- a/www/extensions/json-enc.md
+++ b/www/extensions/json-enc.md
@@ -7,12 +7,14 @@ title: </> htmx - high power tools for html
 
 This extension encodes parameters in JSON format instead of url format.
 
+### Install
+
+```html
+<script src="https://unpkg.com/htmx.org/dist/ext/json-enc.js">
+```
+
 ### Usage
 
 ```html
 <div hx-post='/test' hx-ext='json-enc'>click me</div>
 ```
-
-### Source
-
-<https://unpkg.com/htmx.org/dist/ext/json-enc.js>

--- a/www/extensions/loading-states.md
+++ b/www/extensions/loading-states.md
@@ -5,7 +5,13 @@ title: </> htmx - high power tools for html
 
 ## The `loading-states` Extension
 
-This extension allows you to easily manage loading states while a request is in flight, including disabling elements, and adding and removing CSS classes. 
+This extension allows you to easily manage loading states while a request is in flight, including disabling elements, and adding and removing CSS classes.
+
+### Install
+
+```html
+<script src="https://unpkg.com/htmx.org/dist/ext/loading-states.js">
+```
 
 ### Usage
 
@@ -20,11 +26,11 @@ Add the following class to your stylesheet to make sure elements are hidden by d
 ```
 
 ### Supported attributes
-  
+
 - `data-loading`
 
   Shows the element. The default style is `inline-block`, but it's possible to use any display style by specifying it in the attribute value.
-  
+
   ```html
   <div data-loading>loading</div>
 
@@ -32,7 +38,7 @@ Add the following class to your stylesheet to make sure elements are hidden by d
 
   <div data-loading="flex">loading</div>
   ```
-  
+
 - `data-loading-class`
 
   Adds, then removes, CSS classes to the element:
@@ -41,8 +47,8 @@ Add the following class to your stylesheet to make sure elements are hidden by d
   <div class="transition-all ease-in-out duration-600" data-loading-class="bg-gray-100 opacity-80">
   ...
   </div>
-  ``` 
-  
+  ```
+
 - `data-loading-class-remove`
 
   Removes, then adds back, CSS classes from the element.
@@ -71,26 +77,26 @@ Add the following class to your stylesheet to make sure elements are hidden by d
 - `data-loading-delay`
 
   Some actions may update quickly and showing a loading state in these cases may be more of a distraction. This attribute ensures that the loading state changes are applied only after 200ms if the request is not finished. The default delay can be modified through the attribute value and expressed in milliseconds:
-  
+
   ```html
   <button type="submit" data-loading-disable data-loading-delay="1000">Submit</button>
   ```
-  
+
   You can place the `data-loading-delay` attribute directly on the element you want to disable, or in any parent element.
-  
+
 - `data-loading-target`
 
   Allows setting a different target to apply the loading states. The attribute value can be any valid CSS selector. The example below disables the submit button and shows the loading state when the form is submitted.
-  
+
   ```html
   <form hx-post="/save"
     data-loading-target="#loading"
     data-loading-class-remove="hidden">
-    
+
     <button type="submit" data-loading-disable>Submit</button>
 
   </form>
-  
+
   <div id="loading" class="hidden">Loading ...</div>
   ```
 
@@ -103,7 +109,7 @@ Add the following class to your stylesheet to make sure elements are hidden by d
     <button type="submit" data-loading-disable data-loading-path="/save">Submit</button>
   </form>
   ```
-  
+
    You can place the `data-loading-path` attribute directly on the loading state element, or in any parent element.
 
   ```html
@@ -113,9 +119,9 @@ Add the following class to your stylesheet to make sure elements are hidden by d
   ```
 
 - `data-loading-states`
-  
-  This attribute is optional and it allows defining a scope for the loading states so only elements within that scope are processed. 
-  
+
+  This attribute is optional and it allows defining a scope for the loading states so only elements within that scope are processed.
+
   ```html
   <div data-loading-states>
     <div hx-get=""></div>
@@ -131,7 +137,3 @@ Add the following class to your stylesheet to make sure elements are hidden by d
     <div data-loading>loading</div>
   </form>
   ```
-
-  #### Source
-
-<https://unpkg.com/htmx.org/dist/ext/loading-states.js>

--- a/www/extensions/method-override.md
+++ b/www/extensions/method-override.md
@@ -8,6 +8,12 @@ title: </> htmx - high power tools for html
 This extension makes non-`GET` and `POST` requests use a `POST` with the `X-HTTP-Method-Override` header set to the
 actual HTTP method.  This is necessary when dealing with some firewall or proxy situations.
 
+### Install
+
+```html
+<script src="https://unpkg.com/htmx.org/dist/ext/method-override.js">
+```
+
 #### Usage
 
 ```html
@@ -17,8 +23,3 @@ actual HTTP method.  This is necessary when dealing with some firewall or proxy 
 </button>
 </body>
 ```
-
-#### Source
-
-<https://unpkg.com/htmx.org/dist/ext/method-override.js>
-

--- a/www/extensions/morphdom-swap.md
+++ b/www/extensions/morphdom-swap.md
@@ -10,6 +10,12 @@ swapping mechanism in htmx.
 
 The `morphdom` library does not support morph element to multiple elements. If the result of `hx-select` is more than one element, it will pick the first one.
 
+### Install
+
+```html
+<script src="https://unpkg.com/htmx.org/dist/ext/morphdom-swap.js">
+```
+
 #### Usage
 
 ```html
@@ -20,8 +26,3 @@ The `morphdom` library does not support morph element to multiple elements. If t
    <button hx-swap="morphdom">This button will be swapped with morphdom!</button>
 </body>
 ```
-
-#### Source
-
-<https://unpkg.com/htmx.org/dist/ext/morphdom-swap.js>
-

--- a/www/extensions/multi-swap.md
+++ b/www/extensions/multi-swap.md
@@ -5,11 +5,17 @@ title: </> htmx - multi-swap extension
 
 ## The `multi-swap` extension
 
-This extension allows you to swap multiple elements marked with the `id` attribute from the HTML response. You can also choose for each element which [swap method](/docs/#swapping) should be used. 
+This extension allows you to swap multiple elements marked with the `id` attribute from the HTML response. You can also choose for each element which [swap method](/docs/#swapping) should be used.
 
 Multi-swap can help in cases where OOB ([Out of Band Swaps](/docs/#oob_swaps)) is not enough for you. OOB requires HTML tags marked with `hx-swap-oob` attributes to be at the TOP level of HTML, which significantly limited its use. With OOB is not possible to swap multiple elements arbitrarily placed and nested in the DOM tree.
 
 It is a very powerful tool in conjunction with `hx-boost` and `preload` extension.
+
+### Install
+
+```html
+<script src="https://unpkg.com/htmx.org/dist/ext/multi-swap.js">
+```
 
 #### Usage
 
@@ -64,8 +70,3 @@ The use case below shows how to ensure that only the `#submenu` and `#content` e
 * Attribute `hx-swap` value **must not contain spaces**, otherwise only the part of the value up to the first space will be accepted.
 * If the `delete` swap method is used, the HTML response must also contain deleted element (it can be empty div with `id` attribute).
 * Only elements with an `id` selector are supported, as the function internally uses OOB internal method. So it is not possible to use `class` or any other selectors.
-
-#### Source
-
-<https://unpkg.com/htmx.org/dist/ext/multi-swap.js>
-

--- a/www/extensions/path-deps.md
+++ b/www/extensions/path-deps.md
@@ -27,6 +27,12 @@ You can use a `*` to match any path component:
        path-deps="/contacts/*">...</div>
 ```
 
+### Install
+
+```html
+<script src="https://unpkg.com/htmx.org/dist/ext/path-deps.js">
+```
+
 #### Usage
 
 ```html
@@ -55,7 +61,3 @@ This method manually triggers a refresh for the given path.
   // Trigger a refresh on all elements with the path-deps attribute '/path/to/refresh', including elements with a parent path, e.g. '/path'
   PathDeps.refresh('/path/to/refresh');
 ```
-
-#### Source
-
-<https://unpkg.com/htmx.org/dist/ext/path-deps.js>

--- a/www/extensions/preload.md
+++ b/www/extensions/preload.md
@@ -5,9 +5,15 @@ title: </> htmx - high power tools for html
 
 ## The `preload` Extension
 
-The `preload` extension allows you to load HTML fragments into your browser's cache before they are requested by the user, so that additional pages appear to users to load nearly instantaneously.  As a developer, you can customize its behavior to fit your applications needs and use cases.  
+The `preload` extension allows you to load HTML fragments into your browser's cache before they are requested by the user, so that additional pages appear to users to load nearly instantaneously.  As a developer, you can customize its behavior to fit your applications needs and use cases.
 
 **IMPORTANT:** Preloading content judiciously can improve your web application's perceived performance, but preloading too many resources can negatively impact your visitors' bandwidth and your server performance by initiating too many unused requests.  Use this extension carefully!
+
+### Install
+
+```html
+<script src="https://unpkg.com/htmx.org/dist/ext/preload.js">
+```
 
 ### Usage
 
@@ -79,7 +85,7 @@ Preload can also listen to any custom event within the system, triggering resour
 <body hx-ext="preload">
     <button hx-get="/server" preload="preload:init" hx-target="idLoadMore">Load More</a>
     <div id="idLoadMore">
-        Content for this DIV will be preloaded as soon as the page is ready.  
+        Content for this DIV will be preloaded as soon as the page is ready.
         Clicking the button above will swap it into the DOM.
     </div>
 </body>
@@ -98,7 +104,3 @@ To accomodate touchscreen devices, an additional `ontouchstart` event handler is
 ### Credits
 
 The behavior for this plugin was inspired by the work done by [Alexandre Dieulot](https://github.com/dieulot) on [InstantClick](http://instantclick.io/), which is released under the MIT license.
-
-### Source
-
-<https://unpkg.com/htmx.org/dist/ext/preload.js>

--- a/www/extensions/remove-me.md
+++ b/www/extensions/remove-me.md
@@ -7,15 +7,17 @@ title: </> htmx - high power tools for html
 
 The `remove-me` extension allows you to remove an element after a specified interval.
 
+### Install
+
+```html
+<script src="https://unpkg.com/htmx.org/dist/ext/remove-me.js">
+```
+
 ### Usage
 
 ```html
 <div hx-ext="remove-me">
     <!-- Removes this div after 1 second -->
     <div remove-me="1s">To Be Removed...</div>
-</div> 
+</div>
 ```
-
-### Source
-
-<https://unpkg.com/htmx.org/dist/ext/remove-me.js>

--- a/www/extensions/restored.md
+++ b/www/extensions/restored.md
@@ -7,6 +7,12 @@ title: </> htmx - high power tools for html
 
 This extension triggers an event ``restored`` whenever a back button even is detected while using ``hx-boost``.
 
+### Install
+
+```html
+<script src="https://unpkg.com/htmx.org/dist/ext/restored.js">
+```
+
 ### Usage
 A page utilizing ``hx-boost`` that will reload the ``h1`` each time the back button is pressed:
 ```html
@@ -15,7 +21,3 @@ A page utilizing ``hx-boost`` that will reload the ``h1`` each time the back but
     <a href="/other_page">I'll be back</a>
 </body>
 ```
-
-### Source
-
-<https://unpkg.com/htmx.org/dist/ext/restored.js>

--- a/www/extensions/server-sent-events.md
+++ b/www/extensions/server-sent-events.md
@@ -17,6 +17,12 @@ Use the following attributes to configure how SSE connections behave:
 * `sse-swap="<message-name>"` - The name of the message to swap into the DOM.
 * `hx-trigger="sse:<message-name>"` - SSE messages can also trigger HTTP callbacks using the [`hx-trigger`](/attributes/hx-trigger) attribute.
 
+### Install
+
+```html
+<script src="https://unpkg.com/htmx.org/dist/ext/sse.js">
+```
+
 ### Usage
 
 ```html
@@ -118,7 +124,3 @@ Previous versions of htmx used a built-in tag `hx-sse` to implement Server Sent 
 *[Wikipedia](https://en.wikipedia.org/wiki/Server-sent_events)
 *[MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events)
 *[Can I Use?](https://caniuse.com/eventsource)
-
-### Source
-
-<https://unpkg.com/htmx.org/dist/ext/sse.js>

--- a/www/extensions/web-sockets.md
+++ b/www/extensions/web-sockets.md
@@ -19,6 +19,12 @@ Use the following attributes to configure how WebSockets behave:
   event
   of the event specified by [`hx-trigger`])
 
+### Install
+
+```html
+<script src="https://unpkg.com/htmx.org/dist/ext/ws.js">
+```
+
 ### Usage
 
 ```html
@@ -240,7 +246,3 @@ extension instead. Here are the steps you need to take to migrate to this versio
 | `hx-ws=""`              | `hx-ext="ws"`        | Use the `hx-ext="ws"` attribute to install the WebSockets extension into any HTML element.                                       |
 | `hx-ws="connect:<url>"` | `ws-connect="<url>"` | Add a new attribute `ws-connect` to the tag that defines the extension to specify the URL of the WebSockets server you're using. |
 | `hx-ws="send"`          | `ws-send=""`         | Add a new attribute `ws-send` to mark any child forms that should send data to your WebSocket server                             |
-
-### Source
-
-<https://unpkg.com/htmx.org/dist/ext/ws.js>

--- a/www/reference.md
+++ b/www/reference.md
@@ -12,7 +12,7 @@ title: </> htmx - Attributes
 * [htmx Request Headers](#request_headers)
 * [htmx Response Headers](#response_headers)
 * [htmx Events](#events)
-* [htmx Extensions](/extensions#reference)
+* [htmx Extensions](/extensions#included)
 * [Javascript API](#api)
 
 ## <a name="attributes"></a> [Core Attribute Reference](#attributes)
@@ -116,7 +116,7 @@ The table below lists all other attributes available in htmx.
 | `HX-Redirect`                                    | can be used to do a client-side redirect to a new location
 | `HX-Refresh`                                     | if set to "true" the client side will do a a full refresh of the page
 | [`HX-Replace-Url`](/headers/hx-replace-url)      | replaces the current URL in the location bar
-| `HX-Reswap`                                      | Allows you to specify how the response will be swapped. See [hx-swap](/attributes/hx-swap) for possible values 
+| `HX-Reswap`                                      | Allows you to specify how the response will be swapped. See [hx-swap](/attributes/hx-swap) for possible values
 | `HX-Retarget`                                    | A CSS selector that updates the target of the content update to a different element on the page
 | [`HX-Trigger`](/headers/hx-trigger)              | allows you to trigger client side events, see the [documentation](/headers/hx-trigger) for more info
 | [`HX-Trigger-After-Settle`](/headers/hx-trigger) | allows you to trigger client side events, see the [documentation](/headers/hx-trigger) for more info
@@ -145,8 +145,8 @@ The table below lists all other attributes available in htmx.
 | [`htmx:confirm`](/events#htmx:confirm)  | triggered after a trigger occurs on an element, allows you to cancel (or delay) issuing the AJAX request
 | [`htmx:historyCacheError`](/events#htmx:historyCacheError)  | triggered on an error during cache writing
 | [`htmx:historyCacheMiss`](/events#htmx:historyCacheMiss)  | triggered on a cache miss in the history subsystem
-| [`htmx:historyCacheMissError`](/events#htmx:historyCacheMissError)  | triggered on a unsuccessful remote retrieval 
-| [`htmx:historyCacheMissLoad`](/events#htmx:historyCacheMissLoad)  | triggered on a succesful remote retrieval 
+| [`htmx:historyCacheMissError`](/events#htmx:historyCacheMissError)  | triggered on a unsuccessful remote retrieval
+| [`htmx:historyCacheMissLoad`](/events#htmx:historyCacheMissLoad)  | triggered on a succesful remote retrieval
 | [`htmx:historyRestore`](/events#htmx:historyRestore)  | triggered when htmx handles a history restoration action
 | [`htmx:beforeHistorySave`](/events#htmx:beforeHistorySave)  | triggered before content is saved to the history cache
 | [`htmx:load`](/events#htmx:load)  | triggered when new content is added to the DOM


### PR DESCRIPTION
Discord has seen many question about extension not working, primarily because extension script is not included on the page. This PR attempts to partially resolve this problem by putting installation instructions in a more prominent place