### PR TITLE
Fix: `hx-on` event listener clean-up

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -916,7 +916,7 @@ return (function () {
             if (internalData.onHandlers) {
                 for (let i = 0; i < internalData.onHandlers.length; i++) {
                     const handlerInfo = internalData.onHandlers[i];
-                    elt.removeEventListener(handlerInfo.name, handlerInfo.handler);
+                    elt.removeEventListener(handlerInfo.event, handlerInfo.listener);
                 }
                 delete internalData.onHandlers
             }
@@ -1901,9 +1901,10 @@ return (function () {
             var nodeData = getInternalData(elt);
             nodeData.onHandlers = [];
             var func = new Function("event", code + "; return;");
-            var listener = elt.addEventListener(eventName, function (e) {
+            var listener = function (e) {
                 return func.call(elt, e);
-            });
+            };
+            elt.addEventListener(eventName, listener);
             nodeData.onHandlers.push({event:eventName, listener:listener});
             return {nodeData, code, func, listener};
         }


### PR DESCRIPTION
Event listeners added to an element via `hx-on` will not be removed in `deInitOnHandlers` as intended.

The reasons are as follows:

- in `addHxOnEventHandler`, the return value of `addEventListener`, which is `undefined`, was set as `listener` in the object pushed to `onHandlers`
- in `deInitOnHandlers`, the wrong keys were used to access event name and listener from an object contained in `onHandlers`

This PR fixes both these issues.