### PR TITLE
docs: fix link by removing extra parenthesis

### DIFF
--- a/www/content/essays/rest-explained.md
+++ b/www/content/essays/rest-explained.md
@@ -233,7 +233,7 @@ From the paper:
 
 This is all very true, and is why the web has been so successful and will continue to be successful.
 
-## [Sections 5.4](https://www.ics.uci.edu/~fielding/pubs/dissertation/rest_arch_style.htm#sec_5_4) & [5.5]((https://www.ics.uci.edu/~fielding/pubs/dissertation/rest_arch_style.htm#sec_5_5)) - Related Work & Summary
+## [Sections 5.4](https://www.ics.uci.edu/~fielding/pubs/dissertation/rest_arch_style.htm#sec_5_4) & [5.5](https://www.ics.uci.edu/~fielding/pubs/dissertation/rest_arch_style.htm#sec_5_5) - Related Work & Summary
 
 These brief sections are not relevant to non-academics interested in REST. 
 


### PR DESCRIPTION
**PR Summary**:
PR contains a simple fix to broken hyperlink found in the docs. There are extra parenthesis that should be removed. Relevant docs page can be found [here](https://htmx.org/essays/rest-explained/#sections-5-4-5-5-related-work-summary).