### PR TITLE
Make elementSelector, elementSwapStyle in multi-swap.js cleaner and m…

### DIFF
--- a/src/ext/multi-swap.js
+++ b/src/ext/multi-swap.js
@@ -16,10 +16,8 @@
                 var elements = swapStyle.replace(/^multi\s*:\s*/, '').split(/\s*,\s*/);
 
                 elements.map(function (element) {
-                    var split = element.split(/\s*:\s*/);
-                    var elementSelector = split[0];
-                    var elementSwapStyle = typeof (split[1]) !== "undefined" ? split[1] : "innerHTML";
-
+                    const [elementSelector, elementSwapStyle = "innerHTML"] = element.split(/\s*:\s*/);
+                    
                     if (elementSelector.charAt(0) !== '#') {
                         console.error("HTMX multi-swap: unsupported selector '" + elementSelector + "'. Only ID selectors starting with '#' are supported.");
                         return;


### PR DESCRIPTION
In this updated code, the variable declarations for split, elementSelector, and elementSwapStyle are combined into a single line. Array destructuring is used to assign the values from element.split(/\s*:\s*/). The first element is assigned to elementSelector, and the second element, if present, is assigned to elementSwapStyle. If the second element is null or undefined, the default value of "innerHTML" is used.

This change reduces the code length and improves readability by eliminating the need for the typeof check and using a more concise syntax for variable declaration and assignment.