### PR TITLE
Add support for event cancellation (preventDefault) in extensions

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2127,7 +2127,7 @@ return (function () {
                 eventResult = eventResult && elt.dispatchEvent(kebabedEvent)
             }
             withExtensions(elt, function (extension) {
-                eventResult = eventResult && (extension.onEvent(eventName, event) !== false)
+                eventResult = eventResult && (extension.onEvent(eventName, event) !== false && !event.defaultPrevented)
             });
             return eventResult;
         }

--- a/test/core/extensions.js
+++ b/test/core/extensions.js
@@ -1,0 +1,42 @@
+describe('Core htmx extension tests', function() {
+    beforeEach(function() {
+        this.server = makeServer();
+        clearWorkArea();
+    });
+    afterEach(function() {
+        this.server.restore();
+        clearWorkArea();
+    });
+
+    it('should support event cancellation by returning false', function() {
+        htmx.defineExtension('ext-prevent-request', {
+            onEvent: function(name, evt) {
+                if (name === 'htmx:beforeRequest') {
+                    return false;
+                }
+            }
+        });
+
+        this.server.respondWith('GET', '/test', 'clicked!');
+        var div = make('<div hx-get="/test" hx-ext="ext-prevent-request">Click Me!</div>')
+        div.click();
+        this.server.respond();
+        div.innerHTML.should.equal('Click Me!');
+    });
+
+    it('should support event cancellation with preventDefault', function() {
+        htmx.defineExtension('ext-prevent-request', {
+            onEvent: function(name, evt) {
+                if (name === 'htmx:beforeRequest') {
+                    evt.preventDefault();
+                }
+            }
+        });
+
+        this.server.respondWith('GET', '/test', 'clicked!');
+        var div = make('<div hx-get="/test" hx-ext="ext-prevent-request">Click Me!</div>')
+        div.click();
+        this.server.respond();
+        div.innerHTML.should.equal('Click Me!');
+    });
+});

--- a/test/index.html
+++ b/test/index.html
@@ -54,6 +54,7 @@
 <script src="core/internals.js"></script>
 <script src="core/api.js"></script>
 <script src="core/ajax.js"></script>
+<script src="core/extensions.js"></script>
 <script src="core/verbs.js"></script>
 <script src="core/parameters.js"></script>
 <script src="core/headers.js"></script>


### PR DESCRIPTION
As the title says, this PR adds support to cancel an event also with `preventDefault()` within `onEvent` of an extension.