### PR TITLE
[Bugfix] Encode DELETE payload as URL params like GET, instead of using body

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3001,7 +3001,7 @@ return (function () {
             var pathNoAnchor = splitPath[0];
             var anchor = splitPath[1];
             var finalPathForGet = null;
-            if (verb === 'get') {
+            if (verb === 'get' || verb === 'delete') {
                 finalPathForGet = pathNoAnchor;
                 var values = Object.keys(filteredParameters).length !== 0;
                 if (values) {
@@ -3015,7 +3015,7 @@ return (function () {
                         finalPathForGet += "#" + anchor;
                     }
                 }
-                xhr.open('GET', finalPathForGet, true);
+                xhr.open(verb.toUpperCase(), finalPathForGet, true);
             } else {
                 xhr.open(verb.toUpperCase(), path, true);
             }


### PR DESCRIPTION
Currently, htmx sends values in the request body for DELETE requests.
While this seems to be _allowed_, the [RFC](https://www.rfc-editor.org/rfc/rfc7231#section-4.3.5) says:
>  A payload within a DELETE request message has no defined semantics;
   sending a payload body on a DELETE request might cause some existing
   implementations to reject the request.

And this is exactly what happens with a Golang backend. As [its doc](https://pkg.go.dev/net/http#Request.ParseForm) says: 
> For POST, PUT, and PATCH requests, it also reads the request body, parses it as a form [...]
> For other HTTP methods, or when the Content-Type is not application/x-www-form-urlencoded, the request Body is not read

A simple fix here is to handle DELETE requests like GET requests in the core, so the parameters get URL encoded instead, then any backend would handle those DELETE requests as expected