### PR TITLE
Fixed typo

### DIFF
--- a/www/docs.md
+++ b/www/docs.md
@@ -485,7 +485,7 @@ Imagine this content is replaced by htmx via an ajax request with this new conte
 
 Note two things: 
 
-* The div has the *same* id in the original an in the new content
+* The div has the *same* id in the original and in the new content
 * The `red` class has been added to the new content
 
 Given this situation, we can write a CSS transition from the old state to the new state:
@@ -671,7 +671,7 @@ a wider audience to use your sites functionality.
 Other htmx patterns can be adapted to achieve progressive enhancement as well, but they will require more thought.  
 
 Consider the [active search](/examples/active-search) example.  As it is written, it will not degrade gracefully:
-someone who does not have javascript enabled will not be able to use this feature. This is done for simplicities sake, 
+someone who does not have javascript enabled will not be able to use this feature. This is done for simplicity’s sake, 
 to keep the example as brief as possible.  
  
 However, you could wrap the htmx-enhanced input in a form element:


### PR DESCRIPTION
- Fixed "for simplicities sake" to "For simplicity’s sake".
- Fixed "The div has the same id in the original an in the new content" to "The div has the same id in the original and in the new content".