### PR TITLE
History: restoration of scroll position on back/forward navigation

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2100,7 +2100,9 @@ return (function () {
                 swapInnerHTML(historyElement, fragment, settleInfo)
                 settleImmediately(settleInfo.tasks);
                 document.title = cached.title;
-                window.scrollTo(0, cached.scroll);
+                setTimeout(function () {
+                    window.scrollTo(0, cached.scroll);
+                }, 0); // next 'tick', so browser has time to render layout
                 currentPathForHistory = path;
                 triggerEvent(getDocument().body, "htmx:historyRestore", {path:path, item:cached});
             } else {


### PR DESCRIPTION
Currently the restored scroll position is set before the browser has been able to fully swap in and render new content; that means if the cached scroll position of the restored page _exceeds the height of the page you are navigating from_, then the scroll position may not be restored correctly. As it's a race between the page being rendered in time and the scroll position being set, the problem is intermittent and may depend on factors such as the complexity of the markup being rendered or available memory.

This PR simply defers setting the scroll position to the next 'tick', to give the browser time to do its thing.