### PR TITLE
[New feature] Comma separated list syntax for HX-Trigger response header

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1095,7 +1095,10 @@ return (function () {
                     }
                 }
             } else {
-                triggerEvent(elt, triggerBody, []);
+                var eventNames = triggerBody.split(",")
+                for (var i = 0; i < eventNames.length; i++) {
+                    triggerEvent(elt, eventNames[i].trim(), []);
+                }
             }
         }
 

--- a/test/core/headers.js
+++ b/test/core/headers.js
@@ -168,6 +168,78 @@ describe("Core htmx AJAX headers", function () {
         htmx.off('foo', handler);
     })
 
+    it("should handle simple comma separated list HX-Trigger response header properly", function () {
+        this.server.respondWith("GET", "/test", [200, {"HX-Trigger": "foo, bar"}, ""]);
+
+        var div = make('<div hx-get="/test"></div>');
+        var invokedEventFoo = false;
+        var invokedEventBar = false;
+        div.addEventListener("foo", function (evt) {
+            invokedEventFoo = true;
+        });
+        div.addEventListener("bar", function (evt) {
+            invokedEventBar = true;
+        });
+        div.click();
+        this.server.respond();
+        invokedEventFoo.should.equal(true);
+        invokedEventBar.should.equal(true);
+    })
+
+    it("should handle simple comma separated list without space HX-Trigger response header properly", function () {
+        this.server.respondWith("GET", "/test", [200, {"HX-Trigger": "foo,bar"}, ""]);
+
+        var div = make('<div hx-get="/test"></div>');
+        var invokedEventFoo = false;
+        var invokedEventBar = false;
+        div.addEventListener("foo", function (evt) {
+            invokedEventFoo = true;
+        });
+        div.addEventListener("bar", function (evt) {
+            invokedEventBar = true;
+        });
+        div.click();
+        this.server.respond();
+        invokedEventFoo.should.equal(true);
+        invokedEventBar.should.equal(true);
+    })
+
+    it("should handle dot path in comma separated list HX-Trigger response header properly", function () {
+        this.server.respondWith("GET", "/test", [200, {"HX-Trigger": "foo.bar,bar.baz"}, ""]);
+
+        var div = make('<div hx-get="/test"></div>');
+        var invokedEventFoo = false;
+        var invokedEventBar = false;
+        div.addEventListener("foo.bar", function (evt) {
+            invokedEventFoo = true;
+        });
+        div.addEventListener("bar.baz", function (evt) {
+            invokedEventBar = true;
+        });
+        div.click();
+        this.server.respond();
+        invokedEventFoo.should.equal(true);
+        invokedEventBar.should.equal(true);
+    })
+
+    it("should handle a namespaced comma separated list HX-Trigger response header properly", function () {
+        this.server.respondWith("GET", "/test", [200, {"HX-Trigger": "namespace:foo,bar"}, ""]);
+
+        var div = make('<div hx-get="/test"></div>');
+        var invokedEventFoo = false;
+        var invokedEventBar = false;
+        div.addEventListener("namespace:foo", function (evt) {
+            invokedEventFoo = true;
+        });
+        div.addEventListener("bar", function (evt) {
+            invokedEventBar = true;
+        });
+        div.click();
+        this.server.respond();
+        invokedEventFoo.should.equal(true);
+        invokedEventBar.should.equal(true);
+    })
+
     it("should handle HX-Retarget", function () {
         this.server.respondWith("GET", "/test", [200, {"HX-Retarget": "#d2"}, "Result"]);
 
@@ -202,6 +274,26 @@ describe("Core htmx AJAX headers", function () {
         htmx.off('foo', handler);
     })
 
+    it("should handle simple comma separated list HX-Trigger-After-Swap response header properly w/ outerHTML swap", function () {
+        this.server.respondWith("GET", "/test", [200, {"HX-Trigger-After-Swap": "foo, bar"}, ""]);
+
+        var div = make('<div hx-swap="outerHTML" hx-get="/test"></div>');
+        var invokedEventFoo = false;
+        var invokedEventBar = false;
+        var handlerFoo = htmx.on('foo', function (evt) {
+            invokedEventFoo = true;
+        });
+        var handlerBar = htmx.on('bar', function (evt) {
+            invokedEventBar = true;
+        });
+        div.click();
+        this.server.respond();
+        invokedEventFoo.should.equal(true);
+        invokedEventBar.should.equal(true);
+        htmx.off('foo', handlerFoo);
+        htmx.off('bar', handlerBar);
+    })
+
     it("should handle simple string HX-Trigger-After-Settle response header properly w/ outerHTML swap", function () {
         this.server.respondWith("GET", "/test", [200, {"HX-Trigger-After-Settle": "foo"}, ""]);
 
@@ -214,6 +306,26 @@ describe("Core htmx AJAX headers", function () {
         this.server.respond();
         invokedEvent.should.equal(true);
         htmx.off('foo', handler);
+    })
+
+    it("should handle simple comma separated list HX-Trigger-After-Settle response header properly w/ outerHTML swap", function () {
+        this.server.respondWith("GET", "/test", [200, {"HX-Trigger-After-Settle": "foo, bar"}, ""]);
+
+        var div = make('<div hx-swap="outerHTML" hx-get="/test"></div>');
+        var invokedEventFoo = false;
+        var invokedEventBar = false;
+        var handlerFoo = htmx.on('foo', function (evt) {
+            invokedEventFoo = true;
+        });
+        var handlerBar = htmx.on('bar', function (evt) {
+            invokedEventBar = true;
+        });
+        div.click();
+        this.server.respond();
+        invokedEventFoo.should.equal(true);
+        invokedEventBar.should.equal(true);
+        htmx.off('foo', handlerFoo);
+        htmx.off('bar', handlerBar);
     })
 
 

--- a/www/content/headers/hx-trigger.md
+++ b/www/content/headers/hx-trigger.md
@@ -60,9 +60,15 @@ document.body.addEventListener("showMessage", function(evt){
 
 Each property of the JSON object on the right hand side will be copied onto the details object for the event.
 
-Finally, if you wish to invoke multiple events, you can simply add additional properties to the top level JSON
+### Multiple Triggers
+
+If you wish to invoke multiple events, you can simply add additional properties to the top level JSON
 object:
 
 `HX-Trigger: {"event1":"A message", "event2":"Another message"}`
+
+You may as well trigger multiple events with no additional details by sending event names separated by commas, like so:
+
+`HX-Trigger: event1, event2`
 
 Using events gives you a lot of flexibility to add functionality to normal htmx responses.

--- a/www/content/headers/hx-trigger.md
+++ b/www/content/headers/hx-trigger.md
@@ -67,7 +67,7 @@ object:
 
 `HX-Trigger: {"event1":"A message", "event2":"Another message"}`
 
-You may as well trigger multiple events with no additional details by sending event names separated by commas, like so:
+You may also trigger multiple events with no additional details by sending event names separated by commas, like so:
 
 `HX-Trigger: event1, event2`
 


### PR DESCRIPTION
Adds support for comma separated list of event names to the `HX-Trigger` response header.
Currently, to trigger multiple events with that header, you have to use the JSON syntax, even if you don't have any additional data to send.

This change lets you specify a list of event names, separated by commas, without additional details, like so:
`HX-Trigger: event1, event2`

The syntax is similar to the one of the [`hx-target`](https://htmx.org/attributes/hx-trigger/#multiple-triggers) attribute, that also supports a comma separated list syntax