### PR TITLE
Add support for from: modifier on intersect events

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1766,6 +1766,7 @@ return (function () {
                 maybeReveal(elt);
             } else if (triggerSpec.trigger === "intersect") {
                 var observerOptions = {};
+                const from = triggerSpec.from ? querySelectorExt(elt, triggerSpec.from) : elt;
                 if (triggerSpec.root) {
                     observerOptions.root = querySelectorExt(elt, triggerSpec.root)
                 }
@@ -1776,12 +1777,12 @@ return (function () {
                     for (var i = 0; i < entries.length; i++) {
                         var entry = entries[i];
                         if (entry.isIntersecting) {
-                            triggerEvent(elt, "intersect");
+                            triggerEvent(from, "intersect");
                             break;
                         }
                     }
                 }, observerOptions);
-                observer.observe(elt);
+                observer.observe(from);
                 addEventListener(elt, handler, nodeData, triggerSpec);
             } else if (triggerSpec.trigger === "load") {
                 if (!maybeFilterEvent(triggerSpec, elt, makeEvent("load", {elt: elt}))) {


### PR DESCRIPTION
This would allow you to do infinite scroll with better locality of behaviour, by putting the attribs on the list itself:

```HTML
<ul id="tweets"
    hx-get="/api/moretweetspls/"
    hx-swap="beforeend"
    hx-include="#tweets li:last-child"
    hx-trigger="intersect from:footer"
>

    <div class="tweet">
        <input hidden name="timestamp" value="123456789"/>
    </div>

    <div class="tweet">
        <input hidden name="timestamp" value="123456788"/>
    </div>

</ul>

<footer>mAdE wItH &#10084; In dUdErStaDt</footer>
```

thx