### PR TITLE
Clear lastButtonClicked ref if it was removed from the DOM

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2453,6 +2453,9 @@ return (function () {
             var formValues = {};
             var errors = [];
             var internalData = getInternalData(elt);
+            if (internalData.lastButtonClicked && !bodyContains(internalData.lastButtonClicked)) {
+                internalData.lastButtonClicked = null
+            }
 
             // only validate when form is directly submitted and novalidate or formnovalidate are not set
             // or if the element has an explicit hx-validate="true" on it


### PR DESCRIPTION
This addresses #1749 

- htmx uses [an internal data](https://github.com/bigskysoftware/htmx/blob/master/src/htmx.js#L2446) to keep track of the last clicked button in a form
- it [relies on the focusout](https://github.com/bigskysoftware/htmx/blob/master/src/htmx.js#L1911) event to clear that reference
- on Chrome, the focusout event gets called when the element is swapped and removed from the DOM
- however on Firefox for some reason, the event isn't fired at all, so the reference is never cleared, the internal state still has a reference to the removed button as the last clicked button, thus its values gets included, until you click out to focusout the form

This change adds a check right before using that `lastButtonClicked` property, making sure the referenced button is still in the DOM