### PR TITLE
Remove logAll from tests

### DIFF
--- a/test/core/security.js
+++ b/test/core/security.js
@@ -107,7 +107,6 @@ describe("security options", function() {
     })
 
     it("can make egress cross site requests when htmx.config.selfRequestsOnly is enabled", function(done){
-        htmx.logAll()
         // should trigger send error, rather than reject
         var listener = htmx.on("htmx:sendError", function (){
             htmx.off("htmx:sendError", listener);
@@ -120,7 +119,6 @@ describe("security options", function() {
     })
 
     it("can't make egress cross site requests when htmx.config.selfRequestsOnly is enabled", function(done){
-        htmx.logAll()
         // should trigger send error, rather than reject
         htmx.config.selfRequestsOnly = true;
         var listener = htmx.on("htmx:invalidPath", function (){
@@ -135,7 +133,6 @@ describe("security options", function() {
     })
 
     it("can cancel egress request based on htmx:validateUrl event", function(done){
-        htmx.logAll()
         // should trigger send error, rather than reject
         var pathVerifier = htmx.on("htmx:validateUrl", function (evt){
             evt.preventDefault();


### PR DESCRIPTION
Fix the CI (our logs are so extensive the tests actually can't run with this on).