### PR TITLE
fix accesibility and keyboard navigation issues in examples

### DIFF
--- a/www/content/examples/animations.md
+++ b/www/content/examples/animations.md
@@ -2,7 +2,7 @@
 title = "Animations"
 template = "demo.html"
 +++
-        
+
 htmx is designed to allow you to use [CSS transitions](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions)
 to add smooth animations and transitions to your web page using only CSS and HTML.  Below are a few examples of
 various animation techniques.
@@ -42,7 +42,7 @@ This div will poll every second and will get replaced with new content which cha
   Color Swap Demo
 </div>
 ```
-  
+
 Because the div has a stable id, `color-demo`, htmx will structure the swap such that a CSS transition, defined on the
 `.smooth` class, applies to the style update from `red` to `blue`, and smoothly transitions between them.
 
@@ -71,7 +71,7 @@ Because the div has a stable id, `color-demo`, htmx will structure the swap such
 
 ### Smooth Progress Bar
 
-The [Progress Bar](@/examples/progress-bar.md) demo uses this basic CSS animation technique as well, by updating the `length` 
+The [Progress Bar](@/examples/progress-bar.md) demo uses this basic CSS animation technique as well, by updating the `length`
 property of a progress bar element, allowing for a smooth animation.
 
 ## Swap Transitions {#swapping}
@@ -79,7 +79,7 @@ property of a progress bar element, allowing for a smooth animation.
 ### Fade Out On Swap
 
 If you want to fade out an element that is going to be removed when the request ends, you want to take advantage
-of the `htmx-swapping` class with some CSS and extend the swap phase to be long enough for your animation to 
+of the `htmx-swapping` class with some CSS and extend the swap phase to be long enough for your animation to
 complete.  This can be done like so:
 
 ```html
@@ -178,7 +178,7 @@ is a form that on submit will change its look to indicate that a request is bein
     transition: opacity 300ms linear;
   }
 </style>
-<form hx-post="/name">
+<form hx-post="/name" hx-swap="outerHTML">
 <label>Name:</label><input name="name"><br/>
 <button>Submit</button>
 </form>
@@ -193,10 +193,12 @@ is a form that on submit will change its look to indicate that a request is bein
   }
 </style>
 
-<form hx-post="/name">
+<div aria-live="polite">
+<form hx-post="/name" hx-swap="outerHTML">
 <label>Name:</label><input name="name"><br/>
 <button>Submit</button>
 </form>
+</div>
 
 <script>
   onPost("/name", function(){ return "Submitted!"; });
@@ -238,14 +240,14 @@ the transition time.  This avoids flickering that can happen if the transition i
 ### Using the View Transition API {#view-transitions}
 
 htmx provides access to the new  [View Transitions API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API)
-via the `transition` option of the [`hx-swap`](/attributes/hx-swap) attribute.  
+via the `transition` option of the [`hx-swap`](/attributes/hx-swap) attribute.
 
-Below is an example of a swap that uses a view transition.  The transition is tied to the outer div via a 
+Below is an example of a swap that uses a view transition.  The transition is tied to the outer div via a
 `view-transition-name` property in CSS, and that transition is defined in terms of `::view-transition-old`
 and `::view-transition-new`, using `@keyframes` to define the animation.  (Fuller details on the View Transition
 API can be found on the [Chrome Developer Page](https://developer.chrome.com/docs/web-platform/view-transitions/) on them.)
 
-The old content of this transition should slide out to the left and the new content should slide in from the right.  
+The old content of this transition should slide out to the left and the new content should slide in from the right.
 
 Note that, as of this writing, the visual transition will only occur on Chrome 111+, but more browsers are expected to
 implement this feature in the near future.

--- a/www/content/examples/bulk-update.md
+++ b/www/content/examples/bulk-update.md
@@ -2,15 +2,15 @@
 title = "Bulk Update"
 template = "demo.html"
 +++
-        
-This demo shows how to implement a common pattern where rows are selected and then bulk updated.  This is 
+
+This demo shows how to implement a common pattern where rows are selected and then bulk updated.  This is
 accomplished by putting a form around a table, with checkboxes in the table, and then including the checked
 values in `PUT`'s to two different endpoints: `activate` and `deactivate`:
 
 ```html
 <div hx-include="#checked-contacts" hx-target="#tbody">
-  <a class="btn" hx-put="/activate">Activate</a>
-  <a class="btn" hx-put="/deactivate">Deactivate</a>
+  <button class="btn" hx-put="/activate">Activate</button>
+  <button class="btn" hx-put="/deactivate">Deactivate</button>
 </div>
 
 <form id="checked-contacts">
@@ -90,7 +90,7 @@ You can see a working example of this code below.
         }
       }
     }()
-    
+
     function getIds(params) {
       if(params['ids']) {
         if(Array.isArray(params['ids'])) {
@@ -126,7 +126,7 @@ You can see a working example of this code below.
 
     // templates
     function displayUI(contacts) {
-      return `<h3>Select Rows And Activate Or Deactivate Below<h3>
+      return `<h3>Select Rows And Activate Or Deactivate Below</h3>
                <form id="checked-contacts">
                 <table>
                   <thead>
@@ -145,11 +145,11 @@ You can see a working example of this code below.
               <br/>
               <br/>
               <div hx-include="#checked-contacts" hx-target="#tbody">
-                <a class="btn" hx-put="/activate">Activate</a>
-                <a class="btn" hx-put="/deactivate">Deactivate</a>
+                <button class="btn" hx-put="/activate">Activate</button>
+                <button class="btn" hx-put="/deactivate">Deactivate</button>
               </div>`
     }
-    
+
     function displayTable(ids, contacts, action) {
       var txt = "";
       for (var i = 0; i < contacts.length; i++) {

--- a/www/content/examples/click-to-edit.md
+++ b/www/content/examples/click-to-edit.md
@@ -36,7 +36,7 @@ The click to edit pattern provides a way to offer inline editing of all or part 
   </div>
   <button class="btn">Submit</button>
   <button class="btn" hx-get="/contact/1">Cancel</button>
-</form> 
+</form>
 ```
 
 * The form issues a `PUT` back to `/contacts/1`, following the usual REST-ful pattern.
@@ -75,18 +75,18 @@ The click to edit pattern provides a way to offer inline editing of all or part 
     function formTemplate(contact) {
 return `<form hx-put="/contact/1" hx-target="this" hx-swap="outerHTML">
   <div>
-    <label>First Name</label>
-    <input type="text" name="firstName" value="${contact.firstName}">
+    <label for="firstName">First Name</label>
+    <input autofocus type="text" id="firstName" name="firstName" value="${contact.firstName}">
   </div>
   <div class="form-group">
-    <label>Last Name</label>
-    <input type="text" name="lastName" value="${contact.lastName}">
+    <label for="lastName">Last Name</label>
+    <input type="text" id="lastName" name="lastName" value="${contact.lastName}">
   </div>
   <div class="form-group">
-    <label>Email Address</label>
-    <input type="email" name="email" value="${contact.email}">
+    <label for="email">Email Address</label>
+    <input type="email" id="email" name="email" value="${contact.email}">
   </div>
-  <button class="btn">Submit</button>
+  <button class="btn" type="submit">Submit</button>
   <button class="btn" hx-get="/contact/1">Cancel</button>
 </form>`
     }

--- a/www/content/examples/click-to-load.md
+++ b/www/content/examples/click-to-load.md
@@ -9,13 +9,13 @@ the final row:
 ```html
 <tr id="replaceMe">
   <td colspan="3">
-    <button class='btn' hx-get="/contacts/?page=2" 
-                        hx-target="#replaceMe" 
+    <button class='btn' hx-get="/contacts/?page=2"
+                        hx-target="#replaceMe"
                         hx-swap="outerHTML">
          Load More Agents... <img class="htmx-indicator" src="/img/bars.svg">
     </button>
   </td>
-</tr> 
+</tr>
 ```
 
 This row contains a button that will replace the entire row with the next page of
@@ -48,31 +48,31 @@ results (which will contain a button to load the *next* page of results).  And s
         }
       }
     }()
-    
+
     // routes
     init("/demo", function(request, params){
         var contacts = dataStore.contactsForPage(1)
         return tableTemplate(contacts)
     });
-    
+
     onGet(/\/contacts.*/, function(request, params){
         var page = parseInt(params['page']);
         var contacts = dataStore.contactsForPage(page)
         return rowsTemplate(page, contacts);
     });
-    
+
     // templates
     function tableTemplate(contacts) {
         return `<table><thead><tr><th>Name</th><th>Email</th><th>ID</th></tr></thead><tbody>
                 ${rowsTemplate(1, contacts)}
                 </tbody></table>`
     }
-    
+
     function rowsTemplate(page, contacts) {
       var txt = "";
       for (var i = 0; i < contacts.length; i++) {
         var c = contacts[i];
-        txt += "<tr><td>" + c.name + "</td><td>" + c.email + "</td><td>" + c.id + "</td></tr>\n";
+        txt += `<tr ${i==0&&'autofocus'}><td>  ${c.name}  </td><td>  ${c.email}  </td><td>  ${c.id}  </td></tr>\n`;
       }
       txt += loadMoreRow(page);
       return txt;
@@ -82,8 +82,8 @@ results (which will contain a button to load the *next* page of results).  And s
       return `<tr id="replaceMe">
   <td colspan="3">
     <center>
-      <button class='btn' hx-get="/contacts/?page=${page + 1}" 
-                       hx-target="#replaceMe" 
+      <button class='btn' hx-get="/contacts/?page=${page + 1}"
+                       hx-target="#replaceMe"
                        hx-swap="outerHTML">
          Load More Agents... <img class="htmx-indicator" src="/img/bars.svg">
        </button>

--- a/www/content/examples/click-to-load.md
+++ b/www/content/examples/click-to-load.md
@@ -72,7 +72,7 @@ results (which will contain a button to load the *next* page of results).  And s
       var txt = "";
       for (var i = 0; i < contacts.length; i++) {
         var c = contacts[i];
-        txt += `<tr ${i==0&&'autofocus'}><td>  ${c.name}  </td><td>  ${c.email}  </td><td>  ${c.id}  </td></tr>\n`;
+        txt += `<tr><td>${c.name}</td><td>${c.email}</td><td>${c.id}</td></tr>\n`;
       }
       txt += loadMoreRow(page);
       return txt;

--- a/www/content/examples/inline-validation.md
+++ b/www/content/examples/inline-validation.md
@@ -41,7 +41,7 @@ When a request occurs, it will return a partial to replace the outer div.  It mi
   <input name="email" hx-post="/contact/email" hx-indicator="#ind" value="test@foo.com">
   <img id="ind" src="/img/bars.svg" class="htmx-indicator"/>
   <div class='error-message'>That email is already taken.  Please enter another email.</div>
-</div> 
+</div>
 ```
 
 Note that this div is annotated with the `error` class and includes an error message element.
@@ -92,7 +92,7 @@ Below is a working demo of this example.  The only email that will be accepted i
     onPost("/contact", function(request, params){
       return formTemplate();
     });
-    
+
     onPost(/\/contact\/email.*/, function(request, params){
         var email = params['email'];
         if(!/\S+@\S+\.\S+/.test(email)) {
@@ -103,38 +103,38 @@ Below is a working demo of this example.  The only email that will be accepted i
           return emailInputTemplate(email);
         }
      });
-    
+
     // templates
     function demoTemplate() {
-        
+
         return `<h3>Signup Form</h3><p>Enter an email into the input below and on tab out it will be validated.  Only "test@test.com" will pass.</p> ` + formTemplate();
     }
-    
+
     function formTemplate() {
       return `<form hx-post="/contact">
   <div hx-target="this" hx-swap="outerHTML">
-    <label>Email Address</label>
-    <input name="email" hx-post="/contact/email" hx-indicator="#ind">
+    <label for="email">Email Address</label>
+    <input name="email" id="email" hx-post="/contact/email" hx-indicator="#ind">
     <img id="ind" src="/img/bars.svg" class="htmx-indicator"/>
   </div>
   <div class="form-group">
-    <label>First Name</label>
-    <input type="text" class="form-control" name="firstName">
+    <label for="firstName">First Name</label>
+    <input type="text" class="form-control" name="firstName" id="firstName">
   </div>
   <div class="form-group">
-    <label>Last Name</label>
-    <input type="text" class="form-control" name="lastName">
+    <label for="lastName">Last Name</label>
+    <input type="text" class="form-control" name="lastName" id="lastName">
   </div>
-  <button class="btn btn-default" disabled>Submit</button>
+  <button type='submit' class="btn btn-default" disabled>Submit</button>
 </form>`;
     }
-    
+
         function emailInputTemplate(val, errorMsg) {
             return `<div hx-target="this" hx-swap="outerHTML" class="${errorMsg ? "error" : "valid"}">
   <label>Email Address</label>
-  <input name="email" hx-post="/contact/email" hx-indicator="#ind" value="${val}">
+  <input name="email" hx-post="/contact/email" hx-indicator="#ind" value="${val}" aria-invalid="${!!errorMsg}">
   <img id="ind" src="/img/bars.svg" class="htmx-indicator"/>
-  ${errorMsg ? ("<div class='error-message'>" + errorMsg + "</div>") : ""}
+  ${errorMsg ? (`<div class='error-message' >${errorMsg}</div>`) : ""}
 </div>`;
         }
 </script>

--- a/www/content/examples/lazy-load.md
+++ b/www/content/examples/lazy-load.md
@@ -53,7 +53,7 @@ img {
 
     // templates
     function lazyTemplate(page) {
-      return `<div hx-get="/graph" aria-busy='true' hx-trigger="load">
+      return `<div hx-get="/graph" aria-busy="true" hx-trigger="load">
   <img  alt="Result loading..." class="htmx-indicator" width="150" src="/img/bars.svg"/>
 </div>`;
     }

--- a/www/content/examples/lazy-load.md
+++ b/www/content/examples/lazy-load.md
@@ -46,14 +46,14 @@ img {
     init("/demo", function(request, params){
       return lazyTemplate();
     });
-    
+
     onGet("/graph", function(request, params){
       return "<img alt='Tokyo Climate' src='/img/tokyo.png'>";
     });
-    
+
     // templates
     function lazyTemplate(page) {
-      return `<div hx-get="/graph" hx-trigger="load">
+      return `<div hx-get="/graph" aria-busy='true' hx-trigger="load">
   <img  alt="Result loading..." class="htmx-indicator" width="150" src="/img/bars.svg"/>
 </div>`;
     }

--- a/www/content/examples/lazy-load.md
+++ b/www/content/examples/lazy-load.md
@@ -53,7 +53,7 @@ img {
 
     // templates
     function lazyTemplate(page) {
-      return `<div hx-get="/graph" aria-busy="true" hx-trigger="load">
+      return `<div hx-get="/graph" hx-trigger="load">
   <img  alt="Result loading..." class="htmx-indicator" width="150" src="/img/bars.svg"/>
 </div>`;
     }

--- a/www/content/examples/progress-bar.md
+++ b/www/content/examples/progress-bar.md
@@ -20,8 +20,8 @@ This div is then replaced with a new div that reloads itself every 600ms:
 
 ```html
 <div hx-target="this"
-    hx-get="/job" 
-    hx-trigger="load delay:600ms" 
+    hx-get="/job"
+    hx-trigger="load delay:600ms"
     hx-swap="outerHTML">
   <h3>Running</h3>
   <div class="progress">
@@ -40,8 +40,8 @@ extension in this example):
 
 ```html
 <div hx-target="this"
-    hx-get="/job" 
-    hx-trigger="none" 
+    hx-get="/job"
+    hx-trigger="none"
     hx-swap="outerHTML">
   <h3>Complete</h3>
   <div class="progress">
@@ -49,7 +49,7 @@ extension in this example):
   </div>
 <button id="restart-btn" class="btn" hx-post="/start" classes="add show:600ms">
   Restart Job
-</button> 
+</button>
 </div>
 ```
 
@@ -125,17 +125,17 @@ This example uses styling cribbed from the bootstrap progress bar:
     init("/demo", function(request, params){
       return startButton("Start Progress");
     });
-    
+
     onPost("/start", function(request, params){
         var job = jobManager.start();
         return jobStatusTemplate(job);
     });
-    
+
     onGet("/job", function(request, params){
         var job = jobManager.currentProcess();
         return jobStatusTemplate(job);
     });
-    
+
     // templates
     function startButton(message) {
       return `<div hx-target="this" hx-swap="outerHTML">
@@ -145,15 +145,19 @@ This example uses styling cribbed from the bootstrap progress bar:
   </button>
 </div>`;
     }
-    
+
     function jobStatusTemplate(job) {
         return `<div hx-target="this"
-    hx-get="/job" 
-    hx-trigger="${job.complete ? 'none' : 'load delay:600ms'}" 
-    hx-swap="outerHTML">
-  <h3>${job.complete ? "Complete" : "Running"}</h3>
-  <div class="progress">
-    <div id="pb" class="progress-bar" style="width:${job.percentComplete}%">
+    hx-get="/job"
+    hx-trigger="${job.complete ? 'none' : 'load delay:600ms'}"
+    hx-swap="outerHTML"
+    >
+  <h3 id="pblabel">${job.complete ? "Complete" : "Running"}</h3>
+
+  <div>
+    <div class="progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${job.percentComplete}" aria-labelledby="pblabel">
+      <div id="pb" class="progress-bar" style="width:${job.percentComplete}%">
+    </div>
   </div>
 </div>
 ${restartButton(job)}`;
@@ -161,7 +165,8 @@ ${restartButton(job)}`;
 
     function restartButton(job) {
       if(job.complete){
-        return `<button id="restart-btn" class="btn" hx-post="/start" classes="add show:600ms">
+        return `
+<button id="restart-btn" class="btn" hx-post="/start" classes="add show:600ms">
   Restart Job
 </button>`
       } else {

--- a/www/content/examples/progress-bar.md
+++ b/www/content/examples/progress-bar.md
@@ -16,40 +16,51 @@ We start with an initial state with a button that issues a `POST` to `/start` to
 </div>
 ```
 
-This div is then replaced with a new div that reloads itself every 600ms:
+This div is then replaced with a new div containing status and a progress bar that reloads itself every 600ms:
 
 ```html
-<div hx-target="this"
-    hx-get="/job"
-    hx-trigger="load delay:600ms"
-    hx-swap="outerHTML">
-  <h3>Running</h3>
-  <div class="progress">
-    <div id="pb" class="progress-bar" style="width:0%"></div>
+<div hx-trigger="done" hx-get="/job" hx-swap="outerHTML" hx-target="this">
+  <h3 role="status" id="pblabel" tabindex="-1" autofocus>Running</h3>
+
+  <div
+    hx-get="/job/progress"
+    hx-trigger="every 600ms"
+    hx-target="this"
+    hx-swap="innerHTML">
+    <div class="progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-labelledby="pblabel">
+      <div id="pb" class="progress-bar" style="width:0%">
+    </div>
   </div>
 </div>
+
 ```
 
-This HTML is rerendered every 600 milliseconds, with the "width" style attribute on the progress bar being updated.
+This progress bar is updated every 600 milliseconds, with the "width" style attribute and `aria-valuenow` attributed set to current progress value.
 Because there is an id on the progress bar div, htmx will smoothly transition between requests by settling the
-style attribute into its new value.  This, when coupled with CSS transitions, make the visual transition continuous
+style attribute into its new value.  This, when coupled with CSS transitions, makes the visual transition continuous
 rather than jumpy.
 
-Finally, when the process is complete, a restart button is added to the UI (we are using the [`class-tools`](@/extensions/class-tools.md)
-extension in this example):
+Finally, when the process is complete, a server returns `HX-Trigger: done` header, which triggers an update of the UI to "Complete" state
+with a restart button added to the UI (we are using the [`class-tools`](@/extensions/class-tools.md) extension in this example to add fade-in effect on the button):
 
 ```html
-<div hx-target="this"
-    hx-get="/job"
+<div hx-trigger="done" hx-get="/job" hx-swap="outerHTML" hx-target="this">
+  <h3 role="status" id="pblabel" tabindex="-1" autofocus>Complete</h3>
+
+  <div
+    hx-get="/job/progress"
     hx-trigger="none"
-    hx-swap="outerHTML">
-  <h3>Complete</h3>
-  <div class="progress">
-      <div id="pb" class="progress-bar" style="width:100%"></div>
+    hx-target="this"
+    hx-swap="innerHTML">
+      <div class="progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="122" aria-labelledby="pblabel">
+        <div id="pb" class="progress-bar" style="width:122%">
+      </div>
+    </div>
   </div>
-<button id="restart-btn" class="btn" hx-post="/start" classes="add show:600ms">
-  Restart Job
-</button>
+
+  <button id="restart-btn" class="btn" hx-post="/start" classes="add show:600ms">
+    Restart Job
+  </button>
 </div>
 ```
 
@@ -136,6 +147,15 @@ This example uses styling cribbed from the bootstrap progress bar:
         return jobStatusTemplate(job);
     });
 
+    onGet("/job/progress", function(request, params, responseHeaders){
+        var job = jobManager.currentProcess();
+
+        if (job.complete) {
+          responseHeaders["HX-Trigger"] = "done";
+        }
+        return jobProgressTemplate(job);
+    });
+
     // templates
     function startButton(message) {
       return `<div hx-target="this" hx-swap="outerHTML">
@@ -146,21 +166,25 @@ This example uses styling cribbed from the bootstrap progress bar:
 </div>`;
     }
 
-    function jobStatusTemplate(job) {
-        return `<div hx-target="this"
-    hx-get="/job"
-    hx-trigger="${job.complete ? 'none' : 'load delay:600ms'}"
-    hx-swap="outerHTML"
-    >
-  <h3 id="pblabel">${job.complete ? "Complete" : "Running"}</h3>
-
-  <div>
-    <div class="progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${job.percentComplete}" aria-labelledby="pblabel">
+    function jobProgressTemplate(job) {
+      return `<div class="progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${job.percentComplete}" aria-labelledby="pblabel">
       <div id="pb" class="progress-bar" style="width:${job.percentComplete}%">
     </div>
+  </div>`
+    }
+
+    function jobStatusTemplate(job) {
+        return `<div hx-trigger="done" hx-get="/job" hx-swap="outerHTML" hx-target="this">
+  <h3 role="status" id="pblabel" tabindex="-1" autofocus>${job.complete ? "Complete" : "Running"}</h3>
+
+  <div
+    hx-get="/job/progress"
+    hx-trigger="${job.complete ? 'none' : 'every 600ms'}"
+    hx-target="this"
+    hx-swap="innerHTML">
+    ${jobProgressTemplate(job)}
   </div>
-</div>
-${restartButton(job)}`;
+  ${restartButton(job)}`;
     }
 
     function restartButton(job) {

--- a/www/content/examples/tabs-hateoas.md
+++ b/www/content/examples/tabs-hateoas.md
@@ -16,9 +16,9 @@ Subsequent tab pages display all tabs and highlight the selected one accordingly
 
 ```html
 <div class="tab-list">
-	<a hx-get href="#" class="selected">Tab 1</a>
-	<a hx-get href="#">Tab 2</a>
-	<a hx-get href="#">Tab 3</a>
+	<a hx-get="/tab1" href="#" class="selected">Tab 1</a>
+	<a hx-get="/tab2" href="#">Tab 2</a>
+	<a hx-get="/tab3" href="#">Tab 3</a>
 </div>
 
 <div class="tab-content">

--- a/www/content/examples/tabs-hateoas.md
+++ b/www/content/examples/tabs-hateoas.md
@@ -15,13 +15,13 @@ The main page simply includes the following HTML to load the initial tab into th
 Subsequent tab pages display all tabs and highlight the selected one accordingly.
 
 ```html
-<div class="tab-list">
-	<a hx-get="/tab1" href="#" class="selected">Tab 1</a>
-	<a hx-get="/tab2" href="#">Tab 2</a>
-	<a hx-get="/tab3" href="#">Tab 3</a>
+<div class="tab-list" role="tablist">
+	<button hx-get="/tab1" class="selected" role="tab" aria-selected="false" aria-controls="tab-content">Tab 1</button>
+	<button hx-get="/tab2" role="tab" aria-selected="false" aria-controls="tab-content">Tab 2</button>
+	<button hx-get="/tab3" role="tab" aria-selected="false" aria-controls="tab-content">Tab 3</button>
 </div>
 
-<div class="tab-content">
+<div id="tab-content" role="tabpanel" class="tab-content">
 	Commodo normcore truffaut VHS duis gluten-free keffiyeh iPhone taxidermy godard ramps anim pour-over.
 	Pitchfork vegan mollit umami quinoa aute aliquip kinfolk eiusmod live-edge cardigan ipsum locavore.
 	Polaroid duis occaecat narwhal small batch food truck.
@@ -34,12 +34,12 @@ Subsequent tab pages display all tabs and highlight the selected one accordingly
 {{ demoenv() }}
 
 <div id="tabs" hx-target="this" hx-swap="innerHTML">
-		<div class="tab-list">
-			<a hx-get="/tab1" href="#" class="selected">Tab 1</a>
-			<a hx-get="/tab2" href="#">Tab 2</a>
-			<a hx-get="/tab3" href="#">Tab 3</a>
+		<div class="tab-list" role="tablist">
+			<button hx-get="/tab1" class="selected" role="tab" aria-selected="false" aria-controls="tab-content">Tab 1</button>
+			<button hx-get="/tab2" role="tab" aria-selected="false" aria-controls="tab-content">Tab 2</button>
+			<button hx-get="/tab3" role="tab" aria-selected="false" aria-controls="tab-content">Tab 3</button>
 		</div>
-		<div class="tab-content">
+		<div id="tab-content" role="tabpanel" class="tab-content">
 			Commodo normcore truffaut VHS duis gluten-free keffiyeh iPhone taxidermy godard ramps anim pour-over.
 			Pitchfork vegan mollit umami quinoa aute aliquip kinfolk eiusmod live-edge cardigan ipsum locavore.
 			Polaroid duis occaecat narwhal small batch food truck.
@@ -53,13 +53,13 @@ Subsequent tab pages display all tabs and highlight the selected one accordingly
 <script>
 	onGet("/tab1", function() {
 		return `
-		<div class="tab-list">
-			<a hx-get="/tab1" href="#" class="selected" autofocus>Tab 1</a>
-			<a hx-get="/tab2" href="#">Tab 2</a>
-			<a hx-get="/tab3" href="#">Tab 3</a>
+		<div class="tab-list" role="tablist">
+			<button hx-get="/tab1" class="selected" aria-selected="true" autofocus role="tab" aria-controls="tab-content">Tab 1</button>
+			<button hx-get="/tab2" role="tab" aria-selected="false" aria-controls="tab-content">Tab 2</button>
+			<button hx-get="/tab3" role="tab" aria-selected="false" aria-controls="tab-content">Tab 3</button>
 		</div>
 
-		<div class="tab-content">
+		<div id="tab-content" role="tabpanel" class="tab-content">
 			Commodo normcore truffaut VHS duis gluten-free keffiyeh iPhone taxidermy godard ramps anim pour-over.
 			Pitchfork vegan mollit umami quinoa aute aliquip kinfolk eiusmod live-edge cardigan ipsum locavore.
 			Polaroid duis occaecat narwhal small batch food truck.
@@ -71,13 +71,13 @@ Subsequent tab pages display all tabs and highlight the selected one accordingly
 
 	onGet("/tab2", function() {
 		return `
-		<div class="tab-list">
-			<a href="#" hx-get="/tab1">Tab 1</a>
-			<a href="#" hx-get="/tab2" class="selected" autofocus>Tab 2</a>
-			<a href="#" hx-get="/tab3">Tab 3</a>
+		<div class="tab-list" role="tablist">
+			<button hx-get="/tab1" role="tab" aria-selected="false" aria-controls="tab-content">Tab 1</button>
+			<button hx-get="/tab2" class="selected" aria-selected="true" autofocus role="tab" aria-controls="tab-content">Tab 2</button>
+			<button hx-get="/tab3" role="tab" aria-selected="false" aria-controls="tab-content">Tab 3</button>
 		</div>
 
-		<div class="tab-content">
+		<div id="tab-content" role="tabpanel" class="tab-content">
 			Kitsch fanny pack yr, farm-to-table cardigan cillum commodo reprehenderit plaid dolore cronut meditation.
 			Tattooed polaroid veniam, anim id cornhole hashtag sed forage.
 			Microdosing pug kitsch enim, kombucha pour-over sed irony forage live-edge.
@@ -90,13 +90,13 @@ Subsequent tab pages display all tabs and highlight the selected one accordingly
 
 	onGet("/tab3", function() {
 		return `
-		<div class="tab-list">
-			<a href="#" hx-get="/tab1">Tab 1</a>
-			<a href="#" hx-get="/tab2">Tab 2</a>
-			<a href="#" hx-get="/tab3" class="selected" autofocus>Tab 3</a>
+		<div class="tab-list" role="tablist">
+			<button hx-get="/tab1" role="tab" aria-selected="false" aria-controls="tab-content">Tab 1</button>
+			<button hx-get="/tab2" role="tab" aria-selected="false" aria-controls="tab-content">Tab 2</button>
+			<button hx-get="/tab3" class="selected" aria-selected="true" autofocus role="tab" aria-controls="tab-content">Tab 3</button>
 		</div>
 
-		<div class="tab-content">
+		<div id="tab-content" role="tabpanel" class="tab-content">
 			Aute chia marfa echo park tote bag hammock mollit artisan listicle direct trade.
 			Raw denim flexitarian eu godard etsy.
 			Poke tbh la croix put a bird on it fixie polaroid aute cred air plant four loko gastropub swag non brunch.
@@ -115,13 +115,19 @@ Subsequent tab pages display all tabs and highlight the selected one accordingly
 		border-bottom: solid 3px #eee;
 	}
 
-	#tabs > .tab-list a {
+	#tabs > .tab-list button {
+		border: none;
 		display: inline-block;
 		padding: 5px 10px;
 		cursor:pointer;
+		background-color: transparent;
 	}
 
-	#tabs > .tab-list a.selected {
+	#tabs > .tab-list button:hover {
+		color: var(--midBlue);
+	}
+
+	#tabs > .tab-list button.selected {
 		background-color: #eee;
 	}
 

--- a/www/content/examples/tabs-hateoas.md
+++ b/www/content/examples/tabs-hateoas.md
@@ -33,7 +33,21 @@ Subsequent tab pages display all tabs and highlight the selected one accordingly
 
 {{ demoenv() }}
 
-<div id="tabs" hx-get="/tab1" hx-trigger="load delay:100ms" hx-target="#tabs" hx-swap="innerHTML"></div>
+<div id="tabs" hx-target="this" hx-swap="innerHTML">
+		<div class="tab-list">
+			<a hx-get="/tab1" href="#" class="selected">Tab 1</a>
+			<a hx-get="/tab2" href="#">Tab 2</a>
+			<a hx-get="/tab3" href="#">Tab 3</a>
+		</div>
+		<div class="tab-content">
+			Commodo normcore truffaut VHS duis gluten-free keffiyeh iPhone taxidermy godard ramps anim pour-over.
+			Pitchfork vegan mollit umami quinoa aute aliquip kinfolk eiusmod live-edge cardigan ipsum locavore.
+			Polaroid duis occaecat narwhal small batch food truck.
+			PBR&B venmo shaman small batch you probably haven't heard of them hot chicken readymade.
+			Enim tousled cliche woke, typewriter single-origin coffee hella culpa.
+			Art party readymade 90's, asymmetrical hell of fingerstache ipsum.
+		</div>
+</div>
 
 
 <script>

--- a/www/content/examples/tabs-hateoas.md
+++ b/www/content/examples/tabs-hateoas.md
@@ -35,7 +35,7 @@ Subsequent tab pages display all tabs and highlight the selected one accordingly
 
 <div id="tabs" hx-target="this" hx-swap="innerHTML">
 		<div class="tab-list" role="tablist">
-			<button hx-get="/tab1" class="selected" role="tab" aria-selected="false" aria-controls="tab-content">Tab 1</button>
+			<button hx-get="/tab1" class="selected" role="tab" aria-selected="true" aria-controls="tab-content">Tab 1</button>
 			<button hx-get="/tab2" role="tab" aria-selected="false" aria-controls="tab-content">Tab 2</button>
 			<button hx-get="/tab3" role="tab" aria-selected="false" aria-controls="tab-content">Tab 3</button>
 		</div>

--- a/www/content/examples/tabs-hateoas.md
+++ b/www/content/examples/tabs-hateoas.md
@@ -16,17 +16,17 @@ Subsequent tab pages display all tabs and highlight the selected one accordingly
 
 ```html
 <div class="tab-list">
-	<a hx-get="/tab1" class="selected">Tab 1</a>
-	<a hx-get="/tab2">Tab 2</a>
-	<a hx-get="/tab3">Tab 3</a>
+	<a hx-get href="#" class="selected">Tab 1</a>
+	<a hx-get href="#">Tab 2</a>
+	<a hx-get href="#">Tab 3</a>
 </div>
 
 <div class="tab-content">
-	Commodo normcore truffaut VHS duis gluten-free keffiyeh iPhone taxidermy godard ramps anim pour-over. 
-	Pitchfork vegan mollit umami quinoa aute aliquip kinfolk eiusmod live-edge cardigan ipsum locavore. 
-	Polaroid duis occaecat narwhal small batch food truck. 
-	PBR&B venmo shaman small batch you probably haven't heard of them hot chicken readymade. 
-	Enim tousled cliche woke, typewriter single-origin coffee hella culpa. 
+	Commodo normcore truffaut VHS duis gluten-free keffiyeh iPhone taxidermy godard ramps anim pour-over.
+	Pitchfork vegan mollit umami quinoa aute aliquip kinfolk eiusmod live-edge cardigan ipsum locavore.
+	Polaroid duis occaecat narwhal small batch food truck.
+	PBR&B venmo shaman small batch you probably haven't heard of them hot chicken readymade.
+	Enim tousled cliche woke, typewriter single-origin coffee hella culpa.
 	Art party readymade 90's, asymmetrical hell of fingerstache ipsum.
 </div>
 ```
@@ -40,17 +40,17 @@ Subsequent tab pages display all tabs and highlight the selected one accordingly
 	onGet("/tab1", function() {
 		return `
 		<div class="tab-list">
-			<a hx-get="/tab1" class="selected">Tab 1</a>
-			<a hx-get="/tab2">Tab 2</a>
-			<a hx-get="/tab3">Tab 3</a>
+			<a hx-get="/tab1" href="#" class="selected" autofocus>Tab 1</a>
+			<a hx-get="/tab2" href="#">Tab 2</a>
+			<a hx-get="/tab3" href="#">Tab 3</a>
 		</div>
-		
+
 		<div class="tab-content">
-			Commodo normcore truffaut VHS duis gluten-free keffiyeh iPhone taxidermy godard ramps anim pour-over. 
-			Pitchfork vegan mollit umami quinoa aute aliquip kinfolk eiusmod live-edge cardigan ipsum locavore. 
-			Polaroid duis occaecat narwhal small batch food truck. 
-			PBR&B venmo shaman small batch you probably haven't heard of them hot chicken readymade. 
-			Enim tousled cliche woke, typewriter single-origin coffee hella culpa. 
+			Commodo normcore truffaut VHS duis gluten-free keffiyeh iPhone taxidermy godard ramps anim pour-over.
+			Pitchfork vegan mollit umami quinoa aute aliquip kinfolk eiusmod live-edge cardigan ipsum locavore.
+			Polaroid duis occaecat narwhal small batch food truck.
+			PBR&B venmo shaman small batch you probably haven't heard of them hot chicken readymade.
+			Enim tousled cliche woke, typewriter single-origin coffee hella culpa.
 			Art party readymade 90's, asymmetrical hell of fingerstache ipsum.
 		</div>`
 	})
@@ -58,18 +58,18 @@ Subsequent tab pages display all tabs and highlight the selected one accordingly
 	onGet("/tab2", function() {
 		return `
 		<div class="tab-list">
-			<a hx-get="/tab1">Tab 1</a>
-			<a hx-get="/tab2" class="selected">Tab 2</a>
-			<a hx-get="/tab3">Tab 3</a>
+			<a href="#" hx-get="/tab1">Tab 1</a>
+			<a href="#" hx-get="/tab2" class="selected" autofocus>Tab 2</a>
+			<a href="#" hx-get="/tab3">Tab 3</a>
 		</div>
-		
+
 		<div class="tab-content">
-			Kitsch fanny pack yr, farm-to-table cardigan cillum commodo reprehenderit plaid dolore cronut meditation. 
-			Tattooed polaroid veniam, anim id cornhole hashtag sed forage. 
-			Microdosing pug kitsch enim, kombucha pour-over sed irony forage live-edge. 
-			Vexillologist eu nulla trust fund, street art blue bottle selvage raw denim. 
-			Dolore nulla do readymade, est subway tile affogato hammock 8-bit. 
-			Godard elit offal pariatur you probably haven't heard of them post-ironic. 
+			Kitsch fanny pack yr, farm-to-table cardigan cillum commodo reprehenderit plaid dolore cronut meditation.
+			Tattooed polaroid veniam, anim id cornhole hashtag sed forage.
+			Microdosing pug kitsch enim, kombucha pour-over sed irony forage live-edge.
+			Vexillologist eu nulla trust fund, street art blue bottle selvage raw denim.
+			Dolore nulla do readymade, est subway tile affogato hammock 8-bit.
+			Godard elit offal pariatur you probably haven't heard of them post-ironic.
 			Prism street art cray salvia.
 		</div>`
 	})
@@ -77,15 +77,15 @@ Subsequent tab pages display all tabs and highlight the selected one accordingly
 	onGet("/tab3", function() {
 		return `
 		<div class="tab-list">
-			<a hx-get="/tab1">Tab 1</a>
-			<a hx-get="/tab2">Tab 2</a>
-			<a hx-get="/tab3" class="selected">Tab 3</a>
+			<a href="#" hx-get="/tab1">Tab 1</a>
+			<a href="#" hx-get="/tab2">Tab 2</a>
+			<a href="#" hx-get="/tab3" class="selected" autofocus>Tab 3</a>
 		</div>
-		
+
 		<div class="tab-content">
-			Aute chia marfa echo park tote bag hammock mollit artisan listicle direct trade. 
-			Raw denim flexitarian eu godard etsy. 
-			Poke tbh la croix put a bird on it fixie polaroid aute cred air plant four loko gastropub swag non brunch. 
+			Aute chia marfa echo park tote bag hammock mollit artisan listicle direct trade.
+			Raw denim flexitarian eu godard etsy.
+			Poke tbh la croix put a bird on it fixie polaroid aute cred air plant four loko gastropub swag non brunch.
 			Iceland fanny pack tumeric magna activated charcoal bitters palo santo laboris quis consectetur cupidatat portland aliquip venmo.
 		</div>`
 	})

--- a/www/content/examples/tabs-hyperscript.md
+++ b/www/content/examples/tabs-hyperscript.md
@@ -3,7 +3,7 @@ title = "Tabs (Using Hyperscript)"
 template = "demo.html"
 +++
 
-This example shows how to load tab contents using htmx, and to select the "active" tab using Javascript.  This reduces some duplication by offloading some of the work of re-rendering the tab HTML from your application server to your clients' browsers.  
+This example shows how to load tab contents using htmx, and to select the "active" tab using Javascript.  This reduces some duplication by offloading some of the work of re-rendering the tab HTML from your application server to your clients' browsers.
 
 You may also consider [a more idiomatic approach](@/examples/tabs-hateoas.md) that follows the principle of [Hypertext As The Engine Of Application State](https://en.wikipedia.org/wiki/HATEOAS).
 
@@ -13,9 +13,9 @@ The HTML below displays a list of tabs, with added HTMX to dynamically load each
 
 ```html
 <div id="tabs" hx-target="#tab-contents" _="on htmx:afterOnLoad take .selected for event.target">
-	<a hx-get="/tab1" class="selected">Tab 1</a>
-	<a hx-get="/tab2">Tab 2</a>
-	<a hx-get="/tab3">Tab 3</a>
+	<a href="#" hx-get="/tab1" class="selected">Tab 1</a>
+	<a href="#" hx-get="/tab2">Tab 2</a>
+	<a href="#" hx-get="/tab3">Tab 3</a>
 </div>
 
 <div id="tab-contents" hx-get="/tab1" hx-trigger="load"></div>
@@ -24,9 +24,9 @@ The HTML below displays a list of tabs, with added HTMX to dynamically load each
 {{ demoenv() }}
 
 <div id="tabs" hx-target="#tab-contents" _="on click take .selected for event.target">
-	<a hx-get="/tab1" class="selected">Tab 1</a>
-	<a hx-get="/tab2">Tab 2</a>
-	<a hx-get="/tab3">Tab 3</a>
+	<a href="#" hx-get="/tab1" class="selected">Tab 1</a>
+	<a href="#" hx-get="/tab2">Tab 2</a>
+	<a href="#" hx-get="/tab3">Tab 3</a>
 </div>
 
 <div id="tab-contents" hx-get="/tab1" hx-trigger="load"></div>
@@ -35,31 +35,31 @@ The HTML below displays a list of tabs, with added HTMX to dynamically load each
 <script>
 	onGet("/tab1", function() {
 		return `
-			<p>Commodo normcore truffaut VHS duis gluten-free keffiyeh iPhone taxidermy godard ramps anim pour-over. 
-			Pitchfork vegan mollit umami quinoa aute aliquip kinfolk eiusmod live-edge cardigan ipsum locavore. 
-			Polaroid duis occaecat narwhal small batch food truck. 
-			PBR&B venmo shaman small batch you probably haven't heard of them hot chicken readymade. 
-			Enim tousled cliche woke, typewriter single-origin coffee hella culpa. 
+			<p>Commodo normcore truffaut VHS duis gluten-free keffiyeh iPhone taxidermy godard ramps anim pour-over.
+			Pitchfork vegan mollit umami quinoa aute aliquip kinfolk eiusmod live-edge cardigan ipsum locavore.
+			Polaroid duis occaecat narwhal small batch food truck.
+			PBR&B venmo shaman small batch you probably haven't heard of them hot chicken readymade.
+			Enim tousled cliche woke, typewriter single-origin coffee hella culpa.
 			Art party readymade 90's, asymmetrical hell of fingerstache ipsum.</p>
 		`});
 
 	onGet("/tab2", function() {
 		return `
-			<p>Kitsch fanny pack yr, farm-to-table cardigan cillum commodo reprehenderit plaid dolore cronut meditation. 
-			Tattooed polaroid veniam, anim id cornhole hashtag sed forage. 
-			Microdosing pug kitsch enim, kombucha pour-over sed irony forage live-edge. 
-			Vexillologist eu nulla trust fund, street art blue bottle selvage raw denim. 
-			Dolore nulla do readymade, est subway tile affogato hammock 8-bit. 
-			Godard elit offal pariatur you probably haven't heard of them post-ironic. 
+			<p>Kitsch fanny pack yr, farm-to-table cardigan cillum commodo reprehenderit plaid dolore cronut meditation.
+			Tattooed polaroid veniam, anim id cornhole hashtag sed forage.
+			Microdosing pug kitsch enim, kombucha pour-over sed irony forage live-edge.
+			Vexillologist eu nulla trust fund, street art blue bottle selvage raw denim.
+			Dolore nulla do readymade, est subway tile affogato hammock 8-bit.
+			Godard elit offal pariatur you probably haven't heard of them post-ironic.
 			Prism street art cray salvia.</p>
 		`
 	});
 
 	onGet("/tab3", function() {
 		return `
-			<p>Aute chia marfa echo park tote bag hammock mollit artisan listicle direct trade. 
-			Raw denim flexitarian eu godard etsy. 
-			Poke tbh la croix put a bird on it fixie polaroid aute cred air plant four loko gastropub swag non brunch. 
+			<p>Aute chia marfa echo park tote bag hammock mollit artisan listicle direct trade.
+			Raw denim flexitarian eu godard etsy.
+			Poke tbh la croix put a bird on it fixie polaroid aute cred air plant four loko gastropub swag non brunch.
 			Iceland fanny pack tumeric magna activated charcoal bitters palo santo laboris quis consectetur cupidatat portland aliquip venmo.</p>
 		`
 	});

--- a/www/content/examples/tabs-hyperscript.md
+++ b/www/content/examples/tabs-hyperscript.md
@@ -12,24 +12,24 @@ You may also consider [a more idiomatic approach](@/examples/tabs-hateoas.md) th
 The HTML below displays a list of tabs, with added HTMX to dynamically load each tab pane from the server.  A simple [hyperscript](https://hyperscript.org) event handler uses the [`take` command](https://hyperscript.org/commands/take/) to switch the selected tab when the content is swapped into the DOM.  Alternatively, this could be accomplished with a slightly longer Javascript event handler.
 
 ```html
-<div id="tabs" hx-target="#tab-contents" _="on htmx:afterOnLoad take .selected for event.target">
-	<a href="#" hx-get="/tab1" class="selected">Tab 1</a>
-	<a href="#" hx-get="/tab2">Tab 2</a>
-	<a href="#" hx-get="/tab3">Tab 3</a>
+<div id="tabs" hx-target="#tab-contents" role="tablist" _="on htmx:afterOnLoad set @aria-selected of <[aria-selected=true]/> to false tell the target take .selected set @aria-selected to true">
+	<button role="tab" aria-controls="tab-content" aria-selected="true" hx-get="/tab1" class="selected">Tab 1</button>
+	<button role="tab" aria-controls="tab-content" aria-selected="false" hx-get="/tab2">Tab 2</button>
+	<button role="tab" aria-controls="tab-content" aria-selected="false" hx-get="/tab3">Tab 3</button>
 </div>
 
-<div id="tab-contents" hx-get="/tab1" hx-trigger="load"></div>
+<div id="tab-contents" role="tabpanel" hx-get="/tab1" hx-trigger="load"></div>
 ```
 
 {{ demoenv() }}
 
-<div id="tabs" hx-target="#tab-contents" _="on click take .selected for event.target">
-	<a href="#" hx-get="/tab1" class="selected">Tab 1</a>
-	<a href="#" hx-get="/tab2">Tab 2</a>
-	<a href="#" hx-get="/tab3">Tab 3</a>
+<div id="tabs" hx-target="#tab-contents" role="tablist" _="on htmx:afterOnLoad set @aria-selected of <[aria-selected=true]/> to false tell the target take .selected set @aria-selected to true">
+	<button role="tab" aria-controls="tab-content" aria-selected="true" hx-get="/tab1" class="selected">Tab 1</button>
+	<button role="tab" aria-controls="tab-content" aria-selected="false" hx-get="/tab2">Tab 2</button>
+	<button role="tab" aria-controls="tab-content" aria-selected="false" hx-get="/tab3">Tab 3</button>
 </div>
 
-<div id="tab-contents" hx-get="/tab1" hx-trigger="load"></div>
+<div id="tab-contents" role="tabpanel" hx-get="/tab1" hx-trigger="load"></div>
 
 <script src="https://unpkg.com/hyperscript.org"></script>
 <script>
@@ -42,7 +42,6 @@ The HTML below displays a list of tabs, with added HTMX to dynamically load each
 			Enim tousled cliche woke, typewriter single-origin coffee hella culpa.
 			Art party readymade 90's, asymmetrical hell of fingerstache ipsum.</p>
 		`});
-
 	onGet("/tab2", function() {
 		return `
 			<p>Kitsch fanny pack yr, farm-to-table cardigan cillum commodo reprehenderit plaid dolore cronut meditation.
@@ -54,7 +53,6 @@ The HTML below displays a list of tabs, with added HTMX to dynamically load each
 			Prism street art cray salvia.</p>
 		`
 	});
-
 	onGet("/tab3", function() {
 		return `
 			<p>Aute chia marfa echo park tote bag hammock mollit artisan listicle direct trade.
@@ -76,13 +74,19 @@ The HTML below displays a list of tabs, with added HTMX to dynamically load each
 		border-bottom: solid 3px #eee;
 	}
 
-	#tabs > a {
+	#tabs > button {
+		border: none;
 		display: inline-block;
 		padding: 5px 10px;
 		cursor:pointer;
+		background-color: transparent;
 	}
 
-	#tabs > a.selected {
+	#tabs > button:hover {
+		color: var(--midBlue);
+	}
+
+	#tabs > button.selected {
 		background-color: #eee;
 	}
 

--- a/www/static/js/demo.js
+++ b/www/static/js/demo.js
@@ -3,13 +3,13 @@
 //====================================
 var server = sinon.fakeServer.create();
 server.fakeHTTPMethods = true;
-server.getHTTPMethod = function(xhr) {
+server.getHTTPMethod = function (xhr) {
     return xhr.requestHeaders['X-HTTP-Method-Override'] || xhr.method;
 }
 server.autoRespond = true;
 server.autoRespondAfter = 200;
 server.xhr.useFilters = true;
-server.xhr.addFilter(function (method, url, async, username, password){
+server.xhr.addFilter(function (method, url, async, username, password) {
     return url === "/" || url.indexOf("http") === 0;
 })
 
@@ -46,10 +46,10 @@ function parseParams(str) {
 function getQuery(url) {
     var question = url.indexOf("?");
     var hash = url.indexOf("#");
-    if(hash==-1 && question==-1) return "";
-    if(hash==-1) hash = url.length;
-    return question==-1 || hash==question+1 ? url.substring(hash) :
-        url.substring(question+1,hash);
+    if (hash == -1 && question == -1) return "";
+    if (hash == -1) hash = url.length;
+    return question == -1 || hash == question + 1 ? url.substring(hash) :
+        url.substring(question + 1, hash);
 }
 
 function params(request) {
@@ -58,6 +58,9 @@ function params(request) {
     } else {
         return parseParams(request.requestBody);
     }
+}
+function headers(request) {
+    return request.getAllResponseHeaders().split("\r\n").filter(h => h.toLowerCase().startsWith("hx-")).map(h => h.split(": ")).reduce((acc, v) => ({ ...acc, [v[0]]: v[1] }), {})
 }
 
 //====================================
@@ -75,30 +78,34 @@ function init(path, response) {
 }
 
 function onGet(path, response) {
-    server.respondWith("GET", path, function(request){
-        let body = response(request, params(request));
-        request.respond(200, {}, body);
+    server.respondWith("GET", path, function (request) {
+        let headers = {};
+        let body = response(request, params(request), headers);
+        request.respond(200, headers, body);
     });
 }
 
 function onPut(path, response) {
-    server.respondWith("PUT", path, function(request){
-        let body = response(request, params(request));
-        request.respond(200, {}, body);
+    server.respondWith("PUT", path, function (request) {
+        let headers = {};
+        let body = response(request, params(request), headers);
+        request.respond(200, headers, body);
     });
 }
 
 function onPost(path, response) {
-    server.respondWith("POST", path, function(request){
-        let body = response(request, params(request));
-        request.respond(200, {}, body);
+    server.respondWith("POST", path, function (request) {
+        let headers = {};
+        let body = response(request, params(request), headers);
+        request.respond(200, headers, body);
     });
 }
 
 function onDelete(path, response) {
-    server.respondWith("DELETE", path, function(request){
-        let body = response(request, params(request));
-        request.respond(200, {}, body);
+    server.respondWith("DELETE", path, function (request) {
+        let headers = {};
+        let body = response(request, params(request), headers);
+        request.respond(200, headers, body);
     });
 }
 
@@ -107,7 +114,7 @@ function onDelete(path, response) {
 //====================================
 
 var requestId = 0;
-htmx.on("htmx:beforeSwap", function(event) {
+htmx.on("htmx:beforeSwap", function (event) {
     if (document.getElementById("request-count")) {
         requestId++;
         pushActivityChip(`${server.getHTTPMethod(event.detail.xhr)} ${event.detail.xhr.url}`, `req-${requestId}`, demoResponseTemplate(event.detail));
@@ -128,7 +135,7 @@ function showTimelineEntry(id) {
     var children = document.getElementById("demo-timeline").children;
     for (var i = 0; i < children.length; i++) {
         var child = children[i];
-        if (child.id == id + "-link" ) {
+        if (child.id == id + "-link") {
             child.classList.add('active');
         } else {
             child.classList.remove('active');
@@ -153,19 +160,19 @@ function pushActivityChip(name, id, content) {
 
 function escapeHtml(string) {
     var pre = document.createElement('pre');
-    var text = document.createTextNode( string );
+    var text = document.createTextNode(string);
     pre.appendChild(text);
     return pre.innerHTML;
 }
 
-function demoInitialStateTemplate(html){
+function demoInitialStateTemplate(html) {
     return `<span class="activity initial">
   <b>HTML</b>
   <pre class="language-html"><code class="language-html">${escapeHtml(html)}</code></pre>
 </span>`
 }
 
-function demoResponseTemplate(details){
+function demoResponseTemplate(details) {
     return `<span class="activity response">
   <div>
   <b>${server.getHTTPMethod(details.xhr)}</b> ${details.xhr.url}
@@ -174,8 +181,11 @@ function demoResponseTemplate(details){
     parameters: ${JSON.stringify(params(details.xhr))}
   </div>
   <div>
+    headers: ${JSON.stringify(headers(details.xhr))}
+  </div>
+  <div>
   <b>Response</b>
-  <pre class="language-html"><code class="language-html">${escapeHtml(details.xhr.response)}</code> </pre>  
+  <pre class="language-html"><code class="language-html">${escapeHtml(details.xhr.response)}</code> </pre>
   </div>
 </span>`;
 }


### PR DESCRIPTION
See #1431 

This PR fixes a number of issues with accessibility practices in the examples section of the docs. Most notably:

- fix missing hrefs on links
- replace links with buttons
- add autofocus attribute to inline editing examples and "click to load"
- fix missing input labels
- make a progress bar a Proper Progress bar (aria attributes)

This is not an exhaustive fix of all issues that probably exist in the examples, but an effort to cover most obvious low hanging bugs