### PR TITLE
Include note about 204 in hx-delete docs and examples

### DIFF
--- a/www/content/attributes/hx-delete.md
+++ b/www/content/attributes/hx-delete.md
@@ -13,7 +13,7 @@ the HTML into the DOM using a swap strategy:
 
 This example will cause the `button` to issue a `DELETE` to `/account` and swap the returned HTML into
  the `innerHTML` of the `body`.
- 
+
 ## Notes
 
 * `hx-delete` is not inherited
@@ -21,3 +21,4 @@ This example will cause the `button` to issue a `DELETE` to `/account` and swap 
 * You can control the swap strategy by using the [hx-swap](@/attributes/hx-swap.md) attribute
 * You can control what event triggers the request with the [hx-trigger](@/attributes/hx-trigger.md) attribute
 * You can control the data submitted with the request in various ways, documented here: [Parameters](@/docs.md#parameters)
+* To remove the element following a successful `DELETE`, return a `200` status code with an empty body; if the server responds with a `204`, no swap takes place, documented here: [Requests & Responses](@/docs.md#requests)

--- a/www/content/examples/delete-row.md
+++ b/www/content/examples/delete-row.md
@@ -23,7 +23,7 @@ table body:
 ```
 
 The table body has a [`hx-confirm`](@/attributes/hx-confirm.md) attribute to confirm the delete action.  It also
-set the target to be the `closest tr` that is, the closest table row, for all the buttons ([`hx-target`](@/attributes/hx-target.md) 
+set the target to be the `closest tr` that is, the closest table row, for all the buttons ([`hx-target`](@/attributes/hx-target.md)
 is inherited from parents in the DOM.)  The swap specification in [`hx-swap`](@/attributes/hx-swap.md) says to swap the
 entire target out and to wait 1 second after receiving a response.  This last bit is so that we can use the following
 CSS:
@@ -37,9 +37,9 @@ tr.htmx-swapping td {
 
 To fade the row out before it is swapped/removed.
 
-Each row has a button with a [`hx-delete`](@/attributes/hx-delete.md) attribute containing the url on which to issue a `DELETE` 
-request to delete the row from the server. This request responds with empty content, indicating that the row should
-be replaced with nothing.
+Each row has a button with a [`hx-delete`](@/attributes/hx-delete.md) attribute containing the url on which to issue a `DELETE`
+request to delete the row from the server. This request responds with a `200` status code and empty content, indicating that the
+row should be replaced with nothing.
 
 ```html
 <tr>


### PR DESCRIPTION
## Description
This issue has come up in the Discord a few times, as well as on GitHub: https://github.com/bigskysoftware/htmx/issues/1130

In part because [Mozilla suggets](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/DELETE#responses) a `204 - NO CONTENT` status code as an idiomatic response to the `DELETE` HTTP method, a lot of people come to HTMX (myself included) expecting that returning a `204` will remove the element that sent the delete request from the DOM.

The reason HTMX does not do this is because of an HTMX-wide policy that the `204` response essentially means ["do not swap"](https://htmx.org/attributes/hx-delete/), which is perfectly reasonable once you get to know how the library works. It's also, however, a recurring stumbling block for new users.

I think this can be easily rectified by linking people to the appropriate part of the documentation from the relevant delete pages—since it is reasonably likely they will find the `hx-delete` or delete row examples before digging into the mildly more obscure section about response codes. It also highlights the increased relevance of status codes in HTMX design patterns, relative to JSON-based patterns.