### PR TITLE
Fix: Use getElementById instead of querySelector to work with all valid characters

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3551,7 +3551,7 @@ return (function () {
                                 }
                             }
                             if (responseInfo.pathInfo.anchor) {
-                                var anchorTarget = find("#" + responseInfo.pathInfo.anchor);
+                                var anchorTarget = getDocument().getElementById(responseInfo.pathInfo.anchor);
                                 if(anchorTarget) {
                                     anchorTarget.scrollIntoView({block:'start', behavior: "auto"});
                                 }


### PR DESCRIPTION
Currently clicking the link on this:
```
<html>
    <head>
        <script src="https://unpkg.com/htmx.org@1.9.6/dist/htmx.js" ></script>
    </head>
    <body>
        <a href="" hx-get="other.html#foo()bar">Click me</a>
    </body>
</html>
```
results in
```
DOMException: Failed to execute 'querySelector' on 'Document': '#foo()bar' is not a valid selector.
```
on line 492.

Since responseInfo.pathInfo.anchor is assumed to be an ID here, use getElementById instead of querySelector to allow all characters.

I can't see any problems with this change, but please let me know if I'm missing something.