### PR TITLE
Use raw attribute href on hx-boost

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1348,7 +1348,7 @@ return (function () {
                 var verb, path;
                 if (elt.tagName === "A") {
                     verb = "get";
-                    path = elt.href; // DOM property gives the fully resolved href of a relative link
+                    path = getRawAttribute(elt, 'href')
                 } else {
                     var rawAttribute = getRawAttribute(elt, "method");
                     verb = rawAttribute ? rawAttribute.toLowerCase() : "get";

--- a/test/attributes/hx-disinherit.js
+++ b/test/attributes/hx-disinherit.js
@@ -101,7 +101,7 @@ describe("hx-disinherit attribute", function() {
             var link = byId("a1");
             link.click();
             // should match the fully resolved href of the boosted element
-            should.equal(request.detail.requestConfig.path, request.detail.elt.href);
+            should.equal(request.detail.requestConfig.path, '/test');
             should.equal(request.detail.elt["htmx-internal-data"].boosted, true);
         } finally {
             htmx.off("htmx:beforeRequest", handler);


### PR DESCRIPTION
## Description
This resolves a bug with file system URLs on Windows. It reverts part of a previous change (#1338) where URLs were normalized prior to the request in order to reduce key collisions in the history cache. 

The gist is that on Windows, `elt.href` normalizes relative URLs like this:

```
Boost HTMLAnchorElement
        href resolves to file:///E:/test
        raw attribute : /test
should swap ? false
Response Status Error Code 404 from file:///E:/test
```

Why does `elt.href` normalize relative URLs on Windows file systems differently from how anchor elements normalize URLs? It doesn't. It normalizes the URL into something that is wrong (on Windows) before the `mockServer()` function can get to it. It turns this: 

```html
<a href="/profile">My Profile</a>
<a hx-boost="/profile">My Profile</a>
```

into this:

```html
<a hx-boost="https://example.com/some/qualified/url/profile">My Profile</a>
```

Which, while *usually* the same thing, is still an additional normalization that we perform with JavaScript which deviates from the browser's request normalization, and I can't see any justification for keeping it. Because htmx's history cache is based entirely on response URLs, not request URLs, I am reasonably confident that reverting this line doesn't affect the optimization from #1338 at all. 

And, conceptually, it makes a lot more sense that we would just pass the raw attribute value to the browser's request engine and let it do whatever normalizing it does there—which is less likely to deviate from regular `<a href="">` behavior. Doing it twice introduces the possibility of error without any clear benefit.

@Telroshan and I discovered this bug as part of #1732. ~He doesn't totally agree with me that this change is necessary so if you want a competing view go read that thread.~ See below for some of that discussion, but we agree now.

## Testing
Passes locally and on the CI. I also ran a Windows Server GitHub runner and while that was not very reliable at running our tests, it didn't have the same issue anymore at least.

This change should make it possible for Windows users to run our headless test suite with no errors using `npm t`.

@Telroshan tested on windows and this fixes the tests so he can proceed with #1687 
