### PR TITLE
[Documentation] Make it clear that `from` with a standard selector gets all matching elements

### DIFF
--- a/www/content/attributes/hx-trigger.md
+++ b/www/content/attributes/hx-trigger.md
@@ -55,6 +55,7 @@ is seen again it will reset the delay.
 * `throttle:<timing declaration>` - a throttle will occur before an event triggers a request.  If the event
 is seen again before the delay completes it is ignored, the element will trigger at the end of the delay.
 * `from:<Extended CSS selector>` - allows the event that triggers a request to come from another element in the document (e.g. listening to a key event on the body, to support hot keys)
+  * A standard CSS selector resolves to all elements matching that selector. Thus, `from:input` would listen on every input on the page.
   * The extended CSS selector here allows for the following non-standard CSS values:
     * `document` - listen for events on the document
     * `window` - listen for events on the window


### PR DESCRIPTION
Just to make it clear that
`hx-trigger="keyup from:input"` will retrieve all inputs on the page and listen to keyup on each of them, while
`hx-trigger="keyup from:find input"` will only retrieve the first input child (as well as all the extended selectors described on the reference page)