### PR TITLE
Avoid using logical or assignment

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1874,7 +1874,7 @@ return (function () {
 
         function addHxOnEventHandler(elt, eventName, code) {
             var nodeData = getInternalData(elt);
-            nodeData.onHandlers ||= {};
+            nodeData.onHandlers || (nodeData.onHandlers = {});
             var func = new Function("event", code + "; return;");
             var listener = elt.addEventListener(eventName, function (e) {
                 return func.call(elt, e);

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1874,7 +1874,7 @@ return (function () {
 
         function addHxOnEventHandler(elt, eventName, code) {
             var nodeData = getInternalData(elt);
-            nodeData.onHandlers || (nodeData.onHandlers = {});
+            nodeData.onHandlers = nodeData.onHandlers || {};
             var func = new Function("event", code + "; return;");
             var listener = elt.addEventListener(eventName, function (e) {
                 return func.call(elt, e);


### PR DESCRIPTION
Usage of `||=` can cause errors on some older browsers and/or specific configurations. In particular, I'm getting this when bundling htmx with webpack after upgrading from 1.8.6 to 1.9.0:

```
ERROR in ./node_modules/htmx.org/dist/htmx.min.js 1:22325
Module parse failed: Unexpected token (1:22325)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
```

As ||= seems to be used only once in the codebase I thought avoiding it shouldn't be much of an issue.