### PR TITLE
Fix WebSocket extension trigger handlers initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## [1.9.3] - 2023-04-28
+## [1.9.3] - 2023-06-??
+
+* Fixed bug w/ WebSocket extension initilization caused by "naked" `hx-trigger` feature
 
 ## [1.9.2] - 2023-04-28
 

--- a/src/ext/ws.js
+++ b/src/ext/ws.js
@@ -52,7 +52,7 @@ This extension adds support for WebSockets to htmx.  See /www/extensions/ws.md f
 					return;
 
 				// Try to create websockets when elements are processed
-				case "htmx:afterProcessNode":
+				case "htmx:beforeProcessNode":
 					var parent = evt.target;
 
 					forEach(queryAttributeOnThisOrChildren(parent, "ws-connect"), function (child) {

--- a/test/ext/ws.js
+++ b/test/ext/ws.js
@@ -77,6 +77,17 @@ describe("web-sockets extension", function () {
         this.messages.length.should.equal(1);
     })
 
+    it('sends data to the server with specific trigger', function () {
+        var div = make('<div hx-ext="ws" ws-connect="ws://localhost:8080"><div hx-trigger="click" ws-send id="d1">div1</div></div>');
+        this.tickMock();
+
+        byId("d1").click();
+
+        this.tickMock();
+
+        this.messages.length.should.equal(1);
+    })
+
     it('handles message from the server', function () {
         var div = make('<div hx-ext="ws" ws-connect="ws://localhost:8080"><div id="d1">div1</div><div id="d2">div2</div></div>');
         this.tickMock();


### PR DESCRIPTION
Fix #1396 

"Naked hx-trigger" feature causes event handlers added after https://github.com/bigskysoftware/htmx/blob/master/src/htmx.js#L1938 to be ignored by https://github.com/bigskysoftware/htmx/blob/master/src/htmx.js#L1412. Not sure what to do with this right now, but moving extension initialization sooner seems to fix the problem
