### PR TITLE
Add path-vars extension

### DIFF
--- a/src/ext/path-vars.js
+++ b/src/ext/path-vars.js
@@ -1,0 +1,12 @@
+htmx.defineExtension('path-vars', {
+    onEvent: function (name, evt) {
+        if (name === "htmx:configRequest") {
+            let sourceEventData = evt.detail ? (evt.detail.triggeringEvent ? evt.detail.triggeringEvent.detail : null) : null;
+            if (sourceEventData) {
+                evt.detail.path = evt.detail.path.replace(/{event\.(\w+)}/g, function (_, k) {
+                    return sourceEventData[k];
+                });
+            }
+        }
+    }
+});

--- a/www/content/extensions/_index.md
+++ b/www/content/extensions/_index.md
@@ -76,6 +76,7 @@ See the individual extension documentation for more details.
 | [`morphdom-swap`](@/extensions/morphdom-swap.md)                 | an extension for using the [morphdom](https://github.com/patrick-steele-idem/morphdom) library as the swapping mechanism in htmx.
 | [`multi-swap`](@/extensions/multi-swap.md)                       | allows to swap multiple elements with different swap methods
 | [`path-deps`](@/extensions/path-deps.md)                         | an extension for expressing path-based dependencies [similar to intercoolerjs](http://intercoolerjs.org/docs.html#dependencies)
+| [`path-vars`](@/extensions/path-vars.md)                         | replaces variables in request-path with data from the triggering event 
 | [`preload`](@/extensions/preload.md)                             | preloads selected `href` and `hx-get` targets based on rules you control.
 | [`remove-me`](@/extensions/remove-me.md)                         | allows you to remove an element after a given amount of time
 | [`response-targets`](@/extensions/response-targets.md)           | allows to specify different target elements to be swapped when different HTTP response codes are received

--- a/www/content/extensions/path-vars.md
+++ b/www/content/extensions/path-vars.md
@@ -1,0 +1,31 @@
+---
+layout: layout.njk
+title: </> htmx - high power tools for html
+---
+
+## The `path-vars` Extension
+
+This extension replaces variables in the request path - for example of `hx-get` - with
+data from the triggering event.
+
+### Install
+
+```html
+<script src="https://unpkg.com/htmx.org/dist/ext/path-vars.js">
+```
+
+### Usage
+
+Assuming an event was triggered like
+
+```
+HX-Trigger: {"itemAdded":{"id" : "42"}}
+```
+
+Then its data can be used in requests
+
+```html
+<div hx-ext="path-vars" hx-get="/items/{event.id}" hx-trigger="itemAdded from:body" />
+```
+
+The request to the server is `/items/42`.


### PR DESCRIPTION
Extension to replace variable placeholders in query-path like hx-get with data from the triggering event.