### PR TITLE
Ignore formmethod when value is "dialog"

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2959,7 +2959,10 @@ return (function () {
 
                 var buttonVerb = getRawAttribute(submitter, "formmethod")
                 if (buttonVerb != null) {
-                    verb = buttonVerb;
+                    // ignore buttons with formmethod="dialog"
+                    if (buttonVerb.toLowerCase() !== "dialog") {
+                        verb = buttonVerb;
+                    }
                 }
             }
 

--- a/test/core/ajax.js
+++ b/test/core/ajax.js
@@ -1230,4 +1230,32 @@ describe("Core htmx AJAX Tests", function(){
         this.server.respond();
         values.should.deep.equal({t1: 'textValue', b1: ['inputValue', 'buttonValue'], s1: "selectValue"});
     })
+
+    it('handles form post with button formmethod dialog properly', function () {
+        var values;
+        this.server.respondWith("POST", "/test", function (xhr) {
+            values = getParameters(xhr);
+            xhr.respond(200, {}, "");
+        });
+
+        make('<dialog><form hx-post="/test"><button id="submit" formmethod="dialog" name="foo" value="bar">submit</button></form></dialog>');
+
+        byId("submit").click();
+        this.server.respond();
+        values.should.deep.equal({ foo: 'bar' });
+    })
+
+    it('handles form get with button formmethod dialog properly', function () {
+        var responded = false;
+        this.server.respondWith("GET", "/test", function (xhr) {
+            responded = true;
+            xhr.respond(200, {}, "");
+        });
+
+        make('<dialog><form hx-get="/test"><button id="submit" formmethod="dialog">submit</button></form></dialog>');
+
+        byId("submit").click();
+        this.server.respond();
+        responded.should.equal(true);
+    })
 })


### PR DESCRIPTION
In the following example htmx will issue a `DIALOG` request instead of a `POST` request.

```html
<dialog>
    <form hx-post="/test">
        <button formmethod="dialog" name="foo" value="bar">Submit</button>
    </form>
</dialog>
```

This PR changes the behaviour so that htmx will issue a `POST` request.

Closes https://github.com/bigskysoftware/htmx/issues/1859