### PR TITLE
www: Expand footer links beyond twitter

### DIFF
--- a/www/themes/htmx-theme/templates/base.html
+++ b/www/themes/htmx-theme/templates/base.html
@@ -9,6 +9,8 @@
     {#TODO: only generate this for the home page #}
     <link rel="alternate" type="application/atom+xml" title="Sitewide Atom feed" href="/atom.xml">
     <link rel="stylesheet" href="/css/site.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fork-awesome@1.2.0/css/fork-awesome.min.css"
+        integrity="sha256-XoaMnoYC5TH6/+ihMEnospgm0J1PM/nioxbOUdnM8HY=" crossorigin="anonymous">
     <script src="/js/htmx.js"></script>
     <script src="/js/class-tools.js"></script>
     <script src="/js/preload.js"></script>
@@ -84,7 +86,20 @@
                 <div><a href="/examples/">examples</a></div>
                 <div><a href="/talk/">talk</a></div>
                 <div><a href="/essays/">essays</a></div>
-                <div><a href="https://twitter.com/htmx_org">@htmx_org</a></div>
+                <div>
+                    <a href="https://twitter.com/htmx_org" title="twitter">
+                        <i class="fa fa-twitter"></i>
+                    </a>
+                    <a href="https://github.com/bigskysoftware/htmx" title="github">
+                        <i class="fa fa-github"></i>
+                    </a>
+                    <a href="https://htmx.org/discord" title="discord">
+                        <i class="fa fa-discord-alt" style="font-size: 110%; vertical-align: text-bottom;"></i>
+                    </a>
+                    <a href="https://www.reddit.com/r/htmx/" title="reddit">
+                        <i class="fa fa-reddit-alien" style="vertical-align: text-top;"></i>
+                    </a>
+                </div>
             </div>
         </div>
         <div class="row" style="text-align: center;">


### PR DESCRIPTION
Adds additional community links to the footer, and uses icons for them. This is done for compactness, enhanced visual identifiation, and to distinguish from the other footer links that point to pages within the site.

Before:
![Screenshot from 2023-04-12_00-36-52](https://user-images.githubusercontent.com/478237/231476979-59147706-81d4-46d9-afee-d71035d023a2.png)
After:
![Screenshot from 2023-04-12_00-31-48](https://user-images.githubusercontent.com/478237/231476970-82096884-0119-46d7-b463-b70cdf0cd431.png)

Note: This requires adding the ForkAwesome stylesheet (a FOSS fork of FontAwesome) to the website. If this is undesirable, it's possible to build an optimized version of the stylesheet with only the icons we need.

(Follow-up of #1364, which fixed issues I identified when working on this, that I didn't want to include in the same PR so as to not pollute the diff and to keep changes atomic.)
