### PR TITLE
Added an example project for FastAPI

### DIFF
--- a/www/server-examples.md
+++ b/www/server-examples.md
@@ -42,6 +42,7 @@ These examples may make it a bit easier to get started using htmx with your plat
 ### FastAPI
 
 - <https://github.com/renceInbox/fastapi-todo>
+- <https://github.com/AutomationPanda/bulldoggy-reminders-app>
 
 ### Flask
 


### PR DESCRIPTION
I recently created an example web app named [Bulldoggy: The Reminders App](https://github.com/AutomationPanda/bulldoggy-reminders-app) that uses htmx with FastAPI. I added a link to this project on the [htmx Server-Side Examples](https://htmx.org/server-examples/) page. I'd be honored if you included my example project on the site. Thanks for considering.