### PR TITLE
fix problem with styles at the start of the server content

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -306,6 +306,7 @@ return (function () {
                     case "th":
                         return parseHTML("<table><tbody><tr>" + resp + "</tr></tbody></table>", 3);
                     case "script":
+                    case "style":
                         return parseHTML("<div>" + resp + "</div>", 1);
                     default:
                         return parseHTML(resp, 0);

--- a/test/manual/history_style/1.html
+++ b/test/manual/history_style/1.html
@@ -1,0 +1,16 @@
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <script type="application/javascript" src="../../../src/htmx.js"></script>
+    <title>History - 1</title>
+</head>
+<body style="padding:20px;font-family: sans-serif" hx-boost="true">
+<style>a, a:visited, h1 { color: lime; border: 1px dashed blue; }</style>
+<h1>History Test</h1>
+<a href="1.html">1</a>
+<a href="2.html">2</a>
+<a href="3.html">3</a>
+<a href="4.html">4</a>
+<h3>Page 1</h3>
+</body>
+</html>

--- a/test/manual/history_style/2.html
+++ b/test/manual/history_style/2.html
@@ -1,0 +1,16 @@
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <script type="application/javascript" src="../../../src/htmx.js"></script>
+    <title>History - 2</title>
+</head>
+<body style="padding:20px;font-family: sans-serif" hx-boost="true">
+<style>a, a:visited, h1 { color: magenta; border: 1px solid indigo; }</style>
+<h1>History Test</h1>
+<a href="1.html">1</a>
+<a href="2.html">2</a>
+<a href="3.html">3</a>
+<a href="4.html">4</a>
+<h3>Page 2</h3>
+</body>
+</html>

--- a/test/manual/history_style/3.html
+++ b/test/manual/history_style/3.html
@@ -1,0 +1,16 @@
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <script type="application/javascript" src="../../../src/htmx.js"></script>
+    <title>History - 3</title>
+</head>
+<body style="padding:20px;font-family: sans-serif" hx-boost="true">
+<style>a, a:visited, h1 { color: blue; border: 1px dotted cyan; }</style>
+<h1>History Test</h1>
+<a href="1.html">1</a>
+<a href="2.html">2</a>
+<a href="3.html">3</a>
+<a href="4.html">4</a>
+<h3>Page 3</h3>
+</body>
+</html>

--- a/test/manual/history_style/4.html
+++ b/test/manual/history_style/4.html
@@ -1,0 +1,16 @@
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <script type="application/javascript" src="../../../src/htmx.js"></script>
+    <title>History - 4</title>
+</head>
+<body style="padding:20px;font-family: sans-serif" hx-boost="true">
+<style>a, a:visited, h1 { color: indigo; border: 1px solid lime; }</style>
+<h1>History Test</h1>
+<a href="1.html">1</a>
+<a href="2.html">2</a>
+<a href="3.html">3</a>
+<a href="4.html">4</a>
+<h3>Page 4</h3>
+</body>
+</html>

--- a/test/manual/history_style/index.html
+++ b/test/manual/history_style/index.html
@@ -1,0 +1,26 @@
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <script type="application/javascript" src="../../../src/htmx.js"></script>
+    <title>History - Index</title>
+    <meta name="htmx-config" content='{"historyCacheSize":2}'>
+    <script>
+        htmx.on("htmx:beforeHistorySave", function(evt){
+            console.log("Saving history : ", evt.detail);
+            console.log("History Cache Before:", JSON.parse(localStorage.getItem("htmx-history-cache")))
+            setTimeout(function () {
+                console.log("History Cache After:", JSON.parse(localStorage.getItem("htmx-history-cache")))
+            }, 10);
+        })
+    </script>
+</head>
+<body style="padding:20px;font-family: sans-serif" hx-boost="true">
+<style>a, a:visited, h1 { color: cyan; border: 1px dotted magenta; }</style>
+<h1>History Test</h1>
+<a href="1.html">1</a>
+<a href="2.html">2</a>
+<a href="3.html">3</a>
+<a href="4.html">4</a>
+<h3>Index</h3>
+</body>
+</html>

--- a/test/manual/index.html
+++ b/test/manual/index.html
@@ -34,6 +34,7 @@
             <li><a href="restored">Restored Test</a></li>
             <li><a href="history_regression">Navigate, Refresh, Back Regression</a></li>
             <li><a href="anchors">Anchors</a></li>
+            <li><a href="history_style">History Style</a></li>
         </ul>
     </li>
 </ul>


### PR DESCRIPTION
I was playing around with htmx with a site that has styles embedded in weird places, and noticed that when I navigated through history, occasionally styles were disappearing.

After a bit of investigation I found `makeFragment(..)` and it all made (a bit more) sense.  I've attached a screen recording showing the new tests before + after the fix. I recorded it with firefox but I checked it in chrome + safari too. Don't have IE to check that . . .


https://github.com/bigskysoftware/htmx/assets/183554/2e1367a4-f4ea-44a9-87a0-3a64212e313a

