### PR TITLE
Add interactive check to ready event handler

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3605,7 +3605,7 @@ return (function () {
         //====================================================================
 
         function ready(fn) {
-            if (getDocument().readyState !== 'loading') {
+            if (getDocument().readyState === 'complete') {
                 fn();
             } else {
                 getDocument().addEventListener('DOMContentLoaded', fn);


### PR DESCRIPTION
If HTMX is imported in a module the readyState is "interactive" so the extension processing happens too late. This would fix it.

Rebased version of: #1659