### PR TITLE
Fix inverted elt / target for sse selectAndSwap

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1669,7 +1669,7 @@ return (function () {
                     var target = getTarget(elt)
                     var settleInfo = makeSettleInfo(elt);
 
-                    selectAndSwap(swapSpec.swapStyle, elt, target, response, settleInfo)
+                    selectAndSwap(swapSpec.swapStyle, target, elt, response, settleInfo)
                     settleImmediately(settleInfo.tasks)
                     triggerEvent(elt, "htmx:sseMessage", event)
                 };


### PR DESCRIPTION
It seems this was fixed [in the SSE extension](https://github.com/bigskysoftware/htmx/blob/master/src/ext/sse.js#L282) as parameters are correctly ordered there, but `target`and `elt` are still inverted on the core lib's SSE implementation.

I know you're planning to move it out from the core for htmx 2, but htmx 1 needs some love too and its current state is wrong