### PR TITLE
[fix] events between DOMContentLoaded and readyState.complete might be lost

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3603,16 +3603,28 @@ return (function () {
         //====================================================================
         // Initialization
         //====================================================================
-        var domContentLoaded = false;
+
+        var isReady = false;
         function ready(fn) {
-            if (domContentLoaded) {
+            if (isReady) {
                 fn();
             } else {
-                getDocument().addEventListener('DOMContentLoaded', function() {
-                    domContentLoaded = true;
-                    fn();
-                });
+                document.addEventListener('htmx:ready', fn);
             }
+        }
+
+        function loadComplete() {
+            document.removeEventListener('DOMContentLoaded', loadComplete);
+            window.removeEventListener('load', loadComplete);
+            isReady = true;
+            triggerEvent(document, 'htmx:ready');
+        }
+
+        if (document.readyState === 'complete') {
+            loadComplete();
+        } else {
+            document.addEventListener('DOMContentLoaded', loadComplete);
+            window.addEventListener('load', loadComplete);
         }
 
         function insertIndicatorStyles() {


### PR DESCRIPTION
Relying on [readyState](https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState) `complete` in the `ready` function might cause some of the events registered via `htmx.on()` to be lost between `DOMContentLoaded` and `readyState === complete`.

Here is an example that simulates such a situation.
https://jsfiddle.net/k6pxg5wf/