### PR TITLE
hx-boost and hx-verb do not consider attribute value changes at runtime

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1327,8 +1327,18 @@ return (function () {
                             path = elt.href; // DOM property gives the fully resolved href of a relative link
                         } else {
                             var method = getRawAttribute(elt, "method") || "get";
+                            var action = getRawAttribute(elt, "action");
+                            // support for overriding method and action
+                            if (evt.submitter) {
+                                if (evt.submitter.hasAttribute('formmethod')) {
+                                    method = evt.submitter.getAttribute('formmethod');
+                                }
+                                if (evt.submitter.hasAttribute('formaction')) {
+                                    action = evt.submitter.getAttribute('formaction');
+                                }
+                            }
                             verb = method.toLowerCase();
-                            path = getRawAttribute(elt, "action");
+                            path = action;
                         }
                         issueAjaxRequest(verb, path, elt, evt)
                     }, nodeData, triggerSpec, true);

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1319,19 +1319,17 @@ return (function () {
         function boostElement(elt, nodeData, triggerSpecs) {
             if ((elt.tagName === "A" && isLocalLink(elt) && (elt.target === "" || elt.target === "_self")) || elt.tagName === "FORM") {
                 nodeData.boosted = true;
-                var verb, path;
-                if (elt.tagName === "A") {
-                    verb = "get";
-                    path = elt.href; // DOM property gives the fully resolved href of a relative link
-                } else {
-                    var rawAttribute = getRawAttribute(elt, "method");
-                    verb = rawAttribute ? rawAttribute.toLowerCase() : "get";
-                    if (verb === "get") {
-                    }
-                    path = getRawAttribute(elt, 'action');
-                }
                 triggerSpecs.forEach(function(triggerSpec) {
                     addEventListener(elt, function(elt, evt) {
+                        var verb, path;
+                        if (elt.tagName === "A") {
+                            verb = "get";
+                            path = elt.href; // DOM property gives the fully resolved href of a relative link
+                        } else {
+                            var method = getRawAttribute(elt, "method") || "get";
+                            verb = method.toLowerCase();
+                            path = getRawAttribute(elt, "action");
+                        }
                         issueAjaxRequest(verb, path, elt, evt)
                     }, nodeData, triggerSpec, true);
                 });
@@ -1732,12 +1730,12 @@ return (function () {
             var explicitAction = false;
             forEach(VERBS, function (verb) {
                 if (hasAttribute(elt,'hx-' + verb)) {
-                    var path = getAttributeValue(elt, 'hx-' + verb);
                     explicitAction = true;
-                    nodeData.path = path;
                     nodeData.verb = verb;
                     triggerSpecs.forEach(function(triggerSpec) {
                         addTriggerHandler(elt, triggerSpec, nodeData, function (elt, evt) {
+                            var path = getAttributeValue(elt, 'hx-' + verb);
+                            nodeData.path = path;
                             issueAjaxRequest(verb, path, elt, evt)
                         })
                     });

--- a/test/attributes/hx-boost.js
+++ b/test/attributes/hx-boost.js
@@ -87,6 +87,15 @@ describe("hx-boost attribute", function() {
         div.innerHTML.should.equal('Boosted');
     })
 
+    it('handles form with action and method overriding', function () {
+        this.server.respondWith('GET', '/test-overriding', 'Boosted');
+        var div = make('<div hx-target="this" hx-boost="true"><form id="f1" action="/test" method="post"><button id="b1" formaction="/test-overriding" formmethod="get">Submit</button></form></div>');
+        var btn = byId('b1');
+        btn.click();
+        this.server.respond();
+        div.innerHTML.should.equal('Boosted');
+    })
+
     it('overriding default swap style does not effect boosting', function () {
         htmx.config.defaultSwapStyle = "afterend";
         try {

--- a/test/attributes/hx-boost.js
+++ b/test/attributes/hx-boost.js
@@ -65,6 +65,27 @@ describe("hx-boost attribute", function() {
         div.innerHTML.should.equal("Boosted");
     })
 
+    it('handles anchor with modified href at runtime', function () {
+        this.server.respondWith('GET', '/test-modified', 'Boosted');
+        var div = make('<div hx-target="this" hx-boost="true"><a id="a1" href="/test">Foo</a></div>');
+        var a = byId('a1');
+        a.setAttribute('href', '/test-modified');
+        a.click();
+        this.server.respond();
+        div.innerHTML.should.equal('Boosted');
+    })
+
+    it('handles form with modified action and method at runtime', function () {
+        this.server.respondWith('GET', '/test-modified', 'Boosted');
+        var div = make('<div hx-target="this" hx-boost="true"><form id="f1" action="/test" method="post"><button id="b1">Submit</button></form></div>');
+        var form = byId('f1');
+        form.setAttribute('method', 'GET');
+        form.setAttribute('action', '/test-modified');
+        var btn = byId('b1');
+        btn.click();
+        this.server.respond();
+        div.innerHTML.should.equal('Boosted');
+    })
 
     it('overriding default swap style does not effect boosting', function () {
         htmx.config.defaultSwapStyle = "afterend";

--- a/test/attributes/hx-delete.js
+++ b/test/attributes/hx-delete.js
@@ -31,4 +31,14 @@ describe("hx-delete attribute", function(){
         this.server.respond();
         btn.innerHTML.should.equal("Deleted!");
     });
+
+    it('issues a DELETE request with modified path on click and swaps content', function () {
+        this.server.respondWith('DELETE', '/test-modified', 'Clicked!');
+
+        var btn = make('<button hx-delete="/test">Click Me!</button>')
+        btn.setAttribute('hx-delete', '/test-modified');
+        btn.click();
+        this.server.respond();
+        btn.innerHTML.should.equal('Clicked!');
+    });
 })

--- a/test/attributes/hx-get.js
+++ b/test/attributes/hx-get.js
@@ -126,4 +126,14 @@ describe("hx-get attribute", function() {
             htmx.config.getCacheBusterParam = false;
         }
     });
+
+    it('issues a GET request with modified path on click and swaps content', function () {
+        this.server.respondWith('GET', '/test-modified', 'Clicked!');
+
+        var btn = make('<button hx-get="/test">Click Me!</button>')
+        btn.setAttribute('hx-get', '/test-modified');
+        btn.click();
+        this.server.respond();
+        btn.innerHTML.should.equal('Clicked!');
+    });
 });

--- a/test/attributes/hx-patch.js
+++ b/test/attributes/hx-patch.js
@@ -31,4 +31,14 @@ describe("hx-patch attribute", function(){
         this.server.respond();
         btn.innerHTML.should.equal("Patched!");
     });
+
+    it('issues a PATCH request with modified path on click and swaps content', function () {
+        this.server.respondWith('PATCH', '/test-modified', 'Clicked!');
+
+        var btn = make('<button hx-patch="/test">Click Me!</button>')
+        btn.setAttribute('hx-patch', '/test-modified');
+        btn.click();
+        this.server.respond();
+        btn.innerHTML.should.equal('Clicked!');
+    });
 })

--- a/test/attributes/hx-post.js
+++ b/test/attributes/hx-post.js
@@ -33,4 +33,14 @@ describe("hx-post attribute", function(){
         this.server.respond();
         btn.innerHTML.should.equal("Posted!");
     });
+
+    it('issues a POST request with modified path on click and swaps content', function () {
+        this.server.respondWith('POST', '/test-modified', 'Clicked!');
+
+        var btn = make('<button hx-post="/test">Click Me!</button>')
+        btn.setAttribute('hx-post', '/test-modified');
+        btn.click();
+        this.server.respond();
+        btn.innerHTML.should.equal('Clicked!');
+    });
 })

--- a/test/attributes/hx-put.js
+++ b/test/attributes/hx-put.js
@@ -31,4 +31,14 @@ describe("hx-put attribute", function(){
         this.server.respond();
         btn.innerHTML.should.equal("Putted!");
     });
+
+    it('issues a PUT request with modified path on click and swaps content', function () {
+        this.server.respondWith('PUT', '/test-modified', 'Clicked!');
+
+        var btn = make('<button hx-put="/test">Click Me!</button>')
+        btn.setAttribute('hx-put', '/test-modified');
+        btn.click();
+        this.server.respond();
+        btn.innerHTML.should.equal('Clicked!');
+    });
 })


### PR DESCRIPTION
At the moment htmx does not consider changes to the `href`, `action` and `method` attributes for boosted elements at runtime, nor does it consider changes to the hx-verb attributes (`hx-get`, `hx-post`, etc.). With these code changes, you can adjust the values of these attributes at runtime and htmx will take them into account during the request.

Furthermore, overriding attributes for form submission (`method` and `action` via `formmethod` and `formaction`) is now also supported. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attributes_for_form_submission.