### PR TITLE
Update hx-target relative positional expressions

### DIFF
--- a/www/attributes/hx-target.md
+++ b/www/attributes/hx-target.md
@@ -10,8 +10,12 @@ request.  The value of this attribute can be:
  
  * a CSS query selector of the element to target
  * `this` which indicates that the element that the `hx-target` attribute is on is the target
+ * `next <CSS selector>` which will scan the DOM forward for the first element that matches the given CSS selector. 
+    (e.g. `next .error` will target the closest following sibling element with `error` class)
+ * `previous <CSS selector>` which will scan the DOM backwards for the first element that matches the given CSS selector. 
+    (e.g `previous .error` will target the closest previous sibling with `error` class)
  * `closest <CSS selector>` which will find the closest parent ancestor that matches the given CSS selector. 
-    (e.g. `closest tr` will target the closest table row to the element)
+    (e.g. `closest table` will target the closest parent table to the element)
  * `find <CSS selector>` which will find the first child descendant element that matches the given CSS selector.
     (e.g `find tr` will target the first child descendant row to the element)
 


### PR DESCRIPTION
This change updates `hx-target` docs by adding `next` and `previous` expressions introduced in version [1.8.0](https://github.com/bigskysoftware/htmx/releases/tag/v1.8.0)