### PR TITLE
OOB Swap to accept IDs with special characters

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -760,7 +760,7 @@ return (function () {
          * @returns
          */
         function oobSwap(oobValue, oobElement, settleInfo) {
-            var selector = "#" + oobElement.id;
+            var selector = "#" + CSS.escape(oobElement.id);
             var swapStyle = "outerHTML";
             if (oobValue === "true") {
                 // do nothing

--- a/test/attributes/hx-swap-oob.js
+++ b/test/attributes/hx-swap-oob.js
@@ -30,9 +30,30 @@ describe("hx-swap-oob attribute", function () {
         byId("d2").innerHTML.should.equal("Swapped2");
     })
 
+    it('handles more than one oob swap with special characters properly', function () {
+        this.server.respondWith("GET", "/test", "Clicked<div id='d:1' hx-swap-oob='true'>Swapped1</div><div id='d,2' hx-swap-oob='true'>Swapped2</div>");
+        var div = make('<div hx-get="/test">click me</div>');
+        make('<div id="d:1"></div>');
+        make('<div id="d,2"></div>');
+        div.click();
+        this.server.respond();
+        div.innerHTML.should.equal("Clicked");
+        byId("d:1").innerHTML.should.equal("Swapped1");
+        byId("d,2").innerHTML.should.equal("Swapped2");
+    })
+
     it('handles no id match properly', function () {
         this.server.respondWith("GET", "/test", "Clicked<div id='d1' hx-swap-oob='true'>Swapped2</div>");
         var div = make('<div hx-get="/test">click me</div>');
+        div.click();
+        this.server.respond();
+        div.innerText.should.equal("Clicked");
+    })
+
+    it('handles id with special characters match properly', function () {
+        this.server.respondWith("GET", "/test", "Clicked<div id='d/1' hx-swap-oob='true'>Swapped2</div>");
+        var div = make('<div hx-get="/test">click me</div>');
+        make('<div id="d/1"></div>');
         div.click();
         this.server.respond();
         div.innerText.should.equal("Clicked");


### PR DESCRIPTION
Refer to #1537 

Includes test with some special characters for a single id and multiple.

An alternative to escaping would be to use `getElementById` in the relevant case.

This PR does not cover the case where the selector is in the form `beforeend:#some/bad/id` though we may want to add that too?

Note that this will need to be merged with #1563 as it affects the same code
