### PR TITLE
Added more tests for allowEval=false

### DIFF
--- a/test/attributes/hx-on-wildcard.js
+++ b/test/attributes/hx-on-wildcard.js
@@ -130,4 +130,21 @@ describe("hx-on:* attribute", function() {
         delete window.tempCount;
     });
 
+    it("is not evaluated when allowEval is false", function () {
+        var calledEvent = false;
+        var handler = htmx.on("htmx:evalDisallowedError", function(){
+            calledEvent = true;
+        });
+        htmx.config.allowEval = false;
+        try {
+            var btn = make("<button hx-on:click='window.foo = true'>Foo</button>");
+            btn.click();
+            should.not.exist(window.foo);
+        } finally {
+            htmx.config.allowEval = true;
+            htmx.off("htmx:evalDisallowedError", handler);
+            delete window.foo;
+        }
+        calledEvent.should.equal(true);
+    });
 });

--- a/test/attributes/hx-on.js
+++ b/test/attributes/hx-on.js
@@ -119,4 +119,21 @@ describe("hx-on attribute", function() {
         delete window.tempCount;
     });
 
+    it("is not evaluated when allowEval is false", function () {
+        var calledEvent = false;
+        var handler = htmx.on("htmx:evalDisallowedError", function(){
+            calledEvent = true;
+        });
+        htmx.config.allowEval = false;
+        try {
+            var btn = make("<button hx-on='click: window.foo = true'>Foo</button>");
+            btn.click();
+            should.not.exist(window.foo);
+        } finally {
+            htmx.config.allowEval = true;
+            htmx.off("htmx:evalDisallowedError", handler);
+            delete window.foo;
+        }
+        calledEvent.should.equal(true);
+    });
 });

--- a/test/attributes/hx-vals.js
+++ b/test/attributes/hx-vals.js
@@ -252,4 +252,49 @@ describe("hx-vals attribute", function() {
         div.innerHTML.should.equal("Clicked!");
     });
 
+    it('javascript: is not evaluated when allowEval is false', function () {
+        var calledEvent = false;
+        var handler = htmx.on("htmx:evalDisallowedError", function(){
+            calledEvent = true;
+        });
+        try {
+            htmx.config.allowEval = false;
+            this.server.respondWith("POST", "/vars", function (xhr) {
+                var params = getParameters(xhr);
+                should.not.exist(params['i1']);
+                xhr.respond(200, {}, "Clicked!")
+            });
+            var div = make('<div hx-post="/vars" hx-vals="javascript:i1:\'test\'"></div>')
+            div.click();
+            this.server.respond();
+            div.innerHTML.should.equal("Clicked!");
+        } finally {
+            htmx.config.allowEval = true;
+            htmx.off("htmx:evalDisallowedError", handler);
+        }
+        calledEvent.should.equal(true);
+    });
+
+    it('js: is not evaluated when allowEval is false', function () {
+        var calledEvent = false;
+        var handler = htmx.on("htmx:evalDisallowedError", function(){
+            calledEvent = true;
+        });
+        try {
+            htmx.config.allowEval = false;
+            this.server.respondWith("POST", "/vars", function (xhr) {
+                var params = getParameters(xhr);
+                should.not.exist(params['i1']);
+                xhr.respond(200, {}, "Clicked!")
+            });
+            var div = make('<div hx-post="/vars" hx-vals="js:i1:\'test\'"></div>')
+            div.click();
+            this.server.respond();
+            div.innerHTML.should.equal("Clicked!");
+        } finally {
+            htmx.config.allowEval = true;
+            htmx.off("htmx:evalDisallowedError", handler);
+        }
+        calledEvent.should.equal(true);
+    });
 });

--- a/test/attributes/hx-vars.js
+++ b/test/attributes/hx-vars.js
@@ -152,4 +152,26 @@ describe("hx-vars attribute", function() {
         div.innerHTML.should.equal("Clicked!");
     });
 
+    it('is not evaluated when allowEval is false', function () {
+        var calledEvent = false;
+        var handler = htmx.on("htmx:evalDisallowedError", function(){
+            calledEvent = true;
+        });
+        try {
+            htmx.config.allowEval = false;
+            this.server.respondWith("POST", "/vars", function (xhr) {
+                var params = getParameters(xhr);
+                should.not.exist(params['i1']);
+                xhr.respond(200, {}, "Clicked!")
+            });
+            var div = make('<div hx-post="/vars" hx-vals="javascript:i1:\'test\'"></div>')
+            div.click();
+            this.server.respond();
+            div.innerHTML.should.equal("Clicked!");
+        } finally {
+            htmx.config.allowEval = true;
+            htmx.off("htmx:evalDisallowedError", handler);
+        }
+        calledEvent.should.equal(true);
+    });
 });


### PR DESCRIPTION
See #1679

This introduces tests for `hx-on`, `hx-on:*`, `hx-vals`, `hx-vars`, when `allowEval` is false.

`hx-on` & `hx-on:*` tests are currently failing as they do not conform to the expected behaviour, as defined in #1679

I'll follow up with a separate PR to fix these.