### PR TITLE
Add version number to test page

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -14,6 +14,7 @@
 <body style="padding:20px;font-family: sans-serif">
 
 <h1 style="margin-top: 40px">htmx.js test suite</h1>
+<p id="version-number">Version:&nbsp;</p>
 
 <h2>Scratch Page</h2>
 <ul>
@@ -40,6 +41,9 @@
   if (navigator.webdriver) {
     htmx.logAll = function () { }
   }
+
+  // Add the version number to the top
+  document.getElementById('version-number').innerText += htmx.version
 </script>
 
 <script class="mocha-init">

--- a/www/static/test/index.html
+++ b/www/static/test/index.html
@@ -14,6 +14,7 @@
 <body style="padding:20px;font-family: sans-serif">
 
 <h1 style="margin-top: 40px">htmx.js test suite</h1>
+<p id="version-number">Version:&nbsp;</p>
 
 <h2>Scratch Page</h2>
 <ul>
@@ -40,6 +41,9 @@
   if (navigator.webdriver) {
     htmx.logAll = function () { }
   }
+
+  // Add the version number to the top
+  document.getElementById('version-number').innerText += htmx.version
 </script>
 
 <script class="mocha-init">


### PR DESCRIPTION
## Description
Now that we only have a single test page, it's helpful to show which version of htmx the tests are running against.

![Screenshot 2023-09-20 at 1 01 36 PM](https://github.com/bigskysoftware/htmx/assets/23287457/2e38afda-4a6e-40cb-88e7-2454932dbb15)
