### PR TITLE
Fix typo in attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ## [1.9.3] - 2023-07-14
 
-* The `hx-on` attribute has been deprecated (sorry) in favor of `hx-on-<event name>` attributes.  See [`hx-on`](/attributes/hx-on) for more information.
+* The `hx-on` attribute has been deprecated (sorry) in favor of `hx-on:<event name>` attributes.  See [`hx-on`](/attributes/hx-on) for more information.
 * We now have functioning CI using GitHub actions!
 * You can now configure if a type of HTTP request uses the body for parameters or not.  In particular, the `DELETE` _should_ use
   query parameters, according to the spec.  htmx has used the body, instead.  To avoid breaking code we are keeping this undefined


### PR DESCRIPTION
Fixes a typo in the new `hx-on:*` attribute.