### PR TITLE
[Test] Add a test to ensure inputs outside form with `form` attribute work properly

### DIFF
--- a/test/core/ajax.js
+++ b/test/core/ajax.js
@@ -1208,4 +1208,26 @@ describe("Core htmx AJAX Tests", function(){
         this.server.respond();
         values.should.deep.equal({t1: 'textValue', b1: ['inputValue', 'buttonValue']});
     })
+
+    it('properly handles inputs external to form', function () {
+        var values;
+        this.server.respondWith("Post", "/test", function (xhr) {
+            values = getParameters(xhr);
+            xhr.respond(204, {}, "");
+        });
+
+        make('<form id="externalForm" hx-post="/test">' +
+            '   <input type="hidden" name="b1" value="inputValue">' +
+            '</form>' +
+            '<input type="text" name="t1" value="textValue" form="externalForm">' +
+            '<select name="s1" form="externalForm">' +
+            '   <option value="someValue"></option>' +
+            '   <option value="selectValue" selected></option>' +
+            '</select>' +
+            '<button id="submit" form="externalForm" type="submit" name="b1" value="buttonValue">button</button>');
+
+        byId("submit").click();
+        this.server.respond();
+        values.should.deep.equal({t1: 'textValue', b1: ['inputValue', 'buttonValue'], s1: "selectValue"});
+    })
 })


### PR DESCRIPTION
As per [a discussion in the discord](https://discord.com/channels/725789699527933952/1135615265640566794/1154097770362306610), I've realized that in the PR #1559 I had added a bunch of tests about submit buttons/inputs that are outside forms, using the `form` attribute, but none to make sure input _values_ outside forms also work.

They work as expected, but I thought we might just as well add a test case for this scenario too, to prevent any potential future regression