### PR TITLE
fix typo in sse event name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 _site
 test/scratch/scratch.html
 .DS_Store
+.vscode

--- a/src/ext/sse.js
+++ b/src/ext/sse.js
@@ -157,7 +157,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 		};
 
 		source.onopen = function (evt) {
-			api.triggerEvent(elt, "htmx::sseOpen", {source: source});
+			api.triggerEvent(elt, "htmx:sseOpen", {source: source});
 		}
 		
 		// Add message handlers for every `sse-swap` attribute


### PR DESCRIPTION
This typo prevents listening on `htmx:sseOpen` event.