### PR TITLE
[websocket] pass hx-target id in the HEADERS

### DIFF
--- a/src/ext/ws.js
+++ b/src/ext/ws.js
@@ -341,7 +341,7 @@ This extension adds support for WebSockets to htmx.  See /www/extensions/ws.md f
 
 				/** @type {WebSocketWrapper} */
 				var socketWrapper = api.getInternalData(socketElt).webSocket;
-				var headers = api.getHeaders(sendElt, socketElt);
+				var headers = api.getHeaders(sendElt, api.getTarget(sendElt));
 				var results = api.getInputValues(sendElt, 'post');
 				var errors = results.errors;
 				var rawParameters = results.values;

--- a/test/ext/ws.js
+++ b/test/ext/ws.js
@@ -88,6 +88,27 @@ describe("web-sockets extension", function () {
         this.messages.length.should.equal(1);
     })
 
+    it('sends expected headers to the server', function () {
+        var div = make('<div hx-ext="ws" ws-connect="ws://localhost:8080"><button hx-trigger="click" hx-target="#target" ws-send id="d1" name="d1-name">div1</button><output id="target"></output></div>');
+        this.tickMock();
+
+        byId("d1").click();
+
+        this.tickMock();
+
+        this.messages.length.should.equal(1);
+        var message = JSON.parse(this.messages[0]);
+        var headers = message.HEADERS;
+
+        console.log(headers);
+
+        headers['HX-Request'].should.be.equal('true');
+        headers['HX-Current-URL'].should.be.equal(document.location.href)
+        headers['HX-Trigger'].should.be.equal('d1');
+        headers['HX-Trigger-Name'].should.be.equal('d1-name');
+        headers['HX-Target'].should.be.equal('target');
+    })
+
     it('handles message from the server', function () {
         var div = make('<div hx-ext="ws" ws-connect="ws://localhost:8080"><div id="d1">div1</div><div id="d2">div2</div></div>');
         this.tickMock();


### PR DESCRIPTION
Previously, ws.js used `ws-connect` element as target when collecting request headers. Now it correctly takes `hx-target` attribute into account