### PR TITLE
[Bugfix] sse listener removal if element isn't in body anymore

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1653,6 +1653,9 @@ return (function () {
                 var sseEventSource = getInternalData(sseSourceElt).sseEventSource;
                 var sseListener = function (event) {
                     if (maybeCloseSSESource(sseSourceElt)) {
+                        return;
+                    }
+                    if (!bodyContains(elt)) {
                         sseEventSource.removeEventListener(sseEventName, sseListener);
                         return;
                     }


### PR DESCRIPTION
Currently, with the following setup:
```html
<body hx-sse="connect:/sse">
  <div class="some-container">
    <div hx-sse="swap:content">Content</div>
  </div>
</body>
```

If the div defining `hx-sse` gets replaced _(for example, a request is issued and swaps the content of the `some-container` div, or whatever)_, its event listener is actually never removed from the event source defined on the body.

It seems to be an error there in the code, as it's also inconsistent with the other SSE check that's in [`processSSETrigger`](https://github.com/bigskysoftware/htmx/blob/master/src/htmx.js#L1689)
Here the code is
- first checking if the source should be closed (i.e, if the event source element was removed from the body)
- only if the source shouldn't be removed, then it checks if the target element is still in the body. If it's not, it removes the listener binding
- otherwise, proceed normally

Whereas, the current behaviour of [processSSESwap](https://github.com/bigskysoftware/htmx/blob/master/src/htmx.js#L1655) is :
- first checking if the source should be closed (i.e, if the event source element was removed from the body)
- if the source should be closed, remove the listener binding. <= this sounds weird, what's the point of that if the source was closed anyway?
- no check on the target element itself whether it is still in the body or not
- the swap is proceeded as normal, even if the element isn't in the page anymore

Here as well, I know you're planning to move SSE out from the core when htmx 2 happens anyway, but the current state should be fixed nonetheless