### PR TITLE
docs: updating attribute table to use beforeend instead of beforeEnd

### DIFF
--- a/editors/jetbrains/htmx.web-types.json
+++ b/editors/jetbrains/htmx.web-types.json
@@ -193,7 +193,7 @@
         },
         {
           "name": "hx-swap",
-          "description": "The **hx-swap** attribute controls how the response content is swapped into the DOM (e.g. 'outerHTML' or 'beforeEnd')",
+          "description": "The **hx-swap** attribute controls how the response content is swapped into the DOM (e.g. 'outerHTML' or 'beforeend')",
           "description-sections": {
             "Inherited": ""
           },

--- a/www/content/reference.md
+++ b/www/content/reference.md
@@ -28,7 +28,7 @@ The following are the most common attributes when using htmx.
 | [`hx-push-url`](@/attributes/hx-push-url.md)       | pushes the URL into the browser location bar, creating a new history entry
 | [`hx-select`](@/attributes/hx-select.md)           | select content to swap in from a response
 | [`hx-select-oob`](@/attributes/hx-select-oob.md)   | select content to swap in from a response, out of band (somewhere other than the target)
-| [`hx-swap`](@/attributes/hx-swap.md)               | controls how content is swapped in (`outerHTML`, `beforeEnd`, `afterend`, ...)
+| [`hx-swap`](@/attributes/hx-swap.md)               | controls how content is swapped in (`outerHTML`, `beforeend`, `afterend`, ...)
 | [`hx-swap-oob`](@/attributes/hx-swap-oob.md)       | marks content in a response to be out of band (should swap in somewhere other than the target)
 | [`hx-target`](@/attributes/hx-target.md)           | specifies the target element to be swapped
 | [`hx-trigger`](@/attributes/hx-trigger.md)         | specifies the event that triggers the request


### PR DESCRIPTION

I noticed in the table shown in the reference index page was using `beforeEnd` instead of `beforeend` this could lead to confusion among the developers. The hx-swap detailed view shows it correctly. This small PR changes it to `beforeend`.

BTW, I'm loving htmx: it's just amazing!

