### PR TITLE
Add htmx/elem-go server examples

### DIFF
--- a/www/content/server-examples.md
+++ b/www/content/server-examples.md
@@ -150,15 +150,15 @@ These examples may make it a bit easier to get started using htmx with your plat
 
 ## Go
 
-## elem-go
-
-- <https://github.com/chasefleming/elem-go/tree/main/examples/htmx-fiber-counter>
-- <https://github.com/chasefleming/elem-go/tree/main/examples/htmx-fiber-todo>
-
 ### templ
 
 - <https://templ.guide/server-side-rendering/htmx>
 - <https://github.com/jritsema/go-htmx-tailwind-example>
+
+## elem-go
+
+- <https://github.com/chasefleming/elem-go/tree/main/examples/htmx-fiber-counter>
+- <https://github.com/chasefleming/elem-go/tree/main/examples/htmx-fiber-todo>
 
 ## Delphi
 

--- a/www/content/server-examples.md
+++ b/www/content/server-examples.md
@@ -155,7 +155,7 @@ These examples may make it a bit easier to get started using htmx with your plat
 - <https://templ.guide/server-side-rendering/htmx>
 - <https://github.com/jritsema/go-htmx-tailwind-example>
 
-## elem-go
+### elem-go
 
 - <https://github.com/chasefleming/elem-go/tree/main/examples/htmx-fiber-counter>
 - <https://github.com/chasefleming/elem-go/tree/main/examples/htmx-fiber-todo>

--- a/www/content/server-examples.md
+++ b/www/content/server-examples.md
@@ -29,6 +29,7 @@ These examples may make it a bit easier to get started using htmx with your plat
 - <https://github.com/DamianStanger/hapi-htmx>
 
 ## Python
+
 - <https://github.com/PyHAT-stack/awesome-python-htmx>
 
 ### Django
@@ -149,6 +150,11 @@ These examples may make it a bit easier to get started using htmx with your plat
 
 ## Go
 
+## elem-go
+
+- <https://github.com/chasefleming/elem-go/tree/main/examples/htmx-fiber-counter>
+- <https://github.com/chasefleming/elem-go/tree/main/examples/htmx-fiber-todo>
+
 ### templ
 
 - <https://templ.guide/server-side-rendering/htmx>
@@ -157,5 +163,6 @@ These examples may make it a bit easier to get started using htmx with your plat
 ## Delphi
 
 ### DelphiMVCFramework
+
 - <https://github.com/danieleteti/delphi-dmvcframework-htmx-todo>
 - <https://github.com/danieleteti/delphimvcframework/tree/master/samples/htmx>


### PR DESCRIPTION
`elem-go` is an HTML generation library written in Go that offers an integration with `htmx`. More information about this integration can be found in the `elem-go` documentation: [HTMX Integration](https://github.com/chasefleming/elem-go/blob/main/HTMX_INTEGRATION.md).

This PR that includes two example applications showcasing the combined use of `htmx` and `elem-go`:

1. **Counter Example**: Showcases a simple counter that can be incremented interactively.
2. **Todo List Example**: Demonstrates a dynamic todo list where tasks can be added and marked as complete or active.

Thanks!
