### PR TITLE
Add "empty" swap strategy.

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -924,6 +924,10 @@ return (function () {
             return parentElt(target).removeChild(target);
         }
 
+        function swapEmpty(target, fragment, settleInfo) {
+            target.innerHTML = '';
+        }
+
         function swapInnerHTML(target, fragment, settleInfo) {
             var firstChild = target.firstChild;
             insertNodesBefore(target, firstChild, fragment, settleInfo);
@@ -970,6 +974,9 @@ return (function () {
                     return;
                 case "delete":
                     swapDelete(target, fragment, settleInfo);
+                    return;
+                case "empty":
+                    swapEmpty(target, fragment, settleInfo);
                     return;
                 default:
                     var extensions = getExtensions(elt);


### PR DESCRIPTION
This commit adds an "empty" swap strategy that simply sets `target.innerHTML = ''`. In my mind it completes a conceptual 2x2 square of strategies:
```
innerHTML  outerHTML
empty      delete
```

I found this useful when building multistep forms, where I want to clear later steps/results whenever an earlier step is altered. It lets me add a class like "empty-on-step-1" to a number of elements. Then the step-1 htmx response contains an out-of-band element that triggers the empty-swap on all elements with that class: `Div(hx_swap_oob="empty:.empty-on-step-1")`.

If this looks promising to the authors, I am happy to add documentation and tests too.