### PR TITLE
[Performance] Fast path to resolve body selector

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -589,6 +589,8 @@ return (function () {
                 return [document];
             } else if (selector === 'window') {
                 return [window];
+            } else if (selector === 'body') {
+                return [document.body];
             } else {
                 return getDocument().querySelectorAll(normalizeSelector(selector));
             }


### PR DESCRIPTION
It's a pretty common pattern to define trigger events using the `from:body` syntax.

The issue: this "body" selector currently results in a call to `document.querySelectorAll` inside [`querySelectorAllExt`](https://github.com/bigskysoftware/htmx/blob/master/src/htmx.js#L591)

While this may seem a negligible thing, it turns out that on large HTML pages, this makes the initial page load & parsing way slower.
- In [this JSFiddle](https://jsfiddle.net/Lysqa2m9/), using the current state of the lib _(open the developer console to see the logged execution times)_, I get in average the following:
`querySelectorAllExt called 5000 times with 'body', took 180 ms`
- In [this JSFiddle](https://jsfiddle.net/gcdhs27w/), using the suggested change, I get in average the following:
`querySelectorAllExt called 5000 times with 'body', took 3.5 ms`

The example code here is simply letting htmx initialize 5 000 divs, that have the exact same hx-trigger specified, which is in this example `hx-trigger="customEvent from:body"`

While it is negligible on a typical HTML page where you wouldn't have thousands of divs, this example isn't taken out of nowhere, it's actually a real use case I have on [Zorro](https://zorro.management), where a board could totally have thousands of tasks at once.
I'm using a similar `hx-trigger` specifier for every task to trigger individual refreshes on some actions, such as `hx-trigger="refreshTask{{ .ID }} from:body"`.

The suggested change here helps cutting down initial page load times, which contributes to user experience.
The cost is simply 2 more lines of code in the core.