### PR TITLE
hx-on throws an error when used with event names that contain dots

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1889,7 +1889,7 @@ return (function () {
                 var curlyCount = 0;
                 while (lines.length > 0) {
                     var line = lines.shift();
-                    var match = line.match(/^\s*([a-zA-Z:\-]+:)(.*)/);
+                    var match = line.match(/^\s*([a-zA-Z:\-\.]+:)(.*)/);
                     if (curlyCount === 0 && match) {
                         line.split(":")
                         currentEvent = match[1].slice(0, -1); // strip last colon

--- a/test/attributes/hx-on.js
+++ b/test/attributes/hx-on.js
@@ -119,4 +119,11 @@ describe("hx-on attribute", function() {
         delete window.tempCount;
     });
 
+    it("can handle event types with dots", function () {
+        var btn = make("<button hx-on='my.custom.event: window.foo = true'>Foo</button>");
+        btn.dispatchEvent(new CustomEvent('my.custom.event'));
+        window.foo.should.equal(true);
+        delete window.foo;
+    });
+
 });


### PR DESCRIPTION
Unlike `hx-trigger`, `hx-on` does not support event names that contain dots.

```html
<div hx-get="/test" hx-trigger="my.custom.event" hx-on="my.custom.event: alert('Fired!')"></div>
```

Instead htmx throws a SyntaxError:
```
Uncaught SyntaxError: Unexpected token ':'
```