### PR TITLE
Extension to refresh hrefs of anchors with the actual URL used for the Ajax call

### DIFF
--- a/src/ext/refresh-href.js
+++ b/src/ext/refresh-href.js
@@ -1,0 +1,46 @@
+/**
+ * Extension that refreshes href attributes of anchor elements having hx-get attribute,
+ * with the actual URL used to make the Ajax call.
+ * Refresh is made by default on "init" (initialization) and "mouseover" event.
+ * Events can be changed by listing them in refresh-href -attribute, separated by comma.
+ */
+htmx.defineExtension('refresh-href', {
+    onEvent: function(name, evt) {
+        let tag = '_refresh_href_';
+        
+        if (name === "htmx:beforeRequest") {
+            if (evt.detail.requestConfig.triggeringEvent === tag) {
+                // event was sent by this extension -> call handler
+                evt.detail.etc.handler(evt.detail.pathInfo.anchor, evt.detail.pathInfo.finalRequestPath);
+                return false; // prevent actual Ajax call execution
+            }
+        } else if (name === "htmx:afterProcessNode") {
+            let elt = evt.detail.elt;
+            if (elt.tagName === "A" && elt.getAttribute('hx-get')) {
+                // events to hook this extension on.
+                // act directly on initialization and mouseover by default.
+                let node = htmx.closest(elt, "[refresh-href]");
+                let events = (node && node.getAttribute('refresh-href') || "init,mouseover").split(",");
+                
+                events.forEach(function(e) {
+                    let handler = function() {
+                        // Trigger an ajax call, but capture the url and interrupt request in htmx:beforeRequest.
+                        htmx.ajax("GET", elt.getAttribute('hx-get'), {
+                            source: elt,
+                            event: tag,
+                            handler: function(anchor, finalRequestPath) {
+                                let href = finalRequestPath + (anchor && !finalRequestPath.includes('#') ? '#' + anchor : '');
+                                elt.setAttribute('href', href);
+                            }
+                        });
+                    };
+                    if (e === 'init') {
+                        handler();
+                    } else {
+                        elt.addEventListener(e, handler);
+                    }
+                });
+            }
+        }
+    }
+});

--- a/test/ext/refresh-href.js
+++ b/test/ext/refresh-href.js
@@ -1,0 +1,41 @@
+describe("refresh-href extension", function(){
+    it('refreshes a missing href on initialization', function () {
+        var link = make('<a hx-get="/test?qs#frag" hx-ext="refresh-href">link</a>');
+        link.href.should.equal(location.protocol + "//" + location.host + '/test?qs#frag');
+    });
+
+    it('refreshes an empty href on initialization', function () {
+        var link = make('<a hx-get="/test?qs#frag" href hx-ext="refresh-href">link</a>');
+        link.href.should.equal(location.protocol + "//" + location.host + '/test?qs#frag');
+    });
+
+    it('refreshes an empty string href on initialization', function () {
+        var link = make('<a hx-get="/test?qs#frag" href="" hx-ext="refresh-href">link</a>');
+        link.href.should.equal(location.protocol + "//" + location.host + '/test?qs#frag');
+    });
+
+    it('refreshes an existing href on initialization', function () {
+        var link = make('<a hx-get="/test?qs#frag" href="original" hx-ext="refresh-href">link</a>');
+        link.href.should.equal(location.protocol + "//" + location.host + '/test?qs#frag');
+    });
+
+    it('does not refresh on init if event removed', function () {
+        var link = make('<a hx-get="/test" hx-ext="refresh-href" refresh-href="mouseover">link</a>');
+        link.href.should.equal('');
+    });
+
+    it('refreshes href on event', function () {
+        var host = location.protocol + "//" + location.host;
+
+        var param = make('<input name="param" value="val" />');
+        var link = make('<a hx-get="/test?qs#frag" hx-ext="refresh-href" hx-include="[name=\'param\']">link</a>');
+        link.href.should.equal(host + '/test?qs&param=val#frag');
+
+        param.value = "someNewValue";
+        link.href.should.equal(host + '/test?qs&param=val#frag'); // still same
+
+        const event = new MouseEvent('mouseover', {});
+        link.dispatchEvent(event);
+        link.href.should.equal(host + '/test?qs&param=someNewValue#frag'); // refreshed
+    });
+});

--- a/test/index.html
+++ b/test/index.html
@@ -142,6 +142,9 @@
 <script src="../src/ext/ws.js"></script>
 <script src="ext/ws.js"></script>
 
+<script src="../src/ext/refresh-href.js"></script>
+<script src="ext/refresh-href.js"></script>
+
 <!-- events last so they don't screw up other tests -->
 <script src="core/events.js"></script>
 

--- a/www/extensions.md
+++ b/www/extensions.md
@@ -84,6 +84,7 @@ See the individual extension documentation for more details.
 | [`server-sent-events`](/extensions/server-sent-events)       | uni-directional server push messaging via [EventSource](https://developer.mozilla.org/en-US/docs/Web/API/EventSource)
 | [`web-sockets`](/extensions/web-sockets)                     | bi-directional connection to WebSocket servers
 | [`head-support`](/extensions/head-support)                   | support for merging the `head` tag from responses into the existing documents `head`
+| [`refresh-href`](/extensions/refresh-href)                   | refresh href attributes of anchors on events with actual ajax target
 
 </div>
 

--- a/www/extensions/refresh-href.md
+++ b/www/extensions/refresh-href.md
@@ -1,0 +1,25 @@
+---
+layout: layout.njk
+title: </> htmx - high power tools for html
+---
+
+## The `refresh-href` Extension
+
+The `refresh-href` extension refreshes href attributes of anchor elements having hx-get attribute, with the actual URL used to make the Ajax call.
+
+This enables the browser to show the actual target when hovering the link, and makes "Open link in new tab" work, assuming of course the response is a full document.
+
+Refresh is made by default on "init" (initialization) and "mouseover" event. Events can be changed by listing them in refresh-href -attribute, separated by comma.
+
+### Usage
+
+```html
+<div hx-ext="refresh-href">
+    <!-- adds href="/test" on initialization, and refreshes it onmouseover -->
+    <a hx-get="/test">test</div>
+</div>
+```
+
+### Source
+
+<https://unpkg.com/htmx.org/dist/ext/refresh-href.js>


### PR DESCRIPTION
Extension that refreshes href attributes of anchor elements having hx-get attribute, with the actual URL used to make the Ajax call.

Refreshing is made by default on "init" (initialization) and "mouseover" event. These events can be changed by listing them in closest `refresh-href` -attribute, separated by comma.

This solves three problems:
1. Browsers don't consider anchors without href as links. Thus it was necessary to write _some_ href attribute even if hx-get was always used instead.
2. Browsers show href of an anchor when hovering on them. If the url is constructed dynamically (for example using hx-params or hx-include), the shown URL would be incorrect (not the one that would actually get invoked).
3. Browsers offer a possibility to open links in new tab/window through the context menu (e.g. "Open link in new tab"). The value of href is used for this, no Htmx involved, thus opening different page that would be shown if the link was clicked the normal way.

This extension is implemented by initiating a bogus ajax request with Htmx, but interrupting it before actually invoking it. This is a bit hackish, and it would be nicer if Htmx offered some kind of an API method to get the final URL that would be used for a request.

What do you think? Any suggestions for improvement? Any potential edge cases to consider?