### PR TITLE
Add new event htmx:beforeHistoryUpdate

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3357,6 +3357,7 @@ return (function () {
 
                             // if we need to save history, do so
                             if (historyUpdate.type) {
+                                triggerEvent(getDocument().body, 'htmx:beforeHistoryUpdate', mergeObjects({ history: historyUpdate }, responseInfo));
                                 if (historyUpdate.type === "push") {
                                     pushUrlIntoHistory(historyUpdate.path);
                                     triggerEvent(getDocument().body, 'htmx:pushedIntoHistory', {path: historyUpdate.path});

--- a/www/content/events.md
+++ b/www/content/events.md
@@ -343,6 +343,14 @@ This event is triggered after a URL has been pushed into history.
 
 * `detail.path` - the path and query of the URL that has been pushed into history
 
+### Event - `htmx:replacedInHistory` {#htmx:replacedInHistory}
+
+This event is triggered after a URL has been replaced in history.
+
+##### Details
+
+* `detail.path` - the path and query of the URL that has been replaced in history
+
 ### Event - `htmx:responseError` {#htmx:responseError}
 
 This event is triggered when an HTTP error response occurs

--- a/www/content/events.md
+++ b/www/content/events.md
@@ -335,6 +335,19 @@ attribute.  If this event is cancelled, the AJAX request will not occur.
 * `detail.target` - the target of the request
 * `detail.prompt` - the user response to the prompt
 
+### Event - `htmx:beforeHistoryUpdate` {#htmx:beforeHistoryUpdate}
+
+This event is triggered before a history update is performed. It can be
+used to modify the `path` or `type` used to update the history.
+
+##### Details
+
+* `detail.history` - the `path` and `type` (push, replace) for the history update
+* `detail.elt` - the element that dispatched the request
+* `detail.xhr` - the `XMLHttpRequest`
+* `detail.target` - the target of the request
+* `detail.requestConfig` - the configuration of the AJAX request
+
 ### Event - `htmx:pushedIntoHistory` {#htmx:pushedIntoHistory}
 
 This event is triggered after a URL has been pushed into history.


### PR DESCRIPTION
This adds a new event `htmx:beforeHistoryUpdate` that is triggered right before the history is updated. It can be used to modify the `path` or `type` used to update the history.