### PR TITLE
Make htmx.ajax always return a Promise

### DIFF
--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -20,7 +20,7 @@ export function addClass(elt: Element, clazz: string, delay?: number): void;
  * @param path the URL path to make the AJAX
  * @param element the element to target (defaults to the **body**)
  */
-export function ajax(verb: string, path: string, element: Element): void;
+export function ajax(verb: string, path: string, element: Element): Promise<void>;
 
 /**
  * Issues an htmx-style AJAX request
@@ -31,7 +31,7 @@ export function ajax(verb: string, path: string, element: Element): void;
  * @param path the URL path to make the AJAX
  * @param selector a selector for the target
  */
-export function ajax(verb: string, path: string, selector: string): void;
+export function ajax(verb: string, path: string, selector: string): Promise<void>;
 
 /**
  * Issues an htmx-style AJAX request
@@ -46,7 +46,7 @@ export function ajax(
     verb: string,
     path: string,
     context: Partial<{ source: any; event: any; handler: any; target: any; swap: any; values: any; headers: any }>
-): void;
+): Promise<void>;
 
 /**
  * Finds the closest matching element in the given elements parentage, inclusive of the element

--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -19,6 +19,7 @@ export function addClass(elt: Element, clazz: string, delay?: number): void;
  * @param verb 'GET', 'POST', etc.
  * @param path the URL path to make the AJAX
  * @param element the element to target (defaults to the **body**)
+ * @returns Promise that resolves immediately if no request is sent, or when the request is complete
  */
 export function ajax(verb: string, path: string, element: Element): Promise<void>;
 
@@ -30,6 +31,7 @@ export function ajax(verb: string, path: string, element: Element): Promise<void
  * @param verb 'GET', 'POST', etc.
  * @param path the URL path to make the AJAX
  * @param selector a selector for the target
+ * @returns Promise that resolves immediately if no request is sent, or when the request is complete
  */
 export function ajax(verb: string, path: string, selector: string): Promise<void>;
 
@@ -41,6 +43,7 @@ export function ajax(verb: string, path: string, selector: string): Promise<void
  * @param verb 'GET', 'POST', etc.
  * @param path the URL path to make the AJAX
  * @param context a context object that contains any of the following
+ * @returns Promise that resolves immediately if no request is sent, or when the request is complete
  */
 export function ajax(
     verb: string,

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2880,12 +2880,15 @@ return (function () {
             var responseHandler = etc.handler || handleAjaxResponse;
 
             if (!bodyContains(elt)) {
-                return; // do not issue requests for elements removed from the DOM
+                // do not issue requests for elements removed from the DOM
+                maybeCall(resolve);
+                return promise;
             }
             var target = etc.targetOverride || getTarget(elt);
             if (target == null || target == DUMMY_ELT) {
                 triggerErrorEvent(elt, 'htmx:targetError', {target: getAttributeValue(elt, "hx-target")});
-                return;
+                maybeCall(reject);
+                return promise;
             }
 
             // allow event-based confirmation w/ a callback
@@ -2895,7 +2898,8 @@ return (function () {
                 }
                 var confirmDetails = {target: target, elt: elt, path: path, verb: verb, triggeringEvent: event, etc: etc, issueRequest: issueRequest};
                 if (triggerEvent(elt, 'htmx:confirm', confirmDetails) === false) {
-                    return;
+                    maybeCall(resolve);
+                    return promise;
                 }
             }
 
@@ -2916,10 +2920,12 @@ return (function () {
                 syncStrategy = (syncStrings[1] || 'drop').trim();
                 eltData = getInternalData(syncElt);
                 if (syncStrategy === "drop" && eltData.xhr && eltData.abortable !== true) {
-                    return;
+                    maybeCall(resolve);
+                    return promise;
                 } else if (syncStrategy === "abort") {
                     if (eltData.xhr) {
-                        return;
+                        maybeCall(resolve);
+                        return promise;
                     } else {
                         abortable = true;
                     }
@@ -2963,7 +2969,8 @@ return (function () {
                             issueAjaxRequest(verb, path, elt, event, etc)
                         });
                     }
-                    return;
+                    maybeCall(resolve);
+                    return promise;
                 }
             }
 
@@ -3094,7 +3101,8 @@ return (function () {
 
             if (!verifyPath(elt, finalPath, requestConfig)) {
                 triggerErrorEvent(elt, 'htmx:invalidPath', requestConfig)
-                return;
+                maybeCall(reject);
+                return promise;
             };
 
             xhr.open(verb.toUpperCase(), finalPath, true);


### PR DESCRIPTION
According to the [docs](https://htmx.org/api/#ajax), the `htmx.ajax` function returns a `Promise<void>`, but the typedefs say it's just `void`.

This was once fixed in #1265 but it seems to have been overriden in 15d4cac.