### PR TITLE
Support hx-target-5xx syntax in response-targets extension

### DIFF
--- a/test/ext/response-targets.js
+++ b/test/ext/response-targets.js
@@ -263,4 +263,38 @@ describe("response-targets extension", function() {
             htmx.config.responseTargetPrefersExisting = false;
         }
     });
+
+    describe('status code formatting', function()
+    {
+        var attributes = [
+            "hx-target-404",
+
+            "hx-target-40*",
+            "hx-target-40x",
+
+            "hx-target-4*",
+            "hx-target-4x",
+            "hx-target-4**",
+            "hx-target-4xx",
+
+            "hx-target-*",
+            "hx-target-x",
+            "hx-target-***",
+            "hx-target-xxx",
+        ];
+
+        // String replacement because IE11 doesn't support template literals
+        var btnMarkup = '<button hx-ext="response-targets" HX_TARGET="#d1" hx-get="/test">Click Me!</button>';
+        // forEach because IE11 doesn't play nice with closures inside for loops
+        attributes.forEach(function(attribute) {
+            it('supports ' + attribute, function() {
+                this.server.respondWith("GET", "/test", [404, {}, "Not found!"]);
+                var btn = make(btnMarkup.replace("HX_TARGET", attribute));
+                var div1 = make('<div id="d1"></div>')
+                btn.click();
+                this.server.respond();
+                div1.innerHTML.should.equal("Not found!");
+            });
+        });
+    });
 });

--- a/www/content/extensions/response-targets.md
+++ b/www/content/extensions/response-targets.md
@@ -2,7 +2,7 @@
 title = "response-targets"
 +++
 
-This extension allows to specify different target elements to be swapped when
+This extension allows you to specify different target elements to be swapped when
 different HTTP response codes are received.
 
 It uses attribute names in a form of ``hx-target-[CODE]`` where `[CODE]` is a numeric
@@ -100,6 +100,10 @@ be looked up (in the given order):
 * `hx-target-40*`
 * `hx-target-4*`
 * `hx-target-*`.
+
+
+_If you are using tools that do not support asterisks in HTML attributes, you
+may instead use the `x` character, e.g., `hx-target-4xx`._
 
 ## Notes
 


### PR DESCRIPTION
This PR implements #1564, enabling the `5xx` syntax for the response-targets extension.

I refactored the attribute detection logic to make explicit which syntaxes we support. I also added tests to cover all attribute syntaxes.

I updated the docs to note `5xx` as an alternative syntax, leaving the `5*` syntax as the prominent recommendation.

I noticed that while the original issue discussed the syntax `5xx` (double `x`), the extension currently supports `5*` (single asterisk). I hadn't previously noticed the gap between `*`'s wildcard semantics and `x`'s placeholder semantics. I elected to make single/double/triple characters work for both syntaxes (to minimize developer surprise), and we can document only most idiomatic `5*` and `5xx`. If you want me to do something different, let me know.