### PR TITLE
Add logNone function and apply it to tests

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -44,6 +44,7 @@ return (function () {
             defineExtension : defineExtension,
             removeExtension : removeExtension,
             logAll : logAll,
+            logNone : logNone,
             logger : null,
             config : {
                 historyEnabled:true,
@@ -473,6 +474,10 @@ return (function () {
                     console.log(event, elt, data);
                 }
             }
+        }
+
+        function logNone() {
+            htmx.logger = null
         }
 
         function find(eltOrSelector, selector) {

--- a/test/attributes/hx-boost.js
+++ b/test/attributes/hx-boost.js
@@ -1,6 +1,5 @@
 describe("hx-boost attribute", function() {
 
-    htmx.logAll();
     beforeEach(function () {
         this.server = makeServer();
         clearWorkArea();

--- a/test/core/api.js
+++ b/test/core/api.js
@@ -241,13 +241,13 @@ describe("Core htmx API test", function(){
         div3.classList.contains("foo").should.equal(true);
     });
 
-    it('logAll works', function () {
-        var initialLogger = htmx.config.logger
-        try {
-            htmx.logAll();
-        } finally {
-            htmx.config.logger = initialLogger;
-        }
+    it('logAll and logNone works', function () {
+        var initialLogger = htmx.logger
+        htmx.logAll();
+        htmx.logger.should.not.equal(null);
+        htmx.logNone();
+        should.equal(htmx.logger, null);
+        htmx.logger = initialLogger;
     });
 
     it('eval can be suppressed', function () {

--- a/test/core/regressions.js
+++ b/test/core/regressions.js
@@ -130,7 +130,6 @@ describe("Core htmx Regression Tests", function(){
 
     it('a form can reset based on the htmx:afterRequest event', function() {
         this.server.respondWith("POST", "/test", "posted");
-        //htmx.logAll();
 
         var form = make('<div id="d1"></div><form _="on htmx:afterRequest reset() me" hx-post="/test" hx-target="#d1">' +
             '  <input type="text" name="input" id="i1"/>' +
@@ -174,7 +173,6 @@ describe("Core htmx Regression Tests", function(){
 
     it("supports unset on hx-select", function(){
         this.server.respondWith("GET", "/test", "Foo<span id='example'>Bar</span>");
-        htmx.logAll();
         make('<form hx-select="#example">\n' +
             '      <button id="b1" hx-select="unset" hx-get="/test">Initial</button>\n' +
             '</form>')

--- a/www/content/api.md
+++ b/www/content/api.md
@@ -240,6 +240,16 @@ Log all htmx events, useful for debugging.
     htmx.logAll();
 ```
 
+### Method - `htmx.logNone()` {#logNone}
+
+Log no htmx events, call this to turn off the debugger if you previously enabled it.
+
+##### Example
+
+```js
+    htmx.logNone();
+```
+
 ### Property - `htmx.logger` {#logger}
 
 The logger htmx uses to log with


### PR DESCRIPTION
## Summary
New function to turn off the logger after using `logAll()`. I applied to this to the tests as well so that `logAll()` is only used in the specfic places where debug output is required. This makes the console output of the tests dramatically more useful when run from the command line.

## Testing
Compare the two console outputs for the tests. Because the new one doesn't log every single `htmx` event, the (existing) errors are more obvious.