### PR TITLE
Do not initialize htmx automatically on DOM ready when loaded as module

### DIFF
--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -130,6 +130,13 @@ export function findAll(selector: string): NodeListOf<Element>;
 export function findAll(elt: Element, selector: string): NodeListOf<Element>;
 
 /**
+ * When htmx is imported as a module, this function must be called to initialize it.
+ *
+ * https://htmx.org/api/#start
+ */
+export function start(): void;
+
+/**
  * Log all htmx events, useful for debugging.
  *
  * https://htmx.org/api/#logAll
@@ -288,6 +295,8 @@ export function values(elt: Element, requestType?: string): any;
 export const version: string;
 
 export interface HtmxConfig {
+    /** whether or not htmx should be initialized automatically when DOM is ready */
+    autoStart?: boolean;
     /** array of strings: the attributes to settle during the settling phase */
     attributesToSettle?: ["class", "style", "width", "height"] | string[];
     /** if the focused element should be scrolled into view */

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3670,7 +3670,6 @@ return (function () {
 
             mergeMetaConfig();
             insertIndicatorStyles();
-            processNode(body);
 
             body.addEventListener("htmx:abort", function (evt) {
                 var target = evt.target;
@@ -3699,6 +3698,7 @@ return (function () {
             };
 
             setTimeout(function () {
+                processNode(body);
                 triggerEvent(body, 'htmx:load', {}); // give ready handlers a chance to load up before firing this event
                 body = null; // kill reference for gc
             }, 0);

--- a/www/content/api.md
+++ b/www/content/api.md
@@ -103,6 +103,7 @@ Note that using a [meta tag](@/docs.md#config) is the preferred mechanism for se
 
 ##### Properties
 
+* `autoStart:true` - boolean: whether or not htmx should be initialized automatically when DOM is ready. If htmx is loaded as module this defaults to `false` and you must initialize htmx manually by calling `htmx.start()`
 * `attributesToSettle:["class", "style", "width", "height"]` - array of strings: the attributes to settle during the settling phase
 * `defaultSettleDelay:20` - int: the default delay between completing the content swap and settling attributes
 * `defaultSwapDelay:0` - int: the default delay between receiving a response from the server and doing the swap
@@ -228,6 +229,19 @@ or
 
     // find all paragraphs within a given div
     var allParagraphsInMyDiv = htmx.findAll(htmx.find("#my-div"), "p")
+```
+
+### Method - `htmx.start()` {#start}
+
+When htmx is imported as a module, this function must be called to initialize it.
+
+##### Example
+
+```js
+    import htmx from 'htmx.org';
+    import '<extensions>';
+
+    htmx.start();
 ```
 
 ### Method - `htmx.logAll()` {#logAll}

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -132,44 +132,34 @@ and include it where necessary with a `<script>` tag:
 
 You can also add extensions this way, by downloading them from the `ext/` directory.
 
-### npm
+### As a Module
 
-For npm-style build systems, you can install htmx via [npm](https://www.npmjs.com/):
+You can install htmx via NPM or Yarn and import it into a bundle.
+
+Install via [npm](https://www.npmjs.com/):
 
 ```sh
-npm install htmx.org
+npm i htmx.org
 ```
 
-After installing, you’ll need to use appropriate tooling to use `node_modules/htmx.org/dist/htmx.js` (or `.min.js`).
-For example, you might bundle htmx with some extensions and project-specific code.
+Install via [yarn](https://yarnpkg.com/):
 
-### Webpack
+```sh
+yarn add htmx.org
+```
 
-If you are using webpack to manage your javascript:
-
-* Install `htmx` via your favourite package manager (like npm or yarn)
-* Add the import to your `index.js`
+Now import htmx into your bundle and initialize it like so:
 
 ```js
-import 'htmx.org';
+import htmx from 'htmx.org';
+import '<extensions>'
+
+window.htmx = htmx;
+
+htmx.start();
 ```
-
-If you want to use the global `htmx` variable (recommended), you need to inject it to the window scope:
-
-* Create a custom JS file
-* Import this file to your `index.js` (below the import from step 2)
-
-```js
-import 'path/to/my_custom.js';
-```
-
-* Then add this code to the file:
-
-```js
-window.htmx = require('htmx.org');
-```
-
-* Finally, rebuild your bundle
+>The window.htmx = htmx is optional, but is nice to have for freedom and flexibility.
+>If you have imported htmx into a bundle, you must ensure that you have imported or registered any extension after the import of htmx and before the initialization `htmx.start()`.
 
 ## AJAX
 


### PR DESCRIPTION
As discussed in #1469, when using htmx in a module environment, some internal extensions, such as `preload`, do not work properly. This is because htmx initializes itself on DOM ready, while the extensions become available later in the lifecycle. Therefore, it is necessary to disable the auto-initialization of htmx in these environments and expose a new API function `htmx.start()` to initialize htmx manually.

```js
import htmx from 'htmx.org';
import <extensions>

htmx.start();
```

Related Issue: #1469