### PR TITLE
feat: add GoTH stack

### DIFF
--- a/www/content/server-examples.md
+++ b/www/content/server-examples.md
@@ -144,3 +144,7 @@ These examples may make it a bit easier to get started using htmx with your plat
 ### templ
 
 - <https://templ.guide/server-side-rendering/htmx>
+
+### GoTH - Go, Tailwind, Htmx
+
+- <https://github.com/TomDoesTech/GoTH>


### PR DESCRIPTION
# Description

Adds the GoTH stack to the Go section of the server-side examples page