### PR TITLE
Fixed ws and sse references in the docs

### DIFF
--- a/www/content/attributes/hx-sse.md
+++ b/www/content/attributes/hx-sse.md
@@ -84,7 +84,7 @@ data: <div>Content to swap into your HTML page.</div>
 
 ### Test SSE Server
 
-Htmx includes an SSE test server with many more examples of how to use Server Sent Events.  Download the htmx source code from GitHub and navigate to /test/servers/sse to experiment.
+Htmx includes an SSE test server with many more examples of how to use Server Sent Events.  Download the htmx source code from GitHub and navigate to /test/ws-sse to experiment.
 
 ## Notes
 

--- a/www/content/attributes/hx-ws.md
+++ b/www/content/attributes/hx-ws.md
@@ -44,7 +44,7 @@ Own implementations can be provided by setting `htmx.config.wsReconnectDelay` to
 
 ### Test Web Sockets Server
 
-Htmx includes a WebSockets test server with many more examples of how to use Server Sent Events.  Download the htmx source code from GitHub and navigate to /test/servers/ws to experiment.
+Htmx includes a WebSockets test server with many more examples of how to use Server Sent Events.  Download the htmx source code from GitHub and navigate to /test/ws-sse to experiment.
 
 ## Notes
 

--- a/www/content/extensions/server-sent-events.md
+++ b/www/content/extensions/server-sent-events.md
@@ -103,7 +103,7 @@ If the SSE Event Stream is closed unexpectedly, browsers are supposed to attempt
 
 ### Testing SSE Connections with the Demo Server
 
-Htmx includes a demo SSE server written in Go that will help you to see SSE in action, and begin bootstrapping your own SSE code.  It is located in the /test/servers/sse folder of the htmx distribution.  Look at /test/servers/ws/README.md for instructions on running and using the test server.
+Htmx includes a demo SSE server written in Node.js that will help you to see SSE in action, and begin bootstrapping your own SSE code.  It is located in the /test/ws-sse folder of the htmx distribution.  Look at /test/ws-sse/README.md for instructions on running and using the test server.
 
 ### Migrating from Previous Versions
 

--- a/www/content/extensions/web-sockets.md
+++ b/www/content/extensions/web-sockets.md
@@ -237,9 +237,9 @@ specified element, namely `htmx:wsBeforeSend` and `htmx:wsAfterSend` events when
 
 ### Testing with the Demo Server
 
-Htmx includes a demo WebSockets server written in Go that will help you to see WebSockets in action, and begin
-bootstrapping your own WebSockets code. It is located in the /test/servers/ws folder of the htmx distribution. Look at
-/test/servers/ws/README.md for instructions on running and using the test server.
+Htmx includes a demo WebSockets server written in Node.js that will help you to see WebSockets in action, and begin
+bootstrapping your own WebSockets code. It is located in the /test/ws-sse folder of the htmx distribution. Look at
+/test/ws-sse/README.md for instructions on running and using the test server.
 
 ### Migrating from Previous Versions
 


### PR DESCRIPTION
This updates the `ws` and `sse` extension docs to match the changes made in the [recently merged PR](https://github.com/bigskysoftware/htmx/pull/1876) that updated the `ws` and `sse` test servers from Go to Node.js.

