### PR TITLE
[Doc] Fix missing beforeCleanupElement event in doc

### DIFF
--- a/www/content/events.md
+++ b/www/content/events.md
@@ -75,6 +75,14 @@ This event is triggered after new content has been [swapped into the DOM](@/docs
 * `detail.target` - the target of the request
 * `detail.requestConfig` - the configuration of the AJAX request
 
+### Event - `htmx:beforeCleanupElement` {#htmx:beforeCleanupElement}
+
+This event is triggered before htmx [disables](@/attributes/hx-disable.md) an element or removes it from the DOM.
+
+##### Details
+
+* `detail.elt` - the cleaned up element
+
 ### Event - `htmx:beforeOnLoad` {#htmx:beforeOnLoad}
 
 This event is triggered before any response processing occurs.  If the event is cancelled, no swap will occur.

--- a/www/content/reference.md
+++ b/www/content/reference.md
@@ -136,6 +136,7 @@ The table below lists all other attributes available in htmx.
 | [`htmx:afterRequest`](@/events.md#htmx:afterRequest)  | triggered after an AJAX request has completed
 | [`htmx:afterSettle`](@/events.md#htmx:afterSettle)  | triggered after the DOM has settled
 | [`htmx:afterSwap`](@/events.md#htmx:afterSwap)  | triggered after new content has been swapped in
+| [`htmx:beforeCleanupElement`](@/events.md#htmx:beforeCleanupElement)  | triggered before htmx [disables](@/attributes/hx-disable.md) an element or removes it from the DOM
 | [`htmx:beforeOnLoad`](@/events.md#htmx:beforeOnLoad)  | triggered before any response processing occurs
 | [`htmx:beforeProcessNode`](@/events.md#htmx:beforeProcessNode) | triggered before htmx initializes a node
 | [`htmx:beforeRequest`](@/events.md#htmx:beforeRequest)  | triggered before an AJAX request is made


### PR DESCRIPTION
This adds a mention to the [htmx:beforeCleanupElement](https://github.com/bigskysoftware/htmx/blob/master/src/htmx.js#L955) event, which was missing from the docs