### PR TITLE
Fix for race condition in readystate detection

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3742,7 +3742,7 @@ return (function () {
             if (isReady || getDocument().readyState === 'complete') {
                 fn();
             } else {
-                getDocument().addEventListener('DOMContentLoaded', fn);
+                getDocument().addEventListener('readystatechange', () => ready(fn), {once:true});
             }
         }
 

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3742,7 +3742,7 @@ return (function () {
             if (isReady || getDocument().readyState === 'complete') {
                 fn();
             } else {
-                getDocument().addEventListener('readystatechange', () => ready(fn), {once:true});
+                getDocument().addEventListener('readystatechange', function() {ready(fn)}, {once:true});
             }
         }
 

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3727,47 +3727,32 @@ return (function () {
         /**
          * We want to initialize the page elements after DOMContentLoaded
          * fires, but there isn't always a good way to tell whether
-         * it has already fired or not.
+         * it has already fired when we get here or not.
          */
-        var isReady = false;
-        if ( getDocument().readyState === "complete" ) {
-            // DOMContentLoaded definitely already fired
-            isReady = true;
-        } else {
-            // DOMContentLoaded *maybe* already fired, so we'll
-            // watch for a DOM or a readystate event
-            getDocument().addEventListener('DOMContentLoaded', function() {
-                isReady = true;
-                readyComplete();
-            });
-            getDocument().addEventListener('readystatechange', function() {
-                if ( getDocument().readyState !== 'complete' ) return;
+        function ready(functionToCall) {
+            // call the function exactly once no matter how many times this is called
+            var callReadyFunction = function() {
+                if (!functionToCall) return;
+                functionToCall();
+                functionToCall = null;
+            };
 
-                isReady = true;
-                readyComplete();
-            });
-        }
-
-        /**
-         * Execute a function now if DOMContentLoaded
-         * has fired, otherwise wait for it to happen.
-         */
-        var pendingCalls = [];
-        function ready(fn) {
-            if ( isReady ) {
-                fn();
-            } else {
-                pendingCalls.push( fn );
+            if (getDocument().readyState === "complete") {
+                // DOMContentLoaded definitely fired, we can initialize the page
+                callReadyFunction();
             }
-        }
-
-        /**
-         * Execute the function calls which were queued up
-         * by ready() before the page had loaded.
-         */
-        function readyComplete() {
-            forEach( pendingCalls, function(fn) { fn() });
-            pendingCalls = [];
+            else {
+                /* DOMContentLoaded *maybe* already fired, wait for
+                 * the next DOMContentLoaded or readystatechange event
+                 */
+                getDocument().addEventListener("DOMContentLoaded", function() {
+                    callReadyFunction();
+                });
+                getDocument().addEventListener("readystatechange", function() {
+                    if (getDocument().readyState !== "complete") return;
+                    callReadyFunction();
+                });
+            }
         }
 
         function insertIndicatorStyles() {


### PR DESCRIPTION
This is an attempt to address the situation where the `DOMContentLoaded` event has already fired, but `readyState` has not yet reached "complete" (for example it can be "interactive"). In this case initialization will never happen because `DOMContentLoaded` will never fire again. If we're looking for a "complete" ready state, the `DOMContentLoaded` event is irrelevant, we should be looking for ready state changes.