### PR TITLE
solve CSP issue with indicator style via opt-in

### DIFF
--- a/src/htmx.css
+++ b/src/htmx.css
@@ -1,0 +1,13 @@
+:root {
+  --indicator-class: "htmx-indicator";
+  --request-class: "htmx-request";
+}
+
+.htmx-indicator {
+  opacity: 0;
+  transition: opacity 200ms ease-in;
+}
+
+.htmx-indicator .htmx-request, .htmx-indicator.htmx-request{
+  opacity: 1;
+}

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3494,12 +3494,21 @@ return (function () {
 
         function insertIndicatorStyles() {
             if (htmx.config.includeIndicatorStyles !== false) {
-                getDocument().head.insertAdjacentHTML("beforeend",
-                    "<style>\
-                      ." + htmx.config.indicatorClass + "{opacity:0;transition: opacity 200ms ease-in;}\
-                      ." + htmx.config.requestClass + " ." + htmx.config.indicatorClass + "{opacity:1}\
-                      ." + htmx.config.requestClass + "." + htmx.config.indicatorClass + "{opacity:1}\
-                    </style>");
+                var customIndicatorClass = getComputedStyle(document.body).getPropertyValue("--indicator-class");
+                var customRequestClass = getComputedStyle(document.body).getPropertyValue("--request-class");
+                if (customIndicatorClass !== "" && customRequestClass !== "") {
+                  // override custom indicator and request classes
+                  htmx.config.indicatorClass = customIndicatorClass;
+                  htmx.config.requestClass = customRequestClass;
+                } else {
+                  // previous behavior
+                  getDocument().head.insertAdjacentHTML("beforeend",
+                      "<style>\
+                        ." + htmx.config.indicatorClass + "{opacity:0;transition: opacity 200ms ease-in;}\
+                        ." + htmx.config.requestClass + " ." + htmx.config.indicatorClass + "{opacity:1}\
+                        ." + htmx.config.requestClass + "." + htmx.config.indicatorClass + "{opacity:1}\
+                      </style>");
+                }
             }
         }
 


### PR DESCRIPTION
Hi, this solves https://github.com/bigskysoftware/htmx/issues/1062 by allowing the user to explicitly specify indicator classes via CSS variables. A CSS file is included for illustration but is not strictly necessary.

The new mechanism is an opt-in, it is used only if the user specifies class names using both variables, otherwise the previous mechanism that injects styles into the page is used. It allows willing users to circumvent the CSP issue.