### PR TITLE
Update docs.md

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -477,7 +477,7 @@ The modifiers available on `hx-swap` are:
 | `transition`  | `true` or `false`, whether to use the view transition API for this swap                                  |
 | `swap`        | The swap delay to use (e.g. `100ms`) between when old content is cleared and the new content is inserted |
 | `settle`      | The settle delay to use (e.g. `100ms`) between when new content is inserted and when it is settled       |
-| `ignoreTitle` | If set to `true`, any title found in the new content will be ignored and not update the docuemnt title   |
+| `ignoreTitle` | If set to `true`, any title found in the new content will be ignored and not update the document title   |
 | `scroll`      | `top` or `bottom`, will scroll the target element to its top or bottom                                   |
 | `show`        | `top` or `bottom`, will scroll the target elements top or bottom into view                               |
 


### PR DESCRIPTION
fix: spelling mistake 'docuemnt' in swap-options