### PR TITLE
Remove reference to Python 2 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Note there is an old broken package called `htmx`.  This is `htmx.org`.
 
 To develop htmx locally, you will need to install the development dependencies.
 
-__Requires Python 2 and Node 15.__
+__Requires Python and Node 15.__
 
 Run:
 


### PR DESCRIPTION
Since `1.8.6` Python 2 is no longer required: https://htmx.org/posts/2023-03-02-htmx-1.8.6-is-released/

This PR updates the reference in the `README.md` file.

