### PR TITLE
[Bugfix] Handle dynamically added hx-disable

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -937,6 +937,9 @@ return (function () {
                     }
                 });
             }
+            if (internalData.initHash) {
+                internalData.initHash = null
+            }
             deInitOnHandlers(element);
         }
 
@@ -1344,6 +1347,10 @@ return (function () {
                 }
                 triggerSpecs.forEach(function(triggerSpec) {
                     addEventListener(elt, function(elt, evt) {
+                        if (closest(elt, htmx.config.disableSelector)) {
+                            cleanUpElement(elt)
+                            return
+                        }
                         issueAjaxRequest(verb, path, elt, evt)
                     }, nodeData, triggerSpec, true);
                 });
@@ -1753,6 +1760,10 @@ return (function () {
                     nodeData.verb = verb;
                     triggerSpecs.forEach(function(triggerSpec) {
                         addTriggerHandler(elt, triggerSpec, nodeData, function (elt, evt) {
+                            if (closest(elt, htmx.config.disableSelector)) {
+                                cleanUpElement(elt)
+                                return
+                            }
                             issueAjaxRequest(verb, path, elt, evt)
                         })
                     });
@@ -1948,16 +1959,16 @@ return (function () {
         }
 
         function initNode(elt) {
-            if (elt.closest && elt.closest(htmx.config.disableSelector)) {
+            if (closest(elt, htmx.config.disableSelector)) {
+                cleanUpElement(elt)
                 return;
             }
             var nodeData = getInternalData(elt);
             if (nodeData.initHash !== attributeHash(elt)) {
-
-                nodeData.initHash = attributeHash(elt);
-
                 // clean up any previously processed info
                 deInitNode(elt);
+
+                nodeData.initHash = attributeHash(elt);
 
                 processHxOn(elt);
 
@@ -2001,6 +2012,10 @@ return (function () {
 
         function processNode(elt) {
             elt = resolveTarget(elt);
+            if (closest(elt, htmx.config.disableSelector)) {
+                cleanUpElement(elt)
+                return;
+            }
             initNode(elt);
             forEach(findElementsToProcess(elt), function(child) { initNode(child) });
             // Because it happens second, the new way of adding onHandlers superseeds the old one

--- a/test/core/security.js
+++ b/test/core/security.js
@@ -18,7 +18,7 @@ describe("security options", function() {
         btn.innerHTML.should.equal("Initial");
     })
 
-    it("can disable a parent  elt", function(){
+    it("can disable a parent elt", function(){
         this.server.respondWith("GET", "/test", "Clicked!");
 
         var div = make('<div hx-disable><button id="b1" hx-get="/test">Initial</button></div>')
@@ -28,5 +28,81 @@ describe("security options", function() {
         btn.innerHTML.should.equal("Initial");
     })
 
+    it("can disable a single elt dynamically", function(){
+        this.server.respondWith("GET", "/test", "Clicked!");
 
+        var btn = make('<button id="b1" hx-get="/test">Initial</button>')
+        btn.click();
+        this.server.respond();
+        btn.innerHTML.should.equal("Clicked!");
+
+        this.server.respondWith("GET", "/test", "Clicked a second time");
+
+        btn.setAttribute("hx-disable", "")
+        btn.click();
+        this.server.respond();
+        btn.innerHTML.should.equal("Clicked!");
+    })
+
+    it("can disable a single elt dynamically & enable it back", function(){
+        this.server.respondWith("GET", "/test", "Clicked!");
+
+        var btn = make('<button id="b1" hx-get="/test">Initial</button>')
+        btn.click();
+        this.server.respond();
+        btn.innerHTML.should.equal("Clicked!");
+
+        this.server.respondWith("GET", "/test", "Clicked a second time");
+
+        btn.setAttribute("hx-disable", "")
+        btn.click();
+        this.server.respond();
+        btn.innerHTML.should.equal("Clicked!");
+
+        btn.removeAttribute("hx-disable")
+        htmx.process(btn)
+        btn.click();
+        this.server.respond();
+        btn.innerHTML.should.equal("Clicked a second time");
+    })
+
+    it("can disable a single parent elt dynamically", function(){
+        this.server.respondWith("GET", "/test", "Clicked!");
+
+        var div = make('<div><button id="b1" hx-get="/test">Initial</button></div>')
+        var btn = byId("b1");
+        btn.click();
+        this.server.respond();
+        btn.innerHTML.should.equal("Clicked!");
+
+        this.server.respondWith("GET", "/test", "Clicked a second time");
+
+        div.setAttribute("hx-disable", "")
+        btn.click();
+        this.server.respond();
+        btn.innerHTML.should.equal("Clicked!");
+    })
+
+    it("can disable a single parent elt dynamically & enable it back", function(){
+        this.server.respondWith("GET", "/test", "Clicked!");
+
+        var div = make('<div><button id="b1" hx-get="/test">Initial</button></div>')
+        var btn = byId("b1");
+        btn.click();
+        this.server.respond();
+        btn.innerHTML.should.equal("Clicked!");
+
+        this.server.respondWith("GET", "/test", "Clicked a second time");
+
+        div.setAttribute("hx-disable", "")
+        btn.click();
+        this.server.respond();
+        btn.innerHTML.should.equal("Clicked!");
+
+        div.removeAttribute("hx-disable")
+        htmx.process(div)
+        btn.click();
+        this.server.respond();
+        btn.innerHTML.should.equal("Clicked a second time");
+    })
 });


### PR DESCRIPTION
This fixes #1176 
When dynamically adding hx-disable to an element from your custom code:
- If any trigger handler is triggered on an element, it first checks if the element is currently disabled or not. If it is, cleans up the element _(which removes all htmx listeners from it)_ & aborts the handler
- You can also call `htmx.process` right after adding the attribute, to force the clean up immediately

When **removing** hx-disable from an element from your custom code:
- You will have to explicitly call `htmx.process` to have htmx initialize that element and bind handlers again

Added test cases for `hx-disable` dynamic addition / removal