### PR TITLE
Allow CSS selectors with whitespace in `hx-trigger`

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1235,13 +1235,13 @@ return (function () {
         }
 
         function consumeCSSSelector(tokens) {
-            var result = "";
-            if (tokens.length > 0 && tokens[0].match(COMBINED_SELECTOR_START)) {
+            var result;
+            if (tokens.length > 0 && COMBINED_SELECTOR_START.test(tokens[0])) {
                 tokens.shift();
-                result += consumeUntil(tokens, COMBINED_SELECTOR_END).trim();
+                result = consumeUntil(tokens, COMBINED_SELECTOR_END).trim();
                 tokens.shift();
             } else {
-                result += consumeUntil(tokens, WHITESPACE_OR_COMMA);
+                result = consumeUntil(tokens, WHITESPACE_OR_COMMA);
             }
             return result;
         }
@@ -1294,7 +1294,7 @@ return (function () {
                                     triggerSpec.delay = parseInterval(consumeUntil(tokens, WHITESPACE_OR_COMMA));
                                 } else if (token === "from" && tokens[0] === ":") {
                                     tokens.shift();
-                                    if (tokens[0].match(COMBINED_SELECTOR_START)) {
+                                    if (COMBINED_SELECTOR_START.test(tokens[0])) {
                                         var from_arg = consumeCSSSelector(tokens);
                                     } else {
                                         var from_arg = consumeUntil(tokens, WHITESPACE_OR_COMMA);

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1310,14 +1310,17 @@ return (function () {
                                     triggerSpec.from = from_arg;
                                 } else if (token === "target" && tokens[0] === ":") {
                                     tokens.shift();
-                                    triggerSpec.target = consumeUntil(tokens, WHITESPACE_OR_COMMA);
+                                    triggerSpec.target = consumeCSSSelector(tokens);
                                 } else if (token === "throttle" && tokens[0] === ":") {
                                     tokens.shift();
                                     triggerSpec.throttle = parseInterval(consumeUntil(tokens, WHITESPACE_OR_COMMA));
                                 } else if (token === "queue" && tokens[0] === ":") {
                                     tokens.shift();
                                     triggerSpec.queue = consumeUntil(tokens, WHITESPACE_OR_COMMA);
-                                } else if ((token === "root" || token === "threshold") && tokens[0] === ":") {
+                                } else if (token === "root" && tokens[0] === ":") {
+                                    tokens.shift();
+                                    triggerSpec[token] = consumeCSSSelector(tokens);
+                                } else if (token === "threshold" && tokens[0] === ":") {
                                     tokens.shift();
                                     triggerSpec[token] = consumeUntil(tokens, WHITESPACE_OR_COMMA);
                                 } else {

--- a/test/attributes/hx-trigger.js
+++ b/test/attributes/hx-trigger.js
@@ -895,7 +895,7 @@ describe("hx-trigger attribute", function(){
         form.innerHTML.should.equal("Called!");
     })
 
-    it("correctly handles CSS selectors that contain whitespace", function(){
+    it("correctly handles CSS descendant combinators", function(){
         this.server.respondWith("GET", "/test", "Clicked!");
 
         var outer = make("<div id='outer'><div id='inner'></div><div id='other' hx-get='/test' hx-trigger='click from:previous (#outer div)'>Unclicked.</div></div>");
@@ -907,6 +907,36 @@ describe("hx-trigger attribute", function(){
         this.server.respond();
         other.innerHTML.should.equal("Clicked!");
     })
+
+
+    it('correctly handles CSS descendant combinators in modifier target', function() {
+        this.server.respondWith('GET', '/test', 'Called');
+
+        document.addEventListener('htmx:syntax:error', function(evt) {
+            chai.assert.fail('htmx:syntax:error');
+        });
+
+        make('<div class="d1"><a id="a1" class="a1">Click me</a><a id="a2" class="a2">Click me</a></div>');
+        var div = make('<div hx-trigger="click from:body target:(.d1 .a2)" hx-get="/test">Not Called</div>');
+
+        byId('a1').click();
+        this.server.respond();
+        div.innerHTML.should.equal("Not Called");
+
+        byId('a2').click();
+        this.server.respond();
+        div.innerHTML.should.equal("Called");
+    });
+
+    it('correctly handles CSS descendant combinators in modifier root', function() {
+        this.server.respondWith('GET', '/test', 'Called');
+
+        document.addEventListener('htmx:syntax:error', function(evt) {
+            chai.assert.fail('htmx:syntax:error');
+        });
+
+        make('<div hx-trigger="intersect root:{form input}" hx-get="/test">Not Called</div>');
+    });
 
 
 })

--- a/test/attributes/hx-trigger.js
+++ b/test/attributes/hx-trigger.js
@@ -898,13 +898,29 @@ describe("hx-trigger attribute", function(){
     it("correctly handles CSS descendant combinators", function(){
         this.server.respondWith("GET", "/test", "Clicked!");
 
-        var outer = make("<div id='outer'><div id='inner'></div><div id='other' hx-get='/test' hx-trigger='click from:previous (#outer div)'>Unclicked.</div></div>");
+        var outer = make(`
+        <div>
+            <div id='outer'>
+                <div id='first'>
+                    <div id='inner'></div>
+                </div>
+                <div id='second' hx-get='/test' hx-trigger='click from:previous (#outer div)'>Unclicked.</div>
+            </div>
+            <div id='other' hx-get='/test' hx-trigger='click from:(div #inner)'>Unclicked.</div>
+        </div>
+        `);
+
         var inner = byId("inner");
+        var second = byId("second");
         var other = byId("other");
 
+        second.innerHTML.should.equal("Unclicked.");
         other.innerHTML.should.equal("Unclicked.");
+
         inner.click();
         this.server.respond();
+
+        second.innerHTML.should.equal("Clicked!");
         other.innerHTML.should.equal("Clicked!");
     })
 

--- a/test/attributes/hx-trigger.js
+++ b/test/attributes/hx-trigger.js
@@ -899,7 +899,7 @@ describe("hx-trigger attribute", function(){
         this.server.respondWith("GET", "/test", "Clicked!");
 
         var outer = make("<div id='outer'><div id='inner'></div><div id='other' hx-get='/test' hx-trigger='click from:previous (#outer div)'>Unclicked.</div></div>");
-        var inner = byId("inner")
+        var inner = byId("inner");
         var other = byId("other");
 
         other.innerHTML.should.equal("Unclicked.");

--- a/test/attributes/hx-trigger.js
+++ b/test/attributes/hx-trigger.js
@@ -895,5 +895,18 @@ describe("hx-trigger attribute", function(){
         form.innerHTML.should.equal("Called!");
     })
 
+    it("correctly handles CSS selectors that contain whitespace", function(){
+        this.server.respondWith("GET", "/test", "Clicked!");
+
+        var outer = make("<div id='outer'><div id='inner'></div><div id='other' hx-get='/test' hx-trigger='click from:previous (#outer div)'>Unclicked.</div></div>");
+        var inner = byId("inner")
+        var other = byId("other");
+
+        other.innerHTML.should.equal("Unclicked.");
+        inner.click();
+        this.server.respond();
+        other.innerHTML.should.equal("Clicked!");
+    })
+
 
 })

--- a/www/content/attributes/hx-trigger.md
+++ b/www/content/attributes/hx-trigger.md
@@ -153,3 +153,4 @@ The AJAX request can be triggered via JavaScript [`htmx.trigger()`](@/api.md#tri
 
 * `hx-trigger` is not inherited
 * `hx-trigger` can be used without an AJAX request, in which case it will only fire the `htmx:trigger` event
+* In order to pass a CSS selector that contains whitespace (e.g. `form input`) to the `from`- or `target`-modifier, surround the selector in parentheses or curly brackets (e.g. `from:(form input)` or `from:nearest (form input)`)


### PR DESCRIPTION
A CSS selector that uses the descendant combinator, e.g. `form input` to target an `input` that is in a `form`, causes an HTMX syntax error, as the parsing of the `hx-trigger` consumes tokens until it finds whitespace, at which point it will try to parse `input` as a token and flag it as invalid syntax.

As suggested in #569, we could allow for such selectors when wrapping them in for instance curly brackets or parentheses. 

I implemented this logic, allowing for either parentheses or curly braces to wrap a selector. This works for both regular CSS selectors as well as extended CSS selectors using e.g. `from`.

I'd like to have allowed for square brackets or single/double quotes as well, but since those are both used already when parsing `hx-trigger`, this wasn't possible.

---
Examples:

```html
<div id="outer">
    <div class="first">Click me!</div>
    <div>Or click me</div>
</div>

<!-- Matches the second child div above -->
<div hx-get="/second-clicked" hx-trigger="click from:previous (#outer div)">Don't click me.</div>
<!-- Or, equivalently: -->
<div hx-get="/second-clicked" hx-trigger="click from:{#outer div:last-child}">Don't click me.</div>

<!-- Matches the first child div above -->
<div hx-get="/first-clicked" hx-trigger="click from:(#outer div.first)">Don't click me.</div>
```

---
Of course, feel free to say "no thanks" and close this PR 😊