### PR TITLE
Remove engine from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
   "types": "dist/htmx.d.ts",
   "unpkg": "dist/htmx.min.js",
   "web-types": "editors/jetbrains/htmx.web-types.json",
-  "engines": {
-    "node": "15.x"
-  },
   "scripts": {
     "test": "mocha-chrome test/index.html",
     "test-types": "tsc --project ./jsconfig.json",


### PR DESCRIPTION
The engine is intended to signify that node 15 should be used for development, but it's causing issues for people who `npm install` htmx and have node in "strict-engine" mode.

Resolves:  #1584