### PR TITLE
Essay update: Twinspark has changed the address

### DIFF
--- a/www/content/essays/hypermedia-driven-applications.md
+++ b/www/content/essays/hypermedia-driven-applications.md
@@ -133,7 +133,7 @@ The following libraries allow developers to create HDAs:
 
 * <https://htmx.org>
 * <https://unpoly.com/>
-* <https://kasta-ua.github.io/twinspark-js/>
+* <https://piranha.github.io/twinspark-js/>
 * <https://hotwire.dev>
 * <https://hyperview.org/> (a mobile hypermedia!)
 


### PR DESCRIPTION
The library is now linked to the author's Github account.