### PR TITLE
[Bugfix] Fix submit buttons/inputs handling

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2316,6 +2316,29 @@ return (function () {
             return true;
         }
 
+        function addValueToValues(name, value, values) {
+            // This is a little ugly because both the current value of the named value in the form
+            // and the new value could be arrays, so we have to handle all four cases :/
+            if (name != null && value != null) {
+                var current = values[name];
+                if (current === undefined) {
+                    values[name] = value;
+                } else if (Array.isArray(current)) {
+                    if (Array.isArray(value)) {
+                        values[name] = current.concat(value);
+                    } else {
+                        current.push(value);
+                    }
+                } else {
+                    if (Array.isArray(value)) {
+                        values[name] = [current].concat(value);
+                    } else {
+                        values[name] = [current, value];
+                    }
+                }
+            }
+        }
+
         function processInputValue(processed, values, errors, elt, validate) {
             if (elt == null || haveSeenNode(processed, elt)) {
                 return;
@@ -2332,28 +2355,7 @@ return (function () {
                 if (elt.files) {
                     value = toArray(elt.files);
                 }
-                // This is a little ugly because both the current value of the named value in the form
-                // and the new value could be arrays, so we have to handle all four cases :/
-                if (name != null && value != null) {
-                    var current = values[name];
-                    if (current !== undefined) {
-                        if (Array.isArray(current)) {
-                            if (Array.isArray(value)) {
-                                values[name] = current.concat(value);
-                            } else {
-                                current.push(value);
-                            }
-                        } else {
-                            if (Array.isArray(value)) {
-                                values[name] = [current].concat(value);
-                            } else {
-                                values[name] = [current, value];
-                            }
-                        }
-                    } else {
-                        values[name] = value;
-                    }
-                }
+                addValueToValues(name, value, values);
                 if (validate) {
                     validateElement(elt, errors);
                 }
@@ -2422,17 +2424,8 @@ return (function () {
             if (internalData.lastButtonClicked || elt.tagName === "BUTTON" ||
                 (elt.tagName === "INPUT" && getRawAttribute(elt, "type") === "submit")) {
                 var button = internalData.lastButtonClicked || elt
-                var name = getRawAttribute(button, "name");
-                if (name) {
-                    var currentValue = values[name]
-                    if (typeof currentValue === "undefined") {
-                        values[name] = button.value
-                    } else if (Array.isArray(currentValue)) {
-                        values[name].push(button.value)
-                    } else {
-                        values[name] = [currentValue, button.value];
-                    }
-                }
+                var name = getRawAttribute(button, "name")
+                addValueToValues(name, button.value, values)
             }
 
             return {errors:errors, values:values};

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1833,6 +1833,10 @@ return (function () {
             });
         }
 
+        function hasChanceOfBeingBoosted() {
+            return document.querySelector("[hx-boost], [data-hx-boost]");
+        }
+
         function findHxOnWildcardElements(elt) {
             if (!document.evaluate) return []
 
@@ -1845,7 +1849,8 @@ return (function () {
 
         function findElementsToProcess(elt) {
             if (elt.querySelectorAll) {
-                var results = elt.querySelectorAll(VERB_SELECTOR + ", a, form, [type='submit'], [hx-sse], [data-hx-sse], [hx-ws]," +
+                var boostedElts = hasChanceOfBeingBoosted() ? ", a" : "";
+                var results = elt.querySelectorAll(VERB_SELECTOR + boostedElts + ", form, [type='submit'], [hx-sse], [data-hx-sse], [hx-ws]," +
                     " [data-hx-ws], [hx-ext], [data-hx-ext], [hx-trigger], [data-hx-trigger], [hx-on], [data-hx-on]");
                 return results;
             } else {
@@ -1948,26 +1953,9 @@ return (function () {
             }
         }
 
-        function hasAttributeNameStartsWith(elt, prefix) {
-            for (var i = 0; i < elt.attributes.length; i++) {
-                if (elt.attributes[i].name.indexOf(prefix) === 0) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
         function initNode(elt) {
             if (elt.closest && elt.closest(htmx.config.disableSelector)) {
                 return;
-            }
-            // skip links or forms without hx-* attributes or not nested into hx-boost or hx-ext
-            if ((elt.tagName === 'FORM' || elt.tagName === 'A') &&
-                !hasAttributeNameStartsWith(elt, 'hx-') && !hasAttributeNameStartsWith(elt, 'data-hx-')) {
-                if ((elt.tagName === 'FORM' && !elt.closest('[hx-boost],[data-hx-boost],[hx-ext],[data-hx-ext]')) ||
-                    (elt.tagName === 'A' && !elt.closest('[hx-boost],[data-hx-boost]'))) {
-                    return;
-                }
             }
             var nodeData = getInternalData(elt);
             if (nodeData.initHash !== attributeHash(elt)) {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1845,7 +1845,7 @@ return (function () {
 
         function findElementsToProcess(elt) {
             if (elt.querySelectorAll) {
-                var results = elt.querySelectorAll(VERB_SELECTOR + ", a, form, [type='submit']" + ", [hx-sse], [data-hx-sse], [hx-ws]," +
+                var results = elt.querySelectorAll(VERB_SELECTOR + ", a, form, [type='submit'], [hx-sse], [data-hx-sse], [hx-ws]," +
                     " [data-hx-ws], [hx-ext], [data-hx-ext], [hx-trigger], [data-hx-trigger], [hx-on], [data-hx-on]");
                 return results;
             } else {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2404,6 +2404,14 @@ return (function () {
             // include the element itself
             processInputValue(processed, values, errors, elt, validate);
 
+            // if a button or submit was clicked last, include its value
+            if (internalData.lastButtonClicked || elt.tagName === "BUTTON" ||
+                (elt.tagName === "INPUT" && getRawAttribute(elt, "type") === "submit")) {
+                var button = internalData.lastButtonClicked || elt
+                var name = getRawAttribute(button, "name")
+                addValueToValues(name, button.value, formValues)
+            }
+
             // include any explicit includes
             var includes = findAttributeTargets(elt, "hx-include");
             forEach(includes, function(node) {
@@ -2418,15 +2426,6 @@ return (function () {
 
             // form values take precedence, overriding the regular values
             values = mergeObjects(values, formValues);
-
-            // if a button or submit was clicked last, include its value
-            // clicked button value shouldn't override nor be overridden, and stack with any existing value
-            if (internalData.lastButtonClicked || elt.tagName === "BUTTON" ||
-                (elt.tagName === "INPUT" && getRawAttribute(elt, "type") === "submit")) {
-                var button = internalData.lastButtonClicked || elt
-                var name = getRawAttribute(button, "name")
-                addValueToValues(name, button.value, values)
-            }
 
             return {errors:errors, values:values};
         }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1948,9 +1948,26 @@ return (function () {
             }
         }
 
+        function hasAttributeNameStartsWith(elt, prefix) {
+            for (var i = 0; i < elt.attributes.length; i++) {
+                if (elt.attributes[i].name.indexOf(prefix) === 0) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         function initNode(elt) {
             if (elt.closest && elt.closest(htmx.config.disableSelector)) {
                 return;
+            }
+            // skip links or forms without hx-* attributes or not nested into hx-boost or hx-ext
+            if ((elt.tagName === 'FORM' || elt.tagName === 'A') &&
+                !hasAttributeNameStartsWith(elt, 'hx-') && !hasAttributeNameStartsWith(elt, 'data-hx-')) {
+                if ((elt.tagName === 'FORM' && !elt.closest('[hx-boost],[data-hx-boost],[hx-ext],[data-hx-ext]')) ||
+                    (elt.tagName === 'A' && !elt.closest('[hx-boost],[data-hx-boost]'))) {
+                    return;
+                }
             }
             var nodeData = getInternalData(elt);
             if (nodeData.initHash !== attributeHash(elt)) {

--- a/test/core/ajax.js
+++ b/test/core/ajax.js
@@ -989,4 +989,199 @@ describe("Core htmx AJAX Tests", function(){
         btn.innerHTML.should.equal('<with:colon id="foobar">Foobar</with:colon>');
     });
 
+    it('properly handles clicked submit button with a value inside a htmx form', function () {
+        var values;
+        this.server.respondWith("Post", "/test", function (xhr) {
+            values = getParameters(xhr);
+            xhr.respond(204, {}, "");
+        });
+
+        make('<form hx-post="/test">' +
+            '<input type="text" name="t1" value="textValue">' +
+            '<button id="submit" type="submit" name="b1" value="buttonValue">button</button>' +
+            '</form>');
+
+        byId("submit").click();
+        this.server.respond();
+        values.should.deep.equal({t1: 'textValue', b1: 'buttonValue'});
+    })
+
+    it('properly handles clicked submit input with a value inside a htmx form', function () {
+        var values;
+        this.server.respondWith("Post", "/test", function (xhr) {
+            values = getParameters(xhr);
+            xhr.respond(204, {}, "");
+        });
+
+        make('<form hx-post="/test">' +
+            '<input type="text" name="t1" value="textValue">' +
+            '<input id="submit" type="submit" name="b1" value="buttonValue">' +
+            '</form>');
+
+        byId("submit").click();
+        this.server.respond();
+        values.should.deep.equal({t1: 'textValue', b1: 'buttonValue'});
+    })
+
+    it('properly handles clicked submit button with a value inside a non-htmx form', function () {
+        var values;
+        this.server.respondWith("Post", "/test", function (xhr) {
+            values = getParameters(xhr);
+            xhr.respond(204, {}, "");
+        });
+
+        make('<form>' +
+            '<input type="text" name="t1" value="textValue">' +
+            '<button id="submit" type="submit" name="b1" value="buttonValue" hx-post="/test">button</button>' +
+            '</form>');
+
+        byId("submit").click();
+        this.server.respond();
+        values.should.deep.equal({t1: 'textValue', b1: 'buttonValue'});
+    })
+
+    it('properly handles clicked submit input with a value inside a non-htmx form', function () {
+        var values;
+        this.server.respondWith("Post", "/test", function (xhr) {
+            values = getParameters(xhr);
+            xhr.respond(204, {}, "");
+        });
+
+        make('<form>' +
+            '<input type="text" name="t1" value="textValue">' +
+            '<input id="submit" type="submit" name="b1" value="buttonValue" hx-post="/test">' +
+            '</form>');
+
+        byId("submit").click();
+        this.server.respond();
+        values.should.deep.equal({t1: 'textValue', b1: 'buttonValue'});
+    })
+
+    it('properly handles clicked submit button with a value outside a htmx form', function () {
+        var values;
+        this.server.respondWith("Post", "/test", function (xhr) {
+            values = getParameters(xhr);
+            xhr.respond(204, {}, "");
+        });
+
+        make('<form id="externalForm" hx-post="/test">' +
+            '<input type="text" name="t1" value="textValue">' +
+            '</form>' +
+            '<button id="submit" form="externalForm" type="submit" name="b1" value="buttonValue">button</button>');
+
+        byId("submit").click();
+        this.server.respond();
+        values.should.deep.equal({t1: 'textValue', b1: 'buttonValue'});
+    })
+
+    it('properly handles clicked submit input with a value outside a htmx form', function () {
+        var values;
+        this.server.respondWith("Post", "/test", function (xhr) {
+            values = getParameters(xhr);
+            xhr.respond(204, {}, "");
+        });
+
+        make('<form id="externalForm" hx-post="/test">' +
+            '<input type="text" name="t1" value="textValue">' +
+            '</form>' +
+            '<input id="submit" form="externalForm" type="submit" name="b1" value="buttonValue">');
+
+        byId("submit").click();
+        this.server.respond();
+        values.should.deep.equal({t1: 'textValue', b1: 'buttonValue'});
+    })
+
+    it('properly handles clicked submit button with a value stacking with regular input', function () {
+        var values;
+        this.server.respondWith("Post", "/test", function (xhr) {
+            values = getParameters(xhr);
+            xhr.respond(204, {}, "");
+        });
+
+        make('<form hx-post="/test">' +
+            '<input type="hidden" name="action" value="A">' +
+            '<button id="btnA" type="submit">A</button>' +
+            '<button id="btnB" type="submit" name="action" value="B">B</button>' +
+            '<button id="btnC" type="submit" name="action" value="C">C</button>' +
+            '</form>');
+
+        byId("btnA").click();
+        this.server.respond();
+        values.should.deep.equal({action: 'A'});
+
+        byId("btnB").click();
+        this.server.respond();
+        values.should.deep.equal({action: ['A', 'B']});
+
+        byId("btnC").click();
+        this.server.respond();
+        values.should.deep.equal({action: ['A', 'C']});
+    })
+
+    it('properly handles clicked submit input with a value stacking with regular input', function () {
+        var values;
+        this.server.respondWith("Post", "/test", function (xhr) {
+            values = getParameters(xhr);
+            xhr.respond(204, {}, "");
+        });
+
+        make('<form hx-post="/test">' +
+            '<input type="hidden" name="action" value="A">' +
+            '<input id="btnA" type="submit">A</input>' +
+            '<input id="btnB" type="submit" name="action" value="B">B</input>' +
+            '<input id="btnC" type="submit" name="action" value="C">C</input>' +
+            '</form>');
+
+        byId("btnA").click();
+        this.server.respond();
+        values.should.deep.equal({action: 'A'});
+
+        byId("btnB").click();
+        this.server.respond();
+        values.should.deep.equal({action: ['A', 'B']});
+
+        byId("btnC").click();
+        this.server.respond();
+        values.should.deep.equal({action: ['A', 'C']});
+    })
+
+    it('properly handles clicked submit button with a value inside a form, referencing another form', function () {
+        var values;
+        this.server.respondWith("Post", "/test", function (xhr) {
+            values = getParameters(xhr);
+            xhr.respond(204, {}, "");
+        });
+
+        make('<form id="externalForm" hx-post="/test">' +
+            '<input type="text" name="t1" value="textValue">' +
+            '<input type="hidden" name="b1" value="inputValue">' +
+            '</form>' +
+            '<form hx-post="/test2">' +
+            '<button id="submit" form="externalForm" type="submit" name="b1" value="buttonValue">button</button>' +
+            '</form>');
+
+        byId("submit").click();
+        this.server.respond();
+        values.should.deep.equal({t1: 'textValue', b1: ['inputValue', 'buttonValue']});
+    })
+
+    it('properly handles clicked submit input with a value inside a form, referencing another form', function () {
+        var values;
+        this.server.respondWith("Post", "/test", function (xhr) {
+            values = getParameters(xhr);
+            xhr.respond(204, {}, "");
+        });
+
+        make('<form id="externalForm" hx-post="/test">' +
+            '<input type="text" name="t1" value="textValue">' +
+            '<input type="hidden" name="b1" value="inputValue">' +
+            '</form>' +
+            '<form hx-post="/test2">' +
+            '<input id="submit" form="externalForm" type="submit" name="b1" value="buttonValue">' +
+            '</form>');
+
+        byId("submit").click();
+        this.server.respond();
+        values.should.deep.equal({t1: 'textValue', b1: ['inputValue', 'buttonValue']});
+    })
 })

--- a/test/ext/ws.js
+++ b/test/ext/ws.js
@@ -327,4 +327,162 @@ describe("web-sockets extension", function () {
 
         htmx.off("htmx:wsAfterMessage", handle)
     })
+
+    it('sends data to the server with non-htmx form + submit button & value', function () {
+        make('<form hx-ext="ws" ws-connect="ws://localhost:8080" ws-send>' +
+            '<input type="hidden" name="foo" value="bar">' +
+            '<button id="b1" type="submit" name="action" value="A">A</button>' +
+            '<button id="b2" type="submit" name="action" value="B">B</button>' +
+            '</form>');
+        this.tickMock();
+
+        byId("b1").click();
+
+        this.tickMock();
+
+        this.messages.length.should.equal(1);
+        this.messages[0].should.contains('"foo":"bar"')
+        this.messages[0].should.contains('"action":"A"')
+
+        byId("b2").click();
+
+        this.tickMock();
+
+        this.messages.length.should.equal(2);
+        this.messages[1].should.contains('"foo":"bar"')
+        this.messages[1].should.contains('"action":"B"')
+    })
+
+    it('sends data to the server with non-htmx form + submit input & value', function () {
+        make('<form hx-ext="ws" ws-connect="ws://localhost:8080" ws-send>' +
+            '<input type="hidden" name="foo" value="bar">' +
+            '<input id="b1" type="submit" name="action" value="A">' +
+            '<input id="b2" type="submit" name="action" value="B">' +
+            '</form>');
+        this.tickMock();
+
+        byId("b1").click();
+
+        this.tickMock();
+
+        this.messages.length.should.equal(1);
+        this.messages[0].should.contains('"foo":"bar"')
+        this.messages[0].should.contains('"action":"A"')
+
+        byId("b2").click();
+
+        this.tickMock();
+
+        this.messages.length.should.equal(2);
+        this.messages[1].should.contains('"foo":"bar"')
+        this.messages[1].should.contains('"action":"B"')
+    })
+
+    it('sends data to the server with child non-htmx form + submit button & value', function () {
+        make('<div hx-ext="ws" ws-connect="ws://localhost:8080">' +
+            '<form ws-send>' +
+            '<input type="hidden" name="foo" value="bar">' +
+            '<button id="b1" type="submit" name="action" value="A">A</button>' +
+            '<button id="b2" type="submit" name="action" value="B">B</button>' +
+            '</form>' +
+            '</div>');
+        this.tickMock();
+
+        byId("b1").click();
+
+        this.tickMock();
+
+        this.messages.length.should.equal(1);
+        this.messages[0].should.contains('"foo":"bar"')
+        this.messages[0].should.contains('"action":"A"')
+
+        byId("b2").click();
+
+        this.tickMock();
+
+        this.messages.length.should.equal(2);
+        this.messages[1].should.contains('"foo":"bar"')
+        this.messages[1].should.contains('"action":"B"')
+    })
+
+    it('sends data to the server with child non-htmx form + submit input & value', function () {
+        make('<div hx-ext="ws" ws-connect="ws://localhost:8080">' +
+            '<form ws-send>' +
+            '<input type="hidden" name="foo" value="bar">' +
+            '<input id="b1" type="submit" name="action" value="A">' +
+            '<input id="b2" type="submit" name="action" value="B">' +
+            '</form>' +
+            '</div>');
+        this.tickMock();
+
+        byId("b1").click();
+
+        this.tickMock();
+
+        this.messages.length.should.equal(1);
+        this.messages[0].should.contains('"foo":"bar"')
+        this.messages[0].should.contains('"action":"A"')
+
+        byId("b2").click();
+
+        this.tickMock();
+
+        this.messages.length.should.equal(2);
+        this.messages[1].should.contains('"foo":"bar"')
+        this.messages[1].should.contains('"action":"B"')
+    })
+
+    it('sends data to the server with external non-htmx form + submit button & value', function () {
+        make('<div hx-ext="ws" ws-connect="ws://localhost:8080">' +
+            '<form ws-send id="form">' +
+            '<input type="hidden" name="foo" value="bar">' +
+            '</form>' +
+            '</div>' +
+            '<button id="b1" form="form" type="submit" name="action" value="A">A</button>' +
+            '<button id="b2" form="form" type="submit" name="action" value="B">B</button>');
+        this.tickMock();
+
+        byId("b1").click();
+
+        this.tickMock();
+
+        this.messages.length.should.equal(1);
+        this.messages[0].should.contains('"foo":"bar"')
+        this.messages[0].should.contains('"action":"A"')
+
+        byId("b2").click();
+
+        this.tickMock();
+
+        this.messages.length.should.equal(2);
+        this.messages[1].should.contains('"foo":"bar"')
+        this.messages[1].should.contains('"action":"B"')
+    })
+
+    it('sends data to the server with external non-htmx form + submit input & value', function () {
+        make('<div hx-ext="ws" ws-connect="ws://localhost:8080">' +
+            '<form ws-send id="form">' +
+            '<input type="hidden" name="foo" value="bar">' +
+            '</form>' +
+            '</div>' +
+            '<input id="b1" form="form" type="submit" name="action" value="A">' +
+            '<input id="b2" form="form" type="submit" name="action" value="B">');
+        this.tickMock();
+
+        byId("b1").click();
+
+        this.tickMock();
+
+        this.messages.length.should.equal(1);
+        this.messages[0].should.contains('"foo":"bar"')
+        this.messages[0].should.contains('"action":"A"')
+
+        byId("b2").click();
+
+        this.tickMock();
+
+        this.messages.length.should.equal(2);
+        this.messages[1].should.contains('"foo":"bar"')
+        this.messages[1].should.contains('"action":"B"')
+    })
 });


### PR DESCRIPTION
The suggested changes should fix the following issues:
- #1506
=> values of clicked submit buttons defining a name/value pair, are now correctly included in the request payload
- #1120 
=> Submit buttons/inputs using the [`form attribute`](https://developer.mozilla.org/docs/Web/HTML/Element/button) and placed outside a form, are now correctly included in the request payload when clicked
- #971 / #970 / #1337 
=> `form`, `a` and `input type="submit"` are now processed by htmx not only when the element has `chanceOfBeingBoosted`. This fixes the issue where you had to put `hx-ext` on the form itself, otherwise the button's own value wouldn't be in the payload.
Also, this doesn't seem to do any harm since it doesn't impact the default behaviour when no htmx logic should happen.
    - `htmx:beforeProcessNode` and `htmx:afterProcessNode` are going to be dispatched
    - `processVerbs` won't do anything if the element doesn't declare hx-verb attribute
    - `hasExplicitHttpAction` being false, nothing happens in the following if either
    - `initButtonTracking` will be called for any form OR submit button/input that declares the "form" attribute (i.e. outside a form). `initButtonTracking` is what fixes the issue in the end, as it's going to properly set the form's `internalData.lastButtonClicked` when clicking a button that it outside that form
- #1541
=> values of clicked submit button/input now correctly add to regular input values with the same name, [as it does in a standars form](https://jsfiddle.net/o1qxec4g/)

**Notes**
- Added test cases inspired from all the mentioned issues above
- All tests pass, though let me know if I missed any usecase