### PR TITLE
Closes #1241: Add wsConnecting event

### DIFF
--- a/src/ext/ws.js
+++ b/src/ext/ws.js
@@ -247,6 +247,8 @@ This extension adds support for WebSockets to htmx.  See /www/extensions/ws.md f
 				/** @type {WebSocket} */
 				var socket = socketFunc();
 
+				api.triggerEvent(socketElt, "htmx:wsConnecting");
+
 				this.socket = socket;
 
 				socket.onopen = function (e) {

--- a/src/ext/ws.js
+++ b/src/ext/ws.js
@@ -247,7 +247,10 @@ This extension adds support for WebSockets to htmx.  See /www/extensions/ws.md f
 				/** @type {WebSocket} */
 				var socket = socketFunc();
 
-				api.triggerEvent(socketElt, "htmx:wsConnecting");
+				// The event.type detail is added for interface conformance with the
+				// other two lifecycle events (open and close) so a single handler method
+				// can handle them polymorphically, if required.
+				api.triggerEvent(socketElt, "htmx:wsConnecting", { event: { type: 'connecting' } });
 
 				this.socket = socket;
 

--- a/test/ext/ws.js
+++ b/test/ext/ws.js
@@ -106,7 +106,7 @@ describe("web-sockets extension", function () {
 
         this.tickMock();
 
-        handledEventTypes.should.eql(['connecting', 'open', 'close'])
+        handledEventTypes.should.eql(['connecting', 'open', 'close']);
 
         this.tickMock();
 

--- a/test/ext/ws.js
+++ b/test/ext/ws.js
@@ -89,21 +89,15 @@ describe("web-sockets extension", function () {
     })
 
     it('raises lifecycle events (connecting, open, close) in correct order', function () {
-        var order = 1;
-        var connecting = 0;
-        var open = 0;
-        var closed = 0;
+        var handledEventTypes = [];
+        var handler = function (evt) { handledEventTypes.push(evt.detail.event.type) };
 
-        var connectingHandler = function (evt) { connecting = order++ };
-        var openHandler = function (evt) { open = order++ };
-        var closeHandler = function (evt) { closed = order++ };
-
-        htmx.on("htmx:wsConnecting", connectingHandler);
+        htmx.on("htmx:wsConnecting", handler);
 
         var div = make('<div hx-get="/test" hx-swap="outerHTML" hx-ext="ws" ws-connect="ws://localhost:8080">');
 
-        htmx.on(div, "htmx:wsOpen", openHandler);
-        htmx.on(div, "htmx:wsClose", closeHandler);
+        htmx.on(div, "htmx:wsOpen", handler);
+        htmx.on(div, "htmx:wsClose", handler);
 
         this.tickMock();
 
@@ -112,15 +106,13 @@ describe("web-sockets extension", function () {
 
         this.tickMock();
 
-        connecting.should.be.eql(1);
-        open.should.be.eql(2);
-        closed.should.be.eql(3);
+        handledEventTypes.should.eql(['connecting', 'open', 'close'])
 
         this.tickMock();
 
-        htmx.off("htmx:wsConnecting", connectingHandler);
-        htmx.off(div, "htmx:wsOpen", openHandler);
-        htmx.off(div, "htmx:wsClose", closeHandler);
+        htmx.off("htmx:wsConnecting", handler);
+        htmx.off(div, "htmx:wsOpen", handler);
+        htmx.off(div, "htmx:wsClose", handler);
     })
 
     it('raises htmx:wsConfig when sending, allows message modification', function () {

--- a/test/ext/ws.js
+++ b/test/ext/ws.js
@@ -88,52 +88,7 @@ describe("web-sockets extension", function () {
         byId("d2").innerHTML.should.equal("div2");
     })
 
-    it('raises event when socket is connecting', function () {
-        var myEventCalled = false;
-        var handler = function (evt) {
-            myEventCalled = true;
-        };
-        htmx.on("htmx:wsConnecting", handler);
-
-        make('<div hx-ext="ws" ws-connect="ws://localhost:8080">');
-        this.tickMock();
-        myEventCalled.should.be.true;
-        htmx.off("htmx:wsConnecting", handler);
-    })
- 
-    it('raises event when socket connected', function () {
-        var myEventCalled = false;
-        var handler = function (evt) {
-            myEventCalled = true;
-        };
-        htmx.on("htmx:wsOpen", handler)
-
-        make('<div hx-ext="ws" ws-connect="ws://localhost:8080">');
-        this.tickMock();
-        myEventCalled.should.be.true;
-        htmx.off("htmx:wsOpen", handler);
-    })
-
-    it('raises event when socket closed', function () {
-        var myEventCalled = false;
-        var handler = function (evt) {
-            myEventCalled = true;
-        };
-
-        var div = make('<div hx-get="/test" hx-swap="outerHTML" hx-ext="ws" ws-connect="ws://localhost:8080">');
-        htmx.on(div, "htmx:wsClose", handler);
-        this.tickMock();
-
-        div.parentElement.removeChild(div);
-
-        this.socketServer.emit('message', 'foo');
-        this.tickMock();
-        myEventCalled.should.be.true;
-        this.tickMock();
-        htmx.off(div, "htmx:wsClose", handler);
-    })
-
-    it('raises lifecycle events in correct order', function () {
+    it('raises lifecycle events (connecting, open, close) in correct order', function () {
         var order = 1;
         var connecting = 0;
         var open = 0;

--- a/www/extensions/web-sockets.md
+++ b/www/extensions/web-sockets.md
@@ -111,9 +111,17 @@ state and sends them once the connection is restored.
 
 WebSockets extensions exposes a set of events that allow you to observe and customize its behavior.
 
+#### <a name="htmx:wsConnecting"></a> Event - [`htmx:wsConnecting`](#htmx:wsConnecting)
+
+This event is triggered when a connection to a WebSocket endpoint is being attempted.
+
+##### Details
+
+* `detail.event.type` - the type of the event (`'connecting'`)
+
 #### <a name="htmx:wsOpen"></a> Event - [`htmx:wsOpen`](#htmx:wsOpen)
 
-This event is triggered when a connection to WebSockets endpoint has been established.
+This event is triggered when a connection to a WebSocket endpoint has been established.
 
 ##### Details
 
@@ -123,7 +131,7 @@ This event is triggered when a connection to WebSockets endpoint has been establ
 
 #### <a name="htmx:wsClose"></a> Event - [`htmx:wsClose`](#htmx:wsClose)
 
-This event is triggered when a connection to WebSockets endpoint has been closed normally.
+This event is triggered when a connection to a WebSocket endpoint has been closed normally.
 You can check if the event was caused by an error by inspecting `detail.event` property.
 
 ##### Details


### PR DESCRIPTION
Adds `wsConnecting` event along with two tests:

1. To ensure `wsConnecting` is raised as expected.
2. To ensure lifecycle event order is `wsConnecting` → `wsOpen` → `wsClosed`.

(If need be, tests can be refactored in the future so test 2, above, replaces the separate tests for wsConnecting, wsOpen, and wsClosed as it implies that they do pass. @Renerick, if you feel it’s helpful to carry out that refactor with this pull request, I’m happy to make the change; I just wanted to keep changes to a minimum.)