### PR TITLE
Wrap type declarations in top-level interface

### DIFF
--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -1,295 +1,302 @@
 // https://htmx.org/reference/#api
 
-/**
- * This method adds a class to the given element.
- *
- * https://htmx.org/api/#addClass
- *
- * @param elt the element to add the class to
- * @param clazz the class to add
- * @param delay the delay (in milliseconds before class is added)
- */
-export function addClass(elt: Element, clazz: string, delay?: number): void;
+// 2 possibilities to declare exports from 'htmx.org' npm package, and how imports look like
 
-/**
- * Issues an htmx-style AJAX request
- *
- * https://htmx.org/api/#ajax
- *
- * @param verb 'GET', 'POST', etc.
- * @param path the URL path to make the AJAX
- * @param element the element to target (defaults to the **body**)
- * @returns Promise that resolves immediately if no request is sent, or when the request is complete
- */
-export function ajax(verb: string, path: string, element: Element): Promise<void>;
+export default HTMX;    // import htmx from 'htmx.org'
+export var htmx: HTMX;  // import { htmx } from 'htmx.org'
 
-/**
- * Issues an htmx-style AJAX request
- *
- * https://htmx.org/api/#ajax
- *
- * @param verb 'GET', 'POST', etc.
- * @param path the URL path to make the AJAX
- * @param selector a selector for the target
- * @returns Promise that resolves immediately if no request is sent, or when the request is complete
- */
-export function ajax(verb: string, path: string, selector: string): Promise<void>;
+export interface HTMX {
 
-/**
- * Issues an htmx-style AJAX request
- *
- * https://htmx.org/api/#ajax
- *
- * @param verb 'GET', 'POST', etc.
- * @param path the URL path to make the AJAX
- * @param context a context object that contains any of the following
- * @returns Promise that resolves immediately if no request is sent, or when the request is complete
- */
-export function ajax(
-    verb: string,
-    path: string,
-    context: Partial<{ source: any; event: any; handler: any; target: any; swap: any; values: any; headers: any }>
-): Promise<void>;
+    /**
+     * This method adds a class to the given element.
+     *
+     * https://htmx.org/api/#addClass
+     *
+     * @param elt the element to add the class to
+     * @param clazz the class to add
+     * @param delay the delay (in milliseconds before class is added)
+     */
+    addClass(elt: Element, clazz: string, delay?: number): void;
 
-/**
- * Finds the closest matching element in the given elements parentage, inclusive of the element
- *
- * https://htmx.org/api/#closest
- *
- * @param elt the element to find the selector from
- * @param selector the selector to find
- */
-export function closest(elt: Element, selector: string): Element | null;
+    /**
+     * Issues an htmx-style AJAX request
+     *
+     * https://htmx.org/api/#ajax
+     *
+     * @param verb 'GET', 'POST', etc.
+     * @param path the URL path to make the AJAX
+     * @param element the element to target (defaults to the **body**)
+     * @returns Promise that resolves immediately if no request is sent, or when the request is complete
+     */
+    ajax(verb: string, path: string, element: Element): Promise<void>;
 
-/**
- * A property holding the configuration htmx uses at runtime.
- *
- * Note that using a [meta tag](https://htmx.org/docs/#config) is the preferred mechanism for setting these properties.
- *
- * https://htmx.org/api/#config
- */
-export var config: HtmxConfig;
+    /**
+     * Issues an htmx-style AJAX request
+     *
+     * https://htmx.org/api/#ajax
+     *
+     * @param verb 'GET', 'POST', etc.
+     * @param path the URL path to make the AJAX
+     * @param selector a selector for the target
+     * @returns Promise that resolves immediately if no request is sent, or when the request is complete
+     */
+    ajax(verb: string, path: string, selector: string): Promise<void>;
 
-/**
- * A property used to create new [Server Sent Event](https://htmx.org/docs/#sse) sources. This can be updated to provide custom SSE setup.
- *
- * https://htmx.org/api/#createEventSource
- */
-export var createEventSource: (url: string) => EventSource;
+    /**
+     * Issues an htmx-style AJAX request
+     *
+     * https://htmx.org/api/#ajax
+     *
+     * @param verb 'GET', 'POST', etc.
+     * @param path the URL path to make the AJAX
+     * @param context a context object that contains any of the following
+     * @returns Promise that resolves immediately if no request is sent, or when the request is complete
+     */
+    ajax(
+        verb: string,
+        path: string,
+        context: Partial<{ source: any; event: any; handler: any; target: any; swap: any; values: any; headers: any }>
+    ): Promise<void>;
 
-/**
- * A property used to create new [WebSocket](https://htmx.org/docs/#websockets). This can be updated to provide custom WebSocket setup.
- *
- * https://htmx.org/api/#createWebSocket
- */
-export var createWebSocket: (url: string) => WebSocket;
+    /**
+     * Finds the closest matching element in the given elements parentage, inclusive of the element
+     *
+     * https://htmx.org/api/#closest
+     *
+     * @param elt the element to find the selector from
+     * @param selector the selector to find
+     */
+    closest(elt: Element, selector: string): Element | null;
 
-/**
- * Defines a new htmx [extension](https://htmx.org/extensions).
- *
- * https://htmx.org/api/#defineExtension
- *
- * @param name the extension name
- * @param ext the extension definition
- */
-export function defineExtension(name: string, ext: HtmxExtension): void;
+    /**
+     * A property holding the configuration htmx uses at runtime.
+     *
+     * Note that using a [meta tag](https://htmx.org/docs/#config) is the preferred mechanism for setting these properties.
+     *
+     * https://htmx.org/api/#config
+     */
+    config: HtmxConfig;
 
-/**
- * Finds an element matching the selector
- *
- * https://htmx.org/api/#find
- *
- * @param selector the selector to match
- */
-export function find(selector: string): Element | null;
+    /**
+     * A property used to create new [Server Sent Event](https://htmx.org/docs/#sse) sources. This can be updated to provide custom SSE setup.
+     *
+     * https://htmx.org/api/#createEventSource
+     */
+    createEventSource: (url: string) => EventSource;
 
-/**
- * Finds an element matching the selector
- *
- * https://htmx.org/api/#find
- *
- * @param elt the root element to find the matching element in, inclusive
- * @param selector the selector to match
- */
-export function find(elt: Element, selector: string): Element | null;
+    /**
+     * A property used to create new [WebSocket](https://htmx.org/docs/#websockets). This can be updated to provide custom WebSocket setup.
+     *
+     * https://htmx.org/api/#createWebSocket
+     */
+    createWebSocket: (url: string) => WebSocket;
 
-/**
- * Finds all elements matching the selector
- *
- * https://htmx.org/api/#findAll
- *
- * @param selector the selector to match
- */
-export function findAll(selector: string): NodeListOf<Element>;
+    /**
+     * Defines a new htmx [extension](https://htmx.org/extensions).
+     *
+     * https://htmx.org/api/#defineExtension
+     *
+     * @param name the extension name
+     * @param ext the extension definition
+     */
+    defineExtension(name: string, ext: HtmxExtension): void;
 
-/**
- * Finds all elements matching the selector
- *
- * https://htmx.org/api/#findAll
- *
- * @param elt the root element to find the matching elements in, inclusive
- * @param selector the selector to match
- */
-export function findAll(elt: Element, selector: string): NodeListOf<Element>;
+    /**
+     * Finds an element matching the selector
+     *
+     * https://htmx.org/api/#find
+     *
+     * @param selector the selector to match
+     */
+    find(selector: string): Element | null;
 
-/**
- * Log all htmx events, useful for debugging.
- *
- * https://htmx.org/api/#logAll
- */
-export function logAll(): void;
+    /**
+     * Finds an element matching the selector
+     *
+     * https://htmx.org/api/#find
+     *
+     * @param elt the root element to find the matching element in, inclusive
+     * @param selector the selector to match
+     */
+    find(elt: Element, selector: string): Element | null;
 
-/**
- * The logger htmx uses to log with
- *
- * https://htmx.org/api/#logger
- */
-export var logger: (elt: Element, eventName: string, detail: any) => void | null;
+    /**
+     * Finds all elements matching the selector
+     *
+     * https://htmx.org/api/#findAll
+     *
+     * @param selector the selector to match
+     */
+    findAll(selector: string): NodeListOf<Element>;
 
-/**
- * Removes an event listener from an element
- *
- * https://htmx.org/api/#off
- *
- * @param eventName the event name to remove the listener from
- * @param listener the listener to remove
- */
-export function off(eventName: string, listener: (evt: Event) => void): (evt: Event) => void;
+    /**
+     * Finds all elements matching the selector
+     *
+     * https://htmx.org/api/#findAll
+     *
+     * @param elt the root element to find the matching elements in, inclusive
+     * @param selector the selector to match
+     */
+    findAll(elt: Element, selector: string): NodeListOf<Element>;
 
-/**
- * Removes an event listener from an element
- *
- * https://htmx.org/api/#off
- *
- * @param target the element to remove the listener from
- * @param eventName the event name to remove the listener from
- * @param listener the listener to remove
- */
-export function off(target: string, eventName: string, listener: (evt: Event) => void): (evt: Event) => void;
+    /**
+     * Log all htmx events, useful for debugging.
+     *
+     * https://htmx.org/api/#logAll
+     */
+    logAll(): void;
 
-/**
- * Adds an event listener to an element
- *
- * https://htmx.org/api/#on
- *
- * @param eventName the event name to add the listener for
- * @param listener the listener to add
- */
-export function on(eventName: string, listener: (evt: Event) => void): (evt: Event) => void;
+    /**
+     * The logger htmx uses to log with
+     *
+     * https://htmx.org/api/#logger
+     */
+    logger(elt: Element, eventName: string, detail: any): void | null;
 
-/**
- * Adds an event listener to an element
- *
- * https://htmx.org/api/#on
- *
- * @param target the element to add the listener to
- * @param eventName the event name to add the listener for
- * @param listener the listener to add
- */
-export function on(target: string, eventName: string, listener: (evt: Event) => void): (evt: Event) => void;
+    /**
+     * Removes an event listener from an element
+     *
+     * https://htmx.org/api/#off
+     *
+     * @param eventName the event name to remove the listener from
+     * @param listener the listener to remove
+     */
+    off(eventName: string, listener: (evt: Event) => void): (evt: Event) => void;
 
-/**
- * Adds a callback for the **htmx:load** event. This can be used to process new content, for example initializing the content with a javascript library
- *
- * https://htmx.org/api/#onLoad
- *
- * @param callback the callback to call on newly loaded content
- */
-export function onLoad(callback: (element: Element) => void): void;
+    /**
+     * Removes an event listener from an element
+     *
+     * https://htmx.org/api/#off
+     *
+     * @param target the element to remove the listener from
+     * @param eventName the event name to remove the listener from
+     * @param listener the listener to remove
+     */
+    off(target: string, eventName: string, listener: (evt: Event) => void): (evt: Event) => void;
 
-/**
- * Parses an interval string consistent with the way htmx does. Useful for plugins that have timing-related attributes.
- *
- * Caution: Accepts an int followed by either **s** or **ms**. All other values use **parseFloat**
- *
- * https://htmx.org/api/#parseInterval
- *
- * @param str timing string
- */
-export function parseInterval(str: string): number;
+    /**
+     * Adds an event listener to an element
+     *
+     * https://htmx.org/api/#on
+     *
+     * @param eventName the event name to add the listener for
+     * @param listener the listener to add
+     */
+    on(eventName: string, listener: (evt: Event) => void): (evt: Event) => void;
 
-/**
- * Processes new content, enabling htmx behavior. This can be useful if you have content that is added to the DOM outside of the normal htmx request cycle but still want htmx attributes to work.
- *
- * https://htmx.org/api/#process
- *
- * @param element element to process
- */
-export function process(element: Element): void;
+    /**
+     * Adds an event listener to an element
+     *
+     * https://htmx.org/api/#on
+     *
+     * @param target the element to add the listener to
+     * @param eventName the event name to add the listener for
+     * @param listener the listener to add
+     */
+    on(target: string, eventName: string, listener: (evt: Event) => void): (evt: Event) => void;
 
-/**
- * Removes an element from the DOM
- *
- * https://htmx.org/api/#remove
- *
- * @param elt element to remove
- * @param delay the delay (in milliseconds before element is removed)
- */
-export function remove(elt: Element, delay?: number): void;
+    /**
+     * Adds a callback for the **htmx:load** event. This can be used to process new content, for example initializing the content with a javascript library
+     *
+     * https://htmx.org/api/#onLoad
+     *
+     * @param callback the callback to call on newly loaded content
+     */
+    onLoad(callback: (element: Element) => void): void;
 
-/**
- * Removes a class from the given element
- *
- * https://htmx.org/api/#removeClass
- *
- * @param elt element to remove the class from
- * @param clazz the class to remove
- * @param delay the delay (in milliseconds before class is removed)
- */
-export function removeClass(elt: Element, clazz: string, delay?: number): void;
+    /**
+     * Parses an interval string consistent with the way htmx does. Useful for plugins that have timing-related attributes.
+     *
+     * Caution: Accepts an int followed by either **s** or **ms**. All other values use **parseFloat**
+     *
+     * https://htmx.org/api/#parseInterval
+     *
+     * @param str timing string
+     */
+    parseInterval(str: string): number;
 
-/**
- * Removes the given extension from htmx
- *
- * https://htmx.org/api/#removeExtension
- *
- * @param name the name of the extension to remove
- */
-export function removeExtension(name: string): void;
+    /**
+     * Processes new content, enabling htmx behavior. This can be useful if you have content that is added to the DOM outside of the normal htmx request cycle but still want htmx attributes to work.
+     *
+     * https://htmx.org/api/#process
+     *
+     * @param element element to process
+     */
+    process(element: Element): void;
 
-/**
- * Takes the given class from its siblings, so that among its siblings, only the given element will have the class.
- *
- * https://htmx.org/api/#takeClass
- *
- * @param elt the element that will take the class
- * @param clazz the class to take
- */
-export function takeClass(elt: Element, clazz: string): void;
+    /**
+     * Removes an element from the DOM
+     *
+     * https://htmx.org/api/#remove
+     *
+     * @param elt element to remove
+     * @param delay the delay (in milliseconds before element is removed)
+     */
+    remove(elt: Element, delay?: number): void;
 
-/**
- * Toggles the given class on an element
- *
- * https://htmx.org/api/#toggleClass
- *
- * @param elt the element to toggle the class on
- * @param clazz the class to toggle
- */
-export function toggleClass(elt: Element, clazz: string): void;
+    /**
+     * Removes a class from the given element
+     *
+     * https://htmx.org/api/#removeClass
+     *
+     * @param elt element to remove the class from
+     * @param clazz the class to remove
+     * @param delay the delay (in milliseconds before class is removed)
+     */
+    removeClass(elt: Element, clazz: string, delay?: number): void;
 
-/**
- * Triggers a given event on an element
- *
- * https://htmx.org/api/#trigger
- *
- * @param elt the element to trigger the event on
- * @param name the name of the event to trigger
- * @param detail details for the event
- */
-export function trigger(elt: Element, name: string, detail: any): void;
+    /**
+     * Removes the given extension from htmx
+     *
+     * https://htmx.org/api/#removeExtension
+     *
+     * @param name the name of the extension to remove
+     */
+    removeExtension(name: string): void;
 
-/**
- * Returns the input values that would resolve for a given element via the htmx value resolution mechanism
- *
- * https://htmx.org/api/#values
- *
- * @param elt the element to resolve values on
- * @param requestType the request type (e.g. **get** or **post**) non-GET's will include the enclosing form of the element. Defaults to **post**
- */
-export function values(elt: Element, requestType?: string): any;
+    /**
+     * Takes the given class from its siblings, so that among its siblings, only the given element will have the class.
+     *
+     * https://htmx.org/api/#takeClass
+     *
+     * @param elt the element that will take the class
+     * @param clazz the class to take
+     */
+    takeClass(elt: Element, clazz: string): void;
 
-export const version: string;
+    /**
+     * Toggles the given class on an element
+     *
+     * https://htmx.org/api/#toggleClass
+     *
+     * @param elt the element to toggle the class on
+     * @param clazz the class to toggle
+     */
+    toggleClass(elt: Element, clazz: string): void;
 
+    /**
+     * Triggers a given event on an element
+     *
+     * https://htmx.org/api/#trigger
+     *
+     * @param elt the element to trigger the event on
+     * @param name the name of the event to trigger
+     * @param detail details for the event
+     */
+    trigger(elt: Element, name: string, detail: any): void;
+
+    /**
+     * Returns the input values that would resolve for a given element via the htmx value resolution mechanism
+     *
+     * https://htmx.org/api/#values
+     *
+     * @param elt the element to resolve values on
+     * @param requestType the request type (e.g. **get** or **post**) non-GET's will include the enclosing form of the element. Defaults to **post**
+     */
+    values(elt: Element, requestType?: string): any;
+
+    version: string;
+}
 export interface HtmxConfig {
     /**
      * The attributes to settle during the settling phase.


### PR DESCRIPTION
Solves #1920

All I have done is wrapped all functions and constants defined on top level in an interface, changed formatting to make ts happy.

Htmx types declared as an interface will allow library consumer to do the following in `types.d.ts` file:
```ts
import type { HTMX } from 'htmx.org';

declare global {
  // globalThis definition
  var htmx: HTMX; 

  // window defintion
  interface Window {
    htmx: HTMX; 
  }
}
```
which is then included in tsconfig.json:
```json
"compilerOptions": {
    "types": [
        "./types.d.ts"
    ]
}
```

There is 2 ways the package can declare its exports, as default or as named export. Both implementations and import syntax can be seen below:
```ts
export default HTMX;    // import htmx from 'htmx.org'
export var htmx: HTMX;  // import { htmx } from 'htmx.org'
```

`npm run test-types` had 20 issues before and after the changes.

Also, I have noticed that many types are not correct, as they differ from the api reference. And `this` is not typed at all. I'd love to commit more PRs to remove this discrepancy. 