### PR TITLE
Add hx-eval attribute

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1688,6 +1688,16 @@ return (function () {
                     });
                 }
             });
+            if (!explicitAction && hasAttribute(elt,'hx-eval')) {
+                var str = getAttributeValue(elt, 'hx-eval');
+                explicitAction = true;
+                triggerSpecs.forEach(function(triggerSpec) {
+                    addTriggerHandler(elt, triggerSpec, nodeData, function (elt, evt) {
+                        var toEval = new Function(str).bind(elt)
+                        return maybeEval(elt, toEval)
+                    })
+                });
+            }
             return explicitAction;
         }
 
@@ -1772,7 +1782,7 @@ return (function () {
             if (elt.querySelectorAll) {
                 var boostedElts = hasChanceOfBeingBoosted() ? ", a, form" : "";
                 var results = elt.querySelectorAll(VERB_SELECTOR + boostedElts + ", [hx-sse], [data-hx-sse], [hx-ws]," +
-                    " [data-hx-ws], [hx-ext], [data-hx-ext]");
+                    " [data-hx-ws], [hx-ext], [data-hx-ext], [hx-eval], [data-hx-eval]");
                 return results;
             } else {
                 return [];

--- a/test/attributes/hx-eval.js
+++ b/test/attributes/hx-eval.js
@@ -1,0 +1,17 @@
+describe("hx-eval attribute", function(){
+
+    it('executes the script', function(){
+      var btn = make('<button hx-eval="this.innerText=\'Clicked!\'">Click Me!</button>')
+      btn.innerHTML.should.equal("Click Me!");
+      btn.click();
+      btn.innerHTML.should.equal("Clicked!");
+    });
+
+    it('executes the script with the data-* prefix', function(){
+      var btn = make('<button data-hx-eval="this.innerText=\'Clicked!\'">Click Me!</button>')
+      btn.innerHTML.should.equal("Click Me!");
+      btn.click();
+      btn.innerHTML.should.equal("Clicked!");
+    });
+})
+

--- a/test/index.html
+++ b/test/index.html
@@ -84,6 +84,7 @@
 <script src="attributes/hx-vals.js"></script>
 <script src="attributes/hx-vars.js"></script>
 <script src="attributes/hx-ws.js"></script>
+<script src="attributes/hx-eval.js"></script>
 
 <!-- hyperscript integration -->
 <script src="lib/_hyperscript.js"></script>

--- a/www/attributes/hx-eval.md
+++ b/www/attributes/hx-eval.md
@@ -1,0 +1,24 @@
+---
+layout: layout.njk
+title: </> htmx - hx-eval
+---
+
+## `hx-eval`
+
+The `hx-eval` attribute will cause an element to execute a client-side script.
+
+In the context of the attribute, `this` refers to the element the attribute is placed on.
+
+```html
+  <div hx-eval="this.innerText='Clicked'">Click me!</div>
+```
+
+
+### Notes
+
+* `hx-eval` is not inherited.
+
+* You can control when the script executes with `hx-trigger`.
+
+* `hx-eval` cannot be used in conjunction with an AJAX request.
+


### PR DESCRIPTION
## Description
Add a new `hx-eval` attribute which executes a client-side action instead of making a network request. The script specified in `hx-eval` is triggered the same way an `hx-METHOD` would be triggered: the "natural action" or whatever is specified by `hx-trigger`. Within the scope of the script's execution, `this` is bound to the DOM Element on which the attribute is defined.

This change could also be thought of as `onhtmx=` (in the same pattern as `onclick`, `onmousedown`, etc.) that allows the user to execute simple simple scripts though the HTMX paradigm. It respects the user's `htmx.config.allowEval` setting, and normal security warnings about evaluating untrusted JS apply. To keep things simple to start, this attribute can only be used instead of one of the `hx-METHOD` attributes—if an `hx-METHOD` attribute is also set, `hx-eval` will be ignored.

## Example Usage
Say that you are submitting a form and you want to indicate to your users that the form was submitted. One way you might do this is to return a form exactly like the one submitted, but with a confirmation somewhere. So 
the form might show an input and a submit button:
```html
<form hx-put=/user>
<input type=text name=username>
<button type=submit >Save</button>
</form>
```

And on click the server returns the following:
```html
<form hx-put=/user>
<input type=text name=username>
<button type=submit>Saved!</button>
</form>
```

Now how to reset the form, so that the button says "Save" again, without adding a lot of client-side logic? The simplest solution available currently is to return a button like this:

```html
<form hx-put=/user>
<input type=text name=username>
<button type=submit hx-get="/components/save-button" hx-trigger="load delay:2s">Saved!</button>
</form>
```

which waits 2 seconds and then fetches a button from the backend. I dislike this solution for simple reason that the roundtrip to replace a button adds a totally unnecessary network call, and requires me to specify two additional components (a "save" button and a "saved" button) in my templates. Instead we can do something like this:

```html
<form hx-put=/user>
<input type=text name=username>
<button type=submit hx-eval="this.innerText = 'Save'" hx-trigger="load delay:2s">Saved!</button>
</form>
```

This is a simple (though practical) example, but the potential for this attribute is significant as it provides a non-event mechanism for hooking into  more complex frontend logic. Another basic example would be a toast that dismisses itself some time being loaded.

## Why not use events?
The problem with events is that they violate [locality of behavior](https://htmx.org/essays/locality-of-behaviour/).

The event lives in a part of the document that is not being swapped, so if you start adding in additional events they can be difficult to keep track of, or, if done incorrectly, cause memory leaks. An `hx-eval` attribute allows the element itself to define what this element should do, in a manner that conforms with the HTMX paradigm and upholds its safety guarantees (listeners will get removed, `allowEval` can be disabled).

## Why not an extension?
I'm obviously happy to consider that, but I think that `hx-eval` is an extension-enabling functionality, and therefore belongs in the core. It provides a component-owned way to kick out to additional scripts that exist in the global scope, such as functions and other frameworks.