### PR TITLE
[htmx 2.0] The overhaul of htmx's extensibility and feature separation

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -8,7 +8,9 @@
         "lib": [ "dom" ]
     },
     "include": [
-        "./src/htmx.js"
+        "./src/htmx.js",
+        "./src/ext/*.js",
+        "./test/**/*.js",
     ],
     "verbose": true
 }

--- a/src/ext/alpine-morph.js
+++ b/src/ext/alpine-morph.js
@@ -1,16 +1,14 @@
-htmx.defineExtension('alpine-morph', {
-    isInlineSwap: function (swapStyle) {
-        return swapStyle === 'morph';
-    },
-    handleSwap: function (swapStyle, target, fragment) {
-        if (swapStyle === 'morph') {
+htmx.registerExtension('alpine-morph', (features) => {
+    features.addSwap('alpine-morph', {
+        isInlineSwap: true,
+        handleSwap: (target, fragment) => {
             if (fragment.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
                 Alpine.morph(target, fragment.firstElementChild);
-                return [target];
+                return { newElements: [target] };
             } else {
                 Alpine.morph(target, fragment.outerHTML);
-                return [target];
+                return { newElements: [target] };
             }
-        }
-    }
-});
+        },
+    })
+})

--- a/src/ext/alpine-morph.js
+++ b/src/ext/alpine-morph.js
@@ -1,14 +1,16 @@
-htmx.registerExtension('alpine-morph', (features) => {
-    features.addSwap('alpine-morph', {
-        isInlineSwap: true,
-        handleSwap: (target, fragment) => {
-            if (fragment.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
-                Alpine.morph(target, fragment.firstElementChild);
-                return { newElements: [target] };
-            } else {
-                Alpine.morph(target, fragment.outerHTML);
-                return { newElements: [target] };
-            }
-        },
-    })
+htmx.registerExtension('alpine-morph', {
+    swaps: {
+        'apline-morph': {
+            isInlineSwap: true,
+            handleSwap: (target, fragment) => {
+                if (fragment.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
+                    Alpine.morph(target, fragment.firstElementChild);
+                    return { newElements: [target] };
+                } else {
+                    Alpine.morph(target, fragment.outerHTML);
+                    return { newElements: [target] };
+                }
+            },
+        }
+    }
 })

--- a/src/ext/json-enc.js
+++ b/src/ext/json-enc.js
@@ -1,8 +1,8 @@
-htmx.registerExtension('json-enc', features => {
-    features.addEncoding('application/json', parameters => {
-        return {
+htmx.registerExtension('json-enc', {
+    encodings: {
+        'application/json': parameters => ({
             contentType: 'application/json',
             body: JSON.stringify(parameters)
-        }
-    })
+        })
+    }
 })

--- a/src/ext/json-enc.js
+++ b/src/ext/json-enc.js
@@ -1,12 +1,8 @@
-htmx.defineExtension('json-enc', {
-    onEvent: function (name, evt) {
-        if (name === "htmx:configRequest") {
-            evt.detail.headers['Content-Type'] = "application/json";
+htmx.registerExtension('json-enc', features => {
+    features.addEncoding('application/json', parameters => {
+        return {
+            contentType: 'application/json',
+            body: JSON.stringify(parameters)
         }
-    },
-    
-    encodeParameters : function(xhr, parameters, elt) {
-        xhr.overrideMimeType('text/json');
-        return (JSON.stringify(parameters));
-    }
-});
+    })
+})

--- a/src/ext/morphdom-swap.js
+++ b/src/ext/morphdom-swap.js
@@ -1,14 +1,16 @@
-htmx.registerExtension('morphdom-swap', (features) => {
-    features.addSwap('morphdom', {
-        isInlineSwap: true,
-        handleSwap: (target, fragment) => {
-            if (fragment.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
-                morphdom(target, fragment.firstElementChild);
-                return {newElements: [target]};
-            } else {
-                morphdom(target, fragment.outerHTML);
-                return {newElements: [target]};
-            }
-        },
-    })
+htmx.registerExtension('morphdom-swap', {
+    swaps: {
+        'morphdom': {
+            isInlineSwap: true,
+            handleSwap: (target, fragment) => {
+                if (fragment.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
+                    morphdom(target, fragment.firstElementChild);
+                    return { newElements: [target] };
+                } else {
+                    morphdom(target, fragment.outerHTML);
+                    return { newElements: [target] };
+                }
+            },
+        }
+    }
 })

--- a/src/ext/morphdom-swap.js
+++ b/src/ext/morphdom-swap.js
@@ -1,16 +1,14 @@
-htmx.defineExtension('morphdom-swap', {
-    isInlineSwap: function(swapStyle) {
-        return swapStyle === 'morphdom';
-    },
-    handleSwap: function (swapStyle, target, fragment) {
-        if (swapStyle === 'morphdom') {
+htmx.registerExtension('morphdom-swap', (features) => {
+    features.addSwap('morphdom', {
+        isInlineSwap: true,
+        handleSwap: (target, fragment) => {
             if (fragment.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
                 morphdom(target, fragment.firstElementChild);
-                return [target];
+                return {newElements: [target]};
             } else {
                 morphdom(target, fragment.outerHTML);
-                return [target];
+                return {newElements: [target]};
             }
-        }
-    }
-});
+        },
+    })
+})

--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -55,23 +55,13 @@ export interface HtmxConfig {
     scrollBehavior?: "smooth";
 }
 
-/**
- * A registrator for htmx features
- */
-export interface FeaturesRegistration {
-    /** Registration of body encoder
-     * @param name Name of the encoding
-     * @param encoder Encoding function
-     */
-    addEncoding(name: string, encoder: BodyEncoding | string): void
-
-    /** Registration of response swap method
-     * @param name Name of the morph
-     * @param swapper Swapping function
-     */
-    addSwap(name: string, swapper: Swap | string): void
+interface Feature<T> {
+    [key: string]: string | T
 }
-
+type FeaturesCollection = {
+    encodings: Feature<BodyEncoding>
+    swaps: Feature<Swap>
+}
 
 /*
 ===== Public JS API =====
@@ -398,8 +388,8 @@ const version: string;
 ===== Extensibility =====
 */
 
-type EncodedBody = { contentType: string, body: XMLHttpRequestBodyInit };
-type BodyEncoding = (parameters: object) => EncodedBody;
+type EncodingResult = { contentType: string, body: XMLHttpRequestBodyInit };
+type BodyEncoding = (parameters: object) => EncodingResult;
 
 type SwapResult = { newElements: HTMLElement[] };
 type Swap = { isInlineSwap?: boolean, handleSwap: (target: HTMLElement, fragment: HTMLElement, settleInfo?: object) => SwapResult | void }
@@ -407,29 +397,17 @@ type Swap = { isInlineSwap?: boolean, handleSwap: (target: HTMLElement, fragment
 /**
  * Register htmx 2.0 extension
  * @param name extension name
- * @param registration registration factory
+ * @param features features extension provides
  */
-export function registerExtension(name: string, registration: (features: FeaturesRegistration) => void): void
+export function registerExtension(name: string, features: Partial<FeaturesCollection>): void
 
 /*
 ===== End Extensions =====
 */
 
 export module Internal {
-    interface Feature<T> {
-        [key: string]: string | T
-    }
-
-    type FeaturesCollection = {
-        encodings: Feature<BodyEncoding>
-        swaps: Feature<Swap>
-    }
-
-    type FeatureCollectionNames = keyof FeaturesCollection
-
     type FeatureSet = {
         name: string,
-        features: FeaturesCollection,
-        registration: FeaturesRegistration,
+        features: Partial<FeaturesCollection>,
     }
 }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -35,9 +35,9 @@ return (function () {
         var extensionFeatures = {};
 
         /**
-         * @type {typeof htmx}
+         * @type {typeof import("./htmx")}
          */
-        var htmxObj = {
+        var htmx = {
             onLoad: onLoadHelper,
             process: processNode,
             on: addEventListenerImpl,
@@ -98,7 +98,7 @@ return (function () {
             // TODO 2.0 - should we remove/move these?
             createWebSocket: function(url){
                 var sock = new WebSocket(url, []);
-                sock.binaryType = htmxObj.config.wsBinaryType;
+                sock.binaryType = htmx.config.wsBinaryType;
                 return sock;
             },
             version: "1.9.3",
@@ -349,7 +349,7 @@ return (function () {
          */
         function makeFragment(resp) {
             var partialResponse = !aFullPageResponse(resp);
-            if (htmxObj.config.useTemplateFragments && partialResponse) {
+            if (htmx.config.useTemplateFragments && partialResponse) {
                 var documentFragment = parseHTML("<body><template>" + resp + "</template></body>", 0);
                 // @ts-ignore type mismatch between DocumentFragment and Element.
                 // TODO: Are these close enough for htmx to use interchangably?
@@ -524,14 +524,14 @@ return (function () {
         }
 
         function onLoadHelper(callback) {
-            var value = htmxObj.on("htmx:load", function(evt) {
+            var value = htmx.on("htmx:load", function(evt) {
                 callback(evt.detail.elt);
             });
             return value;
         }
 
         function logAll(){
-            htmxObj.logger = function(elt, event, data) {
+            htmx.logger = function(elt, event, data) {
                 if(console) {
                     console.log(event, elt, data);
                 }
@@ -539,7 +539,7 @@ return (function () {
         }
 
         function logNone() {
-            htmxObj.logger = null
+            htmx.logger = null
         }
 
         function find(eltOrSelector, selector) {
@@ -762,7 +762,7 @@ return (function () {
         }
 
         function shouldSettleAttribute(name) {
-            var attributesToSettle = htmxObj.config.attributesToSettle;
+            var attributesToSettle = htmx.config.attributesToSettle;
             for (var i = 0; i < attributesToSettle.length; i++) {
                 if (name === attributesToSettle[i]) {
                     return true;
@@ -897,7 +897,7 @@ return (function () {
             if (child.nodeType == Node.TEXT_NODE || child.nodeType == Node.COMMENT_NODE) return
 
             const task = () => {
-                removeClassFromElement(child, htmxObj.config.addedClass)
+                removeClassFromElement(child, htmx.config.addedClass)
                 processNode(child)
                 processScripts(child)
                 processFocus(child)
@@ -918,7 +918,7 @@ return (function () {
             handleAttributes(parentNode, fragment, settleInfo);
             while(fragment.childNodes.length > 0){
                 var child = fragment.firstChild;
-                addClassToElement(child, htmxObj.config.addedClass);
+                addClassToElement(child, htmx.config.addedClass);
                 parentNode.insertBefore(child, insertBefore);
                 pushChildLoadTasks(child, settleInfo)
             }
@@ -1054,7 +1054,7 @@ return (function () {
             var swapFeature = getFeature(elt, "swaps", swapStyle);
 
             if (!swapFeature) {
-                swapFeature = getFeature(elt, "swaps", htmxObj.config.defaultSwapStyle)
+                swapFeature = getFeature(elt, "swaps", htmx.config.defaultSwapStyle)
             }
 
             var swapResult = swapFeature.handleSwap(target, fragment, settleInfo);
@@ -1579,8 +1579,8 @@ return (function () {
                 });
                 newScript.textContent = script.textContent;
                 newScript.async = false;
-                if (htmxObj.config.inlineScriptNonce) {
-                    newScript.nonce = htmxObj.config.inlineScriptNonce;
+                if (htmx.config.inlineScriptNonce) {
+                    newScript.nonce = htmx.config.inlineScriptNonce;
                 }
                 var parent = script.parentElement;
 
@@ -1668,7 +1668,7 @@ return (function () {
 
         function processHxOn(elt) {
             var hxOnValue = getAttributeValue(elt, 'hx-on');
-            if (hxOnValue && htmxObj.config.allowEval) {
+            if (hxOnValue && htmx.config.allowEval) {
                 var handlers = {}
                 var lines = hxOnValue.split("\n");
                 var currentEvent = null;
@@ -1693,7 +1693,7 @@ return (function () {
         }
 
         function initNode(elt) {
-            if (elt.closest && elt.closest(htmxObj.config.disableSelector)) {
+            if (elt.closest && elt.closest(htmx.config.disableSelector)) {
                 return;
             }
             var nodeData = getInternalData(elt);
@@ -1865,8 +1865,8 @@ return (function () {
             }
             detail["elt"] = elt;
             var event = makeEvent(eventName, detail);
-            if (htmxObj.logger && !ignoreEventForLogging(eventName)) {
-                htmxObj.logger(elt, eventName, detail);
+            if (htmx.logger && !ignoreEventForLogging(eventName)) {
+                htmx.logger(elt, eventName, detail);
             }
             if (detail.error) {
                 logError(detail.error);
@@ -1911,7 +1911,7 @@ return (function () {
             var newHistoryItem = {url:url, content: content, title:title, scroll:scroll};
             triggerEvent(getDocument().body, "htmx:historyItemCreated", {item:newHistoryItem, cache: historyCache})
             historyCache.push(newHistoryItem)
-            while (historyCache.length > htmxObj.config.historyCacheSize) {
+            while (historyCache.length > htmx.config.historyCacheSize) {
                 historyCache.shift();
             }
             while(historyCache.length > 0){
@@ -1942,7 +1942,7 @@ return (function () {
         }
 
         function cleanInnerHtmlForHistory(elt) {
-            var className = htmxObj.config.requestClass;
+            var className = htmx.config.requestClass;
             var clone = elt.cloneNode(true);
             forEach(findAll(clone, "." + className), function(child){
                 removeClassFromElement(child, className);
@@ -1965,25 +1965,25 @@ return (function () {
                 saveToHistoryCache(path, cleanInnerHtmlForHistory(elt), getDocument().title, window.scrollY);
             }
 
-            if (htmxObj.config.historyEnabled) history.replaceState({htmx: true}, getDocument().title, window.location.href);
+            if (htmx.config.historyEnabled) history.replaceState({htmx: true}, getDocument().title, window.location.href);
         }
 
         function pushUrlIntoHistory(path) {
             // remove the cache buster parameter, if any
-            if (htmxObj.config.getCacheBusterParam) {
+            if (htmx.config.getCacheBusterParam) {
                 path = path.replace(/org\.htmx\.cache-buster=[^&]*&?/, '')
                 if (path.endsWith('&') || path.endsWith("?")) {
                     path = path.slice(0, -1);
                 }
             }
-            if(htmxObj.config.historyEnabled) {
+            if(htmx.config.historyEnabled) {
                 history.pushState({htmx:true}, "", path);
             }
             currentPathForHistory = path;
         }
 
         function replaceUrlInHistory(path) {
-            if(htmxObj.config.historyEnabled)  history.replaceState({htmx:true}, "", path);
+            if(htmx.config.historyEnabled)  history.replaceState({htmx:true}, "", path);
             currentPathForHistory = path;
         }
 
@@ -2045,7 +2045,7 @@ return (function () {
                 currentPathForHistory = path;
                 triggerEvent(getDocument().body, "htmx:historyRestore", {path:path, item:cached});
             } else {
-                if (htmxObj.config.refreshOnHistoryMiss) {
+                if (htmx.config.refreshOnHistoryMiss) {
 
                     // @ts-ignore: optional parameter in reload() function throws error
                     window.location.reload(true);
@@ -2063,7 +2063,7 @@ return (function () {
             forEach(indicators, function (ic) {
                 var internalData = getInternalData(ic);
                 internalData.requestCount = (internalData.requestCount || 0) + 1;
-                ic.classList["add"].call(ic.classList, htmxObj.config.requestClass);
+                ic.classList["add"].call(ic.classList, htmx.config.requestClass);
             });
             return indicators;
         }
@@ -2073,7 +2073,7 @@ return (function () {
                 var internalData = getInternalData(ic);
                 internalData.requestCount = (internalData.requestCount || 0) - 1;
                 if (internalData.requestCount === 0) {
-                    ic.classList["remove"].call(ic.classList, htmxObj.config.requestClass);
+                    ic.classList["remove"].call(ic.classList, htmx.config.requestClass);
                 }
             });
         }
@@ -2338,9 +2338,9 @@ return (function () {
         function getSwapSpecification(elt, swapInfoOverride) {
             var swapInfo = swapInfoOverride ? swapInfoOverride : getClosestAttributeValue(elt, "hx-swap");
             var swapSpec = {
-                "swapStyle" : getInternalData(elt).boosted ? 'innerHTML' : htmxObj.config.defaultSwapStyle,
-                "swapDelay" : htmxObj.config.defaultSwapDelay,
-                "settleDelay" : htmxObj.config.defaultSettleDelay
+                "swapStyle" : getInternalData(elt).boosted ? 'innerHTML' : htmx.config.defaultSwapStyle,
+                "swapDelay" : htmx.config.defaultSwapDelay,
+                "settleDelay" : htmx.config.defaultSettleDelay
             }
             if (getInternalData(elt).boosted && !isAnchorLink(elt)) {
               swapSpec["show"] = "top"
@@ -2387,7 +2387,7 @@ return (function () {
         }
 
         function getEncoding(elt) {
-            return getClosestAttributeValue(elt, "hx-encoding") || (matches(elt, "form") && getRawAttribute(elt, 'enctype')) || htmxObj.config.defaultEncoding;
+            return getClosestAttributeValue(elt, "hx-encoding") || (matches(elt, "form") && getRawAttribute(elt, 'enctype')) || htmx.config.defaultEncoding;
         }
 
         /** @returns {import("./htmx").EncodingResult | XMLHttpRequestBodyInit} */
@@ -2444,11 +2444,11 @@ return (function () {
                 }
                 if (swapSpec.show === "top" && (first || target)) {
                     target = target || first;
-                    target.scrollIntoView({block:'start', behavior: htmxObj.config.scrollBehavior});
+                    target.scrollIntoView({block:'start', behavior: htmx.config.scrollBehavior});
                 }
                 if (swapSpec.show === "bottom" && (last || target)) {
                     target = target || last;
-                    target.scrollIntoView({block:'end', behavior: htmxObj.config.scrollBehavior});
+                    target.scrollIntoView({block:'end', behavior: htmx.config.scrollBehavior});
                 }
             }
         }
@@ -2502,7 +2502,7 @@ return (function () {
         }
 
         function maybeEval(elt, toEval, defaultVal) {
-            if (htmxObj.config.allowEval) {
+            if (htmx.config.allowEval) {
                 return toEval();
             } else {
                 triggerErrorEvent(elt, 'htmx:evalDisallowedError');
@@ -2749,7 +2749,7 @@ return (function () {
             var allParameters = mergeObjects(rawParameters, expressionVars);
             var filteredParameters = filterValues(allParameters, elt);
 
-            if (htmxObj.config.getCacheBusterParam && verb === 'get') {
+            if (htmx.config.getCacheBusterParam && verb === 'get') {
                 filteredParameters['org.htmx.cache-buster'] = getRawAttribute(target, "id") || "true";
             }
 
@@ -2770,8 +2770,8 @@ return (function () {
                 target:target,
                 verb:verb,
                 errors:errors,
-                withCredentials: etc.credentials || requestAttrValues.credentials || htmxObj.config.withCredentials,
-                timeout:  etc.timeout || requestAttrValues.timeout || htmxObj.config.timeout,
+                withCredentials: etc.credentials || requestAttrValues.credentials || htmx.config.withCredentials,
+                timeout:  etc.timeout || requestAttrValues.timeout || htmx.config.timeout,
                 path:path,
                 triggeringEvent:event
             };
@@ -3092,7 +3092,7 @@ return (function () {
                 }
                 var swapSpec = getSwapSpecification(elt, swapOverride);
 
-                target.classList.add(htmxObj.config.swappingClass);
+                target.classList.add(htmx.config.swappingClass);
 
                 // optional transition API promise callbacks
                 var settleResolve = null;
@@ -3121,7 +3121,7 @@ return (function () {
                             !bodyContains(selectionInfo.elt) &&
                             selectionInfo.elt.id) {
                             var newActiveElt = document.getElementById(selectionInfo.elt.id);
-                            var focusOptions = { preventScroll: swapSpec.focusScroll !== undefined ? !swapSpec.focusScroll : !htmxObj.config.defaultFocusScroll };
+                            var focusOptions = { preventScroll: swapSpec.focusScroll !== undefined ? !swapSpec.focusScroll : !htmx.config.defaultFocusScroll };
                             if (newActiveElt) {
                                 // @ts-ignore
                                 if (selectionInfo.start && newActiveElt.setSelectionRange) {
@@ -3136,10 +3136,10 @@ return (function () {
                             }
                         }
 
-                        target.classList.remove(htmxObj.config.swappingClass);
+                        target.classList.remove(htmx.config.swappingClass);
                         forEach(settleInfo.elts, function (elt) {
                             if (elt.classList) {
-                                elt.classList.add(htmxObj.config.settlingClass);
+                                elt.classList.add(htmx.config.settlingClass);
                             }
                             triggerEvent(elt, 'htmx:afterSwap', responseInfo);
                         });
@@ -3158,7 +3158,7 @@ return (function () {
                             });
                             forEach(settleInfo.elts, function (elt) {
                                 if (elt.classList) {
-                                    elt.classList.remove(htmxObj.config.settlingClass);
+                                    elt.classList.remove(htmx.config.settlingClass);
                                 }
                                 triggerEvent(elt, 'htmx:afterSettle', responseInfo);
                             });
@@ -3213,7 +3213,7 @@ return (function () {
                     }
                 };
 
-                var shouldTransition = htmxObj.config.globalViewTransitions
+                var shouldTransition = htmx.config.globalViewTransitions
                 if(swapSpec.hasOwnProperty('transition')){
                     shouldTransition = swapSpec.transition;
                 }
@@ -4075,12 +4075,12 @@ return (function () {
         }
 
         function insertIndicatorStyles() {
-            if (htmxObj.config.includeIndicatorStyles !== false) {
+            if (htmx.config.includeIndicatorStyles !== false) {
                 getDocument().head.insertAdjacentHTML("beforeend",
                     "<style>\
-                      ." + htmxObj.config.indicatorClass + "{opacity:0;transition: opacity 200ms ease-in;}\
-                      ." + htmxObj.config.requestClass + " ." + htmxObj.config.indicatorClass + "{opacity:1}\
-                      ." + htmxObj.config.requestClass + "." + htmxObj.config.indicatorClass + "{opacity:1}\
+                      ." + htmx.config.indicatorClass + "{opacity:0;transition: opacity 200ms ease-in;}\
+                      ." + htmx.config.requestClass + " ." + htmx.config.indicatorClass + "{opacity:1}\
+                      ." + htmx.config.requestClass + "." + htmx.config.indicatorClass + "{opacity:1}\
                     </style>");
             }
         }
@@ -4098,7 +4098,7 @@ return (function () {
         function mergeMetaConfig() {
             var metaConfig = getMetaConfig();
             if (metaConfig) {
-                htmxObj.config = mergeObjects(htmxObj.config , metaConfig)
+                htmx.config = mergeObjects(htmx.config , metaConfig)
             }
         }
 
@@ -4140,7 +4140,7 @@ return (function () {
             }, 0);
         })
 
-        return htmxObj;
+        return htmx;
     }
 )()
 }));

--- a/test/core/internals.js
+++ b/test/core/internals.js
@@ -129,7 +129,7 @@ describe("Core htmx internals Tests", function() {
     it("encoding values respects enctype on forms", function(){
         var form = make("<form enctype='multipart/form-data'></form>");
         var value = htmx._("encodeParamsForBody")(null, form, {});
-        (value instanceof FormData).should.equal(true);
+        (value.body instanceof FormData).should.equal(true);
     })
 
 });

--- a/test/ext/extension-swap.js
+++ b/test/ext/extension-swap.js
@@ -7,15 +7,17 @@ describe("default extensions behavior", function () {
         this.server = makeServer();
         clearWorkArea();
 
-        htmx.registerExtension("ext-testswap", (features) => {
-            features.addSwap("testswap", {
-                handleSwap: (target, fragment) => {
-                    // simple outerHTML replacement for tests
-                    var parentEl = target.parentElement;
-                    parentEl.removeChild(target);
-                    return { newElements: [parentEl.appendChild(fragment)] };  // return the newly added element
+        htmx.registerExtension("ext-testswap", {
+            swaps: {
+                "testswap": {
+                    handleSwap: (target, fragment) => {
+                        // simple outerHTML replacement for tests
+                        var parentEl = target.parentElement;
+                        parentEl.removeChild(target);
+                        return { newElements: [parentEl.appendChild(fragment)] };  // return the newly added element
+                    }
                 }
-            });
+            }
         });
 
         htmx.defineExtension("ext-testswap", {

--- a/test/ext/json-enc.js
+++ b/test/ext/json-enc.js
@@ -12,7 +12,7 @@ describe("json-enc extension", function() {
     it('handles basic post properly', function () {
         var jsonResponseBody = JSON.stringify({});
         this.server.respondWith("POST", "/test", jsonResponseBody);
-        var div = make("<div hx-post='/test' hx-ext='json-enc'>click me</div>");
+        var div = make("<div hx-post='/test' hx-ext='json-enc' hx-encoding='application/json'>click me</div>");
         div.click();
         this.server.respond();
         this.server.lastRequest.response.should.equal("{}");
@@ -21,7 +21,7 @@ describe("json-enc extension", function() {
     it('handles basic put properly', function () {
         var jsonResponseBody = JSON.stringify({});
         this.server.respondWith("PUT", "/test", jsonResponseBody);
-        var div = make('<div hx-put="/test" hx-ext="json-enc">click me</div>');
+        var div = make('<div hx-put="/test" hx-ext="json-enc" hx-encoding="application/json">click me</div>');
         div.click();
         this.server.respond();
         this.server.lastRequest.response.should.equal("{}");
@@ -30,7 +30,7 @@ describe("json-enc extension", function() {
     it('handles basic patch properly', function () {
         var jsonResponseBody = JSON.stringify({});
         this.server.respondWith("PATCH", "/test", jsonResponseBody);
-        var div = make('<div hx-patch="/test" hx-ext="json-enc">click me</div>');
+        var div = make('<div hx-patch="/test" hx-ext="json-enc" hx-encoding="application/json">click me</div>');
         div.click();
         this.server.respond();
         this.server.lastRequest.response.should.equal("{}");
@@ -39,7 +39,7 @@ describe("json-enc extension", function() {
     it('handles basic delete properly', function () {
         var jsonResponseBody = JSON.stringify({});
         this.server.respondWith("DELETE", "/test", jsonResponseBody);
-        var div = make('<div hx-delete="/test" hx-ext="json-enc">click me</div>');
+        var div = make('<div hx-delete="/test" hx-ext="json-enc" hx-encoding="application/json">click me</div>');
         div.click();
         this.server.respond();
         this.server.lastRequest.response.should.equal("{}");
@@ -56,7 +56,7 @@ describe("json-enc extension", function() {
             xhr.respond(200, {}, JSON.stringify(ans));
         });
 
-        var html = make('<form hx-post="/test" hx-ext="json-enc" > ' +
+        var html = make('<form hx-post="/test" hx-ext="json-enc" hx-encoding="application/json" > ' +
             '<input type="text"  name="username" value="joe"> ' +
             '<input type="password"  name="password" value="123456"> ' +
         '<button  id="btnSubmit">Submit</button> ');
@@ -77,7 +77,7 @@ describe("json-enc extension", function() {
             xhr.respond(200, {}, JSON.stringify(ans));
         });
 
-        var html = make('<form hx-put="/test" hx-ext="json-enc" > ' +
+        var html = make('<form hx-put="/test" hx-ext="json-enc" hx-encoding="application/json" > ' +
             '<input type="text"  name="username" value="joe"> ' +
             '<input type="password"  name="password" value="123456"> ' +
         '<button  id="btnSubmit">Submit</button> ');
@@ -99,7 +99,7 @@ describe("json-enc extension", function() {
             xhr.respond(200, {}, JSON.stringify(ans));
         });
 
-        var html = make('<form hx-patch="/test" hx-ext="json-enc" > ' +
+        var html = make('<form hx-patch="/test" hx-ext="json-enc" hx-encoding="application/json" > ' +
             '<input type="text"  name="username" value="joe"> ' +
             '<input type="password"  name="password" value="123456"> ' +
         '<button  id="btnSubmit">Submit</button> ');
@@ -120,7 +120,7 @@ describe("json-enc extension", function() {
             xhr.respond(200, {}, JSON.stringify(ans));
         });
 
-        var html = make('<form hx-delete="/test" hx-ext="json-enc" > ' +
+        var html = make('<form hx-delete="/test" hx-ext="json-enc" hx-encoding="application/json" > ' +
             '<input type="text"  name="username" value="joe"> ' +
             '<input type="password"  name="password" value="123456"> ' +
         '<button  id="btnSubmit">Submit</button> ');
@@ -129,8 +129,5 @@ describe("json-enc extension", function() {
         this.server.respond();
         this.server.lastRequest.response.should.equal('{"passwordok":true}');
     })
-
-
-
 });
 


### PR DESCRIPTION
This PR is a proof of concept of brand new way to organize internal architecture and extensions in htmx 2.0. Drawing inspiration from _hyperscript, I introduce concepts of "features" and "feature sets" to group together related functionality of the core and provide clear, unambiguous extensibility points.

## But why?

Current implementation of extensions was, evidently, a later addition to htmx 1. While it did serve the purpose fairly well, the design of it left quite a bit to be desired. Have a look at this extension contract

```ts
export interface HtmxExtension {
    init(api): void;
    onEvent(name: string, evt: CustomEvent): boolean | void;
    transformResponse(text: string, xhr: XMLHttpRequest, elt: HTMLElement): any;
    isInlineSwap(swapStyle: string): boolean;
    handleSwap(swapStyle: string, target: HTMLElement, fragment: HTMLElement, settleInfo: any): HTMLElement[] | boolean;
    encodeParameters(xhr: XMLHttpRequest, parameters: object, elt: HTMLElement): XMLHttpRequestBodyInit;
}
```

Personally, here is a list of things I don't like:

1. Inconsistent extension points. This contract features:
   - `transformResponse`, `handleSwap`, `encodeParameters`, which are pretty obvious what their purpose are
   - `isInlineSwap`, which is called literally once when performing OOB swaps
   - `init` and `onEvent`, which can do literally anything (also fun fact, `onEvent` will always be called *last*, after every other event handler)
2. Inconsistent interactions with other htmx features
   - `handleSwap` will have the value of `hx-swap` attribute passed to the extension to match against (see morphdom and alpine-morph extensions). Extension is activated by a custom value of standard htmx attribute
   - `encodeParameters` will encode *any* request, ignoring values of `hx-encoding` and `enctype` (it has no obligations to read the value of hx-encoding, see json-enc extension).  Extension is activated by the presence of `hx-ext` attribute and has the power to override both default behavior and explicitly specified behavior
   - `tranformResponse` doesn't even have a corresponding htmx attribute or config value (see client-side-template extension).      Again, extension is activated by the presence of `hx-ext` attribute and has the power to do anything
3. Boilerplate extension invocation syntax. Every time htmx (or extensions) pass through an extension point, there has to be a call to `withExtensions` method which needs a lambda which actually calls the extension and performs a side effect of setting the result, and then there has to be a check if `withExtensions` did anything and if not, then core htmx will be called

## Goals

As such, I formulated this list of goals with this design

1. Extensions as first class citizens with clear place in htmx world
2. No boilerplate for extension invocation
3. No way to implicitly override defaults and core features
4. Provide straightforward extension points to create swaps, encodings, headers, response transformers and, ideally, attributes

## The outcome

**Disclaimer**: This is not final and not complete implementation. At this moment, the goal is to showcase the idea and evaluate if it's worth to consider moving forward. I converted only swaps and encodings to showcase how it would look and work in the core and in the extensions

Due to formatting and moving code around, the diff may be a bit messy (make sure to disable whitespace diff). Here is an overview of what's going on:

1. There is a new internal entity called `FeatureSet`, which carries within itself a `FeatureCollection`, which stores the `Feature`s. A `Feature` represents, well, a feature of htmx (in this implementation this includes swaps and encoding) and is itself a collection of named implementations of given feature (i.e., specific swap strategies or encodings)
2. Core htmx features (agains, swaps and encodings) are collected in the `coreFeatureSet` 
3. Extensions are implemented by registering their own feature collections.
5. Calls to `withExtensions` when passing through extension points were replaced by single `getFeature` method, which provides access to both core and extension features
      - if the feature implementation is defined in the core, it always has a priority over extensions. It's not possible to override `innerHTML` or `multipart/form-data`
      - otherwise, the method recursively collects extensions defined by hx-ext (similar to how `withExtenstions` does it) and from them retrieves the required implementation

There are some shortcomings of course:

1. It's not covered by tests at all (although everything else works (mostly))
2. There is no way to dynamically match attribute value (multi-swap extension relies on mini-syntax in `hx-swap`)
3. You probably will find other things

## But why not events?

In the discord, there was an idea of reworking extensibility to completely rely on events. While I like this idea, events carry additional semantics, such as bubbling, cancellation and execution order, which I find undesirable for extensions, especially if the extension wants to integrate with htmx's request pipeline. Also, they contradict my goals 1 and 2. Finally, htmx 2 includes exposing more public methods (such as swaps) in public API, and if the user wants to call `swap` with a swap provided by extension, events make it super non-trivial.

## This is too much

Soo... As I was preparing this I looked through the extensions. And there's a lot of them which really simple. They include a single and `onEvent` definition and that's it. And you know what? They are perfect. 

Like, how would you provide an extension point for [event-header](https://github.com/bigskysoftware/htmx/blob/master/src/ext/event-header.js), or [debug](https://github.com/bigskysoftware/htmx/blob/master/src/ext/debug.js), or [ajax-header](https://github.com/bigskysoftware/htmx/blob/master/src/ext/ajax-header.js), or [disable-element](https://github.com/bigskysoftware/htmx/blob/master/src/ext/disable-element.js)? Do you need an extension point for them? But then, how would you implement them? As attribute? Is there really a need to make a custom attribute for debug? Is it worth making user to both define `hx-ext` AND some `hx-debug` attribute to have it doing basically exactly the same? Maybe we could allow extensions to define some "root" "pseudo-attribute" which will be automatically set up on `hx-ext` but idk

And also, this is a big change. Like, complete overhaul of all internals and all extensions. While I believe it will be change for the best, it's still a lot of work within completely new paradigm. Breaking changes? Oh yes. Can it be adapted to the old extension syntax? Unlikely, but I haven't tried.

At least the HTML attributes should work the same

So, these thoughts above are the reason why I mentioned that I want to scratch everything and completely rework it. But as it stands now, I have no idea where to move. This PR is a product of about 1.5 weeks of thinking and prototyping, so I have relatively clear vision how this could be done, and I don't have an alternative with same level of clarity.

## So what if yes?

If we agreed that this is a worthy endeavor, then me and anyone who wishes to assist would work on migrating htmx features and extension to new framework, ensuring that all tests remain green with minimal (ideally zero) modifications. Ideally, we also adapt the simple extensions, mentioned above, to work with no modifications at all.

The drawback is that we would probably need a temporary feature freeze for 2.0, so that all existing features can be migrated and no new features will be lost

As I see it, such a massive refactoring would result in much more clear separation of different aspects of htmx, so then we can move forward with exposing those aspects as public API methods

## But what if maybe?

Of course, this is all subject to discussion and modifications. I fully recognize how radical this change is and will have no problems to tone it down a bit

## And what if no?

Back to the drawing board

## Why did you add `registerExtension`

So that `defineExtesion` keeps working while this is in progress, I'm not attached to the name

## Acknowledgments

- hyperscript.org for inspiration
- https://discord.com/channels/725789699527933952/1046573806547910677/1119478583493152870 for voicing this idea
