### PR TITLE
Support formaction and formmethod on <button>

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2927,6 +2927,21 @@ return (function () {
                 return;
             }
 
+            var eltData = getInternalData(elt);
+            var submitter = eltData.lastButtonClicked;
+
+            if (submitter) {
+                var buttonPath = getRawAttribute(submitter, "formaction");
+                if (buttonPath != null) {
+                    path = buttonPath;
+                }
+
+                var buttonVerb = getRawAttribute(submitter, "formmethod")
+                if (buttonVerb != null) {
+                    verb = buttonVerb;
+                }
+            }
+
             // allow event-based confirmation w/ a callback
             if (!confirmed) {
                 var issueRequest = function() {
@@ -2939,7 +2954,6 @@ return (function () {
             }
 
             var syncElt = elt;
-            var eltData = getInternalData(elt);
             var syncStrategy = getClosestAttributeValue(elt, "hx-sync");
             var queueStrategy = null;
             var abortable = false;

--- a/test/attributes/hx-boost.js
+++ b/test/attributes/hx-boost.js
@@ -28,6 +28,24 @@ describe("hx-boost attribute", function() {
         div.innerHTML.should.equal("Boosted");
     })
 
+    it('handles basic form post with button formaction properly', function () {
+        this.server.respondWith("POST", "/test", "Boosted");
+        var div = make('<div hx-target="this" hx-boost="true"><form id="f1" method="post"><button id="b1" formaction="/test">Submit</button></form></div>');
+        var btn = byId('b1');
+        btn.click();
+        this.server.respond();
+        div.innerHTML.should.equal("Boosted");
+    })
+
+    it('handles basic form post with button formmethod properly', function () {
+        this.server.respondWith("POST", "/test", "Boosted");
+        var div = make('<div hx-target="this" hx-boost="true"><form id="f1" action="/test"><button id="b1" formmethod="post">Submit</button></form></div>');
+        var btn = byId('b1');
+        btn.click();
+        this.server.respond();
+        div.innerHTML.should.equal("Boosted");
+    })
+
     it('handles basic form post properly w/ explicit action', function () {
         this.server.respondWith("POST", "/test", "Boosted");
         var div = make('<div hx-target="this"><form id="f1" action="/test" method="post"  hx-trigger="click" hx-boost="true"></form></div>');


### PR DESCRIPTION
Bug: The these two forms should POST to the same URL but do not.

```html
<form>
  <button formaction="/action" formmethod="POST">Submit</button>
</form>
<form hx-boost="true">
  <button formaction="/action" formmethod="POST">Submit Boosted</button>
</form>
```

Fix: take into account formaction and formmethod of the submitter.

I'm not familiar with the HTMX codebase but `issueAjaxRequest` seemed like a reasonable place to handle this. ~`event.submitter` is relatively new as well, so you might want a more backwards compatible implementation, but this shows the gist of the issue and the fix.~

Instead of using event.submitter, I have opted to use the tracked button click on the internal data. This should work on all browser targets supported by HTMX.