### PR TITLE
Fix: form submission of email inputs with `multiple` attribute

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2440,7 +2440,7 @@ return (function () {
             if (shouldInclude(elt)) {
                 var name = getRawAttribute(elt,"name");
                 var value = elt.value;
-                if (elt.multiple) {
+                if (elt.multiple && elt.tagName === "SELECT") {
                     value = toArray(elt.querySelectorAll("option:checked")).map(function (e) { return e.value });
                 }
                 // include file inputs

--- a/test/core/ajax.js
+++ b/test/core/ajax.js
@@ -481,6 +481,33 @@ describe("Core htmx AJAX Tests", function(){
         values.should.deep.equal({multiSelect:["m1", "m3", "m7", "m8"]});
     });
 
+    it('properly handles multiple email input', function()
+    {
+        var values;
+        this.server.respondWith("Post", "/test", function (xhr) {
+            values = getParameters(xhr);
+            xhr.respond(204, {}, "");
+        });
+
+        var form = make('<form hx-post="/test" hx-trigger="click">' +
+            '<input id="multiEmail" name="multiEmail" multiple>'+
+            '</form>');
+
+        form.click();
+        this.server.respond();
+        values.should.deep.equal({multiEmail: ''});
+
+        byId("multiEmail").value = 'foo@example.com';
+        form.click();
+        this.server.respond();
+        values.should.deep.equal({multiEmail:"foo@example.com"});
+
+        byId("multiEmail").value = 'foo@example.com,bar@example.com';
+        form.click();
+        this.server.respond();
+        values.should.deep.equal({multiEmail:"foo@example.com,bar@example.com"});
+    });
+
     it('properly handles checkbox inputs', function()
     {
         var values;


### PR DESCRIPTION
Fixes form submissions of `type="email"` inputs with the `multiple` attribute. These inputs' values were previously being ignored because all inputs with the `multiple` attribute were assumed to be `select` elements.

I added one test in `ajax.js`, but I can add more in other places if needed.

closes #1912 