### PR TITLE
Fixes #1246: ws extension socketWrapper methods are undefined

### DIFF
--- a/src/ext/ws.js
+++ b/src/ext/ws.js
@@ -177,11 +177,6 @@ This extension adds support for WebSockets to htmx.  See /www/extensions/ws.md f
 	 */
 	function createWebsocketWrapper(socketElt, socketFunc) {
 		var wrapper = {
-			publicInterface: {
-				send: this.send,
-				sendImmediately: this.sendImmediately,
-				queue: this.queue
-			},
 			socket: null,
 			messageQueue: [],
 			retryCount: 0,
@@ -290,6 +285,12 @@ This extension adds support for WebSockets to htmx.  See /www/extensions/ws.md f
 		}
 
 		wrapper.init();
+
+		wrapper.publicInterface = {
+			send: wrapper.send.bind(wrapper),
+			sendImmediately: wrapper.sendImmediately.bind(wrapper),
+			queue: wrapper.messageQueue
+		};
 
 		return wrapper;
 	}

--- a/test/ext/ws.js
+++ b/test/ext/ws.js
@@ -120,7 +120,7 @@ describe("web-sockets extension", function () {
         htmx.off(div, "htmx:wsClose", handler)
     })
 
-    it('raises htmx:wsConfig when sending, allows message modification', function () {
+    it('raises htmx:wsConfigSend when sending, allows message modification', function () {
         var myEventCalled = false;
 
         function handle(evt) {
@@ -141,6 +141,35 @@ describe("web-sockets extension", function () {
         this.messages.length.should.equal(1);
         this.messages[0].should.contains('"foo":"bar"')
         htmx.off("htmx:wsConfigSend", handle)
+    })
+
+    it('passes socketWrapper to htmx:wsConfigSend', function () {
+        var socketWrapper = null;
+
+        function handle(evt) {
+            evt.preventDefault();
+            socketWrapper = evt.detail.socketWrapper;
+            socketWrapper.send(JSON.stringify({foo: 'bar'}), evt.detail.elt)
+        }
+
+        htmx.on("htmx:wsConfigSend", handle)
+
+        var div = make('<div hx-ext="ws" ws-connect="ws://localhost:8080"><div ws-send id="d1">div1</div></div>');
+        this.tickMock();
+
+        byId("d1").click();
+
+        this.tickMock();
+
+        socketWrapper.should.not.be.null;
+        socketWrapper.send.should.be.a('function');
+        socketWrapper.sendImmediately.should.be.a('function');
+        socketWrapper.queue.should.be.an('array');
+
+        this.messages.length.should.equal(1);
+        this.messages[0].should.contains('"foo":"bar"')
+
+        htmx.off("htmx:wsConfigSend", handle);
     })
 
     it('cancels sending when htmx:wsConfigSend is cancelled', function () {


### PR DESCRIPTION
The problem was twofold:

- Scope/methods were not bound to the object.
- There was a typo in the array name.

The PR fixes the issue and adds a test that demonstrates handling the `wsConfigSend` event, cancelling the event, and sending a separate message instead, using the `socketWrapper`’s `send()` method. (And tests for expected types of the other members of its public interface.)