### PR TITLE
Added a link to spookylukey/django-htmx-patterns

### DIFF
--- a/www/content/essays/template-fragments.md
+++ b/www/content/essays/template-fragments.md
@@ -141,7 +141,7 @@ Here are some known implementations of the fragment concept:
 * PHP
   * [Latte](https://latte.nette.org/en/template-inheritance#toc-blocks) - Use the 3rd parameter to only render 1 block from the template -  `$Latte_Engine->render('path/to/template.latte', [ 'foo' => 'bar' ], 'content');`
 * Python
-  * [Django Render Block Extension](https://pypi.org/project/django-render-block/)
+  * [Django Render Block Extension](https://pypi.org/project/django-render-block/) - see [example code for htmx](https://github.com/spookylukey/django-htmx-patterns/blob/master/inline_partials.rst)
   * [jinja2-fragments package](https://github.com/sponsfreixes/jinja2-fragments)
   * [jinja_partials package](https://github.com/mikeckennedy/jinja_partials) ([discussion](https://github.com/mikeckennedy/jinja_partials/issues/1) on motivation)
   * [chameleon_partials package](https://github.com/mikeckennedy/chameleon_partials)

--- a/www/content/server-examples.md
+++ b/www/content/server-examples.md
@@ -33,6 +33,7 @@ These examples may make it a bit easier to get started using htmx with your plat
 ### Django
 
 - <https://github.com/adamchainz/django-htmx>
+- <https://github.com/spookylukey/django-htmx-patterns/>
 - <https://github.com/idlesign/django-siteajax>
 - <https://github.com/guettli/django-htmx-fun/>
 


### PR DESCRIPTION
I've put my repo 2nd in the list because it is more popular (going by github stars) than the ones below it, and is growing into a fairly comprehensive list of solutions. Nice feedback I've had includes - https://github.com/spookylukey/django-htmx-patterns/discussions/2#discussioncomment-4847375

Also added a deep link to the relevant page from the "Template Fragments" essay.