### PR TITLE
Fix reference in notes from `hx-disable-elts` to `hx-disable-elt`

### DIFF
--- a/www/content/attributes/hx-disabled-elt.md
+++ b/www/content/attributes/hx-disabled-elt.md
@@ -23,4 +23,4 @@ which will prevent further clicks from occurring.
 
 ## Notes
 
-* `hx-disable-elts` is inherited and can be placed on a parent element
+* `hx-disable-elt` is inherited and can be placed on a parent element


### PR DESCRIPTION
https://htmx.org/attributes/hx-disabled-elt/

I think this was originally `hx-disabled-elts` and all the references to it were then changed to `hx-disabled-elts` except the reference in the notes, in the footer.