### PR TITLE
partial fix for sticky form submissions

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2448,6 +2448,7 @@ return (function () {
                 var button = internalData.lastButtonClicked || elt
                 var name = getRawAttribute(button, "name")
                 addValueToValues(name, button.value, formValues)
+                internalData.lastButtonClicked = null;
             }
 
             // include any explicit includes

--- a/test/core/ajax.js
+++ b/test/core/ajax.js
@@ -1064,7 +1064,7 @@ describe("Core htmx AJAX Tests", function(){
             xhr.respond(204, {}, "");
         });
 
-        make('<form id="externalForm" hx-post="/test" hx-trigger="input from:#idText">' +
+        make('<form id="externalForm" hx-post="/test" hx-trigger="click from:#idText, submit">' +
             '<input id="idText" type="text" name="t1" value="textValue">' +
             '</form>' +
             '<button id="submit" form="externalForm" type="submit" name="b1" value="buttonValue">button</button>');
@@ -1074,9 +1074,10 @@ describe("Core htmx AJAX Tests", function(){
         values.should.deep.equal({ t1: 'textValue', b1: 'buttonValue' });
 
         // don't include the button if the form is submitted again a different way
-        input("idText").value = "newTextValue";
+        byId("idText").value = "newTextValue";
+        byId("idText").click();
         this.server.respond();
-        values.should.deep.equal({ t1: 'newTextValue', b2: 'button2Value' });
+        values.should.deep.equal({ t1: 'newTextValue' });
     })
 
     it('properly handles clicked submit input with a value outside a htmx form', function () {

--- a/test/core/ajax.js
+++ b/test/core/ajax.js
@@ -1064,14 +1064,19 @@ describe("Core htmx AJAX Tests", function(){
             xhr.respond(204, {}, "");
         });
 
-        make('<form id="externalForm" hx-post="/test">' +
-            '<input type="text" name="t1" value="textValue">' +
+        make('<form id="externalForm" hx-post="/test" hx-trigger="input from:#idText">' +
+            '<input id="idText" type="text" name="t1" value="textValue">' +
             '</form>' +
             '<button id="submit" form="externalForm" type="submit" name="b1" value="buttonValue">button</button>');
 
         byId("submit").click();
         this.server.respond();
-        values.should.deep.equal({t1: 'textValue', b1: 'buttonValue'});
+        values.should.deep.equal({ t1: 'textValue', b1: 'buttonValue' });
+
+        // don't include the button if the form is submitted again a different way
+        input("idText").value = "newTextValue";
+        this.server.respond();
+        values.should.deep.equal({ t1: 'newTextValue', b2: 'button2Value' });
     })
 
     it('properly handles clicked submit input with a value outside a htmx form', function () {


### PR DESCRIPTION
(see issue #1749 )

I think this test reproduces the issue, but I'm having trouble with the test case: it seems to send the test runner into an endless loop and I can't figure out why.

I think the fix also is incomplete because it breaks another test. :(