### PR TITLE
[Draft] Proposed HX-Retarget-Root header

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3294,8 +3294,20 @@ return (function () {
                 }
             }
 
-            if (hasHeader(xhr,/HX-Retarget:/i)) {
-                responseInfo.target = getDocument().querySelector(xhr.getResponseHeader("HX-Retarget"));
+            if (hasHeader(xhr, /HX-Retarget:/i)) {
+                var retargetSelector = xhr.getResponseHeader("HX-Retarget")
+                if (hasHeader(xhr, /HX-Retarget-Root:/i)) {
+                    var retargetRootSelector = xhr.getResponseHeader("HX-Retarget-Root")
+                    var retargetRoot
+                    if (retargetRootSelector === "this") {
+                        retargetRoot = elt;
+                    } else {
+                        retargetRoot = getDocument().querySelector(xhr.getResponseHeader("HX-Retarget-Root"))
+                    }
+                    responseInfo.target = querySelectorExt(retargetRoot, retargetSelector)
+                } else {
+                    responseInfo.target = getDocument().querySelector(retargetSelector);
+                }
             }
 
             var historyUpdate = determineHistoryUpdates(elt, responseInfo);

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3302,7 +3302,7 @@ return (function () {
                     if (retargetRootSelector === "this") {
                         retargetRoot = elt;
                     } else {
-                        retargetRoot = getDocument().querySelector(xhr.getResponseHeader("HX-Retarget-Root"))
+                        retargetRoot = getDocument().querySelector(retargetRootSelector)
                     }
                     responseInfo.target = querySelectorExt(retargetRoot, retargetSelector)
                 } else {

--- a/test/manual/hx-retarget-root.html
+++ b/test/manual/hx-retarget-root.html
@@ -1,0 +1,42 @@
+<html lang="en">
+<head>
+	<meta charset="utf-8" />
+	<title>HX Retarget sample - to be removed and replaced with actual tests</title>
+	<script src="../../node_modules/sinon/pkg/sinon.js"></script>
+	<script src="../util/util.js"></script>
+	<script src="../../src/htmx.js"></script>
+
+	<script>
+		let requestCount = 0;
+		var server = sinon.fakeServer.create({respondImmediately: true});
+		server.respondWith("GET", "/sample", [200, {
+			"HX-Retarget": "#retargeted"
+		}, "Hi"]);
+		server.respondWith("GET", "/retarget-root", [200, {
+			"HX-Retarget": "find .child",
+			"HX-Retarget-Root": "#div1"
+		}, "Retargeted root"]);
+		server.respondWith("GET", "/retarget-root-this", [200, {
+			"HX-Retarget": "find .withThis",
+			"HX-Retarget-Root": "this"
+		}, "Retargeted root with this"]);
+	</script>
+
+	
+
+</head>
+<body style="padding:20px;font-family: sans-serif">
+<h1>Sample</h1>
+<div style="margin: 20px 0; border-bottom: solid 1px gray" hx-get="/sample" hx-trigger="load">
+	<div id="retargeted"></div>
+</div>
+<div style="margin: 20px 0; border-bottom: solid 1px gray" hx-get="/retarget-root" hx-trigger="load" id="div1">
+	<div class="child">Hello</div>
+	<div>Untouched</div>
+</div>
+<div hx-get="/retarget-root-this" hx-trigger="load">
+	<div class="child">Untouched</div>
+	<div class="withThis"></div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Referring to #1640 , it does feel as though HX-Retarget could behave like `hx-target` in the same type of relationship as HX-Reswap/hx-swap

Specifically, hx-target has modifiers `closest`, `find` etc, but `HX-Retarget` is a direct `querySelector` from `document`

For backwards compatibility's sake, this PR would introduce a `HX-Retarget-Root` header:

1. if unset, behavior is unchanged, HX-Retarget is a simple querySelector from `document`
2. if set, the value of `HX-Retarget` can use the modifiers e.g. `find div` and it is triggered not from `document` but from an element determined as follows:
    1. the element which initially triggered the request if `HX-Retarget-Root: this`
    2. an element found by `document.querySelector(xhr.getHeaderValue('HX-Retarget-Root'))` otherwise

This PR is not ready for merge at all, tests are not written and there is a manual test which would be removed.; it is meant to showcase the behavior 

I'll write tests/documentation if the  maintainers feel that this is of interest to the project.

Thanks!