### PR TITLE
:label: types ajax return

### DIFF
--- a/dist/htmx.d.ts
+++ b/dist/htmx.d.ts
@@ -20,7 +20,7 @@ export function addClass(elt: Element, clazz: string, delay?: number): void;
  * @param path the URL path to make the AJAX
  * @param element the element to target (defaults to the **body**)
  */
-export function ajax(verb: string, path: string, element: Element): void;
+export function ajax(verb: string, path: string, element: Element): Promise<void>;
 
 /**
  * Issues an htmx-style AJAX request
@@ -31,7 +31,7 @@ export function ajax(verb: string, path: string, element: Element): void;
  * @param path the URL path to make the AJAX
  * @param selector a selector for the target
  */
-export function ajax(verb: string, path: string, selector: string): void;
+export function ajax(verb: string, path: string, selector: string): Promise<void>;
 
 /**
  * Issues an htmx-style AJAX request
@@ -46,7 +46,7 @@ export function ajax(
     verb: string,
     path: string,
     context: Partial<{ source: any; event: any; handler: any; target: any; values: any; headers: any }>
-): void;
+): Promise<void>;
 
 /**
  * Finds the closest matching element in the given elements parentage, inclusive of the element


### PR DESCRIPTION
The types incorrectly labeled the return type of `htmx.ajax` as being `void` when it, in fact, returns a `Promise<void>`

This just fixes that.