### PR TITLE
Include default config values in TypeScript definitions

### DIFF
--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -288,44 +288,99 @@ export function values(elt: Element, requestType?: string): any;
 export const version: string;
 
 export interface HtmxConfig {
-    /** array of strings: the attributes to settle during the settling phase */
+    /**
+     * The attributes to settle during the settling phase.
+     * @default ["class", "style", "width", "height"]
+     */
     attributesToSettle?: ["class", "style", "width", "height"] | string[];
-    /** if the focused element should be scrolled into view */
+    /**
+     * If the focused element should be scrolled into view.
+     * @default false
+    */
     defaultFocusScroll?: boolean;
-    /** the default delay between completing the content swap and settling attributes */
+    /**
+     * The default delay between completing the content swap and settling attributes.
+     * @default 20
+     */
     defaultSettleDelay?: number;
-    /** the default delay between receiving a response from the server and doing the swap */
+    /**
+     * The default delay between receiving a response from the server and doing the swap.
+     * @default 0
+     */
     defaultSwapDelay?: number;
-    /** the default swap style to use if **[hx-swap](https://htmx.org/attributes/hx-swap)** is omitted */
+    /**
+     * The default swap style to use if **[hx-swap](https://htmx.org/attributes/hx-swap)** is omitted.
+     * @default "innerHTML"
+     */
     defaultSwapStyle?: "innerHTML" | string;
-    /** the number of pages to keep in **localStorage** for history support */
+    /**
+     * The number of pages to keep in **localStorage** for history support.
+     * @default 10
+     */
     historyCacheSize?: number;
-    /** whether or not to use history */
+    /**
+     * Whether or not to use history.
+     * @default true
+     */
     historyEnabled?: boolean;
-    /** if true, htmx will inject a small amount of CSS into the page to make indicators invisible unless the **htmx-indicator** class is present */
+    /**
+     * If true, htmx will inject a small amount of CSS into the page to make indicators invisible unless the **htmx-indicator** class is present.
+     * @default true
+     */
     includeIndicatorStyles?: boolean;
-    /** the class to place on indicators when a request is in flight */
+    /**
+     * The class to place on indicators when a request is in flight.
+     * @default "htmx-indicator"
+     */
     indicatorClass?: "htmx-indicator" | string;
-    /** the class to place on triggering elements when a request is in flight */
+    /**
+     * The class to place on triggering elements when a request is in flight.
+     * @default "htmx-request"
+     */
     requestClass?: "htmx-request" | string;
-    /** the class to temporarily place on elements that htmx has added to the DOM */
+    /**
+     * The class to temporarily place on elements that htmx has added to the DOM.
+     * @default "htmx-added" 
+     */
     addedClass?: "htmx-added" | string;
-    /** the class to place on target elements when htmx is in the settling phase */
+    /**
+     * The class to place on target elements when htmx is in the settling phase.
+     * @default "htmx-settling"
+     */
     settlingClass?: "htmx-settling" | string;
-    /** the class to place on target elements when htmx is in the swapping phase */
+    /**
+     * The class to place on target elements when htmx is in the swapping phase.
+     * @default "htmx-swapping"
+     */
     swappingClass?: "htmx-swapping" | string;
-    /** allows the use of eval-like functionality in htmx, to enable **hx-vars**, trigger conditions & script tag evaluation. Can be set to **false** for CSP compatibility */
+    /**
+     * Allows the use of eval-like functionality in htmx, to enable **hx-vars**, trigger conditions & script tag evaluation. Can be set to **false** for CSP compatibility.
+     * @default true
+     */
     allowEval?: boolean;
-    /** use HTML template tags for parsing content from the server. This allows you to use Out of Band content when returning things like table rows, but it is *not* IE11 compatible. */
+    /**
+     * Use HTML template tags for parsing content from the server. This allows you to use Out of Band content when returning things like table rows, but it is *not* IE11 compatible.
+     * @default false
+     */
     useTemplateFragments?: boolean;
-    /** allow cross-site Access-Control requests using credentials such as cookies, authorization headers or TLS client certificates */
+    /**
+     * Allow cross-site Access-Control requests using credentials such as cookies, authorization headers or TLS client certificates.
+     * @default false
+     */
     withCredentials?: boolean;
-    /** the default implementation of **getWebSocketReconnectDelay** for reconnecting after unexpected connection loss by the event code **Abnormal Closure**, **Service Restart** or **Try Again Later** */
+    /**
+     * The default implementation of **getWebSocketReconnectDelay** for reconnecting after unexpected connection loss by the event code **Abnormal Closure**, **Service Restart** or **Try Again Later**.
+     * @default "full-jitter"
+     */
     wsReconnectDelay?: "full-jitter" | string | ((retryCount: number) => number);
     // following don't appear in the docs
+    /** @default false */
     refreshOnHistoryMiss?: boolean;
+    /** @default 0 */
     timeout?: number;
+    /** @default "[hx-disable], [data-hx-disable]" */
     disableSelector?: "[hx-disable], [data-hx-disable]" | string;
+    /** @default "smooth" */
     scrollBehavior?: "smooth" | "auto";
 }
 


### PR DESCRIPTION
This PR proposes including default config values in the types. The desired DX improvement is to make it easier to reference a property's default value, as the default behavior for IDEs is to jump to the type definitions and not the source code.

---

<img width="880" alt="VS Code hover" src="https://github.com/bigskysoftware/htmx/assets/10718366/c21fd1fe-7390-4cae-8330-cc1c7645fd7b">
