### PR TITLE
Fix URL Params Appending on Boost

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3102,7 +3102,7 @@ return (function () {
 
             // behavior of anchors w/ empty href is to use the current URL
             if (path == null || path === "") {
-                path = getDocument().location.href;
+                path = getDocument().location.href.split('?')[0];
             }
 
 


### PR DESCRIPTION
This PR fixes #1788.
The change simply takes the URL part without any query params when AJAX request is issued on boosted element.
In case of anchor tags, the **href** value simply provides the requested URL but in case of forms, the location object is used to get the current href value.

Should this change include a test?
If yes then can somebody help me with that?