### PR TITLE
Escape colon characters in querySelector

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -793,7 +793,8 @@ return (function () {
             forEach(fragment.querySelectorAll("[id]"), function (newNode) {
                 if (newNode.id && newNode.id.length > 0) {
                     var normalizedId = newNode.id.replace("'", "\\'");
-                    var oldNode = parentNode.querySelector(newNode.tagName + "[id='" + normalizedId + "']");
+                    var normalizedTag = newNode.tagName.replace(':', '\\:');
+                    var oldNode = parentNode.querySelector(normalizedTag + "[id='" + normalizedId + "']");
                     if (oldNode && oldNode !== parentNode) {
                         var newAttributes = newNode.cloneNode();
                         cloneAttributes(newNode, oldNode);

--- a/test/core/ajax.js
+++ b/test/core/ajax.js
@@ -979,4 +979,14 @@ describe("Core htmx AJAX Tests", function(){
         }
     });
 
+    it('should load tags with colon in their names', function() {
+        this.server.respondWith('GET', '/test', '<with:colon id="foobar">Foobar</with:colon>');
+
+        var btn = make('<button hx-get="/test">Give me colons!</button>');
+        btn.click();
+        this.server.respond();
+
+        btn.innerHTML.should.equal('<with:colon id="foobar">Foobar</with:colon>');
+    });
+
 })


### PR DESCRIPTION
I had a page with some svg tags containing colons characters. When swapping those tags, a javascript error occured:

```
ncaught DOMException: Element.querySelector: 'sodipodi:namedview[id='namedview3825']' is not a valid selector
```

This pull requests add proper escaping to tag name containing colons.