### PR TITLE
Track DOM content loaded for ready() function

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3603,9 +3603,22 @@ return (function () {
         //====================================================================
         // Initialization
         //====================================================================
+        var isReady = false
+        getDocument().addEventListener('DOMContentLoaded', function() {
+            isReady = true
+        })
 
+        /**
+         * Execute a function now if DOMContentLoaded has fired, otherwise listen for it.
+         *
+         * This function uses isReady because there is no realiable way to ask the browswer whether
+         * the DOMContentLoaded event has already been fired; there's a gap between DOMContentLoaded
+         * firing and readystate=complete.
+         */
         function ready(fn) {
-            if (getDocument().readyState === 'complete') {
+            // Checking readyState here is a failsafe in case the htmx script tag entered the DOM by
+            // some means other than the initial page load.
+            if (isReady || getDocument().readyState === 'complete') {
                 fn();
             } else {
                 getDocument().addEventListener('DOMContentLoaded', fn);


### PR DESCRIPTION
## Description
Updated version of #1659 and #1681 based on conversation with @xhaggi.

Basically there's a gap between the `DOMContentLoaded` event firing and the document readystate updating to `complete`. If you look at some [stackoverflow answers](https://stackoverflow.com/questions/9457891/how-to-detect-if-domcontentloaded-was-fired#comment104655688_35996985) you can see that people _think_ these two things should be the same, but they are not.

Fortunately, it's not hard for us to track with a closure. `DOMContentLoaded` will only run after all the deferred scripts have been executed, so as long as we listen for it on the initial execution of `htmx`, we should be safe. For good measure, I ORed it with `getDocument().readystate === 'complete'`, in case someone is doing something insane like hotswapping the htmx script tag into the DOM based on some user action (don't do that).

Sort of an "ugh, JavaScript" moment but I'd argue it's really more of an "ugh, DOM APIs" moment.

DOMContentLoaded event: https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event
Document readystate: https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState