### PR TITLE
Preload extension: Include preloaded node as 'source' for preload so hx-sync/queue works properly

### DIFF
--- a/src/ext/preload.js
+++ b/src/ext/preload.js
@@ -48,9 +48,12 @@ htmx.defineExtension("preload", {
 				// in the future
 				var hxGet = node.getAttribute("hx-get") || node.getAttribute("data-hx-get")
 				if (hxGet) {
-					htmx.ajax("GET", hxGet, {handler:function(elt, info) {
-						done(info.xhr.responseText);
-					}});
+					htmx.ajax("GET", hxGet, {
+						source: node,
+						handler:function(elt, info) {
+							done(info.xhr.responseText);
+						}
+					});
 					return;
 				}
 


### PR DESCRIPTION
I found that when using the `preload="preload:init"` attribute some requests were being dropped. Without the source element, the `body` is used for queuing and `hx-sync` can't be used to override the element.

FYI @benpate 