### PR TITLE
Experimental sqlite extension, request for comments/ideas

### DIFF
--- a/src/ext/sqlite.js
+++ b/src/ext/sqlite.js
@@ -1,0 +1,225 @@
+/*
+
+Extension to use SQLite database over HTTP as a backend for Htmx.
+
+Requires sqlite-wasm-http bundled and served from same host where your application is,
+since Web Workers don't work with cross-domain requests.
+This can be done with webpack, for example:
+
+webpack.config:
+    module.exports = {
+        entry: "./index.js",
+        resolve: {
+            extensions: [".js"],
+        },
+        output: {
+            filename: "sqlite-wasm-http-[name].js",
+            clean: true,
+            asyncChunks: false,
+        }
+    };
+
+package.json:
+    {
+        "devDependencies": {
+            "webpack": "^5.89.0",
+            "webpack-cli": "^5.1.4"
+        },
+        "dependencies": {
+            "sqlite-wasm-http": "^1.1.2"
+        }
+    }
+
+index.js:
+    import {createSQLiteHTTPPool} from 'sqlite-wasm-http';
+    window.createSQLiteHTTPPool = createSQLiteHTTPPool;
+
+
+And include in your HTML:
+<script src="sqlite-wasm-http-main.js"></script>
+
+*/
+
+(function(){
+    var api;
+
+    // lot's of copying from htmx source. It should probably export some of this stuff as functions in internal API?
+    var getParameters = function (elt) {
+        var results = api.getInputValues(elt, 'post');
+        var rawParameters = results.values;
+        var expressionVars = api.getExpressionVars(elt);
+        var allParameters = api.mergeObjects(rawParameters, expressionVars);
+        var filteredParameters = api.filterValues(allParameters, elt);
+        return filteredParameters;
+    };
+
+    // lot's of copying from htmx source. It should probably export some of this stuff as functions in internal API?
+    var swapAndSettle = function(data, elt, responseInfo) {
+        var target = api.getTarget(elt);
+        if (target == null || target == api.DUMMY_ELT) {
+            api.triggerErrorEvent(elt, 'htmx:targetError', {target: api.getAttributeValue(elt, "hx-target")});
+            return;
+        }
+
+        var shouldSwap = data.length > 0;
+        var beforeSwapDetails = {shouldSwap: shouldSwap, target: target, elt: elt};
+        if (!api.triggerEvent(target, 'htmx:beforeSwap', beforeSwapDetails)) return;
+        target = beforeSwapDetails.target;
+        
+        responseInfo.target = target;
+        responseInfo.failed = false;
+        responseInfo.successful = true;
+
+        var serverResponse = JSON.stringify(data);
+        if (beforeSwapDetails.shouldSwap) {
+            api.withExtensions(elt, function (extension) {
+                serverResponse = extension.transformResponse(serverResponse, undefined, elt);
+            });
+
+            var swapSpec = api.getSwapSpecification(elt, undefined);
+
+            target.classList.add(htmx.config.swappingClass);
+
+            var doSwap = function () {
+                try {
+                    var activeElt = document.activeElement;
+                    var selectionInfo = {};
+                    try {
+                        selectionInfo = {
+                            elt: activeElt,
+                            start: activeElt ? activeElt.selectionStart : null,
+                            end: activeElt ? activeElt.selectionEnd : null
+                        };
+                    } catch (e) {
+                        // safari issue - see https://github.com/microsoft/playwright/issues/5894
+                    }
+
+                    var settleInfo = api.makeSettleInfo(target);
+                    api.selectAndSwap(swapSpec.swapStyle, target, elt, serverResponse, settleInfo, undefined);
+
+                    if (selectionInfo.elt &&
+                        !api.bodyContains(selectionInfo.elt) &&
+                        api.getRawAttribute(selectionInfo.elt, "id")) {
+                        var newActiveElt = document.getElementById(api.getRawAttribute(selectionInfo.elt, "id"));
+                        var focusOptions = { preventScroll: swapSpec.focusScroll !== undefined ? !swapSpec.focusScroll : !htmx.config.defaultFocusScroll };
+                        if (newActiveElt) {
+                            if (selectionInfo.start && newActiveElt.setSelectionRange) {
+                                try {
+                                    newActiveElt.setSelectionRange(selectionInfo.start, selectionInfo.end);
+                                } catch (e) {
+                                    // the setSelectionRange method is present on fields that don't support it, so just let this fail
+                                }
+                            }
+                            newActiveElt.focus(focusOptions);
+                        }
+                    }
+
+                    target.classList.remove(htmx.config.swappingClass);
+                    settleInfo.elts.forEach(function (elt) {
+                        if (elt.classList) {
+                            elt.classList.add(htmx.config.settlingClass);
+                        }
+                        api.triggerEvent(elt, 'htmx:afterSwap', responseInfo);
+                    });
+
+                    var doSettle = function () {
+                        settleInfo.tasks.forEach(function (task) {
+                            task.call();
+                        });
+                        settleInfo.elts.forEach(function (elt) {
+                            if (elt.classList) {
+                                elt.classList.remove(htmx.config.settlingClass);
+                            }
+                            api.triggerEvent(elt, 'htmx:afterSettle', responseInfo);
+                        });
+                    }
+
+                    if (swapSpec.settleDelay > 0) {
+                        setTimeout(doSettle, swapSpec.settleDelay)
+                    } else {
+                        doSettle();
+                    }
+                } catch (e) {
+                    api.triggerErrorEvent(elt, 'htmx:swapError', responseInfo);
+                    throw e;
+                }
+            };
+
+            var shouldTransition = htmx.config.globalViewTransitions
+            if(swapSpec.hasOwnProperty('transition')){
+                shouldTransition = swapSpec.transition;
+            }
+
+            if(shouldTransition &&
+                api.triggerEvent(elt, 'htmx:beforeTransition', responseInfo) &&
+                typeof Promise !== "undefined" && document.startViewTransition){
+                var settlePromise = new Promise(function (_resolve, _reject) {
+                    settleResolve = _resolve;
+                    settleReject = _reject;
+                });
+                var innerDoSwap = doSwap;
+                doSwap = function() {
+                    document.startViewTransition(function () {
+                        innerDoSwap();
+                        return settlePromise;
+                    });
+                }
+            }
+
+
+            if (swapSpec.swapDelay > 0) {
+                setTimeout(doSwap, swapSpec.swapDelay)
+            } else {
+                doSwap();
+            }
+        }
+    };
+
+    htmx.defineExtension('sqlite', {
+        init: function (internalAPI) {
+            api = internalAPI;
+        },
+        onEvent: function (name, evt) {
+            if (name === "htmx:afterProcessNode") {
+                let elt = evt.detail.elt;
+
+                if (elt.hasAttribute('hx-sql')) {
+                    var triggerSpecs = api.getTriggerSpecs(elt);
+                    triggerSpecs.forEach(function(triggerSpec) {
+                        var nodeData = api.getInternalData(elt);
+                        api.addTriggerHandler(elt, triggerSpec, nodeData, function (elt, evt) {
+                            if (htmx.closest(elt, htmx.config.disableSelector)) {
+                                cleanUpElement(elt);
+                                return;
+                            }
+                            
+                            var binds = getParameters(elt);
+                            Object.keys(binds).forEach(k => {
+                                binds['$' + k] = binds[k];
+                                delete binds[k];
+                            });
+
+                            var sql = elt.getAttribute('hx-sql');
+                            if (sql == "") {
+                                sql = elt.value;
+                            }
+                            
+                            let db = htmx.closest(elt, '[hx-sqlite]').getAttribute('hx-sqlite');
+                            createSQLiteHTTPPool({ workers: 1 })
+                                .then(pool => pool.open(db).then(() => pool))
+                                .then(pool => pool.exec(sql, binds, { rowMode: "object" }).finally(() => pool.close()))
+                                .then(data => data.map(x => x.row))
+                                .then(data => {
+                                    var responseInfo = { elt: elt, xhr: { response: data }, target: api.getTarget(elt) };
+                                    if (!api.triggerEvent(elt, 'htmx:beforeOnLoad', responseInfo)) return;
+
+                                    swapAndSettle(data, elt, responseInfo);
+                                });
+                        })
+                    });
+                }
+            }
+        }
+    });
+
+})();


### PR DESCRIPTION
This is an experimental extension to use Htmx to query a SQLite database served over HTTP, instead of using XHRs. I'm not expecting this to be merged, but I decided to submit this as a pull-request for discussion and ideas and just visibility, since I think this is an extremely cool possibility :)

The idea is to use SQLite (WASM) running in the browser using the database file served via HTTP as range requests so that even large databases are usable. The functionality is implemented in https://github.com/mmomtchev/sqlite-wasm-http.

This extension tries to use it through Htmx preserving all relevant Htmx functionality. While Htmx itself sometimes removes the need for a complex frontend, a SQLite database could in some cases remove the need for a complex backend. Please see https://spot.lahteenmaki.net/test.html for some examples demonstrating basic usage and how Htmx still works as expected. Only backend for that "application" is a SQLite database served over HTTP (https://spot.lahteenmaki.net/spot.db).

I'm already using this extension in some hobby projects and I'm planning to keep using it. With this PR I'm hoping to get some additional insight and suggestions for improvement. If this functionality in any form will not be part of official Htmx, I'm going to publish it as an external extension, in which case I would still gladly welcome any ideas for improvement.

Known issues:
- elements need hx-boost to get "registered", I don't know if there's another way to do this? Would be cool if extensions could add additional VERBS so that hx-sql could be used identically to hx-get.
- since sqlite-wasm-http uses Web Workers and they need a _file_ to execute, the code cannot be bundled to a single js file. I think.
- since Web Workers don't work with cross-domain requests, the files cannot be used directly from a CDN, which is unfortunate for blog-post-examples but probably not an issue for a real project.
- Htmx doesn't currently export some functionality like swapping in its internal API, which forces extensions like this to copy-paste a lot of code. Maybe this should be improved?
- Htmx (including extensions API) assumes presence of XHR in several places, and since we don't have any XHR here, there may be some interoperability issues.

What do you think?