### PR TITLE
[Tests] Fix test pipeline timing issues

### DIFF
--- a/test/core/ajax.js
+++ b/test/core/ajax.js
@@ -969,15 +969,15 @@ describe("Core htmx AJAX Tests", function(){
     it('scripts w/ src attribute are properly loaded', function(done)
     {
         try {
-            this.server.respondWith("GET", "/test", "<script src='setGlobal.js'></script>");
+            this.server.respondWith("GET", "/test", "<script id='setGlobalScript' src='setGlobal.js'></script>");
             var div = make("<div hx-get='/test'></div>");
             div.click();
             this.server.respond();
-            setTimeout(function () {
+            byId("setGlobalScript").addEventListener("load", function () {
                 window.globalWasCalled.should.equal(true);
                 delete window.globalWasCalled;
                 done();
-            }, 400);
+            })
         } finally {
             delete window.globalWasCalled;
         }

--- a/test/core/parameters.js
+++ b/test/core/parameters.js
@@ -123,26 +123,34 @@ describe("Core htmx Parameter Handling", function() {
         htmx._("urlEncode")({"foo": "bar", "do" : ["rey", "blah"]}).should.equal("foo=bar&do=rey&do=blah");
     });
 
-    it('form includes last focused button', function () {
+    it('form includes last focused button', function (done) {
         var form = make('<form hx-get="/foo"><input id="i1" name="foo" value="bar"/><input id="i2" name="do" value="rey"/><button id="b1" name="btn" value="bar"></button></form>');
         var input = byId('i1');
         var button = byId('b1');
+        // Listen for focusin on form as it'll bubble up from the button, and htmx binds on the form itself
+        form.addEventListener("focusin", function () {
+            var vals = htmx._('getInputValues')(form).values;
+            vals['foo'].should.equal('bar');
+            vals['do'].should.equal('rey');
+            vals['btn'].should.equal('bar');
+            done();
+        });
         button.focus();
-        var vals = htmx._('getInputValues')(form).values;
-        vals['foo'].should.equal('bar');
-        vals['do'].should.equal('rey');
-        vals['btn'].should.equal('bar');
     })
 
-    it('form includes last focused submit', function () {
+    it('form includes last focused submit', function (done) {
         var form = make('<form hx-get="/foo"><input id="i1" name="foo" value="bar"/><input id="i2" name="do" value="rey"/><input type="submit" id="s1" name="s1" value="bar"/></form>');
         var input = byId('i1');
         var button = byId('s1');
+        // Listen for focusin on form as it'll bubble up from the button, and htmx binds on the form itself
+        form.addEventListener("focusin", function () {
+            var vals = htmx._('getInputValues')(form).values;
+            vals['foo'].should.equal('bar');
+            vals['do'].should.equal('rey');
+            vals['s1'].should.equal('bar');
+            done();
+        });
         button.focus();
-        var vals = htmx._('getInputValues')(form).values;
-        vals['foo'].should.equal('bar');
-        vals['do'].should.equal('rey');
-        vals['s1'].should.equal('bar');
     })
 
     it('form does not include button when focus is lost', function () {

--- a/test/core/security.js
+++ b/test/core/security.js
@@ -107,6 +107,7 @@ describe("security options", function() {
     })
 
     it("can make egress cross site requests when htmx.config.selfRequestsOnly is enabled", function(done){
+        this.timeout(4000)
         // should trigger send error, rather than reject
         var listener = htmx.on("htmx:sendError", function (){
             htmx.off("htmx:sendError", listener);
@@ -119,6 +120,7 @@ describe("security options", function() {
     })
 
     it("can't make egress cross site requests when htmx.config.selfRequestsOnly is enabled", function(done){
+        this.timeout(4000)
         // should trigger send error, rather than reject
         htmx.config.selfRequestsOnly = true;
         var listener = htmx.on("htmx:invalidPath", function (){
@@ -133,6 +135,7 @@ describe("security options", function() {
     })
 
     it("can cancel egress request based on htmx:validateUrl event", function(done){
+        this.timeout(4000)
         // should trigger send error, rather than reject
         var pathVerifier = htmx.on("htmx:validateUrl", function (evt){
             evt.preventDefault();
@@ -149,6 +152,7 @@ describe("security options", function() {
     })
 
     it("can cancel egress request based on htmx:validateUrl event, sameHost is false", function(done){
+        this.timeout(4000)
         // should trigger send error, rather than reject
         var pathVerifier = htmx.on("htmx:validateUrl", function (evt){
             if (evt.detail.sameHost === false) {

--- a/test/index.html
+++ b/test/index.html
@@ -161,8 +161,10 @@
 <div id="mocha"></div>
 
 <script class="mocha-exec">
-    mocha.setup({globals: ['$0', '$1', '$2', '$3', '$4', 'performance', 'requestAnimationFrame', 'cancelAnimationFrame']}); <!-- IE11 -->
-    mocha.run();
+    document.addEventListener("DOMContentLoaded", function () {
+        mocha.setup({globals: ['$0', '$1', '$2', '$3', '$4', 'performance', 'requestAnimationFrame', 'cancelAnimationFrame']}); <!-- IE11 -->
+        mocha.run();
+    })
 </script>
 <em>Work Area</em>
 <hr/>


### PR DESCRIPTION
- Most important change is calling mocha run on DOMContentLoaded instead of directly from the inline script (it could run mocha before htmx initialized itself, that caused the 84 errors scenario, probably the 24 errors one too)
- Changed a few hardcoded setTimeouts to rely on event listeners instead
- Increased the timeout to 4s (formerly 2) on the 4 tests making a request to hypermedia.systems ; those were causing random local errors where the (at least my) network connection would apparently not be enough to fetch the page in less than 2s