### PR TITLE
Document hx-select-oob swap-strategy capabilities

### DIFF
--- a/www/content/attributes/hx-select-oob.md
+++ b/www/content/attributes/hx-select-oob.md
@@ -24,6 +24,23 @@ This button will issue a `GET` to `/info` and then select the element with the i
 which will replace the entire button in the DOM, and, in addition, pick out an element with the id `alert` 
 in the response and swap it in for div in the DOM with the same ID.
 
+Each value in the comma separated list of values can specify any valid [`hx-swap`](@/attributes/hx-swap.md)
+strategy by separating the selector and the swap strategy with a `:`.
+
+For example, to prepend the alert content instead of replacing it:
+
+```html
+<div>
+   <div id="alert"></div>
+    <button hx-get="/info"
+            hx-select="#info-details"
+            hx-swap="outerHTML"
+            hx-select-oob="#alert:afterbegin">
+        Get Info!
+    </button>
+</div>
+```
+
 ## Notes
 
 * `hx-select-oob` is inherited and can be placed on a parent element


### PR DESCRIPTION
👋 I've been playing with HTMX in a side project and so far it's been pretty great! I had run into a use-case for using `hx-select-oob` with `afterbegin` swapping behavior but didn't see it publicly documented and discovered the behavior after diving into the source since I had a feeling it would support it somehow.

I found that behavior [here](https://github.com/bigskysoftware/htmx/blob/47af93bdb0c9f5d356e36fd6073e0b74d12b9242/www/static/test/1.9.0/src/htmx.js#L803-L808) and wanted try documenting it so it's easy for folks to find in the future.