### PR TITLE
Missing types 1.8.6

### DIFF
--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -324,7 +324,7 @@ export interface HtmxConfig {
     refreshOnHistoryMiss?: boolean;
     timeout?: number;
     disableSelector?: "[hx-disable], [data-hx-disable]" | string;
-    scrollBehavior?: "smooth";
+    scrollBehavior?: "smooth" | "auto";
 }
 
 /**

--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -45,7 +45,7 @@ export function ajax(verb: string, path: string, selector: string): void;
 export function ajax(
     verb: string,
     path: string,
-    context: Partial<{ source: any; event: any; handler: any; target: any; values: any; headers: any }>
+    context: Partial<{ source: any; event: any; handler: any; target: any; swap: any; values: any; headers: any }>
 ): void;
 
 /**


### PR DESCRIPTION
hi, we ran into these two type errors after upgrading to 1.8.6 and using `import htmx from "htmx.org"` rather than grabbing it off of `window`

the relevant documentation for each: 

1. [config scroll behavior](https://htmx.org/api/#config)
2. [ajax swap](https://htmx.org/api/#ajax)
