### PR TITLE
Sortable example fixes

### DIFF
--- a/www/content/examples/sortable.md
+++ b/www/content/examples/sortable.md
@@ -15,7 +15,11 @@ htmx.onLoad(function(content) {
       var sortable = sortables[i];
       new Sortable(sortable, {
           animation: 150,
-          ghostClass: 'blue-background-class'
+          ghostClass: 'blue-background-class',
+          filter: ".htmx-indicator",
+          onMove: function (evt) {
+            return evt.related.className.indexOf('htmx-indicator') === -1;
+          }
       });
     }
 })
@@ -56,7 +60,11 @@ That's it!
           var sortable = sortables[i];
           new Sortable(sortable, {
               animation: 150,
-              ghostClass: 'blue-background-class'
+              ghostClass: 'blue-background-class',
+              filter: ".htmx-indicator",
+              onMove: function (evt) {
+                return evt.related.className.indexOf('htmx-indicator') === -1;
+              }
           });
         }
     })

--- a/www/content/examples/sortable.md
+++ b/www/content/examples/sortable.md
@@ -64,7 +64,7 @@ That's it!
     var listItems = [1, 2, 3, 4, 5]
     // routes
     init("/demo", function(request, params){
-      return '<form id=example1" class="list-group col sortable" hx-post="/items" hx-trigger="end">' +
+      return '<form id="example1" class="list-group col sortable" hx-post="/items" hx-trigger="end">' +
       listContents()
       + "\n</form>";
     });

--- a/www/content/examples/sortable.md
+++ b/www/content/examples/sortable.md
@@ -13,13 +13,25 @@ htmx.onLoad(function(content) {
     var sortables = content.querySelectorAll(".sortable");
     for (var i = 0; i < sortables.length; i++) {
       var sortable = sortables[i];
-      new Sortable(sortable, {
+      var sortableInstance = new Sortable(sortable, {
           animation: 150,
           ghostClass: 'blue-background-class',
+
+          // Make the `.htmx-indicator` unsortable
           filter: ".htmx-indicator",
           onMove: function (evt) {
             return evt.related.className.indexOf('htmx-indicator') === -1;
+          },
+
+          // Disable sorting on the `end` event
+          onEnd: function (evt) {
+            this.option("disabled", true);
           }
+      });
+
+      // Re-enable sorting on the `htmx:afterSwap` event
+      sortable.addEventListener("htmx:afterSwap", function() {
+        sortableInstance.option("disabled", false);
       });
     }
 })
@@ -57,20 +69,26 @@ That's it!
     htmx.onLoad(function(content) {
         var sortables = content.querySelectorAll(".sortable");
         for (var i = 0; i < sortables.length; i++) {
-          var sortableList = sortables[i];
-          sortable = new Sortable(sortableList, {
+          var sortable = sortables[i];
+          var sortableInstance = new Sortable(sortable, {
               animation: 150,
               ghostClass: 'blue-background-class',
+
+              // Make the `.htmx-indicator` unsortable
               filter: ".htmx-indicator",
               onMove: function (evt) {
                 return evt.related.className.indexOf('htmx-indicator') === -1;
               },
+
+              // Disable sorting on the `end` event
               onEnd: function (evt) {
                 this.option("disabled", true);
               }
           });
-          sortableList.addEventListener("htmx:afterSwap", function() {
-            sortable.option("disabled", false);
+
+          // Re-enable sorting on the `htmx:afterSwap` event
+          sortable.addEventListener("htmx:afterSwap", function() {
+            sortableInstance.option("disabled", false);
           });
         }
     })

--- a/www/content/examples/sortable.md
+++ b/www/content/examples/sortable.md
@@ -57,14 +57,20 @@ That's it!
     htmx.onLoad(function(content) {
         var sortables = content.querySelectorAll(".sortable");
         for (var i = 0; i < sortables.length; i++) {
-          var sortable = sortables[i];
-          new Sortable(sortable, {
+          var sortableList = sortables[i];
+          sortable = new Sortable(sortableList, {
               animation: 150,
               ghostClass: 'blue-background-class',
               filter: ".htmx-indicator",
               onMove: function (evt) {
                 return evt.related.className.indexOf('htmx-indicator') === -1;
+              },
+              onEnd: function (evt) {
+                this.option("disabled", true);
               }
+          });
+          sortableList.addEventListener("htmx:afterSwap", function() {
+            sortable.option("disabled", false);
           });
         }
     })

--- a/www/content/examples/sortable.md
+++ b/www/content/examples/sortable.md
@@ -85,8 +85,8 @@ That's it!
     
     // templates
     function listContents() {
-      return '<div class="htmx-indicator">Updating...</div>' + listItems.map(function(val) {
-        return "  <div style='border:1px solid #DEDEDE; padding:12px; margin: 8px; width:200px' ><input type='hidden' name='item' value='" + val + "'/> Item " + val +"</div>";
+      return '<div class="htmx-indicator" style="cursor: default">Updating...</div>' + listItems.map(function(val) {
+        return `  <div style="border:1px solid #DEDEDE; padding:12px; margin: 8px; width:200px; cursor: grab" ondrag="this.style.cursor = 'grabbing'" ><input type="hidden" name="item" value="` + val + `"/> Item ` + val + `</div>`;
       }).join("\n");
     }
 


### PR DESCRIPTION
### Main changes:

- Fix bug where, when an item is dragged fast enough before a previous request is completed, dropping it after the request's completion resulted in the addition of an extra item to the list. This is fixed by disabling the sortable on its `end` event, and re-enabling it on its `htmx:afterSwap` event.

    Before:
    
    https://github.com/bigskysoftware/htmx/assets/6943864/290ca6e8-8d17-42db-9fa7-1f58b75abffa
    
    After:
    
    https://github.com/bigskysoftware/htmx/assets/6943864/cafa81ec-8204-42ef-9a7d-af8e41835172
    
- Disable draggability of the `.htmx-indicator` ("Updating...") element.

    Before:
    
    https://github.com/bigskysoftware/htmx/assets/6943864/5f292592-5966-42ca-b7a4-312bac161e1a
    
    After:
    
    https://github.com/bigskysoftware/htmx/assets/6943864/e0eb73c4-4962-4bf8-b533-0d67587bdb46

### Other changes:

- Indicate draggable items by showing a grabbing cursor, and change the cursor on `.htmx-indicator` to `default` rather than `text`, since it's not supposed to be selectable especially while hidden.
- Add missing quote to the form's id.