### PR TITLE
Make htmx available in window scope to import extensions without UMD in modules

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3678,6 +3678,9 @@ return (function () {
             }, 0);
         })
 
+        // make htmx available in window scope to import extensions without UMD in modules
+        window.htmx = htmx;
+
         return htmx;
     }
 )()


### PR DESCRIPTION
This will fix #1469 and partially #1690 without introducing a UMD wrapper for each extension by simply making htmx available in window scope.