### PR TITLE
[enhancement] hx-reset attribute

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3440,6 +3440,22 @@ return (function () {
                             maybeCall(settleResolve);
                         }
 
+                        // hx-reset attribute
+                        var formElt
+                        if(hasAttribute(elt, "hx-reset")) {
+                            var resetTarget = getAttributeValue(elt, "hx-reset");
+                            if(!resetTarget) {
+                                if(elt.tagName === "FORM") formElt = elt
+                                else if(elt.form) formElt = elt.form
+                            } else {
+                                formElt = document.querySelector(resetTarget)
+                            }
+                        } else if(elt.form && elt.form.hasAttribute("hx-reset")) {
+                            formElt = elt.form
+                        }
+                        
+                        if(formElt && formElt.reset) formElt.reset()
+
                         if (swapSpec.settleDelay > 0) {
                             setTimeout(doSettle, swapSpec.settleDelay)
                         } else {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3450,7 +3450,7 @@ return (function () {
                             } else {
                                 formElt = document.querySelector(resetTarget)
                             }
-                        } else if(elt.form && elt.form.hasAttribute("hx-reset")) {
+                        } else if(elt.form && hasAttribute(elt.form, "hx-reset")) {
                             formElt = elt.form
                         }
                         

--- a/test/attributes/hx-reset.js
+++ b/test/attributes/hx-reset.js
@@ -1,0 +1,168 @@
+describe("hx-reset attribute", function() {
+    beforeEach(function () {
+        this.server = makeServer();
+        clearWorkArea();
+    });
+    afterEach(function () {
+        this.server.restore();
+        clearWorkArea();
+    });
+
+    it('should reset the form if hx-reset is present on form and response is successful', function () {
+        var response = sinon.spy(function(xhr) {
+            getParameters(xhr)["i1"].should.equal("user typed value");
+            xhr.respond(200, {}, "Hello");
+        })
+        this.server.respondWith("POST", "/test", response);
+        var form = make('<form hx-reset hx-post="/test" hx-trigger="click from:#i1"><input id="i1" name="i1" value="default value"/></form>')
+        var reset = sinon.spy(form, "reset");
+        var input = byId("i1")
+        input.value = "user typed value"
+        input.click()
+        this.server.respond();
+        response.calledOnce.should.equal(true, "Expected server to be called but it was not"); // make sure the server was called
+        reset.calledOnce.should.equal(true); // check at the form call level
+    });
+    it('should reset the form if hx-reset is present on triggering element and response successful, even with separate target', function () {
+        var response = sinon.spy(function(xhr) {
+            getParameters(xhr)["i1"].should.equal("user typed value");
+            xhr.respond(200, {}, "Hello");
+        })
+        this.server.respondWith("POST", "/test", response);
+        var form = make('<div id="theTarget"></div><form hx-reset hx-target="#theTarget" hx-post="/test" hx-trigger="click from:#i1"><input id="i1" name="i1" value="default value"/></form>')
+        var reset = sinon.spy(form, "reset");
+        var input = byId("i1")
+        input.value = "user typed value"
+        input.click()
+        this.server.respond();
+        response.calledOnce.should.equal(true, "Expected server to be called but it was not"); // make sure the server was called
+        reset.calledOnce.should.equal(true); // check at the form call level
+        input.value.should.equal("default value"); // check at the input level - though that tests the browser more than htmx
+    });
+    it('should reset the form if hx-reset is present on form, when request is triggered by child', function () {
+        var response = sinon.spy(function(xhr) {
+            getParameters(xhr)["i1"].should.equal("user typed value");
+            xhr.respond(200, {}, "Hello");
+        })
+        this.server.respondWith("POST", "/test", response);
+        var form = make('<form hx-reset><input hx-post="/test" hx-trigger="click" id="i1" name="i1" value="default value"/></form>')
+        var reset = sinon.spy(form, "reset");
+        var input = byId("i1")
+        input.value = "user typed value"
+        input.click();
+        this.server.respond();
+        response.calledOnce.should.equal(true, "Expected server to be called but it was not");
+        input.value.should.equal("default value");
+        reset.calledOnce.should.equal(true);
+    });
+    it('should reset the form if hx-reset is present on triggering element which has a form value', function () {
+        var response = sinon.spy(function(xhr) {
+            getParameters(xhr)["i1"].should.equal("user typed value");
+            xhr.respond(200, {}, "Hello");
+        })
+        this.server.respondWith("POST", "/test", response);
+        var form = make(`<form>
+            <input hx-post="/test" hx-reset="" hx-trigger="click" id="i1" name="i1" target="#theTarget" value="default value"/>
+            <div id="theTarget"></div>
+        </form>`)
+        var reset = sinon.spy(form, "reset");
+        var input = byId("i1")
+        input.value = "user typed value"
+        input.click();
+        this.server.respond();
+        response.calledOnce.should.equal(true, "Expected server to be called but it was not");
+        reset.calledOnce.should.equal(true);
+        input.value.should.equal("default value");
+    });
+    it('should not reset the form if no hx-reset attribute', function () {
+        var response = sinon.spy(function(xhr) {
+            getParameters(xhr)["i1"].should.equal("user typed value");
+            xhr.respond(200, {}, "Hello");
+        })
+        this.server.respondWith("POST", "/test", response);
+        var form = make('<form><input hx-post="/test" hx-trigger="click" id="i1" name="i1" value="default value"/></form>')
+        var reset = sinon.spy(form, "reset");
+        var input = byId("i1")
+        input.value = "user typed value"
+        input.click();
+        this.server.respond();
+        response.calledOnce.should.equal(true, "Expected server to be called but it was not");
+        input.value.should.equal("user typed value");
+        reset.called.should.equal(false);
+    });
+    it('should not reset the form if response is unsuccessful', function () {
+        var response = sinon.spy(function(xhr) {
+            getParameters(xhr)["i1"].should.equal("user typed value");
+            xhr.respond(400, {}, "Hello");
+        })
+        this.server.respondWith("POST", "/test", response);
+        var form = make('<form hx-reset><input hx-post="/test" hx-trigger="click" id="i1" name="i1" value="default value"/></form>')
+        var reset = sinon.spy(form, "reset");
+        var input = byId("i1")
+        input.value = "user typed value"
+        input.click();
+        this.server.respond();
+        response.calledOnce.should.equal(true, "Expected server to be called but it was not");
+        input.value.should.equal("user typed value");
+        reset.called.should.equal(false);
+    });
+    it('should reset a form specified by querySelector', function () {
+        var response = sinon.spy(function(xhr) {
+            getParameters(xhr)["i1"].should.equal("user typed value");
+            xhr.respond(200, {}, "Hello");
+        })
+        this.server.respondWith("POST", "/test", response);
+        var div = make(`<div>
+            <form id="theForm"></form>
+            <input hx-reset="#theForm" hx-post="/test" hx-trigger="click" id="i1" name="i1" value="default value"/>
+        </div>`)
+        var form = byId("theForm")
+        var reset = sinon.spy(form, "reset");
+        var input = byId("i1")
+        input.value = "user typed value"
+        input.click();
+        this.server.respond();
+        response.calledOnce.should.equal(true, "Expected server to be called but it was not");
+        reset.called.should.equal(true, "Expected form to be reset but form.reset was not called");
+    });
+    it('should reset a form specified by querySelector, even if it also the target', function () {
+        var response = sinon.spy(function(xhr) {
+            getParameters(xhr)["i1"].should.equal("user typed value");
+            xhr.respond(200, {}, "Hello");
+        })
+        this.server.respondWith("POST", "/test", response);
+        var div = make(`<div>
+            <form id="theForm"></form>
+            <input hx-reset="#theForm" hx-post="/test" hx-target="#theForm" hx-trigger="click" id="i1" name="i1" value="default value"/>
+        </div>`)
+        var form = byId("theForm")
+        var reset = sinon.spy(form, "reset");
+        var input = byId("i1")
+        input.value = "user typed value"
+        input.click();
+        this.server.respond();
+        response.calledOnce.should.equal(true, "Expected server to be called but it was not");
+        reset.called.should.equal(true, "Expected form to be reset but form.reset was not called");
+    });
+    it('should ignore if specified target is not a form', function () {
+        var response = sinon.spy(function(xhr) {
+            getParameters(xhr)["i1"].should.equal("user typed value");
+            xhr.respond(200, {}, "Hello");
+        })
+        this.server.respondWith("POST", "/test", response);
+        var div = make(`<div>
+            <div id="theNotForm"></div>
+            <form>
+                <input hx-reset="#theNotForm" hx-post="/test" hx-target="#theNotForm" hx-trigger="click" id="i1" name="i1" value="default value"/>
+            </form>
+        </div>`)
+        var form = byId("theNotForm")
+        var input = byId("i1")
+        input.value = "user typed value"
+        input.click();
+        this.server.respond();
+        response.calledOnce.should.equal(true, "Expected server to be called but it was not");
+        input.value.should.equal("user typed value");
+    });
+
+});

--- a/test/attributes/hx-reset.js
+++ b/test/attributes/hx-reset.js
@@ -1,6 +1,7 @@
 describe("hx-reset attribute", function() {
     beforeEach(function () {
         this.server = makeServer();
+        this.server.respondImmediately = true;
         clearWorkArea();
     });
     afterEach(function () {
@@ -19,7 +20,6 @@ describe("hx-reset attribute", function() {
         var input = byId("i1")
         input.value = "user typed value"
         input.click()
-        this.server.respond();
         response.calledOnce.should.equal(true, "Expected server to be called but it was not"); // make sure the server was called
         reset.calledOnce.should.equal(true); // check at the form call level
     });
@@ -35,7 +35,6 @@ describe("hx-reset attribute", function() {
         var input = byId("i1")
         input.value = "user typed value"
         input.click()
-        this.server.respond();
         response.calledOnce.should.equal(true, "Expected server to be called but it was not"); // make sure the server was called
         reset.calledOnce.should.equal(true); // check at the form call level
         input.value.should.equal("default value"); // check at the input level - though that tests the browser more than htmx
@@ -51,7 +50,6 @@ describe("hx-reset attribute", function() {
         var input = byId("i1")
         input.value = "user typed value"
         input.click();
-        this.server.respond();
         response.calledOnce.should.equal(true, "Expected server to be called but it was not");
         input.value.should.equal("default value");
         reset.calledOnce.should.equal(true);
@@ -70,7 +68,6 @@ describe("hx-reset attribute", function() {
         var input = byId("i1")
         input.value = "user typed value"
         input.click();
-        this.server.respond();
         response.calledOnce.should.equal(true, "Expected server to be called but it was not");
         reset.calledOnce.should.equal(true);
         input.value.should.equal("default value");
@@ -86,7 +83,6 @@ describe("hx-reset attribute", function() {
         var input = byId("i1")
         input.value = "user typed value"
         input.click();
-        this.server.respond();
         response.calledOnce.should.equal(true, "Expected server to be called but it was not");
         input.value.should.equal("user typed value");
         reset.called.should.equal(false);
@@ -102,7 +98,6 @@ describe("hx-reset attribute", function() {
         var input = byId("i1")
         input.value = "user typed value"
         input.click();
-        this.server.respond();
         response.calledOnce.should.equal(true, "Expected server to be called but it was not");
         input.value.should.equal("user typed value");
         reset.called.should.equal(false);
@@ -122,7 +117,6 @@ describe("hx-reset attribute", function() {
         var input = byId("i1")
         input.value = "user typed value"
         input.click();
-        this.server.respond();
         response.calledOnce.should.equal(true, "Expected server to be called but it was not");
         reset.called.should.equal(true, "Expected form to be reset but form.reset was not called");
     });
@@ -141,7 +135,6 @@ describe("hx-reset attribute", function() {
         var input = byId("i1")
         input.value = "user typed value"
         input.click();
-        this.server.respond();
         response.calledOnce.should.equal(true, "Expected server to be called but it was not");
         reset.called.should.equal(true, "Expected form to be reset but form.reset was not called");
     });
@@ -160,7 +153,6 @@ describe("hx-reset attribute", function() {
         var input = byId("i1")
         input.value = "user typed value"
         input.click();
-        this.server.respond();
         response.calledOnce.should.equal(true, "Expected server to be called but it was not");
         input.value.should.equal("user typed value");
     });
@@ -180,7 +172,6 @@ describe("hx-reset attribute", function() {
         var input = byId("i1")
         input.value = "user typed value"
         input.click();
-        this.server.respond();
         response.calledOnce.should.equal(true, "Expected server to be called but it was not");
         input.value.should.equal("user typed value");
         target.textContent.should.equal("Hello");
@@ -196,7 +187,6 @@ describe("hx-reset attribute", function() {
         var input = byId("i1")
         input.value = "user typed value"
         input.click()
-        this.server.respond();
         response.calledOnce.should.equal(true, "Expected server to be called but it was not"); // make sure the server was called
         reset.calledOnce.should.equal(true); // check at the form call level
     });

--- a/test/attributes/hx-reset.js
+++ b/test/attributes/hx-reset.js
@@ -23,6 +23,7 @@ describe("hx-reset attribute", function() {
         response.calledOnce.should.equal(true, "Expected server to be called but it was not"); // make sure the server was called
         reset.calledOnce.should.equal(true); // check at the form call level
     });
+    
     it('should reset the form if hx-reset is present on triggering element and response successful, even with separate target', function () {
         var response = sinon.spy(function(xhr) {
             getParameters(xhr)["i1"].should.equal("user typed value");
@@ -184,5 +185,19 @@ describe("hx-reset attribute", function() {
         input.value.should.equal("user typed value");
         target.textContent.should.equal("Hello");
     });
-
+    it('should reset the form if data-hx-reset is present on form and response is successful', function () {
+        var response = sinon.spy(function(xhr) {
+            getParameters(xhr)["i1"].should.equal("user typed value");
+            xhr.respond(200, {}, "Hello");
+        })
+        this.server.respondWith("POST", "/test", response);
+        var form = make('<form hx-reset hx-post="/test" hx-trigger="click from:#i1"><input id="i1" name="i1" value="default value"/></form>')
+        var reset = sinon.spy(form, "reset");
+        var input = byId("i1")
+        input.value = "user typed value"
+        input.click()
+        this.server.respond();
+        response.calledOnce.should.equal(true, "Expected server to be called but it was not"); // make sure the server was called
+        reset.calledOnce.should.equal(true); // check at the form call level
+    });
 });

--- a/test/attributes/hx-reset.js
+++ b/test/attributes/hx-reset.js
@@ -156,13 +156,33 @@ describe("hx-reset attribute", function() {
                 <input hx-reset="#theNotForm" hx-post="/test" hx-target="#theNotForm" hx-trigger="click" id="i1" name="i1" value="default value"/>
             </form>
         </div>`)
-        var form = byId("theNotForm")
         var input = byId("i1")
         input.value = "user typed value"
         input.click();
         this.server.respond();
         response.calledOnce.should.equal(true, "Expected server to be called but it was not");
         input.value.should.equal("user typed value");
+    });
+    it('should ignore if specified target does not exist', function () {
+        var response = sinon.spy(function(xhr) {
+            getParameters(xhr)["i1"].should.equal("user typed value");
+            xhr.respond(200, {}, "Hello");
+        })
+        this.server.respondWith("POST", "/test", response);
+        var div = make(`<div>
+            <div id="theTarget"></div>
+            <form>
+                <input hx-reset="#theMissingElement" hx-post="/test" hx-target="#theTarget" hx-trigger="click" id="i1" name="i1" value="default value"/>
+            </form>
+        </div>`)
+        var target= byId("theTarget")
+        var input = byId("i1")
+        input.value = "user typed value"
+        input.click();
+        this.server.respond();
+        response.calledOnce.should.equal(true, "Expected server to be called but it was not");
+        input.value.should.equal("user typed value");
+        target.textContent.should.equal("Hello");
     });
 
 });

--- a/test/index.html
+++ b/test/index.html
@@ -75,6 +75,7 @@
 <script src="attributes/hx-push-url.js"></script>
 <script src="attributes/hx-put.js"></script>
 <script src="attributes/hx-request.js"></script>
+<script src="attributes/hx-reset.js"></script>
 <script src="attributes/hx-select.js"></script>
 <script src="attributes/hx-select-oob.js"></script>
 <script src="attributes/hx-sse.js"></script>

--- a/test/manual/hx-reset.html
+++ b/test/manual/hx-reset.html
@@ -1,0 +1,53 @@
+<html>
+<body>
+    <div id="message"></div>
+<form hx-post="/reset" hx-target="#message">
+    <p>No hx reset</p>
+    input 1: <input type="text" name="i1" /><br/>
+    input 2: <input type="text" name="i2" /><br/>
+    <input type = "submit" value = "Submit" />
+</form>
+<form hx-post="/reset" hx-reset hx-target="#message">
+    <p>Hx reset on triggering form</p>
+    input 1: <input type="text" name="i1" /><br/>
+    input 2: <input type="text" name="i2" /><br/>
+    <input type = "submit" value = "Submit" />
+</form>
+<form>
+    <p>Hx reset on triggering element with form parent</p>
+    input 1: <input type="text" name="i1" /><br/>
+    input 2: <input type="text" name="i2" /><br/>
+    <button hx-post="/reset" hx-reset hx-target="#message">Submit</button>
+</form>
+<form data-hx-reset="">
+    <p>Data-Hx reset on triggering element's parent form</p>
+    input 1: <input type="text" name="i1" /><br/>
+    input 2: <input type="text" name="i2" /><br/>
+    <button hx-post="/reset" hx-target="#message">Submit</button>
+</form>
+<div>
+    <p>Hx reset targeting another form</p>
+    <form id="targetForm">
+        input 1: <input type="text" name="i1" /><br/>
+        input 2: <input type="text" name="i2" /><br/>
+    </form>
+    <button hx-post="/reset" hx-reset="#targetForm" hx-target="#message">Submit</button>
+</div>
+<div>
+    <p>Hx reset targeting a form which does not exit</p>
+    <form id="targetForm2">
+        input 1: <input type="text" name="i1" /><br/>
+        input 2: <input type="text" name="i2" /><br/>
+    </form>
+    <button hx-post="/reset" hx-reset="#notTheRightNameForm" hx-target="#message">Submit</button>
+</div>
+<script src="../../node_modules/sinon/pkg/sinon.js"></script>
+<script src="../../src/htmx.js"></script>
+<script src="../util/util.js"></script>
+<script>
+    var server = sinon.fakeServer.create({autoResponse: true});
+    server.autoRespond = true;
+    server.respondWith("POST", "/reset", [200, { "Content-Type": "text/html" }, "Hi"]);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Referring to #1380 

If the proposed behavior is approved, this PR has the following feature and corresponding tests:

1. No change in current behavior
2. if `[data-]hx-reset` is set on an element which triggers a request:
   1. without value: `hx-reset` or `hx-reset=""` 
      a) if the element is a form, reset it on successful request
      b) if element has a form as parent (checked via `element.form`), reset that form on successful request
   2. with value: use querySelector with said value and reset that element. if no element or element is not a form, do nothing
   3. If request is unsuccessful, do not reset form
3. if `hx-reset` is set on a form and one of its children triggers the request, reset the form on successful request

If this is approved, I'll help write the docs