### PR TITLE
[New feature] selector-less next and previous targets

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -600,6 +600,10 @@ return (function () {
                 return [scanForwardQuery(elt, normalizeSelector(selector.substr(5)))];
             } else if (selector.indexOf("previous ") === 0) {
                 return [scanBackwardsQuery(elt, normalizeSelector(selector.substr(9)))];
+            } else if (selector === "nextElementSibling") {
+                return [elt.nextElementSibling]
+            } else if (selector === "previousElementSibling") {
+                return [elt.previousElementSibling]
             } else if (selector === 'document') {
                 return [document];
             } else if (selector === 'window') {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -596,14 +596,14 @@ return (function () {
                 return [closest(elt, normalizeSelector(selector.substr(8)))];
             } else if (selector.indexOf("find ") === 0) {
                 return [find(elt, normalizeSelector(selector.substr(5)))];
+            } else if (selector === "next") {
+                return [elt.nextElementSibling]
             } else if (selector.indexOf("next ") === 0) {
                 return [scanForwardQuery(elt, normalizeSelector(selector.substr(5)))];
+            } else if (selector === "previous") {
+                return [elt.previousElementSibling]
             } else if (selector.indexOf("previous ") === 0) {
                 return [scanBackwardsQuery(elt, normalizeSelector(selector.substr(9)))];
-            } else if (selector === "nextElementSibling") {
-                return [elt.nextElementSibling]
-            } else if (selector === "previousElementSibling") {
-                return [elt.previousElementSibling]
             } else if (selector === 'document') {
                 return [document];
             } else if (selector === 'window') {
@@ -1283,12 +1283,14 @@ return (function () {
                                     var from_arg = consumeUntil(tokens, WHITESPACE_OR_COMMA);
                                     if (from_arg === "closest" || from_arg === "find" || from_arg === "next" || from_arg === "previous") {
                                         tokens.shift();
-                                        from_arg +=
-                                            " " +
-                                            consumeUntil(
-                                                tokens,
-                                                WHITESPACE_OR_COMMA
-                                            );
+                                        var selector = consumeUntil(
+                                            tokens,
+                                            WHITESPACE_OR_COMMA
+                                        )
+                                        // `next` and `previous` allow a selector-less syntax
+                                        if (selector.length > 0) {
+                                            from_arg += " " + selector;
+                                        }
                                     }
                                     triggerSpec.from = from_arg;
                                 } else if (token === "target" && tokens[0] === ":") {

--- a/test/attributes/hx-target.js
+++ b/test/attributes/hx-target.js
@@ -202,4 +202,43 @@ describe("hx-target attribute", function(){
         div3.innerHTML.should.equal("Clicked!");
     });
 
+    it('targets a `nextElementSibling` properly', function()
+    {
+        this.server.respondWith("GET", "/test", "Clicked!");
+        make('<div>' +
+            '  <div id="d3"></div>' +
+            '  <button id="b1" hx-target="nextElementSibling" hx-get="/test">Click Me!</button>' +
+            '  <div id="d1"></div>' +
+            '  <div id="d2"></div>' +
+            '</div>')
+        var btn = byId("b1")
+        var div1 = byId("d1")
+        var div2 = byId("d2")
+        var div3 = byId("d3")
+        btn.click();
+        this.server.respond();
+        div1.innerHTML.should.equal("Clicked!");
+        div2.innerHTML.should.equal("");
+        div3.innerHTML.should.equal("");
+    });
+
+    it('targets a `previousElementSibling` properly', function()
+    {
+        this.server.respondWith("GET", "/test", "Clicked!");
+        make('<div>' +
+            '  <div id="d3"></div>' +
+            '  <button id="b1" hx-target="previousElementSibling" hx-get="/test">Click Me!</button>' +
+            '  <div id="d1"></div>' +
+            '  <div id="d2"></div>' +
+            '</div>')
+        var btn = byId("b1")
+        var div1 = byId("d1")
+        var div2 = byId("d2")
+        var div3 = byId("d3")
+        btn.click();
+        this.server.respond();
+        div1.innerHTML.should.equal("");
+        div2.innerHTML.should.equal("");
+        div3.innerHTML.should.equal("Clicked!");
+    });
 })

--- a/test/attributes/hx-target.js
+++ b/test/attributes/hx-target.js
@@ -202,12 +202,12 @@ describe("hx-target attribute", function(){
         div3.innerHTML.should.equal("Clicked!");
     });
 
-    it('targets a `nextElementSibling` properly', function()
+    it('targets a `next` element properly without selector', function()
     {
         this.server.respondWith("GET", "/test", "Clicked!");
         make('<div>' +
             '  <div id="d3"></div>' +
-            '  <button id="b1" hx-target="nextElementSibling" hx-get="/test">Click Me!</button>' +
+            '  <button id="b1" hx-target="next" hx-get="/test">Click Me!</button>' +
             '  <div id="d1"></div>' +
             '  <div id="d2"></div>' +
             '</div>')
@@ -222,12 +222,12 @@ describe("hx-target attribute", function(){
         div3.innerHTML.should.equal("");
     });
 
-    it('targets a `previousElementSibling` properly', function()
+    it('targets a `previous` element properly without selector', function()
     {
         this.server.respondWith("GET", "/test", "Clicked!");
         make('<div>' +
             '  <div id="d3"></div>' +
-            '  <button id="b1" hx-target="previousElementSibling" hx-get="/test">Click Me!</button>' +
+            '  <button id="b1" hx-target="previous" hx-get="/test">Click Me!</button>' +
             '  <div id="d1"></div>' +
             '  <div id="d2"></div>' +
             '</div>')

--- a/test/attributes/hx-trigger.js
+++ b/test/attributes/hx-trigger.js
@@ -506,14 +506,14 @@ describe("hx-trigger attribute", function(){
         a1.innerHTML.should.equal("Requests: 1");
     });
 
-    it('from clause works with nextElementSibling', function()
+    it('from clause works with next', function()
     {
         var requests = 0;
         this.server.respondWith("GET", "/test", function (xhr) {
             requests++;
             xhr.respond(200, {}, "Requests: " + requests);
         });
-        make('<div hx-trigger="click from:nextElementSibling" hx-target="#a1" hx-get="/test"></div><a id="a1">Requests: 0</a>');
+        make('<div hx-trigger="click from:next" hx-target="#a1" hx-get="/test"></div><a id="a1">Requests: 0</a>');
         var a1 = byId('a1');
         a1.innerHTML.should.equal("Requests: 0");
         a1.click();
@@ -521,14 +521,14 @@ describe("hx-trigger attribute", function(){
         a1.innerHTML.should.equal("Requests: 1");
     });
 
-    it('from clause works with previousElementSibling', function()
+    it('from clause works with previous', function()
     {
         var requests = 0;
         this.server.respondWith("GET", "/test", function (xhr) {
             requests++;
             xhr.respond(200, {}, "Requests: " + requests);
         });
-        make('<a id="a1">Requests: 0</a><div hx-trigger="click from:previousElementSibling" hx-target="#a1" hx-get="/test"></div>');
+        make('<a id="a1">Requests: 0</a><div hx-trigger="click from:previous" hx-target="#a1" hx-get="/test"></div>');
         var a1 = byId('a1');
         a1.innerHTML.should.equal("Requests: 0");
         a1.click();

--- a/test/attributes/hx-trigger.js
+++ b/test/attributes/hx-trigger.js
@@ -506,6 +506,36 @@ describe("hx-trigger attribute", function(){
         a1.innerHTML.should.equal("Requests: 1");
     });
 
+    it('from clause works with nextElementSibling', function()
+    {
+        var requests = 0;
+        this.server.respondWith("GET", "/test", function (xhr) {
+            requests++;
+            xhr.respond(200, {}, "Requests: " + requests);
+        });
+        make('<div hx-trigger="click from:nextElementSibling" hx-target="#a1" hx-get="/test"></div><a id="a1">Requests: 0</a>');
+        var a1 = byId('a1');
+        a1.innerHTML.should.equal("Requests: 0");
+        a1.click();
+        this.server.respond();
+        a1.innerHTML.should.equal("Requests: 1");
+    });
+
+    it('from clause works with previousElementSibling', function()
+    {
+        var requests = 0;
+        this.server.respondWith("GET", "/test", function (xhr) {
+            requests++;
+            xhr.respond(200, {}, "Requests: " + requests);
+        });
+        make('<a id="a1">Requests: 0</a><div hx-trigger="click from:previousElementSibling" hx-target="#a1" hx-get="/test"></div>');
+        var a1 = byId('a1');
+        a1.innerHTML.should.equal("Requests: 0");
+        a1.click();
+        this.server.respond();
+        a1.innerHTML.should.equal("Requests: 1");
+    });
+
     it('event listeners on other elements are removed when an element is swapped out', function()
     {
         var requests = 0;

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -12,10 +12,14 @@ function make(htmlStr) {
         var wa = getWorkArea();
         var child = null;
         var children = fragment.children || fragment.childNodes; // IE
+        var appendedChildren = []
         while(children.length > 0) {
             child = children[0];
             wa.appendChild(child);
-            htmx.process(child);
+            appendedChildren.push(child)
+        }
+        for (var i = 0; i < appendedChildren.length; i++) {
+            htmx.process(appendedChildren[i]);
         }
         return child; // return last added element
     };

--- a/www/content/attributes/hx-target.md
+++ b/www/content/attributes/hx-target.md
@@ -11,12 +11,12 @@ request.  The value of this attribute can be:
   ancestor element or itself, that matches the given CSS selector
   (e.g. `closest tr` will target the closest table row to the element).
 * `find <CSS selector>` which will find the first child descendant element that matches the given CSS selector.
+* `next` which resolves to [element.nextElementSibling](https://developer.mozilla.org/docs/Web/API/Element/nextElementSibling)
 * `next <CSS selector>` which will scan the DOM forward for the first element that matches the given CSS selector.
   (e.g. `next .error` will target the closest following sibling element with `error` class)
+* `previous` which resolves to [element.previousElementSibling](https://developer.mozilla.org/docs/Web/API/Element/previousElementSibling)
 * `previous <CSS selector>` which will scan the DOM backwards for the first element that matches the given CSS selector.
   (e.g `previous .error` will target the closest previous sibling with `error` class)
-* `nextElementSibling` which resolves to [element.nextElementSibling](https://developer.mozilla.org/docs/Web/API/Element/nextElementSibling)
-* `previousElementSibling` which resolves to [element.previousElementSibling](https://developer.mozilla.org/docs/Web/API/Element/previousElementSibling)
 
 
 Here is an example that targets a div:

--- a/www/content/attributes/hx-target.md
+++ b/www/content/attributes/hx-target.md
@@ -15,6 +15,8 @@ request.  The value of this attribute can be:
   (e.g. `next .error` will target the closest following sibling element with `error` class)
 * `previous <CSS selector>` which will scan the DOM backwards for the first element that matches the given CSS selector.
   (e.g `previous .error` will target the closest previous sibling with `error` class)
+* `nextElementSibling` which resolves to [element.nextElementSibling](https://developer.mozilla.org/docs/Web/API/Element/nextElementSibling)
+* `previousElementSibling` which resolves to [element.previousElementSibling](https://developer.mozilla.org/docs/Web/API/Element/previousElementSibling)
 
 
 Here is an example that targets a div:

--- a/www/content/attributes/hx-trigger.md
+++ b/www/content/attributes/hx-trigger.md
@@ -61,6 +61,8 @@ is seen again before the delay completes, it is ignored, the element will trigge
     * `window` - listen for events on the window
     * `closest <CSS selector>` - finds the [closest](https://developer.mozilla.org/docs/Web/API/Element/closest) ancestor element or itself, matching the given css selector
     * `find <CSS selector>` - finds the closest child matching the given css selector
+    * `nextElementSibling` resolves to [element.nextElementSibling](https://developer.mozilla.org/docs/Web/API/Element/nextElementSibling)
+    * `previousElementSibling` resolves to [element.previousElementSibling](https://developer.mozilla.org/docs/Web/API/Element/previousElementSibling)
 * `target:<CSS selector>` - allows you to filter via a CSS selector on the target of the event.  This can be useful when you want to listen for
 triggers from elements that might not be in the DOM at the point of initialization, by, for example, listening on the body,
 but with a target filter for a child element

--- a/www/content/attributes/hx-trigger.md
+++ b/www/content/attributes/hx-trigger.md
@@ -61,8 +61,12 @@ is seen again before the delay completes, it is ignored, the element will trigge
     * `window` - listen for events on the window
     * `closest <CSS selector>` - finds the [closest](https://developer.mozilla.org/docs/Web/API/Element/closest) ancestor element or itself, matching the given css selector
     * `find <CSS selector>` - finds the closest child matching the given css selector
-    * `nextElementSibling` resolves to [element.nextElementSibling](https://developer.mozilla.org/docs/Web/API/Element/nextElementSibling)
-    * `previousElementSibling` resolves to [element.previousElementSibling](https://developer.mozilla.org/docs/Web/API/Element/previousElementSibling)
+    * `next` resolves to [element.nextElementSibling](https://developer.mozilla.org/docs/Web/API/Element/nextElementSibling)
+    * `next <CSS selector>` scans the DOM forward for the first element that matches the given CSS selector.
+      (e.g. `next .error` will target the closest following sibling element with `error` class)
+    * `previous` resolves to [element.previousElementSibling](https://developer.mozilla.org/docs/Web/API/Element/previousElementSibling)
+    * `previous <CSS selector>` scans the DOM backwards for the first element that matches the given CSS selector.
+      (e.g `previous .error` will target the closest previous sibling with `error` class)
 * `target:<CSS selector>` - allows you to filter via a CSS selector on the target of the event.  This can be useful when you want to listen for
 triggers from elements that might not be in the DOM at the point of initialization, by, for example, listening on the body,
 but with a target filter for a child element


### PR DESCRIPTION
I'm very often using the following pattern :
```html
<div class="relative">
    <button hx-get="/some_popup" hx-target="nextElementSibling" hx-swap="outerHTML"></button>
    <div class="popup"></div>
</div>
```
clicking on the button brings in a popup, in place of a initially empty element. The relative parent allows positioning the popup next to the button with a position set to absolute. Ending up with something like:
```html
<div class="relative">
    <button hx-get="/some_popup" hx-target="nextElementSibling" hx-swap="outerHTML"></button>
    <div class="popup visible">
        <button>Action 1</button>
        <button>Action 2</button>
        Or whatever else...
    </div>
</div>
```

Since the JS API exposes [element.nextElementSibling](https://developer.mozilla.org/docs/Web/API/Element/nextElementSibling) and [element.previousElementSibling](https://developer.mozilla.org/docs/Web/API/Element/previousElementSibling), I think eponym values for `hx-target` would make sense and be handy.

The existing way of doing such a thing would be, in this example, to use a `hx-target="next div"` or `hx-target="next .popup"` for example. The current implementation under those next & previous elements, [are calling document.querySelectorAll](https://github.com/bigskysoftware/htmx/blob/master/src/htmx.js#L583) with the passed selector, then comparing positions.

Not that it's especially slow: I tried it out just to see, and for a `next div` selector on a page with ~30 000 divs, it takes from `1.5 ms` if the element is near the start of the results set, up to `75 ms` if it's rather to the end of the results set. Don't get me wrong there ; it's clearly negligible given such a huge page. Still though, in this situation, calling nextElementSibling / previousElementSibling is, in comparison, instant

I thought we might as well simply use the fastest path here, given that this change only adds 482 bytes to the code _(that is, before minification and gzip)_, and, in my opinion, makes for a clearer structure _(readability)_ when you know you're targeting the direct adjacent sibling