### PR TITLE
Cache evaluated trigger specs

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1250,6 +1250,9 @@ return (function () {
 
         var INPUT_SELECTOR = 'input, textarea, select';
 
+        /** @type {Object<string, import("./htmx").HtmxTriggerSpecification[]>} */
+        let triggerSpecsCache = {}
+
         /**
          * @param {HTMLElement} elt
          * @returns {import("./htmx").HtmxTriggerSpecification[]}
@@ -1257,7 +1260,17 @@ return (function () {
         function getTriggerSpecs(elt) {
             var explicitTrigger = getAttributeValue(elt, 'hx-trigger');
             var triggerSpecs = [];
-            if (explicitTrigger) {
+            var shouldEvaluateTrigger = !!explicitTrigger
+            if (shouldEvaluateTrigger) {
+                var cachedTriggerSpecs = triggerSpecsCache[explicitTrigger]
+                if (cachedTriggerSpecs) {
+                    cachedTriggerSpecs.forEach(function(cachedTriggerSpec) {
+                        triggerSpecs.push(cachedTriggerSpec)
+                    })
+                    shouldEvaluateTrigger = false
+                }
+            }
+            if (shouldEvaluateTrigger) {
                 var tokens = tokenizeString(explicitTrigger);
                 do {
                     consumeUntil(tokens, NOT_WHITESPACE);
@@ -1337,6 +1350,10 @@ return (function () {
                     }
                     consumeUntil(tokens, NOT_WHITESPACE);
                 } while (tokens[0] === "," && tokens.shift())
+                triggerSpecsCache[explicitTrigger] = []
+                triggerSpecs.forEach(function (triggerSpec) {
+                    triggerSpecsCache[explicitTrigger].push(triggerSpec)
+                })
             }
 
             if (triggerSpecs.length > 0) {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1261,12 +1261,12 @@ return (function () {
             var explicitTrigger = getAttributeValue(elt, 'hx-trigger');
             var triggerSpecs = [];
             var shouldEvaluateTrigger = !!explicitTrigger
+            // If an explicit trigger attribute is set, check if it has already been computed & cached
             if (shouldEvaluateTrigger) {
                 var cachedTriggerSpecs = triggerSpecsCache[explicitTrigger]
                 if (cachedTriggerSpecs) {
-                    cachedTriggerSpecs.forEach(function(cachedTriggerSpec) {
-                        triggerSpecs.push(cachedTriggerSpec)
-                    })
+                    triggerSpecs = cachedTriggerSpecs
+                    // If it had already been cached, we don't need to evaluate the trigger expression anymore
                     shouldEvaluateTrigger = false
                 }
             }
@@ -1350,10 +1350,7 @@ return (function () {
                     }
                     consumeUntil(tokens, NOT_WHITESPACE);
                 } while (tokens[0] === "," && tokens.shift())
-                triggerSpecsCache[explicitTrigger] = []
-                triggerSpecs.forEach(function (triggerSpec) {
-                    triggerSpecsCache[explicitTrigger].push(triggerSpec)
-                })
+                triggerSpecsCache[explicitTrigger] = triggerSpecs
             }
 
             if (triggerSpecs.length > 0) {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1255,22 +1255,11 @@ return (function () {
 
         /**
          * @param {HTMLElement} elt
+         * @param {string} explicitTrigger
          * @returns {import("./htmx").HtmxTriggerSpecification[]}
          */
-        function getTriggerSpecs(elt) {
-            var explicitTrigger = getAttributeValue(elt, 'hx-trigger');
+        function parseAndCacheTrigger(elt, explicitTrigger) {
             var triggerSpecs = [];
-            var shouldEvaluateTrigger = !!explicitTrigger
-            // If an explicit trigger attribute is set, check if it has already been computed & cached
-            if (shouldEvaluateTrigger) {
-                var cachedTriggerSpecs = triggerSpecsCache[explicitTrigger]
-                if (cachedTriggerSpecs) {
-                    triggerSpecs = cachedTriggerSpecs
-                    // If it had already been cached, we don't need to evaluate the trigger expression anymore
-                    shouldEvaluateTrigger = false
-                }
-            }
-            if (shouldEvaluateTrigger) {
                 var tokens = tokenizeString(explicitTrigger);
                 do {
                     consumeUntil(tokens, NOT_WHITESPACE);
@@ -1351,6 +1340,18 @@ return (function () {
                     consumeUntil(tokens, NOT_WHITESPACE);
                 } while (tokens[0] === "," && tokens.shift())
                 triggerSpecsCache[explicitTrigger] = triggerSpecs
+                return triggerSpecs
+        }
+
+        /**
+         * @param {HTMLElement} elt
+         * @returns {import("./htmx").HtmxTriggerSpecification[]}
+         */
+        function getTriggerSpecs(elt) {
+            var explicitTrigger = getAttributeValue(elt, 'hx-trigger');
+            var triggerSpecs = [];
+            if (explicitTrigger) {
+                triggerSpecs = triggerSpecsCache[explicitTrigger] || parseAndCacheTrigger(elt, explicitTrigger)
             }
 
             if (triggerSpecs.length > 0) {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1337,8 +1337,9 @@ return (function () {
                     }
                     consumeUntil(tokens, NOT_WHITESPACE);
                 } while (tokens[0] === "," && tokens.shift())
-                if (htmx.config.triggerSpecsCache) {
-                    htmx.config.triggerSpecsCache[explicitTrigger] = triggerSpecs
+                var cache = htmx.config.triggerSpecsCache
+                if (cache) {
+                    cache[explicitTrigger] = triggerSpecs
                 }
                 return triggerSpecs
         }
@@ -1351,8 +1352,8 @@ return (function () {
             var explicitTrigger = getAttributeValue(elt, 'hx-trigger');
             var triggerSpecs = [];
             if (explicitTrigger) {
-                triggerSpecs = (htmx.config.triggerSpecsCache && htmx.config.triggerSpecsCache[explicitTrigger])
-                    || parseAndCacheTrigger(elt, explicitTrigger)
+                var cache = htmx.config.triggerSpecsCache
+                triggerSpecs = (cache && cache[explicitTrigger]) || parseAndCacheTrigger(elt, explicitTrigger)
             }
 
             if (triggerSpecs.length > 0) {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -76,7 +76,8 @@ return (function () {
                 methodsThatUseUrlParams: ["get"],
                 selfRequestsOnly: false,
                 ignoreTitle: false,
-                scrollIntoViewOnBoost: true
+                scrollIntoViewOnBoost: true,
+                triggerSpecsCache: null,
             },
             parseInterval:parseInterval,
             _:internalEval,
@@ -1250,9 +1251,6 @@ return (function () {
 
         var INPUT_SELECTOR = 'input, textarea, select';
 
-        /** @type {Object<string, import("./htmx").HtmxTriggerSpecification[]>} */
-        let triggerSpecsCache = {}
-
         /**
          * @param {HTMLElement} elt
          * @param {string} explicitTrigger
@@ -1339,7 +1337,9 @@ return (function () {
                     }
                     consumeUntil(tokens, NOT_WHITESPACE);
                 } while (tokens[0] === "," && tokens.shift())
-                triggerSpecsCache[explicitTrigger] = triggerSpecs
+                if (htmx.config.triggerSpecsCache) {
+                    htmx.config.triggerSpecsCache[explicitTrigger] = triggerSpecs
+                }
                 return triggerSpecs
         }
 
@@ -1351,7 +1351,8 @@ return (function () {
             var explicitTrigger = getAttributeValue(elt, 'hx-trigger');
             var triggerSpecs = [];
             if (explicitTrigger) {
-                triggerSpecs = triggerSpecsCache[explicitTrigger] || parseAndCacheTrigger(elt, explicitTrigger)
+                triggerSpecs = (htmx.config.triggerSpecsCache && htmx.config.triggerSpecsCache[explicitTrigger])
+                    || parseAndCacheTrigger(elt, explicitTrigger)
             }
 
             if (triggerSpecs.length > 0) {


### PR DESCRIPTION
When specifying a `hx-trigger` attribute, `getTriggerSpecs` tokenizes & parses the trigger spec string everytime it's called.
This isn't an issue for most cases, but it performs poorly when operating on a large set of elements.
- In [this JSFiddle](https://jsfiddle.net/8fqzdyba/), using the current state of the lib _(open the developer console to see the logged execution times)_
I get in average the following:
```GetTriggerSpecs:  140 ms, called 2001 times```
- In [this JSFiddle](https://jsfiddle.net/wauz2f0g/) with the system I'm proposing here, I now get in average the following: 
```GetTriggerSpecs:  3 ms, called 2001 times```

The example code here is simply letting htmx initialize 2 000 divs, that have the exact same hx-trigger specified, which is in this example `hx-trigger="click[!ctrlKey&&!shiftKey&&!altKey]`

This example isn't taken out of nowhere, it's actually a real use case I have on [Zorro](https://zorro.management), where a board could totally have 2 000 tasks (and more) at once. I'm using this exact `hx-trigger` specifier for every task that opens a details tab for the clicked task _(excluding shift/alt/ctrl clicks that have selection behaviours and shouldn't trigger a request)_.

The suggested change here helps cutting down initial page load times, which contributes to user experience.

Given that there aren't _that many_ possible hx-trigger specifications (there is technically a defined number of available events & modifiers), I think the added memory footprint of storing an extra copy is negligible, thus I suggest this system of caching the evaluated triggers to skip the tokenization & parsing whenever possible.

Didn't break any test when I ran them locally but let me know if I missed something