### PR TITLE
fix: prevent nodeData.onHandlers overwrite

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1950,7 +1950,9 @@ return (function () {
 
         function addHxOnEventHandler(elt, eventName, code) {
             var nodeData = getInternalData(elt);
-            nodeData.onHandlers ||= [];
+            if (!Array.isArray(nodeData.onHandlers)) {
+                nodeData.onHandlers = [];
+            }
             var func;
             var listener = function (e) {
                 return maybeEval(elt, function() {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1950,7 +1950,7 @@ return (function () {
 
         function addHxOnEventHandler(elt, eventName, code) {
             var nodeData = getInternalData(elt);
-            nodeData.onHandlers = [];
+            nodeData.onHandlers ||= [];
             var func;
             var listener = function (e) {
                 return maybeEval(elt, function() {

--- a/test/attributes/hx-on-wildcard.js
+++ b/test/attributes/hx-on-wildcard.js
@@ -175,4 +175,22 @@ describe("hx-on:* attribute", function() {
         delete window.foo;
         delete window.bar;
     });
+
+    it("cleans up all handlers when the DOM updates", function () {
+        // setup
+        window.foo = 0;
+        window.bar = 0;
+        var div = make("<div hx-on:increment-foo='window.foo++' hx-on:increment-bar='window.bar++'>Foo</div>");
+        make("<div>Another Div</div>"); // sole purpose is to update the DOM
+
+        // check there is just one listener against each event
+        htmx.trigger(div, "increment-foo");
+        htmx.trigger(div, "increment-bar");        
+        window.foo.should.equal(1);
+        window.bar.should.equal(1);
+
+        // teardown
+        delete window.foo;
+        delete window.bar;
+    });
 });

--- a/test/attributes/hx-on-wildcard.js
+++ b/test/attributes/hx-on-wildcard.js
@@ -183,7 +183,7 @@ describe("hx-on:* attribute", function() {
         var div = make("<div hx-on:increment-foo='window.foo++' hx-on:increment-bar='window.bar++'>Foo</div>");
         make("<div>Another Div</div>"); // sole purpose is to update the DOM
 
-        // check there is just one listener against each event
+        // check there is just one handler against each event
         htmx.trigger(div, "increment-foo");
         htmx.trigger(div, "increment-bar");        
         window.foo.should.equal(1);

--- a/test/attributes/hx-on.js
+++ b/test/attributes/hx-on.js
@@ -171,4 +171,23 @@ describe("hx-on attribute", function() {
         delete window.foo;
         delete window.bar;
     });
+
+
+    it("cleans up all handlers when the DOM updates", function () {
+        // setup
+        window.foo = 0;
+        window.bar = 0;
+        var div = make("<div hx-on='increment-foo: window.foo++\nincrement-bar: window.bar++'>Foo</div>");
+        make("<div>Another Div</div>"); // sole purpose is to update the DOM
+
+        // check there is just one listener against each event
+        htmx.trigger(div, "increment-foo");
+        htmx.trigger(div, "increment-bar");        
+        window.foo.should.equal(1);
+        window.bar.should.equal(1);
+
+        // teardown
+        delete window.foo;
+        delete window.bar;
+    });
 });

--- a/test/attributes/hx-on.js
+++ b/test/attributes/hx-on.js
@@ -180,7 +180,7 @@ describe("hx-on attribute", function() {
         var div = make("<div hx-on='increment-foo: window.foo++\nincrement-bar: window.bar++'>Foo</div>");
         make("<div>Another Div</div>"); // sole purpose is to update the DOM
 
-        // check there is just one listener against each event
+        // check there is just one handler against each event
         htmx.trigger(div, "increment-foo");
         htmx.trigger(div, "increment-bar");        
         window.foo.should.equal(1);

--- a/test/attributes/hx-on.js
+++ b/test/attributes/hx-on.js
@@ -172,7 +172,6 @@ describe("hx-on attribute", function() {
         delete window.bar;
     });
 
-
     it("cleans up all handlers when the DOM updates", function () {
         // setup
         window.foo = 0;


### PR DESCRIPTION
Related to this discussion I created: https://github.com/bigskysoftware/htmx/discussions/1861

I started digging into the code a little and realised that `nodeData.onHandlers` can only hold one on-handler at a time since it is wiped every time `addHxOnEventHandler` is called. The fix is to just not do that if `nodeData.onHandlers` already exists.

This is fixes the cause of the problem in the linked discussion because when there are multiple on-handlers on an element, only the last one is stored. So then only the last on-handler gets removed when the DOM updates. Every other on-handler just gets re-added without getting removed beforehand.

PS: I made this PR against the master branch, but please shout if it should be dev.