### PR TITLE
Move load tests to the bottom of the core file

### DIFF
--- a/test/core/api.js
+++ b/test/core/api.js
@@ -8,64 +8,6 @@ describe("Core htmx API test", function(){
         clearWorkArea();
     });
 
-    it('onLoad is called... onLoad', function(done){
-        // also tests on/off
-        this.server.respondWith("GET", "/test", "<div id='d1' hx-get='/test'></div>")
-        var helper = htmx.onLoad(function (elt) {
-            elt.setAttribute("foo", "bar");
-        });
-        var server = this.server;
-        setTimeout(function() {
-            try {
-                var div = make("<div id='d1' hx-get='/test' hx-swap='outerHTML'></div>");
-                div.click();
-                server.respond();
-                byId("d1").getAttribute("foo").should.equal("bar");
-                done();
-            } finally {
-                htmx.off("htmx:load", helper);
-            }
-        }, 10)
-    });
-
-    it('triggers properly', function () {
-        var div = make("<div/>");
-        var myEventCalled = false;
-        var detailStr = "";
-        htmx.on("myEvent", function(evt){
-            myEventCalled = true;
-            detailStr = evt.detail.str;
-        })
-        htmx.trigger(div, "myEvent", {str:"foo"})
-
-        myEventCalled.should.equal(true);
-        detailStr.should.equal("foo");
-    });
-
-    it('triggers properly w/ selector', function () {
-        var div = make("<div id='div1'/>");
-        var myEventCalled = false;
-        var detailStr = "";
-        htmx.on("myEvent", function(evt){
-            myEventCalled = true;
-            detailStr = evt.detail.str;
-        })
-        htmx.trigger("#div1", "myEvent", {str:"foo"})
-
-        myEventCalled.should.equal(true);
-        detailStr.should.equal("foo");
-    });
-
-    it('triggers with no details properly', function () {
-        var div = make("<div/>");
-        var myEventCalled = false;
-        htmx.on("myEvent", function(evt){
-            myEventCalled = true;
-        })
-        htmx.trigger(div, "myEvent")
-        myEventCalled.should.equal(true);
-    });
-
     it('should find properly', function(){
         var div = make("<div id='d1' class='c1 c2'>");
         div.should.equal(htmx.find("#d1"));
@@ -339,5 +281,63 @@ describe("Core htmx API test", function(){
         this.server.respond();
         div.innerHTML.should.equal("delete");
     })
+
+    it('onLoad is called... onLoad', function(){
+        // also tests on/off
+        this.server.respondWith("GET", "/test", "<div id='d1' hx-get='/test'></div>")
+        var helper = htmx.onLoad(function (elt) {
+            elt.setAttribute("foo", "bar");
+        });
+
+        try {
+            var div = make("<div id='d1' hx-get='/test' hx-swap='outerHTML'></div>");
+            div.click();
+            this.server.respond();
+            byId("d1").getAttribute("foo").should.equal("bar");
+            htmx.off("htmx:load", helper);
+        } catch (error) {
+            // Clean up the event if the test fails, then throw it again
+            htmx.off("htmx:load", helper);
+            throw error;
+        }
+    });
+
+    it('triggers properly', function () {
+        var div = make("<div/>");
+        var myEventCalled = false;
+        var detailStr = "";
+        htmx.on("myEvent", function(evt){
+            myEventCalled = true;
+            detailStr = evt.detail.str;
+        })
+        htmx.trigger(div, "myEvent", {str:"foo"})
+
+        myEventCalled.should.equal(true);
+        detailStr.should.equal("foo");
+    });
+
+    it('triggers properly w/ selector', function () {
+        var div = make("<div id='div1'/>");
+        var myEventCalled = false;
+        var detailStr = "";
+        htmx.on("myEvent", function(evt){
+            myEventCalled = true;
+            detailStr = evt.detail.str;
+        })
+        htmx.trigger("#div1", "myEvent", {str:"foo"})
+
+        myEventCalled.should.equal(true);
+        detailStr.should.equal("foo");
+    });
+
+    it('triggers with no details properly', function () {
+        var div = make("<div/>");
+        var myEventCalled = false;
+        htmx.on("myEvent", function(evt){
+            myEventCalled = true;
+        })
+        htmx.trigger(div, "myEvent")
+        myEventCalled.should.equal(true);
+    });
 
 })


### PR DESCRIPTION
## Description 
This "resolves" a timing bug that was occurring in the CI, where these tests would run before the htmx was ready (only in the GitHub actions servers). Not proud of this as a fix but I would like the CI to work again ASAP.

The bug is related to the change from these PRs: 
* https://github.com/bigskysoftware/htmx/pull/1672
* https://github.com/bigskysoftware/htmx/pull/1659

I still think the behavior in these PRs is correct. As best I can tell from [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState), the `loading` state happens before all the deferred scripts are loaded but `DOMContentLoaded` fires after deferred scripts are loaded, even though the MDN page says "[loading] state indicates that the DOMContentLoaded event is about to fire". Which is what we want—we want it to be ready when the scripts are loaded, but we don't care if all the images are loaded. 

What needs to probably happen in the future is that we hold the tests until the ready event has fired.