### PR TITLE
Fix `confirmed` being ignored in htmx:confirm event

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2871,8 +2871,8 @@ return (function () {
             var confirmQuestion = getClosestAttributeValue(elt, "hx-confirm");
             // allow event-based confirmation w/ a callback
             if (!confirmed) {
-                var issueRequest = function() {
-                    return issueAjaxRequest(verb, path, elt, event, etc, true);
+                var issueRequest = function (skipConfirmation) {
+                    return issueAjaxRequest(verb, path, elt, event, etc, skipConfirmation);
                 }
                 var confirmDetails = { target: target, elt: elt, path: path, verb: verb, triggeringEvent: event, etc: etc, issueRequest: issueRequest, question: confirmQuestion };
                 if (triggerEvent(elt, 'htmx:confirm', confirmDetails) === false) {
@@ -2972,8 +2972,7 @@ return (function () {
                 }
             }
 
-
-            if (confirmQuestion) {
+            if (confirmQuestion && !confirmed) {
                 if(!confirm(confirmQuestion)) {
                     maybeCall(resolve);
                     endRequestLock()

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2870,9 +2870,9 @@ return (function () {
 
             var confirmQuestion = getClosestAttributeValue(elt, "hx-confirm");
             // allow event-based confirmation w/ a callback
-            if (!confirmed) {
+            if (confirmed === undefined) {
                 var issueRequest = function(skipConfirmation) {
-                    return issueAjaxRequest(verb, path, elt, event, etc, skipConfirmation);
+                    return issueAjaxRequest(verb, path, elt, event, etc, !!skipConfirmation);
                 }
                 var confirmDetails = {target: target, elt: elt, path: path, verb: verb, triggeringEvent: event, etc: etc, issueRequest: issueRequest, question: confirmQuestion};
                 if (triggerEvent(elt, 'htmx:confirm', confirmDetails) === false) {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2868,12 +2868,13 @@ return (function () {
                 return;
             }
 
+            var confirmQuestion = getClosestAttributeValue(elt, "hx-confirm");
             // allow event-based confirmation w/ a callback
             if (!confirmed) {
                 var issueRequest = function() {
                     return issueAjaxRequest(verb, path, elt, event, etc, true);
                 }
-                var confirmDetails = {target: target, elt: elt, path: path, verb: verb, triggeringEvent: event, etc: etc, issueRequest: issueRequest};
+                var confirmDetails = { target: target, elt: elt, path: path, verb: verb, triggeringEvent: event, etc: etc, issueRequest: issueRequest, question: confirmQuestion };
                 if (triggerEvent(elt, 'htmx:confirm', confirmDetails) === false) {
                     return;
                 }
@@ -2971,7 +2972,7 @@ return (function () {
                 }
             }
 
-            var confirmQuestion = getClosestAttributeValue(elt, "hx-confirm");
+
             if (confirmQuestion) {
                 if(!confirm(confirmQuestion)) {
                     maybeCall(resolve);

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2871,10 +2871,10 @@ return (function () {
             var confirmQuestion = getClosestAttributeValue(elt, "hx-confirm");
             // allow event-based confirmation w/ a callback
             if (!confirmed) {
-                var issueRequest = function (skipConfirmation) {
+                var issueRequest = function(skipConfirmation) {
                     return issueAjaxRequest(verb, path, elt, event, etc, skipConfirmation);
                 }
-                var confirmDetails = { target: target, elt: elt, path: path, verb: verb, triggeringEvent: event, etc: etc, issueRequest: issueRequest, question: confirmQuestion };
+                var confirmDetails = {target: target, elt: elt, path: path, verb: verb, triggeringEvent: event, etc: etc, issueRequest: issueRequest, question: confirmQuestion};
                 if (triggerEvent(elt, 'htmx:confirm', confirmDetails) === false) {
                     return;
                 }

--- a/test/attributes/hx-confirm.js
+++ b/test/attributes/hx-confirm.js
@@ -53,5 +53,33 @@ describe("hx-confirm attribute", function () {
         }
     })
 
+    it('should prompt when htmx:confirm handler calls issueRequest', function () {
+        var confirm = sinon.stub(window, "confirm");
+        try {
+            var btn = make('<button hx-get="/test" hx-confirm="Surely?">Click Me!</button>')
+            var handler = htmx.on("htmx:confirm", function (evt) {
+                evt.preventDefault();
+                evt.detail.issueRequest();
+            });
+            btn.click();
+            confirm.calledOnce.should.equal(true);
+        } finally {
+            htmx.off("htmx:confirm", handler);
+        }
+    })
+
+    it('should include the question in htmx:confirm event', function () {
+        var stub = sinon.stub();
+        try {
+            var btn = make('<button hx-get="/test" hx-confirm="Surely?">Click Me!</button>')
+            var handler = htmx.on("htmx:confirm", stub);
+            btn.click();
+            stub.calledOnce.should.equal(true);
+            stub.firstCall.args[0].detail.should.have.property("question", "Surely?");
+        } finally {
+            htmx.off("htmx:confirm", handler);
+        }
+    })
+
 
 });

--- a/test/attributes/hx-confirm.js
+++ b/test/attributes/hx-confirm.js
@@ -1,71 +1,55 @@
 describe("hx-confirm attribute", function () {
+    var confirm
     beforeEach(function () {
         this.server = makeServer();
+        confirm = sinon.stub(window, "confirm");
         clearWorkArea();
     });
     afterEach(function () {
         this.server.restore();
+        confirm.restore()
         clearWorkArea();
     });
 
     it('prompts using window.confirm when hx-confirm is set', function () {
         this.server.respondWith("GET", "/test", "Clicked!");
-        var confirm = sinon.stub(window, "confirm");
         confirm.returns(true);
-        try {
-            var btn = make('<button hx-get="/test" hx-confirm="Sure?">Click Me!</button>')
-            btn.click();
-            confirm.calledOnce.should.equal(true);
-            this.server.respond();
-            btn.innerHTML.should.equal("Clicked!");
-        } finally {
-            confirm.restore()
-        }
+        var btn = make('<button hx-get="/test" hx-confirm="Sure?">Click Me!</button>')
+        btn.click();
+        confirm.calledOnce.should.equal(true);
+        this.server.respond();
+        btn.innerHTML.should.equal("Clicked!");
     })
 
     it('stops the request if confirm is cancelled', function () {
         this.server.respondWith("GET", "/test", "Clicked!");
-        var confirm = sinon.stub(window, "confirm");
         confirm.returns(false);
-        try {
-            var btn = make('<button hx-get="/test" hx-confirm="Sure?">Click Me!</button>')
-            btn.click();
-            confirm.calledOnce.should.equal(true);
-            this.server.respond();
-            btn.innerHTML.should.equal("Click Me!");
-        } finally {
-            confirm.restore()
-        }
+        var btn = make('<button hx-get="/test" hx-confirm="Sure?">Click Me!</button>')
+        btn.click();
+        confirm.calledOnce.should.equal(true);
+        this.server.respond();
+        btn.innerHTML.should.equal("Click Me!");
     })
 
     it('uses the value of hx-confirm as the prompt', function () {
         this.server.respondWith("GET", "/test", "Clicked!");
-        var confirm = sinon.stub(window, "confirm");
         confirm.returns(false);
-        try {
-            var btn = make('<button hx-get="/test" hx-confirm="Sure?">Click Me!</button>')
-            btn.click();
-            confirm.firstCall.args[0].should.equal("Sure?");
-            this.server.respond();
-            btn.innerHTML.should.equal("Click Me!");
-        } finally {
-            confirm.restore()
-        }
+        var btn = make('<button hx-get="/test" hx-confirm="Sure?">Click Me!</button>')
+        btn.click();
+        confirm.firstCall.args[0].should.equal("Sure?");
+        this.server.respond();
+        btn.innerHTML.should.equal("Click Me!");
     })
 
     it('should prompt when htmx:confirm handler calls issueRequest', function () {
-        var confirm = sinon.stub(window, "confirm");
-        try {
-            var btn = make('<button hx-get="/test" hx-confirm="Surely?">Click Me!</button>')
-            var handler = htmx.on("htmx:confirm", function (evt) {
-                evt.preventDefault();
-                evt.detail.issueRequest();
-            });
-            btn.click();
-            confirm.calledOnce.should.equal(true);
-        } finally {
-            htmx.off("htmx:confirm", handler);
-        }
+        var btn = make('<button hx-get="/test" hx-confirm="Surely?">Click Me!</button>')
+        var handler = htmx.on("htmx:confirm", function (evt) {
+            evt.preventDefault();
+            evt.detail.issueRequest();
+        });
+        btn.click();
+        confirm.calledOnce.should.equal(true);
+        htmx.off("htmx:confirm", handler);
     })
 
     it('should include the question in htmx:confirm event', function () {
@@ -76,6 +60,24 @@ describe("hx-confirm attribute", function () {
             btn.click();
             stub.calledOnce.should.equal(true);
             stub.firstCall.args[0].detail.should.have.property("question", "Surely?");
+        } finally {
+            htmx.off("htmx:confirm", handler);
+        }
+    })
+
+    it('should allow skipping built-in window.confirm when using issueRequest', function () {
+        this.server.respondWith("GET", "/test", "Clicked!");
+        try {
+            var btn = make('<button hx-get="/test" hx-confirm="Sure?">Click Me!</button>')
+            var handler = htmx.on("htmx:confirm", function (evt) {
+                evt.detail.question.should.equal("Sure?");
+                evt.preventDefault();
+                evt.detail.issueRequest(true);
+            });
+            btn.click();
+            confirm.calledOnce.should.equal(false);
+            this.server.respond();
+            btn.innerHTML.should.equal("Clicked!");
         } finally {
             htmx.off("htmx:confirm", handler);
         }

--- a/test/attributes/hx-confirm.js
+++ b/test/attributes/hx-confirm.js
@@ -42,14 +42,17 @@ describe("hx-confirm attribute", function () {
     })
 
     it('should prompt when htmx:confirm handler calls issueRequest', function () {
-        var btn = make('<button hx-get="/test" hx-confirm="Surely?">Click Me!</button>')
-        var handler = htmx.on("htmx:confirm", function (evt) {
-            evt.preventDefault();
-            evt.detail.issueRequest();
-        });
-        btn.click();
-        confirm.calledOnce.should.equal(true);
-        htmx.off("htmx:confirm", handler);
+        try {
+            var btn = make('<button hx-get="/test" hx-confirm="Surely?">Click Me!</button>')
+            var handler = htmx.on("htmx:confirm", function (evt) {
+                evt.preventDefault();
+                evt.detail.issueRequest();
+            });
+            btn.click();
+            confirm.calledOnce.should.equal(true);
+        } finally {
+            htmx.off("htmx:confirm", handler);
+        }
     })
 
     it('should include the question in htmx:confirm event', function () {

--- a/test/attributes/hx-confirm.js
+++ b/test/attributes/hx-confirm.js
@@ -78,7 +78,7 @@ describe("hx-confirm attribute", function () {
                 evt.detail.issueRequest(true);
             });
             btn.click();
-            confirm.calledOnce.should.equal(false);
+            confirm.called.should.equal(false);
             this.server.respond();
             btn.innerHTML.should.equal("Clicked!");
         } finally {
@@ -95,7 +95,7 @@ describe("hx-confirm attribute", function () {
                 evt.detail.issueRequest(true);
             });
             btn.click();
-            confirm.calledOnce.should.equal(false);
+            confirm.called.should.equal(false);
             this.server.respond();
             btn.innerHTML.should.equal("Clicked!");
         } finally {
@@ -114,7 +114,7 @@ describe("hx-confirm attribute", function () {
                 evt.detail.issueRequest();
             });
             btn.click();
-            confirm.calledOnce.should.equal(false); // no hx-confirm means no window.confirm
+            confirm.called.should.equal(false); // no hx-confirm means no window.confirm
             this.server.respond();
             btn.innerHTML.should.equal("Clicked!");
         } finally {

--- a/test/attributes/hx-confirm.js
+++ b/test/attributes/hx-confirm.js
@@ -1,0 +1,57 @@
+describe("hx-confirm attribute", function () {
+    beforeEach(function () {
+        this.server = makeServer();
+        clearWorkArea();
+    });
+    afterEach(function () {
+        this.server.restore();
+        clearWorkArea();
+    });
+
+    it('prompts using window.confirm when hx-confirm is set', function () {
+        this.server.respondWith("GET", "/test", "Clicked!");
+        var confirm = sinon.stub(window, "confirm");
+        confirm.returns(true);
+        try {
+            var btn = make('<button hx-get="/test" hx-confirm="Sure?">Click Me!</button>')
+            btn.click();
+            confirm.calledOnce.should.equal(true);
+            this.server.respond();
+            btn.innerHTML.should.equal("Clicked!");
+        } finally {
+            confirm.restore()
+        }
+    })
+
+    it('stops the request if confirm is cancelled', function () {
+        this.server.respondWith("GET", "/test", "Clicked!");
+        var confirm = sinon.stub(window, "confirm");
+        confirm.returns(false);
+        try {
+            var btn = make('<button hx-get="/test" hx-confirm="Sure?">Click Me!</button>')
+            btn.click();
+            confirm.calledOnce.should.equal(true);
+            this.server.respond();
+            btn.innerHTML.should.equal("Click Me!");
+        } finally {
+            confirm.restore()
+        }
+    })
+
+    it('uses the value of hx-confirm as the prompt', function () {
+        this.server.respondWith("GET", "/test", "Clicked!");
+        var confirm = sinon.stub(window, "confirm");
+        confirm.returns(false);
+        try {
+            var btn = make('<button hx-get="/test" hx-confirm="Sure?">Click Me!</button>')
+            btn.click();
+            confirm.firstCall.args[0].should.equal("Sure?");
+            this.server.respond();
+            btn.innerHTML.should.equal("Click Me!");
+        } finally {
+            confirm.restore()
+        }
+    })
+
+
+});

--- a/test/attributes/hx-confirm.js
+++ b/test/attributes/hx-confirm.js
@@ -82,6 +82,42 @@ describe("hx-confirm attribute", function () {
             htmx.off("htmx:confirm", handler);
         }
     })
+    it('should allow skipping built-in window.confirm when using issueRequest', function () {
+        this.server.respondWith("GET", "/test", "Clicked!");
+        try {
+            var btn = make('<button hx-get="/test" hx-confirm="Sure?">Click Me!</button>')
+            var handler = htmx.on("htmx:confirm", function (evt) {
+                evt.detail.question.should.equal("Sure?");
+                evt.preventDefault();
+                evt.detail.issueRequest(true);
+            });
+            btn.click();
+            confirm.calledOnce.should.equal(false);
+            this.server.respond();
+            btn.innerHTML.should.equal("Clicked!");
+        } finally {
+            htmx.off("htmx:confirm", handler);
+        }
+    })
+    
+    
+    it('should allow htmx:confirm even when no hx-confirm is set', function () {
+        this.server.respondWith("GET", "/test", "Clicked!");
+        try {
+            var btn = make('<button hx-get="/test">Click Me!</button>')
+            var handler = htmx.on("htmx:confirm", function (evt) {
+                evt.detail.should.have.property("question", null);
+                evt.preventDefault();
+                evt.detail.issueRequest();
+            });
+            btn.click();
+            confirm.calledOnce.should.equal(false); // no hx-confirm means no window.confirm
+            this.server.respond();
+            btn.innerHTML.should.equal("Clicked!");
+        } finally {
+            htmx.off("htmx:confirm", handler);
+        }
+    })
 
 
 });

--- a/test/core/events.js
+++ b/test/core/events.js
@@ -1,4 +1,4 @@
-describe("Core htmx Events", function () {
+describe("Core htmx Events", function() {
     beforeEach(function () {
         this.server = makeServer();
         clearWorkArea();

--- a/test/core/events.js
+++ b/test/core/events.js
@@ -1,4 +1,4 @@
-describe("Core htmx Events", function() {
+describe("Core htmx Events", function () {
     beforeEach(function () {
         this.server = makeServer();
         clearWorkArea();
@@ -643,7 +643,7 @@ describe("Core htmx Events", function() {
             this.server.respond();
             div.innerHTML.should.equal("updated");
         } finally {
-            htmx.off("htmx:load", handler);
+            htmx.off("htmx:confirm", handler);
         }
     });
 

--- a/test/index.html
+++ b/test/index.html
@@ -58,6 +58,7 @@
 
 <!-- attribute tests -->
 <script src="attributes/hx-boost.js"></script>
+<script src="attributes/hx-confirm.js"></script>
 <script src="attributes/hx-delete.js"></script>
 <script src="attributes/hx-ext.js"></script>
 <script src="attributes/hx-get.js"></script>

--- a/www/content/attributes/hx-confirm.md
+++ b/www/content/attributes/hx-confirm.md
@@ -13,6 +13,16 @@ Here is an example:
 </button>
 ```
 
+## Event details
+
+The event triggered by `hx-confirm` contains additional properties in its `detail`:
+
+* triggeringEvent: the event that triggered the original request
+* issueRequest(skipConfirmation=false): a callback which can be used to confirm the AJAX request
+* question: the value of the `hx-confirm` attribute on the HTML element
+
 ## Notes
 
 * `hx-confirm` is inherited and can be placed on a parent element
+* `hx-confirm` uses the browser's `window.confirm` by default. You can customize this behavior as shown [in this example](@/examples/confirm.md).
+* a boolean `skipConfirmation` can be passed to the `issueRequest` callback; if true (defaults to false), the `window.confirm` will not be called and the AJAX request is issued directly

--- a/www/content/examples/confirm.md
+++ b/www/content/examples/confirm.md
@@ -8,32 +8,78 @@ action.  This uses the default `confirm()` function in javascript which, while t
 applications UX.
 
 In this example we will see how to use [sweetalert2](https://sweetalert2.github.io) and the [`htmx:confirm`](@/events.md#htmx:confirm)
-event to implement a custom confirmation dialog.
+event to implement a custom confirmation dialog. Below are two examples, one with `hyperscript` using a click+custom event method, and one in vanilla JS and the built-in `hx-confirm` attribute.
+
+## Hyperscript, on click+custom event
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
-<button hx-get="/confirmed"
-        _="on htmx:confirm(issueRequest)
-             halt the event
-             call Swal.fire({title: 'Confirm', text:'Do you want to continue?'})
-             if result.isConfirmed issueRequest()">
+<button hx-get="/confirmed" 
+        hx-trigger='confirmed'
+        _="on click
+            call Swal.fire({title: 'Confirm', text:'Do you want to continue?'})
+            if result.isConfirmed trigger confirmed">
   Click Me
 </button>
 ```
 
 We add some hyperscript to invoke Sweet Alert 2 on a click, asking for confirmation.  If the user confirms
-the dialog, we trigger the request by invoking the `issueRequest()` function, which was destructured from the event
-detail object.
+the dialog, we trigger the request by triggering the custom "confirmed" event
+which is then picked up by `hx-trigger`.
 
 Note that we are taking advantage of the fact that hyperscript is [async-transparent](https://hyperscript.org/docs/#async)
 and automatically resolves the Promise returned by `Swal.fire()`.
 
 A VanillaJS implementation is left as an exercise for the reader.  :)
 
+## Vanilla JS, hx-confirm
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+<script>
+  document.addEventListener("htmx:confirm", function(e) {
+    e.preventDefault()
+    Swal.fire({
+      title: "Proceed?",
+      text: `I ask you... ${e.detail.question}`
+    }).then(function(result) {
+      if(result.isConfirmed) e.detail.issueRequest(true) // use true to skip window.confirm
+    })
+  })
+</script>
+  
+<button hx-get="/confirmed" hx-confirm="Some confirm text here">
+  Click Me
+</button>
+```
+
+We add some javascript to invoke Sweet Alert 2 on a click, asking for confirmation.  If the user confirms
+the dialog, we trigger the request by calling the `issueRequest` method. We pass `skipConfirmation=true` as argument to skip `window.confirm`.
+
+This allows to use `hx-confirm`'s value in the prompt which is convenient
+when the question depends on the element e.g. a django list:
+
+```html
+{% for row in clients %}
+<button hx-post="/delete/{{client.pk}}" hx-confirm="Delete {{client.name}}??">Delete</button>
+{% endfor %}
+```
+
 {{ demoenv() }}
 
 <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
-
+<script>
+  document.addEventListener("htmx:confirm", function(e) {
+    e.preventDefault()
+    Swal.fire({
+      title: "Proceed?",
+      text: `I ask you... ${e.detail.question}`,
+      showCancelButton: true
+    }).then(function(result) {
+      if(result.isConfirmed) e.detail.issueRequest(true)
+    })
+  })
+</script>
 <script>
 
     //=========================================================================
@@ -51,13 +97,17 @@ A VanillaJS implementation is left as an exercise for the reader.  :)
     
     // templates
     function initialUI() {
-      return `<button hx-trigger='confirmed'
-                      hx-get="/confirmed"
-                      _="on click
-                           call Swal.fire({title: 'Confirm', text:'Do you want to continue?'})
-                           if result.isConfirmed trigger confirmed">
-                Click Me
-              </button>`;
+      return `<button hx-get="/confirmed"
+        _="on htmx:confirm(issueRequest)
+             halt the event
+             call Swal.fire({title: 'Confirm', text:'Do you want to continue?'})
+             if result.isConfirmed issueRequest()">
+  Click me (hyperscript click & custom event)
+</button><br><br>
+    <button id="confirmButton" hx-get="/confirmed"  hx-confirm="Some confirm text here">
+  Click Me (vanilla JS, hx-confirm)
+</button>
+`;
     }
 
 </script>


### PR DESCRIPTION
Referring to #1588 

- Adds test for existing `hx-confirm` behavior by stubbing window.confirm; tests were added to a new test file `hx-confirm.js`
- Enhance `htmx:confirm` event detail to include the value found in `hx-confirm` (set to `detail.question`)
- Allow passing `skipConfirmation` to `detail.issueRequest`; when true, this skips window.confirm and triggers the request right away
- Fix the missing check for `confirmed` in original code (that was the original issue)
- Fix typo in [original `htmx:config` test ](https://github.com/bigskysoftware/htmx/blob/2534a970b6d606cb590edd8f6097e4a6440d8d06/test/core/events.js#L646) (incorrect handler would be removed in case of test failure)

Backwards compatibility: if `skipConfirmation` is not passed, the behaviour remains the same as it was previously, meaning it still calls window.confirm if `hx-confirm` has a value; I think it's incorrect, but it is the old behavior, so this should be backwards compatible

Closes #1588 