### PR TITLE
Disable hx-indicator while performing preload ajax requests

### DIFF
--- a/src/ext/preload.js
+++ b/src/ext/preload.js
@@ -48,12 +48,20 @@ htmx.defineExtension("preload", {
 				// in the future
 				var hxGet = node.getAttribute("hx-get") || node.getAttribute("data-hx-get")
 				if (hxGet) {
+					var previousIndicator = node.getAttribute("hx-indicator");
+					node.setAttribute("hx-indicator", "")
+
 					htmx.ajax("GET", hxGet, {
 						source: node,
 						handler:function(elt, info) {
 							done(info.xhr.responseText);
 						}
 					});
+					if(previousIndicator) {
+						node.setAttribute("hx-indicator", previousIndicator)
+					} else {
+						node.removeAttribute("hx-indicator")
+					}
 					return;
 				}
 


### PR DESCRIPTION
Currently preload ajax requests trigger the configured 'hx-indicator', however when preloading that doesn't necessarily make sense. This change ensures that no hx-indicator is triggered during preload, while preserving any configured hx-indicator for regular htmx activities.