### PR TITLE
[Bugfix] Fix hx-trigger `changed` modifier along `from` clause

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1397,9 +1397,12 @@ return (function () {
             } else {
                 eltsToListenOn = [elt];
             }
-            // store the initial value of the element so we can tell if it changes
+            // store the initial values of the elements, so we can tell if they change
             if (triggerSpec.changed) {
-                elementData.lastValue = elt.value;
+                eltsToListenOn.forEach(function (eltToListenOn) {
+                    var eltToListenOnData = getInternalData(eltToListenOn);
+                    eltToListenOnData.lastValue = eltToListenOn.value;
+                })
             }
             forEach(eltsToListenOn, function (eltToListenOn) {
                 var eventListener = function (evt) {
@@ -1439,11 +1442,11 @@ return (function () {
                             }
                         }
                         if (triggerSpec.changed) {
-                            if (elementData.lastValue === elt.value) {
+                            var eltToListenOnData = getInternalData(eltToListenOn)
+                            if (eltToListenOnData.lastValue === eltToListenOn.value) {
                                 return;
-                            } else {
-                                elementData.lastValue = elt.value;
                             }
+                            eltToListenOnData.lastValue = eltToListenOn.value
                         }
                         if (elementData.delayed) {
                             clearTimeout(elementData.delayed);

--- a/test/attributes/hx-trigger.js
+++ b/test/attributes/hx-trigger.js
@@ -42,6 +42,74 @@ describe("hx-trigger attribute", function(){
         div.innerHTML.should.equal("Requests: 1");
     });
 
+    it('changed modifier works along from clause with single input', function()
+    {
+        var requests = 0;
+        this.server.respondWith("GET", "/test", function (xhr) {
+            requests++;
+            xhr.respond(200, {}, "Requests: " + requests);
+        });
+        var input = make('<input type="text"/>');
+        make('<div hx-trigger="click changed from:input" hx-target="#d1" hx-get="/test"></div>')
+        var div = make('<div id="d1"></div>');
+        input.click();
+        this.server.respond();
+        div.innerHTML.should.equal("");
+        input.click();
+        this.server.respond();
+        div.innerHTML.should.equal("");
+        input.value = "bar";
+        input.click();
+        this.server.respond();
+        div.innerHTML.should.equal("Requests: 1");
+        input.click();
+        this.server.respond();
+        div.innerHTML.should.equal("Requests: 1");
+    });
+
+    it('changed modifier works along from clause with two inputs', function()
+    {
+        var requests = 0;
+        this.server.respondWith("GET", "/test", function (xhr) {
+            requests++;
+            xhr.respond(200, {}, "Requests: " + requests);
+        });
+        var input1 = make('<input type="text"/>');
+        var input2 = make('<input type="text"/>');
+        make('<div hx-trigger="click changed from:input" hx-target="#d1" hx-get="/test"></div>')
+        var div = make('<div id="d1"></div>');
+
+        input1.click();
+        this.server.respond();
+        div.innerHTML.should.equal("");
+        input2.click();
+        this.server.respond();
+        div.innerHTML.should.equal("");
+
+        input1.value = "bar";
+        input2.click();
+        this.server.respond();
+        div.innerHTML.should.equal("");
+        input1.click();
+        this.server.respond();
+        div.innerHTML.should.equal("Requests: 1");
+
+        input1.click();
+        this.server.respond();
+        div.innerHTML.should.equal("Requests: 1");
+        input2.click();
+        this.server.respond();
+        div.innerHTML.should.equal("Requests: 1");
+
+        input2.value = "foo";
+        input1.click();
+        this.server.respond();
+        div.innerHTML.should.equal("Requests: 1");
+        input2.click();
+        this.server.respond();
+        div.innerHTML.should.equal("Requests: 2");
+    });
+
     it('once modifier works', function()
     {
         var requests = 0;


### PR DESCRIPTION
Resolves #1565 

Given the following code:
``` html
<form hx-get="/search" hx-target="#result" hx-trigger="keyup changed delay:250ms from:#searchInput, change">
  <label>Search <input id="searchInput" class="flex-grow" type="search" name="search"></label>
  <label>Category <select name="category">
      <option value="A">A</option>
      <option value="B" selected>B</option>
      <option value="C">C</option>
    </select>
  </label>
</form>
```

- Current htmx behaviour on [this JSFiddle](https://jsfiddle.net/7ygfa9zn/)
=> You can see here how the request isn't triggered when typing in the input, only when the `change` event is fired _(which happens in my case, when focusing out the input)_
- New behaviour with the suggested changes on [this JSFiddle](https://jsfiddle.net/1xzg9yts/)
=> You can see here how the request is correctly triggered when typing in the input and changing its value

Added test cases to ensure `changed` works along `from`