### PR TITLE
Add date and author to essay template

### DIFF
--- a/www/config.toml
+++ b/www/config.toml
@@ -7,7 +7,8 @@ build_search_index = false
 generate_feed = true
 
 taxonomies = [
-  { name = "tag", render = false, feed = true }
+  { name = "tag", render = false, feed = true },
+  { name = "author", render = false, feed = false }
 ]
 
 [markdown]

--- a/www/content/essays/10-tips-for-SSR-HDA-apps.md
+++ b/www/content/essays/10-tips-for-SSR-HDA-apps.md
@@ -3,6 +3,7 @@ title = "10 Tips For Building SSR/HDA applications"
 date = 2022-06-13
 updated = 2023-06-13
 [taxonomies]
+author = ["Carson Gross"]
 tag = ["posts"]
 +++
 

--- a/www/content/essays/_index.md
+++ b/www/content/essays/_index.md
@@ -1,6 +1,7 @@
 +++
 title = "Essays"
 insert_anchor_links = "left"
+page_template = "essay.html"
 +++
 
 ### Hypermedia and REST

--- a/www/content/essays/a-real-world-react-to-htmx-port.md
+++ b/www/content/essays/a-real-world-react-to-htmx-port.md
@@ -3,6 +3,7 @@ title = "A Real World React -> htmx Port"
 date = 2022-09-29
 updated = 2022-10-15
 [taxonomies]
+author = ["Carson Gross"]
 tag = ["posts"]
 +++
 

--- a/www/content/essays/a-response-to-rich-harris.md
+++ b/www/content/essays/a-response-to-rich-harris.md
@@ -3,6 +3,7 @@ title = "A Response To &quot;Have Single-Page Apps Ruined the Web?&quot;"
 date = 2021-12-24
 updated = 2022-05-27
 [taxonomies]
+author = ["Carson Gross"]
 tag = ["posts"]
 +++
 

--- a/www/content/essays/architectural-sympathy.md
+++ b/www/content/essays/architectural-sympathy.md
@@ -3,6 +3,7 @@ title = "Architectural Sympathy"
 date = 2023-04-06
 updated = 2023-04-06
 [taxonomies]
+author = ["Carson Gross"]
 +++
 
 

--- a/www/content/essays/complexity-budget.md
+++ b/www/content/essays/complexity-budget.md
@@ -3,6 +3,7 @@ title = "Complexity Budget"
 date = 2020-10-29
 updated = 2022-02-06
 [taxonomies]
+author = ["Carson Gross"]
 tag = ["posts"]
 +++
 

--- a/www/content/essays/hateoas.md
+++ b/www/content/essays/hateoas.md
@@ -3,16 +3,18 @@ title = "HATEOAS"
 date = 2021-10-16
 updated = 2022-02-06
 [taxonomies]
+author = ["Carson Gross"]
 tag = ["posts"]
 [extra]
 show_title = false
+show_author = false
 +++
 
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Lexend+Zetta:wght@900&display=swap&text=HATEOAS" rel="stylesheet">
-<link href="https://fonts.googleapis.com/css2?family=Lexend+Zetta:wght@900&display=swap" rel="stylesheet"> 
-<link href="https://fonts.googleapis.com/css2?family=Source+Serif+Pro:ital,wght@0,400;0,600;0,700;1,400;1,700&display=swap" rel="stylesheet"> 
+<link href="https://fonts.googleapis.com/css2?family=Lexend+Zetta:wght@900&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Source+Serif+Pro:ital,wght@0,400;0,600;0,700;1,400;1,700&display=swap" rel="stylesheet">
 
 <h1>HATEOAS</h1>
 
@@ -31,13 +33,13 @@ Hypermedia as the Engine of Application State (HATEOAS) is a constraint of the [
 With HATEOAS, a client interacts with a network application whose application servers provide information dynamically through [*hypermedia*](https://en.wikipedia.org/wiki/Hypermedia). A REST client needs little to no prior knowledge about how to interact with an application or server beyond a generic understanding of hypermedia.
 
 By contrast, today JSON-based web clients typically interact through a fixed interface shared through documentation via a tool
-such as [swagger](https://swagger.io/). 
+such as [swagger](https://swagger.io/).
 
 The restrictions imposed by HATEOAS decouples client and server. This enables server functionality to evolve independently.
 
 ## Example
 
-A user-agent that implements HTTP makes a HTTP request of a REST end point through a simple URL. All subsequent requests the user-agent may make are discovered within the hypermedia responses to each request. The media types used for these representations, and the link relations they may contain, are standardized. The client transitions through application states by selecting from links within a hypermedia representation or by manipulating the representation in other ways afforded by its media type. 
+A user-agent that implements HTTP makes a HTTP request of a REST end point through a simple URL. All subsequent requests the user-agent may make are discovered within the hypermedia responses to each request. The media types used for these representations, and the link relations they may contain, are standardized. The client transitions through application states by selecting from links within a hypermedia representation or by manipulating the representation in other ways afforded by its media type.
 
 In this way, RESTful interaction is driven by hypermedia, rather than out-of-band information.
 
@@ -89,10 +91,10 @@ Only one link is available: to deposit more money. In the accounts current overd
 this fact is reflected internally in *the hypermedia*.  The web browser does not know about the concept of an overdrawn account or,
 indeed, even what an account is.  It simply knows how to present hypermedia representations to a user.
 
-Hence we have the notion of the Hypermedia being the Engine of Application State. What actions are possible varies as the 
+Hence we have the notion of the Hypermedia being the Engine of Application State. What actions are possible varies as the
 state of the resource varies and this information is encoded in the hypermedia.
 
-Contrast the HTML response above with a typical JSON API which, instead, might return a representation of the account with a 
+Contrast the HTML response above with a typical JSON API which, instead, might return a representation of the account with a
 status field:
 
 ```json
@@ -111,8 +113,8 @@ HTTP/1.1 200 OK
 ```
 
 Here we can see that the client must know specifically what the value of the `status` field means and how it might affect
-the rendering of a user interface, and what actions can be taken with it.  The client must also know what URLs must be used 
-for manipulation of this resource since they are not encoded in the response.  This would typically be achieved by 
+the rendering of a user interface, and what actions can be taken with it.  The client must also know what URLs must be used
+for manipulation of this resource since they are not encoded in the response.  This would typically be achieved by
 consulting documentation for the JSON API.
 
 It is this requirement of out-of-band information that distinguishes this JSON API from a RESTful API that implements
@@ -164,13 +166,13 @@ HTTP/1.1 200 OK
 
 Here, the "hypermedia controls" are encoded in a `links` property on the account object.
 
-Unfortunately, the client of this API still needs to know quite a bit of additional information: 
+Unfortunately, the client of this API still needs to know quite a bit of additional information:
 
 * What http methods can be used against these URLs?
 * Can it issue a `GET` to these URLs in order to get a representation of the mutation in question?
 * If it can `POST` to a given URL, what values are expected?
 
-Compare the above JSON with the following HTTP response, retrieved by a browser after a user has clicked on the 
+Compare the above JSON with the following HTTP response, retrieved by a browser after a user has clicked on the
 link to `/accounts/12345/deposits` found in the first HTML example:
 
 ```html
@@ -187,7 +189,7 @@ HTTP/1.1 200 OK
 ```
 
 Note that this HTML response encodes all the information necessary to update the account balance, providing a `form` with a `method`
-and `action` attribute, as well as the inputs necessary for updating the resource correctly.  
+and `action` attribute, as well as the inputs necessary for updating the resource correctly.
 
 The JSON representation does not have the same self-contained "uniform interface" as the HTML representation does.
 

--- a/www/content/essays/how-did-rest-come-to-mean-the-opposite-of-rest.md
+++ b/www/content/essays/how-did-rest-come-to-mean-the-opposite-of-rest.md
@@ -1,13 +1,11 @@
 +++
 title = "How Did REST Come To Mean The Opposite of REST?"
-author = "Carson Gross <carson@bigsky.software>"
 date = 2022-07-18
 updated = 2022-11-26
 [taxonomies]
+author = ["Carson Gross"]
 tag = ["posts"]
 +++
-
-<h4>18 July 2022</h4>
 
 <style>
   pre {
@@ -20,51 +18,51 @@ tag = ["posts"]
 <img src="/img/tap-the-sign.png" alt="You are wrong" style="width: 80%;margin-left:10%; margin-top: 16px;margin-bottom: 16px">
 
 > I am getting frustrated by the number of people calling any HTTP-based interface a REST API. Today’s example is the
-> SocialSite REST API. That is RPC. It screams RPC. There is so much coupling on display that it should be given an 
+> SocialSite REST API. That is RPC. It screams RPC. There is so much coupling on display that it should be given an
 > X rating.
-> 
-> What needs to be done to make the REST architectural style clear on the notion that hypertext is a constraint? In 
-> other words, if the engine of application state (and hence the API) is not being driven by hypertext, then it cannot 
+>
+> What needs to be done to make the REST architectural style clear on the notion that hypertext is a constraint? In
+> other words, if the engine of application state (and hence the API) is not being driven by hypertext, then it cannot
 > be RESTful and cannot be a REST API. Period. Is there some broken manual somewhere that needs to be fixed?
-> 
+>
 > _--Roy Fielding, Creator of the term REST_
-> 
+>
 > _&nbsp;&nbsp;&nbsp;[REST APIs must be hypertext-driven](https://roy.gbiv.com/untangled/2008/rest-apis-must-be-hypertext-driven)_
 
 
-[REST](https://en.wikipedia.org/wiki/Representational_state_transfer) must be the most broadly misused technical term 
-in computer programming history.  
+[REST](https://en.wikipedia.org/wiki/Representational_state_transfer) must be the most broadly misused technical term
+in computer programming history.
 
-I can't think of anything else that comes close.  
+I can't think of anything else that comes close.
 
 Today, when someone uses the term REST, they are nearly always discussing a JSON-based API using HTTP.
 
-When you see a job post mentioning REST or a company discussing [REST Guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md) 
+When you see a job post mentioning REST or a company discussing [REST Guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md)
 they will rarely mention either hypertext or hypermedia: they will instead mention JSON, GraphQL(!) and the like.
 
-Only a few obstinate folks grumble: but these JSON APIs aren't RESTful!  
+Only a few obstinate folks grumble: but these JSON APIs aren't RESTful!
 
-<iframe src="https://www.youtube.com/embed/HOK6mE7sdvs" title="Doesn't anyone notice this?" 
+<iframe src="https://www.youtube.com/embed/HOK6mE7sdvs" title="Doesn't anyone notice this?"
         frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope"
         style="width: 400px;height:300px;margin-left:15%;margin-top: 16px;margin-bottom: 16px">
 </iframe>
 
-In this post, I'd like to give you a [brief, incomplete and mostly wrong](https://james-iry.blogspot.com/2009/05/brief-incomplete-and-mostly-wrong.html) 
+In this post, I'd like to give you a [brief, incomplete and mostly wrong](https://james-iry.blogspot.com/2009/05/brief-incomplete-and-mostly-wrong.html)
 history of REST, and how we got to a place where its meaning has been nearly perfectly inverted to mean what REST was
 original contrasted with: RPC.
 
 ##  Where Did REST Come From?
 
-The term REST, short for REpresentational State Transfer, came from 
+The term REST, short for REpresentational State Transfer, came from
 [Chapter 5 of Fielding's PhD Dissertation](https://www.ics.uci.edu/~fielding/pubs/dissertation/rest_arch_style.htm).
 Fielding was describing the network architecture of the (then new) world wide web, and contrasting it with other possible
 network architectures, particularly RPC-style network architectures.
 
-It is important to understand that, at the time of his writing (1999-2000), there were no JSON APIs: he was describing 
-the web as it existed at that time, with HTML being exchanged over HTTP as people "surfed the web".  JSON hadn't been 
+It is important to understand that, at the time of his writing (1999-2000), there were no JSON APIs: he was describing
+the web as it existed at that time, with HTML being exchanged over HTTP as people "surfed the web".  JSON hadn't been
 created yet, and broad adoption of JSON was a decade off.
 
-REST described a _network architecture_, and it was defined in terms of _constraints_ on an API, constraints that 
+REST described a _network architecture_, and it was defined in terms of _constraints_ on an API, constraints that
 needed to be met in order to be considered a RESTful API.  The language is academic, which has contributed to the
 confusion around the topic, but it is clear enough that most developers should be able to understand it.
 
@@ -74,7 +72,7 @@ REST has many constraints and concepts within it, but there is one crucial idea 
 most distinguishing characteristic of REST, when contrasted with other possible network architectures.
 
 This is known as the [uniform interface constraint](https://en.wikipedia.org/wiki/Representational_state_transfer#Uniform_interface),
-and more specifically within that concept, the idea of [Hypermedia As The Engine of Application State (HATEOAS)](https://htmx.org/essays/hateoas/) 
+and more specifically within that concept, the idea of [Hypermedia As The Engine of Application State (HATEOAS)](https://htmx.org/essays/hateoas/)
 or as Fielding prefers to call it, the hypermedia constraint.
 
 In order to understand this uniform interface constraint, lets consider two HTTP responses returning information about a
@@ -114,32 +112,32 @@ HTTP/1.1 200 OK
 }
 ```
 
-The crucial difference between these two responses, and why the _HTML response_ is RESTful, but the 
+The crucial difference between these two responses, and why the _HTML response_ is RESTful, but the
 _JSON response_ is not, is this:
 
 <p style="margin:32px;text-align: center;font-weight: bold">The HTML response is entirely self-describing.</p>
 
-A proper hypermedia client that receives this response does not know what a bank account is, what a 
-balance is, etc.  It simply knows how to render a hypermedia, HTML.  
+A proper hypermedia client that receives this response does not know what a bank account is, what a
+balance is, etc.  It simply knows how to render a hypermedia, HTML.
 
-The client knows nothing about the API end points associated with this data, except via URLs and hypermedia controls 
+The client knows nothing about the API end points associated with this data, except via URLs and hypermedia controls
 (links and forms) discoverable within the HTML itself.  If the state of the resource changes such that the allowable
-actions available on that resource change (for example, if the account goes into overdraft) then the HTML response would 
-change to show the new set of actions available.  
+actions available on that resource change (for example, if the account goes into overdraft) then the HTML response would
+change to show the new set of actions available.
 
-The client would render this new HTML, totally unaware of what "overdraft" means or, indeed, even what a bank account is.  
+The client would render this new HTML, totally unaware of what "overdraft" means or, indeed, even what a bank account is.
 
 It is in this manner that hypertext is the engine of application state: the HTML response "carries along" all the API
 information necessary to continue interacting with the system directly within itself.
 
-Now, contrast that with the second JSON response.  
+Now, contrast that with the second JSON response.
 
 In this case the message is _not_ self describing.  Rather, the client must know how to interpret the `status` field to
-display an appropriate user interface.  Further, the client must know what actions are available on the account based on 
-"out-of-band" information, that is, information on the URLs, parameters and so forth, derived from another source of 
-information _outside of the response_, such as swagger API documentation. 
+display an appropriate user interface.  Further, the client must know what actions are available on the account based on
+"out-of-band" information, that is, information on the URLs, parameters and so forth, derived from another source of
+information _outside of the response_, such as swagger API documentation.
 
-The JSON response is not self-describing and does not encode the state of the resource within a hypermedia.  It therefore 
+The JSON response is not self-describing and does not encode the state of the resource within a hypermedia.  It therefore
 fails the uniform interface constraint of REST, and, thus, is not RESTful.
 
 ### Inventor: RESTful APIs Must Be Hypermedia Driven
@@ -147,18 +145,18 @@ fails the uniform interface constraint of REST, and, thus, is not RESTful.
 In [Rest APIs Must Be Hypermedia Driven](https://roy.gbiv.com/untangled/2008/rest-apis-must-be-hypertext-driven), Fielding
 goes on to say:
 
-> A REST API should be entered with no prior knowledge beyond the initial URI (bookmark) and set of standardized media 
+> A REST API should be entered with no prior knowledge beyond the initial URI (bookmark) and set of standardized media
 > types that are appropriate for the intended audience (i.e., expected to be understood by any client that might use the
-> API). From that point on, all application state transitions must be driven by client selection of server-provided 
+> API). From that point on, all application state transitions must be driven by client selection of server-provided
 > choices that are present in the received representations or implied by the user’s manipulation of those representations.
 
 So, in a RESTful system, you should be able to enter the system through a single URL and, from that point on, all navigation
-and actions taken within the system should be entirely provided through self-describing hypermedia: through links and 
-forms in HTML, for example.  Beyond the entry point, in a proper RESTful system, the API client shouldn't need any 
+and actions taken within the system should be entirely provided through self-describing hypermedia: through links and
+forms in HTML, for example.  Beyond the entry point, in a proper RESTful system, the API client shouldn't need any
 additional information about your API.
 
 This is the source of the incredible flexibility of RESTful systems:  since all responses are self describing and
-encode all the currently available actions available there is no need to worry about, for example, versioning your API!  
+encode all the currently available actions available there is no need to worry about, for example, versioning your API!
 In fact, you don't even need to document it!
 
 If things change, the hypermedia responses change, and that's it.
@@ -167,7 +165,7 @@ It's an incredibly flexible and innovative concept for building distributed syst
 
 ### Industry: Lol, No, RESTful APIs Are JSON
 
-Today, most web developers and most companies would call the _second example_ a RESTful API.  
+Today, most web developers and most companies would call the _second example_ a RESTful API.
 
 They probably wouldn't even regard the first response _as an API response_.  It's just HTML!
 
@@ -177,17 +175,17 @@ APIs are always JSON or maybe, if you are fancy, something like Protobuf, right?
 
 <img src="/img/you-are-wrong.png" alt="You are wrong" style="width: 80%;margin-left:10%; margin-top: 16px;margin-bottom: 16px">
 
-Wrong.  
+Wrong.
 
 You are all wrong and you should feel bad.
 
 The first response _is_ an API response, and, in fact, the one that is RESTful!
 
-The second response is, in fact, a _Remote Procedure Call_ (RPC) style of API.  The client and the server are coupled, 
-just like the SocialSite API Fielding complained about back in 2008: a client needs to have additional knowledge about 
-the resource it is working with that must be derived from some other source beyond the JSON response itself.  
+The second response is, in fact, a _Remote Procedure Call_ (RPC) style of API.  The client and the server are coupled,
+just like the SocialSite API Fielding complained about back in 2008: a client needs to have additional knowledge about
+the resource it is working with that must be derived from some other source beyond the JSON response itself.
 
-This API is, in spirit, nearly the opposite of REST.  
+This API is, in spirit, nearly the opposite of REST.
 
 Let's call this style of API "RESTless".
 
@@ -201,14 +199,14 @@ It's a funny story:
 Roy Fielding published his dissertation in 2000.
 
 Around the same time, [XML-RPC](https://en.wikipedia.org/wiki/XML-RPC), an explicitly RPC-inspired protocol was released
-and started to gather steam as a method to build APIs using HTTP.  XML-RPC was part of a larger project called 
+and started to gather steam as a method to build APIs using HTTP.  XML-RPC was part of a larger project called
 [SOAP](https://en.wikipedia.org/wiki/SOAP), from Microsoft.  XML-RPC came out of a long tradition of RPC-style
 protocols, mainly from the enterprise world, with a lot of static typing and early XML-maximalism thrown in as well.
 
 Also arriving at this moment was [AJAX](https://en.wikipedia.org/wiki/Ajax_(programming)), or Asynchronous
 JavaScript and XML.  Note well the XML here.  AJAX, as everyone now knows, allows browsers to issue HTTP requests
 to the server in the background and process the response directly in JavaScript, opening up a whole new world of
-programming for the web.  
+programming for the web.
 
 The question was: what should those requests look like?  They were obviously going to be XML.  Look, it's right there
 in the name.  And this new SOAP/XML-RPC standard was out, maybe that was the right thing?
@@ -220,21 +218,21 @@ if REST, rather than SOAP, should be the preferred mechanism for accessing what 
 The web was proving to be extremely flexible and growing gang busters, so maybe the same network architecture, REST, that
 was working so well for browsers & humans would work well for APIs.
 
-It sounded plausible, especially when XML was the format for APIs: XML sure _looks_ an awful lot like HTML, doesn't it? 
-You can imagine an XML API satisfying all of the RESTful constraints, up to and including the uniform interface.  
+It sounded plausible, especially when XML was the format for APIs: XML sure _looks_ an awful lot like HTML, doesn't it?
+You can imagine an XML API satisfying all of the RESTful constraints, up to and including the uniform interface.
 
 So people began exploring this route as well.
 
 While all this was happening, another important technology was in the process of being born: [JSON](https://www.json.org/json-en.html)
 
 JSON was (literally) JavaScript to SOAP/RPC-XML's Java: simple, dynamic and easy.  It's hard to believe now,
-when JSON is the dominant format for most web APIs, but it actually took a while for JSON to catch on.  As late as 2008, 
+when JSON is the dominant format for most web APIs, but it actually took a while for JSON to catch on.  As late as 2008,
 discussions around API development were mainly around XML, not JSON.
 
 ### Formalizing REST APIs
 
 In 2008, Martin Fowler published an article popularizing the [Richardson Maturity Model](https://martinfowler.com/articles/richardsonMaturityModel.html),
-a model to determine how RESTful a given API was.  
+a model to determine how RESTful a given API was.
 
 The model proposed four "levels", with the first level being Plain Old XML, or The Swamp of POX.
 
@@ -246,33 +244,33 @@ From there, an API could be considered more "mature" as a REST API as it adopted
 * Level 2: HTTP Verbs (using `GET`, `POST`, `DELETE`, etc. properly)
 * Level 3: Hypermedia Controls (e.g. links)
 
-Level 3 is where the uniform interface comes in, which is why this level is considered the most mature and truly "The 
+Level 3 is where the uniform interface comes in, which is why this level is considered the most mature and truly "The
 Glory of REST"
 
 ### "REST" Wins, Kinda...
 
-Unfortunately for the term REST, two things happened at this time: 
+Unfortunately for the term REST, two things happened at this time:
 
 * Everyone switched to JSON
 * Everyone stopped at Level 2 of the RMM
 
-JSON rapidly took over the web service/API world because SOAP/XML-RPC was so dramatically over-engineered.  JSON was simple, 
-"just worked" and was easy to read and understand. 
+JSON rapidly took over the web service/API world because SOAP/XML-RPC was so dramatically over-engineered.  JSON was simple,
+"just worked" and was easy to read and understand.
 
-With this change, the web development world threw off the shackles of the 
+With this change, the web development world threw off the shackles of the
 [J2EE mindset](https://en.wikipedia.org/wiki/Jakarta_EE) conclusively, relegating SOAP/XML-RPC to an enterprise-only affair.
 
-Since the REST approach wasn't as tied to XML as SOAP/XML-RPC was, and since it didn't impose as much formality on 
-end points, REST was the natural place for JSON to take over.  And it did so, rapidly.  
+Since the REST approach wasn't as tied to XML as SOAP/XML-RPC was, and since it didn't impose as much formality on
+end points, REST was the natural place for JSON to take over.  And it did so, rapidly.
 
 During this crucial change, something became increasingly clear: most JSON APIs were stopping at Level 2 of the RMM.
 
 Some pushed through to Level 3 by incorporating hypermedia controls in their responses, but nearly all these APIs still
 needed to publish documentation, indicating that the "Glory of REST" was not being achieved.
 
-JSON taking over as the response format should have been a strong hint as well: JSON is obviously not a hypertext.  You 
-can impose hypermedia controls on top of it, but it isn't natural.  XML at least _looked_ like HTML, kinda, so it was 
-plausible that you could create a hypermedia with it.  
+JSON taking over as the response format should have been a strong hint as well: JSON is obviously not a hypertext.  You
+can impose hypermedia controls on top of it, but it isn't natural.  XML at least _looked_ like HTML, kinda, so it was
+plausible that you could create a hypermedia with it.
 
 JSON was just... data.  Adding hypermedia controls was awkward, non-standardized and rarely used in the manner described
 by the uniform interface constraint.
@@ -286,20 +284,20 @@ That's the one sentence version of how we got here.
 
 Despite the JSON API world never consistently achieving truly RESTful APIs, there were plenty of fights over whether
 or not the RESTless APIs being created were "RESTful": arguments over URL layouts, over which HTTP verb was
-appropriate for a given action, flame wars about media types, and so forth.  
+appropriate for a given action, flame wars about media types, and so forth.
 
 I was young at the time, and the whole thing struck me as opaque, puritanical and alienating, so I pretty much gave up
 on the whole idea of REST: it was something condescending people fought about on the internet.
 
 What I rarely saw mentioned (or, when I did, what I didn't understand) was the concept of the uniform interface and how
-crucial it is to a RESTful system.  
+crucial it is to a RESTful system.
 
 It wasn't until I created [intercooler.js](https://intercoolerjs.org) and a few smart folks started telling me that it was
 RESTful that I got interested in the idea again.
 
 RESTful?  That's a JSON API thing, how could my hack of a front-end library be RESTful?
 
-So I looked into it, reread Fielding's dissertation with fresh eyes, and discovered, lo and behold, not only was 
+So I looked into it, reread Fielding's dissertation with fresh eyes, and discovered, lo and behold, not only was
 intercooler RESTful, but all the "RESTful" JSON APIs I was dealing with weren't RESTful at all!
 
 And, with that, I began boring the internet to tears:
@@ -316,17 +314,17 @@ And, with that, I began boring the internet to tears:
 ### The State of REST Today
 
 Eventually most people got tired of trying to add hypermedia controls to JSON APIs and gave up on it.  While these controls
-worked well in certain specialized situations (e.g. paging), they never achieved the broad, obvious utility 
+worked well in certain specialized situations (e.g. paging), they never achieved the broad, obvious utility
 that REST found in the general, human-oriented internet.  [(I have a theory why that is.)](https://intercoolerjs.org/2016/05/08/hatoeas-is-for-humans.html)
 
-Things settled into this intermediate RESTless state, with REST slowly cementing its meaning as a JSON API at Level 1 
+Things settled into this intermediate RESTless state, with REST slowly cementing its meaning as a JSON API at Level 1
 or 2 of the RMM.  But there was always the possibility that we would break through to Level 3 and the glory of REST.
 
 Then Single Page Applications (SPAs) hit.
 
 When SPAs hit, web development became disconnected entirely from the original underlying RESTful architecture.  The *entire
-networking architecture* of SPA applications moved over to the JSON RPC style.  Additionally, due to the complexity of these 
-applications, developers specialized into front end and back end.  
+networking architecture* of SPA applications moved over to the JSON RPC style.  Additionally, due to the complexity of these
+applications, developers specialized into front end and back end.
 
 The front end developers were obviously _not_ doing anything RESTful: they were working with JavaScript, building DOM
 object, and calling AJAX APIs when needed.  This was much more like thick-client authoring than anything like the
@@ -335,13 +333,13 @@ early web.
 The back end engineers were still concerned with the network architecture to an extent, and they continued to use the
 term "REST" to describe what they were doing.
 
-Even though they were doing things like publishing swagger documentation for their RESTful APIs or [complaining about API 
+Even though they were doing things like publishing swagger documentation for their RESTful APIs or [complaining about API
 churn of their RESTful APIs](https://www.infoq.com/articles/no-more-mvc-frameworks/), things that wouldn't be occurring
 if they were actually creating RESTful APIs.
 
 Finally, in the late 2010s, people had had enough:  REST, even in its RESTless form, simply wasn't keep up with the needs
-of increasingly complex SPA applications.  The applications were becoming more and more like thick clients, and thick 
-client problems need thick client solutions, not bastardized hypermedia client solutions.  
+of increasingly complex SPA applications.  The applications were becoming more and more like thick clients, and thick
+client problems need thick client solutions, not bastardized hypermedia client solutions.
 
 The dam really broke when [GraphQL](https://en.wikipedia.org/wiki/GraphQL) was released.
 
@@ -349,27 +347,27 @@ GraphQL couldn't be less RESTful: you absolutely *have to have* documentation to
 that uses GraphQL.  The client and the server are extremely tightly coupled.  There are no native hypermedia controls
 in it.  It offers schemas and, in many ways, feels a lot like an updated and stripped-down version of XML-RPC.
 
-And here I want to say: that's OK!  
+And here I want to say: that's OK!
 
 People really, really like GraphQL in many cases and, if you are building a thick client style application, that makes a
 lot of sense:
 
 > The short answer to this question is that HATEOAS isn’t a good fit for most modern use cases for APIs. That is why after
-> almost 20 years, HATEOAS still hasn’t gained wide adoption among developers. GraphQL on the other hand is spreading 
+> almost 20 years, HATEOAS still hasn’t gained wide adoption among developers. GraphQL on the other hand is spreading
 > like wildfire because it solves real-world problems.
 >
 > _[GraphQL and REST Level 3 (HATEOAS)](https://techblog.commercetools.com/graphql-and-rest-level-3-hateoas-70904ff1f9cf)_
 
 So GraphQL isn't REST, it doesn't claim to be REST, it doesn't want to be REST.
 
-But, as of today, the vast majority of developers and companies, even as they excitedly add GraphQL functionality to 
+But, as of today, the vast majority of developers and companies, even as they excitedly add GraphQL functionality to
 their APIs, continue to use the term REST to describe what they are building.
 
 ## OK, What Can We Do About This Situation?
 
 Unfortunately, [voidfunc](https://news.ycombinator.com/item?id=32073545) is probably right:
 
-> You can tap the sign as much as you want, that battle was lost a long time ago. REST is just the common term people 
+> You can tap the sign as much as you want, that battle was lost a long time ago. REST is just the common term people
 > use for HTTP+JSON RPC.
 
 We are going to keep calling _obviously_ non-RESTful JSON APIs REST because that's just what everyone calls them now.
@@ -382,14 +380,14 @@ jobs for working on v138 of their RESTful JSON API's swagger documentation.
 [The situation is hopeless, but not serious.](https://wwnorton.com/books/9780393310214)
 
 Regardless, there is an opportunity here to explain REST and, in particular, the uniform interface to a new generation of web
-developers who may have never heard of those concepts in their original context, and who assume REST === JSON APIs.  
+developers who may have never heard of those concepts in their original context, and who assume REST === JSON APIs.
 
-[People sense something is wrong](@/essays/a-response-to-rich-harris.md), and maybe REST, real, actual REST, 
+[People sense something is wrong](@/essays/a-response-to-rich-harris.md), and maybe REST, real, actual REST,
 not RESTless, could be a part of [the answer to that](@/essays/spa-alternative.md).
 
 At the very least, the ideas behind REST are interesting and worth knowing just as general software engineering knowledge.
 
-There is a larger meta-point here too: even a relatively smart group of people (early web developers), with the benefit 
+There is a larger meta-point here too: even a relatively smart group of people (early web developers), with the benefit
 of the internet, and with a pretty clear (if at times academic) specification for the term REST, were unable to keep the
 meaning consistent with its original meaning over period of two decades.
 

--- a/www/content/essays/hypermedia-apis-vs-data-apis.md
+++ b/www/content/essays/hypermedia-apis-vs-data-apis.md
@@ -3,6 +3,7 @@ title = "Hypermedia APIs vs. Data APIs"
 date = 2021-07-17
 updated = 2022-04-07
 [taxonomies]
+author = ["Carson Gross"]
 tag = ["posts"]
 +++
 

--- a/www/content/essays/hypermedia-clients.md
+++ b/www/content/essays/hypermedia-clients.md
@@ -3,6 +3,7 @@ title = "Hypermedia Clients"
 date = 2023-01-28
 updated = 2023-01-29
 [taxonomies]
+author = ["Carson Gross"]
 tag = ["posts"]
 +++
 

--- a/www/content/essays/hypermedia-driven-applications.md
+++ b/www/content/essays/hypermedia-driven-applications.md
@@ -3,6 +3,7 @@ title = "Hypermedia-Driven Applications"
 date = 2022-02-06
 updated = 2022-10-18
 [taxonomies]
+author = ["Carson Gross"]
 tag = ["posts"]
 +++
 

--- a/www/content/essays/hypermedia-friendly-scripting.md
+++ b/www/content/essays/hypermedia-friendly-scripting.md
@@ -3,6 +3,7 @@ title = "Hypermedia-Friendly Scripting"
 date = 2022-11-17
 updated = 2022-11-29
 [taxonomies]
+author = ["Carson Gross"]
 tag = ["posts"]
 +++
 

--- a/www/content/essays/hypermedia-on-whatever-youd-like.md
+++ b/www/content/essays/hypermedia-on-whatever-youd-like.md
@@ -2,6 +2,7 @@
 title = "Hypermedia On Whatever you'd Like"
 date = 2023-05-23
 [taxonomies]
+author = ["Carson Gross"]
 tag = ["posts"]
 +++
 

--- a/www/content/essays/locality-of-behaviour.md
+++ b/www/content/essays/locality-of-behaviour.md
@@ -3,6 +3,7 @@ title = "Locality of Behaviour (LoB)"
 date = 2020-05-29
 updated = 2023-01-20
 [taxonomies]
+author = ["Carson Gross"]
 tag = ["posts"]
 +++
 

--- a/www/content/essays/rest-copypasta.md
+++ b/www/content/essays/rest-copypasta.md
@@ -3,9 +3,11 @@ title = "REST Copypasta"
 date = 2023-06-26
 updated = 2023-06-26
 [taxonomies]
+author = ["Carson Gross"]
 tag = ["posts"]
 [extra]
 show_title = false
+show_author = false
 +++
 
 ## REST copy-pastas
@@ -16,8 +18,8 @@ show_title = false
 
 I'd just like to interject for a moment.  What you're referring to as REST,
 is in fact, JSON/RPC, or as I've recently taken to calling it, REST-less.
-JSON is not a hypermedia unto itself, but rather a plain data format made 
-useful by out of band information as defined by swagger documentation or 
+JSON is not a hypermedia unto itself, but rather a plain data format made
+useful by out of band information as defined by swagger documentation or
 similar.
 
 Many computer users work with a canonical version of REST every day,
@@ -27,7 +29,7 @@ not aware that it is basically the REST-ful architecture, defined by Roy Fieldin
 
 There really is a REST, and these people are using it, but it is just a
 part of The Web they use.  REST is the network architecture: hypermedia encodes the state
-of resources for hypermedia clients. JSON is an essential part of Single Page Applications, 
+of resources for hypermedia clients. JSON is an essential part of Single Page Applications,
 but useless by itself; it can only function in the context of a complete API specification.
 JSON is normally used in combination with SPA libraries: the whole system
 is basically RPC with JSON added, or JSON/RPC.  All these so-called "REST-ful"

--- a/www/content/essays/spa-alternative.md
+++ b/www/content/essays/spa-alternative.md
@@ -3,6 +3,7 @@ title = "SPA Alternative"
 date = 2020-10-29
 updated = 2022-02-06
 [taxonomies]
+author = ["Carson Gross"]
 tag = ["posts"]
 +++
 

--- a/www/content/essays/splitting-your-apis.md
+++ b/www/content/essays/splitting-your-apis.md
@@ -3,6 +3,7 @@ title = "Splitting Your Data &amp; Application APIs: Going Further"
 date = 2021-09-16
 updated = 2022-02-06
 [taxonomies]
+author = ["Carson Gross"]
 tag = ["posts"]
 +++
 

--- a/www/content/essays/template-fragments.md
+++ b/www/content/essays/template-fragments.md
@@ -3,6 +3,7 @@ title = "Template Fragments"
 date = 2022-08-03
 updated = 2023-03-18
 [taxonomies]
+author = ["Carson Gross"]
 tag = ["posts"]
 +++
 

--- a/www/content/essays/two-approaches-to-decoupling.md
+++ b/www/content/essays/two-approaches-to-decoupling.md
@@ -3,6 +3,7 @@ title = "Two Approaches To Decoupling"
 date = 2022-05-01
 updated = 2022-05-01
 [taxonomies]
+author = ["Carson Gross"]
 tag = ["posts"]
 +++
 

--- a/www/content/essays/view-transitions.md
+++ b/www/content/essays/view-transitions.md
@@ -3,6 +3,7 @@ template = "demo.html"
 title = "View Transitions"
 date = 2023-04-11
 [taxonomies]
+author = ["Carson Gross"]
 tag = ["posts"]
 +++
 

--- a/www/content/essays/when-to-use-hypermedia.md
+++ b/www/content/essays/when-to-use-hypermedia.md
@@ -3,6 +3,7 @@ title = "When Should You Use Hypermedia?"
 date = 2022-10-23
 updated = 2023-02-03
 [taxonomies]
+author = ["Carson Gross"]
 tag = ["posts"]
 +++
 

--- a/www/themes/htmx-theme/static/css/site.css
+++ b/www/themes/htmx-theme/static/css/site.css
@@ -129,6 +129,10 @@ table {
   line-height: 1em;
 }
 
+time {
+  font-weight: bold;
+}
+
 a {
 text-decoration: none;
 color: var(--midBlue)

--- a/www/themes/htmx-theme/templates/essay.html
+++ b/www/themes/htmx-theme/templates/essay.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% block title %}
+  {% if page.title -%}
+    {% set html_title = "&lt;/&gt; htmx ~ " ~ page.title -%}
+  {% endif -%}
+{% endblock title %}
+
+{% block content %}
+
+  {% if page.extra and page.extra.show_title is defined -%}
+    {% set show_title = page.extra.show_title -%}
+  {% else -%}
+    {% set show_title = true -%}
+  {% endif -%}
+
+  {% if page.extra and page.extra.show_author is defined -%}
+    {% set show_author = page.extra.show_author -%}
+  {% else -%}
+    {% set show_author = true -%}
+  {% endif -%}
+
+  {% set page_title = page.title -%}
+  {% if show_title %}<h1>{{ page_title | safe }}</h1>{% endif %}
+  {% if show_author and page.taxonomies.author %}
+    <address>{{ page.taxonomies.author | join(sep=", ") }}</address>
+    <time>{{ page.date | date(format="%B %d, %Y") }}</time>
+  {% endif %}
+
+  {{ page.content | safe }}
+  <div style="padding-top: 120px;padding-bottom:40px;text-align: center">
+    &lt;/&gt;
+  </div>
+{% endblock content %}

--- a/www/themes/htmx-theme/templates/page.html
+++ b/www/themes/htmx-theme/templates/page.html
@@ -27,9 +27,4 @@
   {% endif -%}
   {% if show_title %}<h1>{{ page_title | safe }}</h1>{% endif %}
   {{ page.content | safe }}
-  {% if page.path is starting_with("/essays/") -%}
-    <div style="padding-top: 120px;padding-bottom:40px;text-align: center">
-      &lt;/&gt;
-    </div>
-  {% endif -%}
 {% endblock content %}


### PR DESCRIPTION
## Description
Update the static site generator to include the date and author automatically as part of the essays. I made a couple changes to the underlying static structure to make this a little more seamless, including:

* New "essay.html" template for posts in `/essays`
* Added an author taxonomy (can eventually be author pages)
* Added Carson as the author of all the existing esssays
* Cleaned up manual date entires, where they existed

All this will make it easier to publish guest essays and sort the essays (chronologically, by topic, or by author) as the essay base expands.

Please excuse the couple posts where my editor removed trailing whitespace.

Resolves: #1622 

## Testing
See the [netfliy preview page](https://deploy-preview-1654--htmx.netlify.app/essays/).