### PR TITLE
Improve request/response documentation in docs.md

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -917,9 +917,9 @@ htmx includes a number of useful headers in requests:
 |--------|-------------|
 | `HX-Boosted` | indicates that the request is via an element using [hx-boost](@/attributes/hx-boost.md)
 | `HX-Current-URL` | the current URL of the browser
-| `HX-History-Restore-Request` | `true` if the request is for history restoration after a miss in the local history cache
+| `HX-History-Restore-Request` | "true" if the request is for history restoration after a miss in the local history cache
 | `HX-Prompt` | the user response to an [hx-prompt](@/attributes/hx-prompt.md)
-| `HX-Request` | always `true`
+| `HX-Request` | always "true"
 | `HX-Target` | the `id` of the target element if it exists
 | `HX-Trigger-Name` | the `name` of the triggered element if it exists
 | `HX-Trigger` | the `id` of the triggered element if it exists

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -925,13 +925,17 @@ htmx includes a number of useful headers in requests:
 
 htmx supports some htmx-specific response headers:
 
-* `HX-Push` - pushes a new URL into the browser’s address bar
-* `HX-Redirect` - triggers a client-side redirect to a new location
-* `HX-Location` - triggers a client-side redirect to a new location that acts as a swap
-* `HX-Refresh` - if set to "true" the client side will do a full refresh of the page
-* `HX-Trigger` - triggers client side events
-* `HX-Trigger-After-Swap` - triggers client side events after the swap step
-* `HX-Trigger-After-Settle` - triggers client side events after the settle step
+* [`HX-Location`](@/headers/hx-location.md) - allows you to do a client-side redirect that does not do a full page reload
+* [`HX-Push-Url`](@/headers/hx-push-url.md) - pushes a new url into the history stack
+* `HX-Redirect` - can be used to do a client-side redirect to a new location
+* `HX-Refresh` - if set to "true" the client-side will do a full refresh of the page
+* [`HX-Replace-Url`](@/headers/hx-replace-url.md) - replaces the current URL in the location bar
+* `HX-Reswap` - allows you to specify how the response will be swapped. See [hx-swap](@/attributes/hx-swap.md) for possible values
+* `HX-Retarget` - a CSS selector that updates the target of the content update to a different element on the page
+* `HX-Reselect` - a CSS selector that allows you to choose which part of the response is used to be swapped in. Overrides an existing [`hx-select`](@/attributes/hx-select.md) on the triggering element
+* [`HX-Trigger`](@/headers/hx-trigger.md) - allows you to trigger client-side events
+* [`HX-Trigger-After-Settle`](@/headers/hx-trigger.md) - allows you to trigger client-side events after the settle step
+* [`HX-Trigger-After-Swap`](@/headers/hx-trigger.md) - allows you to trigger client-side events after the swap step
 
 For more on the `HX-Trigger` headers, see [`HX-Trigger` Response Headers](@/headers/hx-trigger.md).
 

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -913,13 +913,16 @@ on the client side.
 
 htmx includes a number of useful headers in requests:
 
-| Header | Description
-|--------|--------------
-| `HX-Request` | will be set to "true"
-| `HX-Trigger` | will be set to the id of the element that triggered the request
-| `HX-Trigger-Name` | will be set to the name of the element that triggered the request
-| `HX-Target` | will be set to the id of the target element
-| `HX-Prompt` | will be set to the value entered by the user when prompted via [hx-prompt](@/attributes/hx-prompt.md)
+| Header | Description |
+|--------|-------------|
+| `HX-Boosted` | indicates that the request is via an element using [hx-boost](@/attributes/hx-boost.md)
+| `HX-Current-URL` | the current URL of the browser
+| `HX-History-Restore-Request` | `true` if the request is for history restoration after a miss in the local history cache
+| `HX-Prompt` | the user response to an [hx-prompt](@/attributes/hx-prompt.md)
+| `HX-Request` | always `true`
+| `HX-Target` | the `id` of the target element if it exists
+| `HX-Trigger-Name` | the `name` of the triggered element if it exists
+| `HX-Trigger` | the `id` of the triggered element if it exists
 
 ### Response Headers
 

--- a/www/content/reference.md
+++ b/www/content/reference.md
@@ -95,9 +95,9 @@ The table below lists all other attributes available in htmx.
 |--------|-------------|
 | `HX-Boosted` | indicates that the request is via an element using [hx-boost](@/attributes/hx-boost.md)
 | `HX-Current-URL` | the current URL of the browser
-| `HX-History-Restore-Request` | `true` if the request is for history restoration after a miss in the local history cache
+| `HX-History-Restore-Request` | "true" if the request is for history restoration after a miss in the local history cache
 | `HX-Prompt` | the user response to an [hx-prompt](@/attributes/hx-prompt.md)
-| `HX-Request` | always `true`
+| `HX-Request` | always "true"
 | `HX-Target` | the `id` of the target element if it exists
 | `HX-Trigger-Name` | the `name` of the triggered element if it exists
 | `HX-Trigger` | the `id` of the triggered element if it exists

--- a/www/content/reference.md
+++ b/www/content/reference.md
@@ -110,17 +110,17 @@ The table below lists all other attributes available in htmx.
 
 | Header                                               | Description |
 |------------------------------------------------------|-------------|
-| [`HX-Location`](@/headers/hx-location.md)            | Allows you to do a client-side redirect that does not do a full page reload
+| [`HX-Location`](@/headers/hx-location.md)            | allows you to do a client-side redirect that does not do a full page reload
 | [`HX-Push-Url`](@/headers/hx-push-url.md)            | pushes a new url into the history stack
 | `HX-Redirect`                                        | can be used to do a client-side redirect to a new location
-| `HX-Refresh`                                         | if set to "true" the client side will do a full refresh of the page
+| `HX-Refresh`                                         | if set to "true" the client-side will do a full refresh of the page
 | [`HX-Replace-Url`](@/headers/hx-replace-url.md)      | replaces the current URL in the location bar
-| `HX-Reswap`                                          | Allows you to specify how the response will be swapped. See [hx-swap](@/attributes/hx-swap.md) for possible values
-| `HX-Retarget`                                        | A CSS selector that updates the target of the content update to a different element on the page
-| `HX-Reselect`                                        | A CSS selector that allows you to choose which part of the response is used to be swapped in. Overrides an existing [`hx-select`](@/attributes/hx-select.md) on the triggering element
-| [`HX-Trigger`](@/headers/hx-trigger.md)              | allows you to trigger client side events, see the [documentation](@/headers/hx-trigger.md) for more info
-| [`HX-Trigger-After-Settle`](@/headers/hx-trigger.md) | allows you to trigger client side events, see the [documentation](@/headers/hx-trigger.md) for more info
-| [`HX-Trigger-After-Swap`](@/headers/hx-trigger.md)   | allows you to trigger client side events, see the [documentation](@/headers/hx-trigger.md) for more info
+| `HX-Reswap`                                          | allows you to specify how the response will be swapped. See [hx-swap](@/attributes/hx-swap.md) for possible values
+| `HX-Retarget`                                        | a CSS selector that updates the target of the content update to a different element on the page
+| `HX-Reselect`                                        | a CSS selector that allows you to choose which part of the response is used to be swapped in. Overrides an existing [`hx-select`](@/attributes/hx-select.md) on the triggering element
+| [`HX-Trigger`](@/headers/hx-trigger.md)              | allows you to trigger client-side events
+| [`HX-Trigger-After-Settle`](@/headers/hx-trigger.md) | allows you to trigger client-side events after the settle step
+| [`HX-Trigger-After-Swap`](@/headers/hx-trigger.md)   | allows you to trigger client-side events after the swap step
 
 </div>
 

--- a/www/content/reference.md
+++ b/www/content/reference.md
@@ -92,7 +92,7 @@ The table below lists all other attributes available in htmx.
 <div class="info-table">
 
 | Header | Description |
-|-------|-------------|
+|--------|-------------|
 | `HX-Boosted` | indicates that the request is via an element using [hx-boost](@/attributes/hx-boost.md)
 | `HX-Current-URL` | the current URL of the browser
 | `HX-History-Restore-Request` | `true` if the request is for history restoration after a miss in the local history cache


### PR DESCRIPTION
The documentation seems complete in `reference.md` but the `docs.md` file lacked some attributes