### PR TITLE
Don't preventDefault on events that are filtered

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1413,11 +1413,11 @@ return (function () {
                     if (ignoreBoostedAnchorCtrlClick(elt, evt)) {
                         return;
                     }
-                    if (explicitCancel || shouldCancel(evt, elt)) {
-                        evt.preventDefault();
-                    }
                     if (maybeFilterEvent(triggerSpec, elt, evt)) {
                         return;
+                    }
+                    if (explicitCancel || shouldCancel(evt, elt)) {
+                        evt.preventDefault();
                     }
                     var eventData = getInternalData(evt);
                     eventData.triggerSpec = triggerSpec;

--- a/test/core/regressions.js
+++ b/test/core/regressions.js
@@ -99,7 +99,7 @@ describe("Core htmx Regression Tests", function(){
         byId("d1").innerText.should.equal('Replaced');
     });
 
-    it('does not submit with a false condition on a form', function() {
+    it('submission is aborted but event default is not prevented when event is excluded via filter', function() {
         this.server.respondWith("POST", "/test", "Submitted");
         var defaultPrevented = false;
         htmx.on("click", function(evt) {
@@ -108,7 +108,8 @@ describe("Core htmx Regression Tests", function(){
         var form = make('<form hx-post="/test" hx-trigger="click[false]"></form>');
         form.click()
         this.server.respond();
-        defaultPrevented.should.equal(true);
+        defaultPrevented.should.equal(false);
+        form.innerHTML.should.equal("");
     })
 
     it('two elements can listen for the same event on another element', function() {


### PR DESCRIPTION
Run the `maybeFilterEvent()` check before `evt.preventDefault()` so that events excluded via `hx-trigger` filters are ignored and not prevented.

Prior to this change `<a href="/some/url" hx-get="/some/url" hx-trigger="click[!ctrlKey && !metaKey]">` would not let the browser use default ctrl + click behaviour due to the event being prevented.

This PR makes [the suggestion here](https://github.com/bigskysoftware/htmx/issues/721#issuecomment-1003263995) viable without adding another event listener on your own.

For a bit of context I have a use case where it makes sense to use `hx-get` on a `<a>` tag. It's a modal/overlay thing using `hx-push-url` and `hx-history-elt`. Direct browsing to the url makes sense and I'd really like to keep `<a>` ctrl/meta + click behaviour for the specific link. My current solution is to add another event listener specifically for click + modifier and then do `window.open("/some/url", "_blank")`.

My workaround is to add something like this:
```javascript
  const link = document.querySelector("#some-container a");
  const url = link.getAttribute('href');
  link.addEventListener("click", function (e) {
    if (e.metaKey || e.ctrlKey) {
      e.preventDefault();
      window.open(url, "_blank");
    }
  });
```

It works but requires me to reimplement the default browser behaviour with another event listener. I think it'd make sense in the general case that if you filter an event out explicitly it keeps whatever default there is.