### PR TITLE
Fix missing ignoreTitle property declaration in htmx.config

### DIFF
--- a/dist/htmx.d.ts
+++ b/dist/htmx.d.ts
@@ -395,6 +395,11 @@ export interface HtmxConfig {
      * @default false
      */
     selfRequestsOnly?: boolean;
+    /**
+     * if set to true, htmx will not update the title of the document when a `title` tag is found in new content
+     * @default false
+     */
+    ignoreTitle?: boolean;
 }
 
 /**

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -75,6 +75,7 @@ return (function () {
                 globalViewTransitions: false,
                 methodsThatUseUrlParams: ["get"],
                 selfRequestsOnly: false,
+                ignoreTitle: false,
                 scrollIntoViewOnBoost: true
             },
             parseInterval:parseInterval,


### PR DESCRIPTION
This option was introduced by https://github.com/bigskysoftware/htmx/commit/c230931d42489a629d685bedb440fadd7eaf1416 which also [added documentation](https://github.com/bigskysoftware/htmx/commit/c230931d42489a629d685bedb440fadd7eaf1416#diff-e772080787482bb78eeddd4d3c75a4ecd414c5e06674fde21d4383c1c3927735R1635) for it, but it seems it was forgotten from the htmx.config object iself
That documentation itself states the following:

> defaults to false, if set to true htmx will not update the title of the document when a title tag is found in new content

So I simply added that default value of false in the config