### PR TITLE
Update same site security to use origin

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2848,10 +2848,10 @@ return (function () {
 
         function verifyPath(elt, path, requestConfig) {
             var url = new URL(path, document.location.href);
-            var hostname = document.location.hostname;
-            var sameHost = hostname !== url.hostname;
+            var origin = document.location.origin;
+            var sameHost = origin === url.origin;
             if (htmx.config.selfRequestsOnly) {
-                if (sameHost) {
+                if (!sameHost) {
                     return false;
                 }
             }


### PR DESCRIPTION
As discussed in Discord, use `origin` to compare whether it's the same site to have same behaviour as CSP check with protocol, hostname and port.

Updated `sameHost` boolean to be true if it's the same site, too. 