### PR TITLE
Allow hx-swap options to be used without specifying modifier (innerHTML remains the default)

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2628,6 +2628,8 @@ return (function () {
                             swapSpec["focusScroll"] = focusScrollVal == "true";
                         } else if (i == 0) {
                             swapSpec["swapStyle"] = value;
+                        } else {
+                            logError('Unknown modifier in hx-swap: ' + value);
                         }
                     }
                 }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2599,40 +2599,35 @@ return (function () {
             if (swapInfo) {
                 var split = splitOnWhitespace(swapInfo);
                 if (split.length > 0) {
-                    swapSpec["swapStyle"] = split[0];
-                    for (var i = 1; i < split.length; i++) {
-                        var modifier = split[i];
-                        if (modifier.indexOf("swap:") === 0) {
-                            swapSpec["swapDelay"] = parseInterval(modifier.substr(5));
-                        }
-                        if (modifier.indexOf("settle:") === 0) {
-                            swapSpec["settleDelay"] = parseInterval(modifier.substr(7));
-                        }
-                        if (modifier.indexOf("transition:") === 0) {
-                            swapSpec["transition"] = modifier.substr(11) === "true";
-                        }
-                        if (modifier.indexOf("ignoreTitle:") === 0) {
-                            swapSpec["ignoreTitle"] = modifier.substr(12) === "true";
-                        }
-                        if (modifier.indexOf("scroll:") === 0) {
-                            var scrollSpec = modifier.substr(7);
+                    for (var i = 0; i < split.length; i++) {
+                        var value = split[i];
+                        if (value.indexOf("swap:") === 0) {
+                            swapSpec["swapDelay"] = parseInterval(value.substr(5));
+                        } else if (value.indexOf("settle:") === 0) {
+                            swapSpec["settleDelay"] = parseInterval(value.substr(7));
+                        } else if (value.indexOf("transition:") === 0) {
+                            swapSpec["transition"] = value.substr(11) === "true";
+                        } else if (value.indexOf("ignoreTitle:") === 0) {
+                            swapSpec["ignoreTitle"] = value.substr(12) === "true";
+                        } else if (value.indexOf("scroll:") === 0) {
+                            var scrollSpec = value.substr(7);
                             var splitSpec = scrollSpec.split(":");
                             var scrollVal = splitSpec.pop();
                             var selectorVal = splitSpec.length > 0 ? splitSpec.join(":") : null;
                             swapSpec["scroll"] = scrollVal;
                             swapSpec["scrollTarget"] = selectorVal;
-                        }
-                        if (modifier.indexOf("show:") === 0) {
-                            var showSpec = modifier.substr(5);
+                        } else if (value.indexOf("show:") === 0) {
+                            var showSpec = value.substr(5);
                             var splitSpec = showSpec.split(":");
                             var showVal = splitSpec.pop();
                             var selectorVal = splitSpec.length > 0 ? splitSpec.join(":") : null;
                             swapSpec["show"] = showVal;
                             swapSpec["showTarget"] = selectorVal;
-                        }
-                        if (modifier.indexOf("focus-scroll:") === 0) {
-                            var focusScrollVal = modifier.substr("focus-scroll:".length);
+                        } else if (value.indexOf("focus-scroll:") === 0) {
+                            var focusScrollVal = value.substr("focus-scroll:".length);
                             swapSpec["focusScroll"] = focusScrollVal == "true";
+                        } else if (i == 0) {
+                            swapSpec["swapStyle"] = value;
                         }
                     }
                 }

--- a/test/attributes/hx-swap.js
+++ b/test/attributes/hx-swap.js
@@ -204,6 +204,22 @@ describe("hx-swap attribute", function(){
         swapSpec(make("<div hx-swap='innerHTML settle:11 swap:10'/>")).settleDelay.should.equal(11)
         swapSpec(make("<div hx-swap='innerHTML nonsense settle:11 swap:10'/>")).settleDelay.should.equal(11)
         swapSpec(make("<div hx-swap='innerHTML   nonsense   settle:11   swap:10  '/>")).settleDelay.should.equal(11)
+        
+        swapSpec(make("<div hx-swap='swap:10'/>")).swapStyle.should.equal("innerHTML")
+        swapSpec(make("<div hx-swap='swap:10'/>")).swapDelay.should.equal(10)
+
+        swapSpec(make("<div hx-swap='settle:10'/>")).swapStyle.should.equal("innerHTML")
+        swapSpec(make("<div hx-swap='settle:10'/>")).settleDelay.should.equal(10)
+        
+        swapSpec(make("<div hx-swap='swap:10 settle:11'/>")).swapStyle.should.equal("innerHTML")
+        swapSpec(make("<div hx-swap='swap:10 settle:11'/>")).swapDelay.should.equal(10)
+        swapSpec(make("<div hx-swap='swap:10 settle:11'/>")).settleDelay.should.equal(11)
+
+        swapSpec(make("<div hx-swap='settle:11 swap:10'/>")).swapStyle.should.equal("innerHTML")
+        swapSpec(make("<div hx-swap='settle:11 swap:10'/>")).swapDelay.should.equal(10)
+        swapSpec(make("<div hx-swap='settle:11 swap:10'/>")).settleDelay.should.equal(11)
+
+        swapSpec(make("<div hx-swap='customstyle settle:11 swap:10'/>")).swapStyle.should.equal("customstyle")
     })
 
     it('works with a swap delay', function(done) {

--- a/www/content/attributes/hx-swap.md
+++ b/www/content/attributes/hx-swap.md
@@ -3,11 +3,12 @@ title = "hx-swap"
 +++
 
 The `hx-swap` attribute allows you to specify how the response will be swapped in relative to the
-[target](@/attributes/hx-target.md) of an AJAX request.
+[target](@/attributes/hx-target.md) of an AJAX request. If you do not specify the option, the default is
+`htmx.config.defaultSwapStyle` (`innerHTML`).
 
 The possible values of this attribute are:
 
-* `innerHTML` - The default, replace the inner html of the target element
+* `innerHTML` - Replace the inner html of the target element
 * `outerHTML` - Replace the entire target element with the response
 * `beforebegin` - Insert the response before the target element
 * `afterbegin` - Insert the response before the first child of the target element


### PR DESCRIPTION
This makes the swap style `innerHTML`, `outerHTML` etc. in `hx-swap` optional and improves the handling of unknown values.

@David-Guillot you have requested something like that in https://github.com/bigskysoftware/htmx/issues/407#issuecomment-876543782