### PR TITLE
Add config option to ignore nested oob-swaps instead of processing them

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -259,7 +259,13 @@ var htmx = (function() {
         { code: '204', swap: false },
         { code: '[23]..', swap: true },
         { code: '[45]..', swap: false, error: true }
-      ]
+      ],
+      /**
+       * Whether to process OOB swaps on elements that are nested within the main response element.
+       * @type boolean
+       * @default true
+       */
+      allowNestedOobSwaps: true
     },
     /** @type {typeof parseInterval} */
     parseInterval: null,
@@ -1767,9 +1773,14 @@ var htmx = (function() {
    */
   function findAndSwapOobElements(fragment, settleInfo) {
     forEach(findAll(fragment, '[hx-swap-oob], [data-hx-swap-oob]'), function(oobElement) {
-      const oobValue = getAttributeValue(oobElement, 'hx-swap-oob')
-      if (oobValue != null) {
-        oobSwap(oobValue, oobElement, settleInfo)
+      if (htmx.config.allowNestedOobSwaps || oobElement.parentElement.nodeName === 'BODY') {
+        var oobValue = getAttributeValue(oobElement, 'hx-swap-oob')
+        if (oobValue != null) {
+          oobSwap(oobValue, oobElement, settleInfo)
+        }
+      } else {
+        oobElement.removeAttribute('hx-swap-oob')
+        oobElement.removeAttribute('data-hx-swap-oob')
       }
     })
   }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1773,7 +1773,7 @@ var htmx = (function() {
    */
   function findAndSwapOobElements(fragment, settleInfo) {
     forEach(findAll(fragment, '[hx-swap-oob], [data-hx-swap-oob]'), function(oobElement) {
-      if (htmx.config.allowNestedOobSwaps || oobElement.parentElement.nodeName === 'BODY') {
+      if (htmx.config.allowNestedOobSwaps || oobElement.parentElement === null) {
         var oobValue = getAttributeValue(oobElement, 'hx-swap-oob')
         if (oobValue != null) {
           oobSwap(oobValue, oobElement, settleInfo)

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1774,7 +1774,7 @@ var htmx = (function() {
   function findAndSwapOobElements(fragment, settleInfo) {
     forEach(findAll(fragment, '[hx-swap-oob], [data-hx-swap-oob]'), function(oobElement) {
       if (htmx.config.allowNestedOobSwaps || oobElement.parentElement === null) {
-        var oobValue = getAttributeValue(oobElement, 'hx-swap-oob')
+        const oobValue = getAttributeValue(oobElement, 'hx-swap-oob')
         if (oobValue != null) {
           oobSwap(oobValue, oobElement, settleInfo)
         }

--- a/test/attributes/hx-swap-oob.js
+++ b/test/attributes/hx-swap-oob.js
@@ -26,6 +26,32 @@ describe('hx-swap-oob attribute', function() {
   }
 
   for (const config of [{ allowNestedOobSwaps: true }, { allowNestedOobSwaps: false }]) {
+    it('oob swap works when the response has a body tag with config ' + JSON.stringify(config), function() {
+      Object.assign(htmx.config, config)
+      this.server.respondWith('GET', '/test', "<body>Clicked<div id='d2' hx-swap-oob='true'>Swapped0</div></body>")
+      var div = make('<div hx-get="/test">click me</div>')
+      make('<div id="d2"></div>')
+      div.click()
+      this.server.respond()
+      div.innerHTML.should.equal('Clicked')
+      byId('d2').innerHTML.should.equal('Swapped0')
+    })
+  }
+
+  for (const config of [{ allowNestedOobSwaps: true }, { allowNestedOobSwaps: false }]) {
+    it('oob swap works when the response has html and body tags with config ' + JSON.stringify(config), function() {
+      Object.assign(htmx.config, config)
+      this.server.respondWith('GET', '/test', "<html><body>Clicked<div id='d3' hx-swap-oob='true'>Swapped0</div></body></html>")
+      var div = make('<div hx-get="/test">click me</div>')
+      make('<div id="d3"></div>')
+      div.click()
+      this.server.respond()
+      div.innerHTML.should.equal('Clicked')
+      byId('d3').innerHTML.should.equal('Swapped0')
+    })
+  }
+
+  for (const config of [{ allowNestedOobSwaps: true }, { allowNestedOobSwaps: false }]) {
     it('handles more than one oob swap properly with config ' + JSON.stringify(config), function() {
       Object.assign(htmx.config, config)
       this.server.respondWith('GET', '/test', "Clicked<div id='d1' hx-swap-oob='true'>Swapped1</div><div id='d2' hx-swap-oob='true'>Swapped2</div>")

--- a/test/attributes/hx-swap-oob.js
+++ b/test/attributes/hx-swap-oob.js
@@ -70,15 +70,37 @@ describe('hx-swap-oob attribute', function() {
     byId('d1').innerHTML.should.equal('Swapped5')
   })
 
-  it('oob swaps can be nested in content', function() {
-    this.server.respondWith('GET', '/test', "<div>Clicked<div id='d1' foo='bar' hx-swap-oob='innerHTML'>Swapped6</div></div>")
-    var div = make('<div hx-get="/test">click me</div>')
-    make('<div id="d1"></div>')
-    div.click()
-    this.server.respond()
-    should.equal(byId('d1').getAttribute('foo'), null)
-    div.innerHTML.should.equal('<div>Clicked</div>')
-    byId('d1').innerHTML.should.equal('Swapped6')
+  it('oob swaps can be nested in content when allowNestedOobSwaps is true', function() {
+    var before = htmx.config.allowNestedOobSwaps
+    try {
+      htmx.config.allowNestedOobSwaps = true
+      this.server.respondWith('GET', '/test', "<div>Clicked<div id='d1' foo='bar' hx-swap-oob='innerHTML'>Swapped6</div></div>")
+      var div = make('<div hx-get="/test">click me</div>')
+      make('<div id="d1"></div>')
+      div.click()
+      this.server.respond()
+      should.equal(byId('d1').getAttribute('foo'), null)
+      div.innerHTML.should.equal('<div>Clicked</div>')
+      byId('d1').innerHTML.should.equal('Swapped6')
+    } finally {
+      htmx.config.allowNestedOobSwaps = before
+    }
+  })
+
+  it('oob swaps in nested content are ignored and stripped when allowNestedOobSwaps is false', function() {
+    var before = htmx.config.allowNestedOobSwaps
+    try {
+      htmx.config.allowNestedOobSwaps = false
+      this.server.respondWith('GET', '/test', '<div>Clicked<div hx-swap-oob="innerHTML:#d1">Swapped6.1</div></div>')
+      var div = make('<div hx-get="/test">click me</div>')
+      make('<div id="d1"></div>')
+      div.click()
+      this.server.respond()
+      byId('d1').innerHTML.should.equal('')
+      div.innerHTML.should.equal('<div>Clicked<div>Swapped6.1</div></div>')
+    } finally {
+      htmx.config.allowNestedOobSwaps = before
+    }
   })
 
   it('oob swaps can use selectors to match up', function() {

--- a/www/content/attributes/hx-swap-oob.md
+++ b/www/content/attributes/hx-swap-oob.md
@@ -2,10 +2,10 @@
 title = "hx-swap-oob"
 +++
 
-The `hx-swap-oob` attribute allows you to specify that some content in a response should be 
+The `hx-swap-oob` attribute allows you to specify that some content in a response should be
 swapped into the DOM somewhere other than the target, that is "Out of Band".  This allows you to piggy back updates to other element updates on a response.
 
-Consider the following response HTML: 
+Consider the following response HTML:
 
 ```html
 <div>
@@ -25,7 +25,7 @@ The value of the `hx-swap-oob` can be:
 * any valid [`hx-swap`](@/attributes/hx-swap.md) value
 * any valid [`hx-swap`](@/attributes/hx-swap.md) value, followed by a colon, followed by a CSS selector
 
-If the value is `true` or `outerHTML` (which are equivalent) the element will be swapped inline.  
+If the value is `true` or `outerHTML` (which are equivalent) the element will be swapped inline.
 
 If a swap value is given, that swap strategy will be used.
 
@@ -33,7 +33,7 @@ If a selector is given, all elements matched by that selector will be swapped.  
 
 ### Troublesome Tables
 
-Note that you can use a `template` tag to encapsulate types of elements that, by the HTML spec, can't stand on their own in the 
+Note that you can use a `template` tag to encapsulate types of elements that, by the HTML spec, can't stand on their own in the
 DOM (`<tr>`, `<td>`, `<th>`, `<thead>`, `<tbody>`, `<tfoot>`, `<colgroup>`, `<caption>` & `<col>`).
 
 Here is an example with an out of band swap of a table row being encapsulated in this way:
@@ -50,6 +50,13 @@ Here is an example with an out of band swap of a table row being encapsulated in
 ```
 
 Note that these template tags will be removed from the final content of the page.
+
+## Nested OOB Swaps
+
+By default, any element with `hx-swap-oob=` attribute anywhere in the response is processed for oob swap behavior, including when an element is nested within the main response element.
+This can be problematic when using [template fragments](https://htmx.org/essays/template-fragments/) where a fragment may be reused as a oob-swap target and also as part of a bigger fragment. When the bigger fragment is the main response the inner fragment will still be processed as an oob swap, removing it from the dom.
+
+This behavior can be changed by setting the config `htmx.config.allowNestedOobSwaps` to `false`. If this config option is `false`, OOB swaps are only processed when the element is *adjacent to* the main response element, OOB swaps elsewhere will be ignored and oob-swap-related attributes stripped.
 
 ## Notes
 

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -1637,6 +1637,7 @@ listed below:
 | `htmx.config.ignoreTitle`             | defaults to `false`, if set to `true` htmx will not update the title of the document when a `title` tag is found in new content                                                                                                                                                                                                                   |
 | `htmx.config.disableInheritance`      | disables attribute inheritance in htmx, which can then be overridden by the [`hx-inherit`](@/attributes/hx-inherit.md) attribute                                                                                                                                                                                                                  |
 | `htmx.config.triggerSpecsCache`       | defaults to `null`, the cache to store evaluated trigger specifications into, improving parsing performance at the cost of more memory usage. You may define a simple object to use a never-clearing cache, or implement your own system using a [proxy object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy) |
+| `htmx.config.allowNestedOobSwaps`     | defaults to `true`, whether to process OOB swaps on elements that are nested within the main response element. See [Nested OOB Swaps](@/attributes/hx-swap-oob.md#nested-oob-swaps). |
 
 </div>
 

--- a/www/content/reference.md
+++ b/www/content/reference.md
@@ -250,6 +250,7 @@ listed below:
 | `htmx.config.ignoreTitle`             | defaults to `false`, if set to `true` htmx will not update the title of the document when a `title` tag is found in new content                                            |
 | `htmx.config.scrollIntoViewOnBoost`   | defaults to `true`, whether or not the target of a boosted element is scrolled into the viewport. If `hx-target` is omitted on a boosted element, the target defaults to `body`, causing the page to scroll to the top. |
 | `htmx.config.triggerSpecsCache`       | defaults to `null`, the cache to store evaluated trigger specifications into, improving parsing performance at the cost of more memory usage. You may define a simple object to use a never-clearing cache, or implement your own system using a [proxy object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy) |
+| `htmx.config.allowNestedOobSwaps`     | defaults to `true`, whether to process OOB swaps on elements that are nested within the main response element. See [Nested OOB Swaps](@/attributes/hx-swap-oob.md#nested-oob-swaps). |
 
 </div>
 


### PR DESCRIPTION
This adds a new configuration option, `allowNestedOobSwaps`, which preserves existing behavior when set to the default `true`, but when set to `false` it changes `handleOutOfBandSwaps` to only process elements with `hx-swap-oob` and `data-hx-swap-oob` that appear at the *root* of the response fragment, i.e. elements whose parent element is `body`. Elements deeper in the dom tree fragment are ignored and the `oob-swap` attribute is stripped instead.

> The current system means you can just randomly intersperse oob fragments anywhere within the main response and they are swapped in from wherever to wherever. It seems much more conceptually sound to require all oob-swaps to originate adjacent to the response's main element.

Enabling this configuration option is helpful when you want to reuse a small html fragment to render both as as an element within a larger fragment (say a page) as well as more fine grained interactions where the small fragment is updated out of band. By setting `allowNestedOobSwaps: false`, you can place `hx-swap-oob="true"` on the fragment and leave it: when a full page renders then the attribute ignored since the fragment is nested inside the main response, but if you do want to update the fragment out of band then render it adjacent to the to the root response element and htmx performs the oob swap as expected. However in this scenario if `allowNestedOobSwaps: true` (default) then the small fragment is removed from the root element first and then the root element is swapped leaving you confused about why the small fragment vanished.

Here's an example of how this simplifies htmx usage in Go templates. In particular, note how this eliminates the conditional logic that controls whether `hx-swap-oob="true"` is included in the response or not: https://github.com/infogulch/go-htmx/commit/ea227b68fe8d7e6df9996f7d13eb951ed046f1ee

This PR implements the feature request in #1133