### PR TITLE
Get rid of htmx._ internal eval

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -78,7 +78,6 @@ return (function () {
                 scrollIntoViewOnBoost: true
             },
             parseInterval:parseInterval,
-            _:internalEval,
             createEventSource: function(url){
                 return new EventSource(url, {withCredentials:true})
             },
@@ -95,10 +94,13 @@ return (function () {
             addTriggerHandler: addTriggerHandler,
             bodyContains: bodyContains,
             canAccessLocalStorage: canAccessLocalStorage,
+            cleanInnerHtmlForHistory: cleanInnerHtmlForHistory,
+            encodeParamsForBody: encodeParamsForBody,
             findThisElement: findThisElement,
             filterValues: filterValues,
             hasAttribute: hasAttribute,
             getAttributeValue: getAttributeValue,
+            getCachedHistory: getCachedHistory,
             getClosestAttributeValue: getClosestAttributeValue,
             getClosestMatch: getClosestMatch,
             getExpressionVars: getExpressionVars,
@@ -108,16 +110,24 @@ return (function () {
             getSwapSpecification: getSwapSpecification,
             getTriggerSpecs: getTriggerSpecs,
             getTarget: getTarget,
+            maybeEval: maybeEval,
+            maybeGenerateConditional: maybeGenerateConditional,
+            makeEvent: makeEvent,
             makeFragment: makeFragment,
             mergeObjects: mergeObjects,
             makeSettleInfo: makeSettleInfo,
             oobSwap: oobSwap,
             querySelectorExt: querySelectorExt,
+            restoreHistory: restoreHistory,
+            safelySetHeaderValue: safelySetHeaderValue,
+            saveToHistoryCache: saveToHistoryCache,
             selectAndSwap: selectAndSwap,
             settleImmediately: settleImmediately,
             shouldCancel: shouldCancel,
+            tokenizeString: tokenizeString,
             triggerEvent: triggerEvent,
             triggerErrorEvent: triggerErrorEvent,
+            urlEncode: urlEncode,
             withExtensions: withExtensions,
         }
 
@@ -462,12 +472,6 @@ return (function () {
         //==========================================================================================
         // public API
         //==========================================================================================
-
-        function internalEval(str){
-            return maybeEval(getDocument().body, function () {
-                return eval(str);
-            });
-        }
 
         function onLoadHelper(callback) {
             var value = htmx.on("htmx:load", function(evt) {

--- a/test/attributes/hx-boost.js
+++ b/test/attributes/hx-boost.js
@@ -98,7 +98,7 @@ describe("hx-boost attribute", function() {
 
     it('anchors w/ explicit targets are not boosted', function () {
         var a = make('<a hx-target="this" hx-boost="true" id="a1" href="/test" target="_blank">Foo</a>');
-        var internalData = htmx._("getInternalData")(a);
+        var internalData = htmx.internalAPI.getInternalData(a);
         should.equal(undefined, internalData.boosted);
     })
 

--- a/test/attributes/hx-history.js
+++ b/test/attributes/hx-history.js
@@ -38,7 +38,7 @@ describe("hx-history attribute", function() {
         cache.length.should.equal(2);
 
         // on history navigation, embargoed content is retrieved from server
-        htmx._('restoreHistory')("/test2");
+        htmx.internalAPI.restoreHistory("/test2");
         this.server.respond();
         getWorkArea().textContent.should.equal("test2");
     });

--- a/test/attributes/hx-on.js
+++ b/test/attributes/hx-on.js
@@ -140,7 +140,7 @@ describe("hx-on attribute", function() {
     it("can handle event types with dots", function () {
         var btn = make("<button hx-on='my.custom.event: window.foo = true'>Foo</button>");
         // IE11 doesn't support `new CustomEvent()` so call htmx' internal utility function
-        btn.dispatchEvent(htmx._("makeEvent")('my.custom.event'));
+        btn.dispatchEvent(htmx.internalAPI.makeEvent('my.custom.event'));
         window.foo.should.equal(true);
         delete window.foo;
     });

--- a/test/attributes/hx-push-url.js
+++ b/test/attributes/hx-push-url.js
@@ -59,7 +59,7 @@ describe("hx-push-url attribute", function() {
         var cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME));
 
         cache.length.should.equal(2);
-        htmx._('restoreHistory')("/test1")
+        htmx.internalAPI.restoreHistory("/test1")
         getWorkArea().textContent.should.equal("test1")
     });
 
@@ -78,7 +78,7 @@ describe("hx-push-url attribute", function() {
         this.server.respond();
         workArea.textContent.should.equal("test2")
 
-        htmx._('restoreHistory')("/test1")
+        htmx.internalAPI.restoreHistory("/test1")
         getWorkArea().getElementsByClassName("htmx-request").length.should.equal(0);
     });
 
@@ -117,7 +117,7 @@ describe("hx-push-url attribute", function() {
 
         cache.length.should.equal(2);
         localStorage.removeItem(HTMX_HISTORY_CACHE_NAME); // clear cache
-        htmx._('restoreHistory')("/test1")
+        htmx.internalAPI.restoreHistory("/test1")
         this.server.respond();
         getWorkArea().textContent.should.equal("test1")
     });
@@ -135,32 +135,32 @@ describe("hx-push-url attribute", function() {
 
     it("deals with malformed JSON in history cache when getting", function () {
         localStorage.setItem(HTMX_HISTORY_CACHE_NAME, "Invalid JSON");
-        var history = htmx._('getCachedHistory')('url');
+        var history = htmx.internalAPI.getCachedHistory('url');
         should.equal(history, null);
     });
 
     it("deals with malformed JSON in history cache when saving", function () {
         localStorage.setItem(HTMX_HISTORY_CACHE_NAME, "Invalid JSON");
-        htmx._('saveToHistoryCache')('url', 'content', 'title', 'scroll');
+        htmx.internalAPI.saveToHistoryCache('url', 'content', 'title', 'scroll');
         var cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME));
         cache.length.should.equal(1);
     });
 
     it("does not blow out cache when saving a URL twice", function () {
-        htmx._('saveToHistoryCache')('url1', 'content', 'title', 'scroll');
-        htmx._('saveToHistoryCache')('url2', 'content', 'title', 'scroll');
-        htmx._('saveToHistoryCache')('url3', 'content', 'title', 'scroll');
-        htmx._('saveToHistoryCache')('url2', 'content', 'title', 'scroll');
+        htmx.internalAPI.saveToHistoryCache('url1', 'content', 'title', 'scroll');
+        htmx.internalAPI.saveToHistoryCache('url2', 'content', 'title', 'scroll');
+        htmx.internalAPI.saveToHistoryCache('url3', 'content', 'title', 'scroll');
+        htmx.internalAPI.saveToHistoryCache('url2', 'content', 'title', 'scroll');
         var cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME));
         cache.length.should.equal(3);
     });
 
     it("history cache is LRU", function () {
-        htmx._('saveToHistoryCache')('url1', 'content', 'title', 'scroll');
-        htmx._('saveToHistoryCache')('url2', 'content', 'title', 'scroll');
-        htmx._('saveToHistoryCache')('url3', 'content', 'title', 'scroll');
-        htmx._('saveToHistoryCache')('url2', 'content', 'title', 'scroll');
-        htmx._('saveToHistoryCache')('url1', 'content', 'title', 'scroll');
+        htmx.internalAPI.saveToHistoryCache('url1', 'content', 'title', 'scroll');
+        htmx.internalAPI.saveToHistoryCache('url2', 'content', 'title', 'scroll');
+        htmx.internalAPI.saveToHistoryCache('url3', 'content', 'title', 'scroll');
+        htmx.internalAPI.saveToHistoryCache('url2', 'content', 'title', 'scroll');
+        htmx.internalAPI.saveToHistoryCache('url1', 'content', 'title', 'scroll');
         var cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME));
         cache.length.should.equal(3);
         cache[0].url.should.equal("url3");
@@ -212,7 +212,7 @@ describe("hx-push-url attribute", function() {
         }
         try {
             localStorage.removeItem("htmx-history-cache");
-            htmx._("saveToHistoryCache")("/dummy", bigContent, "Foo", 0);
+            htmx.internalAPI.saveToHistoryCache("/dummy", bigContent, "Foo", 0);
             should.equal(localStorage.getItem("htmx-history-cache"), null);
         } finally {
             // clear history cache afterwards

--- a/test/attributes/hx-sse.js
+++ b/test/attributes/hx-sse.js
@@ -13,7 +13,7 @@ describe("hx-sse attribute", function() {
             sendEvent: function (eventName, data) {
                 var listener = listeners[eventName];
                 if (listener) {
-                    var event = htmx._("makeEvent")(eventName);
+                    var event = htmx.internalAPI.makeEvent(eventName);
                     event.data = data;
                     listener(event);
                 }

--- a/test/attributes/hx-swap.js
+++ b/test/attributes/hx-swap.js
@@ -191,35 +191,34 @@ describe("hx-swap attribute", function(){
     });
 
     it('properly parses various swap specifications', function(){
-        var swapSpec = htmx._("getSwapSpecification"); // internal function for swap spec
-        swapSpec(make("<div/>")).swapStyle.should.equal("innerHTML")
-        swapSpec(make("<div hx-swap='innerHTML'/>")).swapStyle.should.equal("innerHTML")
-        swapSpec(make("<div hx-swap='innerHTML'/>")).swapDelay.should.equal(0)
-        swapSpec(make("<div hx-swap='innerHTML'/>")).settleDelay.should.equal(0) // set to 0 in tests
-        swapSpec(make("<div hx-swap='innerHTML swap:10'/>")).swapDelay.should.equal(10)
-        swapSpec(make("<div hx-swap='innerHTML settle:10'/>")).settleDelay.should.equal(10)
-        swapSpec(make("<div hx-swap='innerHTML swap:10 settle:11'/>")).swapDelay.should.equal(10)
-        swapSpec(make("<div hx-swap='innerHTML swap:10 settle:11'/>")).settleDelay.should.equal(11)
-        swapSpec(make("<div hx-swap='innerHTML settle:11 swap:10'/>")).swapDelay.should.equal(10)
-        swapSpec(make("<div hx-swap='innerHTML settle:11 swap:10'/>")).settleDelay.should.equal(11)
-        swapSpec(make("<div hx-swap='innerHTML nonsense settle:11 swap:10'/>")).settleDelay.should.equal(11)
-        swapSpec(make("<div hx-swap='innerHTML   nonsense   settle:11   swap:10  '/>")).settleDelay.should.equal(11)
+        htmx.internalAPI.getSwapSpecification(make("<div/>")).swapStyle.should.equal("innerHTML")
+        htmx.internalAPI.getSwapSpecification(make("<div hx-swap='innerHTML'/>")).swapStyle.should.equal("innerHTML")
+        htmx.internalAPI.getSwapSpecification(make("<div hx-swap='innerHTML'/>")).swapDelay.should.equal(0)
+        htmx.internalAPI.getSwapSpecification(make("<div hx-swap='innerHTML'/>")).settleDelay.should.equal(0) // set to 0 in tests
+        htmx.internalAPI.getSwapSpecification(make("<div hx-swap='innerHTML swap:10'/>")).swapDelay.should.equal(10)
+        htmx.internalAPI.getSwapSpecification(make("<div hx-swap='innerHTML settle:10'/>")).settleDelay.should.equal(10)
+        htmx.internalAPI.getSwapSpecification(make("<div hx-swap='innerHTML swap:10 settle:11'/>")).swapDelay.should.equal(10)
+        htmx.internalAPI.getSwapSpecification(make("<div hx-swap='innerHTML swap:10 settle:11'/>")).settleDelay.should.equal(11)
+        htmx.internalAPI.getSwapSpecification(make("<div hx-swap='innerHTML settle:11 swap:10'/>")).swapDelay.should.equal(10)
+        htmx.internalAPI.getSwapSpecification(make("<div hx-swap='innerHTML settle:11 swap:10'/>")).settleDelay.should.equal(11)
+        htmx.internalAPI.getSwapSpecification(make("<div hx-swap='innerHTML nonsense settle:11 swap:10'/>")).settleDelay.should.equal(11)
+        htmx.internalAPI.getSwapSpecification(make("<div hx-swap='innerHTML   nonsense   settle:11   swap:10  '/>")).settleDelay.should.equal(11)
         
-        swapSpec(make("<div hx-swap='swap:10'/>")).swapStyle.should.equal("innerHTML")
-        swapSpec(make("<div hx-swap='swap:10'/>")).swapDelay.should.equal(10)
+        htmx.internalAPI.getSwapSpecification(make("<div hx-swap='swap:10'/>")).swapStyle.should.equal("innerHTML")
+        htmx.internalAPI.getSwapSpecification(make("<div hx-swap='swap:10'/>")).swapDelay.should.equal(10)
 
-        swapSpec(make("<div hx-swap='settle:10'/>")).swapStyle.should.equal("innerHTML")
-        swapSpec(make("<div hx-swap='settle:10'/>")).settleDelay.should.equal(10)
+        htmx.internalAPI.getSwapSpecification(make("<div hx-swap='settle:10'/>")).swapStyle.should.equal("innerHTML")
+        htmx.internalAPI.getSwapSpecification(make("<div hx-swap='settle:10'/>")).settleDelay.should.equal(10)
         
-        swapSpec(make("<div hx-swap='swap:10 settle:11'/>")).swapStyle.should.equal("innerHTML")
-        swapSpec(make("<div hx-swap='swap:10 settle:11'/>")).swapDelay.should.equal(10)
-        swapSpec(make("<div hx-swap='swap:10 settle:11'/>")).settleDelay.should.equal(11)
+        htmx.internalAPI.getSwapSpecification(make("<div hx-swap='swap:10 settle:11'/>")).swapStyle.should.equal("innerHTML")
+        htmx.internalAPI.getSwapSpecification(make("<div hx-swap='swap:10 settle:11'/>")).swapDelay.should.equal(10)
+        htmx.internalAPI.getSwapSpecification(make("<div hx-swap='swap:10 settle:11'/>")).settleDelay.should.equal(11)
 
-        swapSpec(make("<div hx-swap='settle:11 swap:10'/>")).swapStyle.should.equal("innerHTML")
-        swapSpec(make("<div hx-swap='settle:11 swap:10'/>")).swapDelay.should.equal(10)
-        swapSpec(make("<div hx-swap='settle:11 swap:10'/>")).settleDelay.should.equal(11)
+        htmx.internalAPI.getSwapSpecification(make("<div hx-swap='settle:11 swap:10'/>")).swapStyle.should.equal("innerHTML")
+        htmx.internalAPI.getSwapSpecification(make("<div hx-swap='settle:11 swap:10'/>")).swapDelay.should.equal(10)
+        htmx.internalAPI.getSwapSpecification(make("<div hx-swap='settle:11 swap:10'/>")).settleDelay.should.equal(11)
 
-        swapSpec(make("<div hx-swap='customstyle settle:11 swap:10'/>")).swapStyle.should.equal("customstyle")
+        htmx.internalAPI.getSwapSpecification(make("<div hx-swap='customstyle settle:11 swap:10'/>")).swapStyle.should.equal("customstyle")
     })
 
     it('works with a swap delay', function(done) {

--- a/test/attributes/hx-trigger.js
+++ b/test/attributes/hx-trigger.js
@@ -229,7 +229,7 @@ describe("hx-trigger attribute", function(){
 
         for (var specString in specExamples) {
             var div = make("<div hx-trigger='" + specString + "'></div>");
-            var spec = htmx._('getTriggerSpecs')(div);
+            var spec = htmx.internalAPI.getTriggerSpecs(div);
             spec.should.deep.equal(specExamples[specString], "Found : " + JSON.stringify(spec) + ", expected : " + JSON.stringify(specExamples[specString]) + " for spec: " + specString);
         }
     });
@@ -237,14 +237,14 @@ describe("hx-trigger attribute", function(){
     it('sets default trigger for forms', function()
     {
         var form = make('<form></form>');
-        var spec = htmx._('getTriggerSpecs')(form);
+        var spec = htmx.internalAPI.getTriggerSpecs(form);
         spec.should.deep.equal([{trigger: 'submit'}]);
     })
 
     it('sets default trigger for form elements', function()
     {
         var form = make('<input></input>');
-        var spec = htmx._('getTriggerSpecs')(form);
+        var spec = htmx.internalAPI.getTriggerSpecs(form);
         spec.should.deep.equal([{trigger: 'change'}]);
     })
 
@@ -253,7 +253,7 @@ describe("hx-trigger attribute", function(){
         var form = make('<form hx-get="/test" hx-trigger="evt[foo]">Not Called</form>');
         form.click();
         form.innerHTML.should.equal("Not Called");
-        var event = htmx._("makeEvent")('evt');
+        var event = htmx.internalAPI.makeEvent('evt');
         form.dispatchEvent(event);
         this.server.respond();
         form.innerHTML.should.equal("Not Called");
@@ -264,7 +264,7 @@ describe("hx-trigger attribute", function(){
         var form = make('<form hx-get="/test" hx-trigger="evt[foo]">Not Called</form>');
         form.click();
         form.innerHTML.should.equal("Not Called");
-        var event = htmx._("makeEvent")('evt');
+        var event = htmx.internalAPI.makeEvent('evt');
         event.foo = true;
         form.dispatchEvent(event);
         this.server.respond();
@@ -274,7 +274,7 @@ describe("hx-trigger attribute", function(){
     it('filters properly compound filter spec', function(){
         this.server.respondWith("GET", "/test", "Called!");
         var div = make('<div hx-get="/test" hx-trigger="evt[foo&&bar]">Not Called</div>');
-        var event = htmx._("makeEvent")('evt');
+        var event = htmx.internalAPI.makeEvent('evt');
         event.foo = true;
         div.dispatchEvent(event);
         this.server.respond();
@@ -288,7 +288,7 @@ describe("hx-trigger attribute", function(){
     it('can refer to target element in condition', function(){
         this.server.respondWith("GET", "/test", "Called!");
         var div = make('<div hx-get="/test" hx-trigger="evt[target.classList.contains(\'doIt\')]">Not Called</div>');
-        var event = htmx._("makeEvent")('evt');
+        var event = htmx.internalAPI.makeEvent('evt');
         div.dispatchEvent(event);
         this.server.respond();
         div.innerHTML.should.equal("Not Called");
@@ -301,7 +301,7 @@ describe("hx-trigger attribute", function(){
     it('can refer to target element in condition w/ equality', function(){
         this.server.respondWith("GET", "/test", "Called!");
         var div = make('<div hx-get="/test" hx-trigger="evt[target.id==\'foo\']">Not Called</div>');
-        var event = htmx._("makeEvent")('evt');
+        var event = htmx.internalAPI.makeEvent('evt');
         div.dispatchEvent(event);
         this.server.respond();
         div.innerHTML.should.equal("Not Called");
@@ -315,7 +315,7 @@ describe("hx-trigger attribute", function(){
         this.server.respondWith("GET", "/test", "Called!");
         var div = make('<div hx-get="/test" hx-trigger="evt[!target.classList.contains(\'disabled\')]">Not Called</div>');
         div.classList.add("disabled");
-        var event = htmx._("makeEvent")('evt');
+        var event = htmx.internalAPI.makeEvent('evt');
         div.dispatchEvent(event);
         this.server.respond();
         div.innerHTML.should.equal("Not Called");
@@ -332,7 +332,7 @@ describe("hx-trigger attribute", function(){
         try {
             this.server.respondWith("GET", "/test", "Called!");
             var div = make('<div hx-get="/test" hx-trigger="evt[globalFun(event)]">Not Called</div>');
-            var event = htmx._("makeEvent")('evt');
+            var event = htmx.internalAPI.makeEvent('evt');
             event.bar = false;
             div.dispatchEvent(event);
             this.server.respond();
@@ -353,7 +353,7 @@ describe("hx-trigger attribute", function(){
         try {
             this.server.respondWith("GET", "/test", "Called!");
             var div = make('<div hx-get="/test" hx-trigger="evt[foo.bar]">Not Called</div>');
-            var event = htmx._("makeEvent")('evt');
+            var event = htmx.internalAPI.makeEvent('evt');
             div.dispatchEvent(event);
             this.server.respond();
             div.innerHTML.should.equal("Not Called");
@@ -370,7 +370,7 @@ describe("hx-trigger attribute", function(){
         try {
             this.server.respondWith("GET", "/test", "Called!");
             var div = make('<div hx-get="/test" hx-trigger="evt[foo]">Not Called</div>');
-            var event = htmx._("makeEvent")('evt');
+            var event = htmx.internalAPI.makeEvent('evt');
             div.dispatchEvent(event);
             this.server.respond();
             div.innerHTML.should.equal("Not Called");
@@ -406,7 +406,7 @@ describe("hx-trigger attribute", function(){
             errorEvent = event;
         });
         try {
-            var event = htmx._("makeEvent")('evt');
+            var event = htmx.internalAPI.makeEvent('evt');
             div.dispatchEvent(event);
             should.not.equal(null, errorEvent);
             should.not.equal(null, errorEvent.detail.source);

--- a/test/core/api.js
+++ b/test/core/api.js
@@ -190,7 +190,7 @@ describe("Core htmx API test", function(){
         });
         try {
             htmx.config.allowEval = false;
-            should.equal(htmx._("tokenizeString"), undefined);
+            should.equal(htmx.internalAPI.maybeEval(document.body, function() { return 'eval'; }), undefined);
         } finally {
             htmx.config.allowEval = true;
             htmx.off("htmx:evalDisallowedError", handler);

--- a/test/core/internals.js
+++ b/test/core/internals.js
@@ -10,15 +10,15 @@ describe("Core htmx internals Tests", function() {
     });
 
     it("makeFragment works with janky stuff", function(){
-        htmx._("makeFragment")("<html></html>").tagName.should.equal("BODY");
-        htmx._("makeFragment")("<html><body></body></html>").tagName.should.equal("BODY");
+        htmx.internalAPI.makeFragment("<html></html>").tagName.should.equal("BODY");
+        htmx.internalAPI.makeFragment("<html><body></body></html>").tagName.should.equal("BODY");
 
         //NB - the tag name should be the *parent* element hosting the HTML since we use the fragment children
         // for the swap
-        htmx._("makeFragment")("<td></td>").tagName.should.equal("TR");
-        htmx._("makeFragment")("<thead></thead>").tagName.should.equal("TABLE");
-        htmx._("makeFragment")("<col></col>").tagName.should.equal("COLGROUP");
-        htmx._("makeFragment")("<tr></tr>").tagName.should.equal("TBODY");
+        htmx.internalAPI.makeFragment("<td></td>").tagName.should.equal("TR");
+        htmx.internalAPI.makeFragment("<thead></thead>").tagName.should.equal("TABLE");
+        htmx.internalAPI.makeFragment("<col></col>").tagName.should.equal("COLGROUP");
+        htmx.internalAPI.makeFragment("<tr></tr>").tagName.should.equal("TBODY");
     })
 
     it("makeFragment works with template wrapping", function(){
@@ -28,19 +28,19 @@ describe("Core htmx internals Tests", function() {
             return
         }
         try {
-            htmx._("makeFragment")("<html></html>").children.length.should.equal(0);
-            htmx._("makeFragment")("<html><body></body></html>").children.length.should.equal(0);
+            htmx.internalAPI.makeFragment("<html></html>").children.length.should.equal(0);
+            htmx.internalAPI.makeFragment("<html><body></body></html>").children.length.should.equal(0);
 
-            var fragment = htmx._("makeFragment")("<td></td>");
+            var fragment = htmx.internalAPI.makeFragment("<td></td>");
             fragment.firstElementChild.tagName.should.equal("TD");
 
-            fragment = htmx._("makeFragment")("<thead></thead>");
+            fragment = htmx.internalAPI.makeFragment("<thead></thead>");
             fragment.firstElementChild.tagName.should.equal("THEAD");
 
-            fragment = htmx._("makeFragment")("<col></col>");
+            fragment = htmx.internalAPI.makeFragment("<col></col>");
             fragment.firstElementChild.tagName.should.equal("COL");
 
-            fragment = htmx._("makeFragment")("<tr></tr>");
+            fragment = htmx.internalAPI.makeFragment("<tr></tr>");
             fragment.firstElementChild.tagName.should.equal("TR");
 
         } finally {
@@ -57,7 +57,7 @@ describe("Core htmx internals Tests", function() {
         }
         htmx.config.useTemplateFragments = true;
         try {
-            var fragment = htmx._("makeFragment")("<td></td><div></div>");
+            var fragment = htmx.internalAPI.makeFragment("<td></td><div></div>");
             fragment.children[0].tagName.should.equal("TD");
             fragment.children[1].tagName.should.equal("DIV");
         } finally {
@@ -68,7 +68,7 @@ describe("Core htmx internals Tests", function() {
     it("set header works with non-ASCII values", function(){
         var xhr = new XMLHttpRequest();
         xhr.open("GET", "/dummy");
-        htmx._("safelySetHeaderValue")(xhr, "Example", "привет");
+        htmx.internalAPI.safelySetHeaderValue(xhr, "Example", "привет");
         // unfortunately I can't test the value :/
         // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest
     })
@@ -88,56 +88,56 @@ describe("Core htmx internals Tests", function() {
     })
 
     it("tokenizes correctly", function() {
-        chai.expect(htmx._("tokenizeString")("a,")).to.be.deep.equal(['a', ',']);
-        chai.expect(htmx._("tokenizeString")("aa,")).to.be.deep.equal(['aa', ',']);
-        chai.expect(htmx._("tokenizeString")("aa,aa")).to.be.deep.equal(['aa', ',', 'aa']);
-        chai.expect(htmx._("tokenizeString")("aa.aa")).to.be.deep.equal(['aa', '.', 'aa']);
+        chai.expect(htmx.internalAPI.tokenizeString("a,")).to.be.deep.equal(['a', ',']);
+        chai.expect(htmx.internalAPI.tokenizeString("aa,")).to.be.deep.equal(['aa', ',']);
+        chai.expect(htmx.internalAPI.tokenizeString("aa,aa")).to.be.deep.equal(['aa', ',', 'aa']);
+        chai.expect(htmx.internalAPI.tokenizeString("aa.aa")).to.be.deep.equal(['aa', '.', 'aa']);
     })
 
     it("tags respond correctly to shouldCancel", function() {
         var anchorThatShouldCancel = make("<a href='/foo'></a>");
-        htmx._("shouldCancel")({type:'click'}, anchorThatShouldCancel).should.equal(true);
+        htmx.internalAPI.shouldCancel({type:'click'}, anchorThatShouldCancel).should.equal(true);
 
         var anchorThatShouldCancel = make("<a href='#'></a>");
-        htmx._("shouldCancel")({type:'click'}, anchorThatShouldCancel).should.equal(true);
+        htmx.internalAPI.shouldCancel({type:'click'}, anchorThatShouldCancel).should.equal(true);
 
         var anchorThatShouldNotCancel = make("<a href='#foo'></a>");
-        htmx._("shouldCancel")({type:'click'}, anchorThatShouldNotCancel).should.equal(false);
+        htmx.internalAPI.shouldCancel({type:'click'}, anchorThatShouldNotCancel).should.equal(false);
 
         var form = make("<form></form>");
-        htmx._("shouldCancel")({type:'submit'}, form).should.equal(true);
+        htmx.internalAPI.shouldCancel({type:'submit'}, form).should.equal(true);
 
         var form = make("<form><input id='i1' type='submit'></form>");
         var input = byId("i1");
-        htmx._("shouldCancel")({type:'click'}, input).should.equal(true);
+        htmx.internalAPI.shouldCancel({type:'click'}, input).should.equal(true);
 
         var form = make("<form><button id='b1' type='submit'></form>");
         var button = byId("b1");
-        htmx._("shouldCancel")({type:'click'}, button).should.equal(true);
+        htmx.internalAPI.shouldCancel({type:'click'}, button).should.equal(true);
 
     })
 
     it("unset properly unsets a given attribute", function(){
         make("<div foo='1'><div foo='2'><div foo='unset' id='d1'></div></div></div>");
         var div = byId("d1");
-        should.equal(undefined, htmx._("getClosestAttributeValue")(div, "foo"));
+        should.equal(undefined, htmx.internalAPI.getClosestAttributeValue(div, "foo"));
     })
 
     it("unset properly unsets a given attribute on a parent", function(){
         make("<div foo='1'><div foo='unset'><div id='d1'></div></div></div>");
         var div = byId("d1");
-        should.equal(undefined, htmx._("getClosestAttributeValue")(div, "foo"));
+        should.equal(undefined, htmx.internalAPI.getClosestAttributeValue(div, "foo"));
     })
 
     it("unset does not unset a value below it in the hierarchy", function(){
         make("<div foo='unset'><div foo='2'><div id='d1'></div></div></div>");
         var div = byId("d1");
-        should.equal("2", htmx._("getClosestAttributeValue")(div, "foo"));
+        should.equal("2", htmx.internalAPI.getClosestAttributeValue(div, "foo"));
     })
 
     it("encoding values respects enctype on forms", function(){
         var form = make("<form enctype='multipart/form-data'></form>");
-        var value = htmx._("encodeParamsForBody")(null, form, {});
+        var value = htmx.internalAPI.encodeParamsForBody(null, form, {});
         (value instanceof FormData).should.equal(true);
     })
 

--- a/test/core/parameters.js
+++ b/test/core/parameters.js
@@ -10,20 +10,20 @@ describe("Core htmx Parameter Handling", function() {
 
     it('Input includes value', function () {
         var input = make('<input name="foo" value="bar"/>');
-        var vals = htmx._('getInputValues')(input).values;
+        var vals = htmx.internalAPI.getInputValues(input).values;
         vals['foo'].should.equal('bar');
     })
 
     it('Input includes value on get', function () {
         var input = make('<input name="foo" value="bar"/>');
-        var vals = htmx._('getInputValues')(input, "get").values;
+        var vals = htmx.internalAPI.getInputValues(input, "get").values;
         vals['foo'].should.equal('bar');
     })
 
     it('Input includes form', function () {
         var form = make('<form><input id="i1" name="foo" value="bar"/><input id="i2" name="do" value="rey"/></form>');
         var input = byId('i1');
-        var vals = htmx._('getInputValues')(input).values;
+        var vals = htmx.internalAPI.getInputValues(input).values;
         vals['foo'].should.equal('bar');
         vals['do'].should.equal('rey');
     })
@@ -31,7 +31,7 @@ describe("Core htmx Parameter Handling", function() {
     it('Input doesnt include form on get', function () {
         var form = make('<form><input id="i1" name="foo" value="bar"/><input id="i2" name="do" value="rey"/></form>');
         var input = byId('i1');
-        var vals = htmx._('getInputValues')(input, 'get').values;
+        var vals = htmx.internalAPI.getInputValues(input, 'get').values;
         vals['foo'].should.equal('bar');
         should.equal(vals['do'], undefined);
     })
@@ -39,55 +39,55 @@ describe("Core htmx Parameter Handling", function() {
     it('non-input includes form', function () {
         var form = make('<form><div id="d1"/><input id="i2" name="do" value="rey"/></form>');
         var div = byId('d1');
-        var vals = htmx._('getInputValues')(div, "post").values;
+        var vals = htmx.internalAPI.getInputValues(div, "post").values;
         vals['do'].should.equal('rey');
     })
 
     it('non-input doesnt include form on get', function () {
         var form = make('<form><div id="d1"/><input id="i2" name="do" value="rey"/></form>');
         var div = byId('d1');
-        var vals = htmx._('getInputValues')(div, "get").values;
+        var vals = htmx.internalAPI.getInputValues(div, "get").values;
         should.equal(vals['do'], undefined);
     })
 
     it('Basic form works on get', function () {
         var form = make('<form><input id="i1" name="foo" value="bar"/><input id="i2" name="do" value="rey"/></form>');
-        var vals = htmx._('getInputValues')(form, 'get').values;
+        var vals = htmx.internalAPI.getInputValues(form, 'get').values;
         vals['foo'].should.equal('bar');
         vals['do'].should.equal('rey');
     })
 
     it('Basic form works on non-get', function () {
         var form = make('<form><input id="i1" name="foo" value="bar"/><input id="i2" name="do" value="rey"/></form>');
-        var vals = htmx._('getInputValues')(form, 'post').values;
+        var vals = htmx.internalAPI.getInputValues(form, 'post').values;
         vals['foo'].should.equal('bar');
         vals['do'].should.equal('rey');
     })
 
     it('Double values are included as array', function () {
         var form = make('<form><input id="i1" name="foo" value="bar"/><input id="i2" name="do" value="rey"/><input id="i2" name="do" value="rey"/></form>');
-        var vals = htmx._('getInputValues')(form).values;
+        var vals = htmx.internalAPI.getInputValues(form).values;
         vals['foo'].should.equal('bar');
         vals['do'].should.deep.equal(['rey', 'rey']);
     })
 
     it('Double values are included as array in correct order', function () {
         var form = make('<form><input id="i1" name="foo" value="bar"/><input id="i2" name="do" value="rey1"/><input id="i3" name="do" value="rey2"/></form>');
-        var vals = htmx._('getInputValues')(byId("i3")).values;
+        var vals = htmx.internalAPI.getInputValues(byId("i3")).values;
         vals['foo'].should.equal('bar');
         vals['do'].should.deep.equal(['rey1', 'rey2']);
     })
 
     it('Double empty values are included as array in correct order', function () {
         var form = make('<form><input id="i1" name="do" value=""/><input id="i2" name="do" value="rey"/><input id="i3" name="do" value=""/></form>');
-        var vals = htmx._('getInputValues')(byId("i3")).values;
+        var vals = htmx.internalAPI.getInputValues(byId("i3")).values;
         vals['do'].should.deep.equal(['', 'rey', '']);
     })
 
     it('hx-include works with form', function () {
         var form = make('<form id="f1"><input id="i1" name="foo" value="bar"/><input id="i2" name="do" value="rey"/><input id="i2" name="do" value="rey"/></form>');
         var div = make('<div hx-include="#f1"></div>');
-        var vals = htmx._('getInputValues')(div).values;
+        var vals = htmx.internalAPI.getInputValues(div).values;
         vals['foo'].should.equal('bar');
         vals['do'].should.deep.equal(['rey', 'rey']);
     })
@@ -95,7 +95,7 @@ describe("Core htmx Parameter Handling", function() {
     it('hx-include works with input', function () {
         var form = make('<form id="f1"><input id="i1" name="foo" value="bar"/><input id="i2" name="do" value="rey"/><input id="i2" name="do" value="rey"/></form>');
         var div = make('<div hx-include="#i1"></div>');
-        var vals = htmx._('getInputValues')(div).values;
+        var vals = htmx.internalAPI.getInputValues(div).values;
         vals['foo'].should.equal('bar');
         should.equal(vals['do'], undefined);
     })
@@ -103,7 +103,7 @@ describe("Core htmx Parameter Handling", function() {
     it('hx-include works with two inputs', function () {
         var form = make('<form id="f1"><input id="i1" name="foo" value="bar"/><input id="i2" name="do" value="rey"/><input id="i2" name="do" value="rey"/></form>');
         var div = make('<div hx-include="#i1, #i2"></div>');
-        var vals = htmx._('getInputValues')(div).values;
+        var vals = htmx.internalAPI.getInputValues(div).values;
         vals['foo'].should.equal('bar');
         vals['do'].should.deep.equal(['rey', 'rey']);
     })
@@ -111,16 +111,16 @@ describe("Core htmx Parameter Handling", function() {
     it('hx-include works with two inputs, plus form', function () {
         var form = make('<form id="f1"><input id="i1" name="foo" value="bar"/><input id="i2" name="do" value="rey"/><input id="i2" name="do" value="rey"/></form>');
         var div = make('<div hx-include="#i1, #i2, #f1"></div>');
-        var vals = htmx._('getInputValues')(div).values;
+        var vals = htmx.internalAPI.getInputValues(div).values;
         vals['foo'].should.equal('bar');
         vals['do'].should.deep.equal(['rey', 'rey']);
     })
 
     it('correctly URL escapes values', function () {
-        htmx._("urlEncode")({}).should.equal("");
-        htmx._("urlEncode")({"foo": "bar"}).should.equal("foo=bar");
-        htmx._("urlEncode")({"foo": "bar", "do" : "rey"}).should.equal("foo=bar&do=rey");
-        htmx._("urlEncode")({"foo": "bar", "do" : ["rey", "blah"]}).should.equal("foo=bar&do=rey&do=blah");
+        htmx.internalAPI.urlEncode({}).should.equal("");
+        htmx.internalAPI.urlEncode({"foo": "bar"}).should.equal("foo=bar");
+        htmx.internalAPI.urlEncode({"foo": "bar", "do" : "rey"}).should.equal("foo=bar&do=rey");
+        htmx.internalAPI.urlEncode({"foo": "bar", "do" : ["rey", "blah"]}).should.equal("foo=bar&do=rey&do=blah");
     });
 
     it('form includes last focused button', function (done) {
@@ -129,7 +129,7 @@ describe("Core htmx Parameter Handling", function() {
         var button = byId('b1');
         // Listen for focusin on form as it'll bubble up from the button, and htmx binds on the form itself
         form.addEventListener("focusin", function () {
-            var vals = htmx._('getInputValues')(form).values;
+            var vals = htmx.internalAPI.getInputValues(form).values;
             vals['foo'].should.equal('bar');
             vals['do'].should.equal('rey');
             vals['btn'].should.equal('bar');
@@ -144,7 +144,7 @@ describe("Core htmx Parameter Handling", function() {
         var button = byId('s1');
         // Listen for focusin on form as it'll bubble up from the button, and htmx binds on the form itself
         form.addEventListener("focusin", function () {
-            var vals = htmx._('getInputValues')(form).values;
+            var vals = htmx.internalAPI.getInputValues(form).values;
             vals['foo'].should.equal('bar');
             vals['do'].should.equal('rey');
             vals['s1'].should.equal('bar');
@@ -159,7 +159,7 @@ describe("Core htmx Parameter Handling", function() {
         var button = byId('s1');
         button.focus();
         input.focus();
-        var vals = htmx._('getInputValues')(form).values;
+        var vals = htmx.internalAPI.getInputValues(form).values;
         vals['foo'].should.equal('bar');
         vals['do'].should.equal('rey');
         should.equal(vals['s1'], undefined);
@@ -171,7 +171,7 @@ describe("Core htmx Parameter Handling", function() {
         var button = byId('s1');
         button.focus();
         anchor.focus();
-        var vals = htmx._('getInputValues')(form).values;
+        var vals = htmx.internalAPI.getInputValues(form).values;
         vals['foo'].should.equal('bar');
         vals['do'].should.equal('rey');
         should.equal(vals['s1'], undefined);
@@ -181,7 +181,7 @@ describe("Core htmx Parameter Handling", function() {
         var form = make('<form hx-get="/foo"><input id="i1" name="foo" value="bar"/><button type="submit" id="btn1" name="do" value="rey"><div id="div1"><span id="span1"></span></div></button></form>');
         var nestedElt = byId('span1');
         nestedElt.click();
-        var vals = htmx._('getInputValues')(form).values;
+        var vals = htmx.internalAPI.getInputValues(form).values;
         vals['do'].should.equal('rey');
     })
 

--- a/test/core/perf.js
+++ b/test/core/perf.js
@@ -59,7 +59,7 @@ describe("Core htmx perf Tests", function() {
         html = stringRepeat(html, size);
         workArea.insertAdjacentHTML("beforeend", html)
         var start = performance.now();
-        htmx._("cleanInnerHtmlForHistory")(workArea);
+        htmx.internalAPI.cleanInnerHtmlForHistory(workArea);
         var end = performance.now();
         var timeInMs = end - start;
         chai.assert(timeInMs < 50, "Should take less than 50ms on most platforms");

--- a/test/core/tokenizer.js
+++ b/test/core/tokenizer.js
@@ -9,7 +9,7 @@ describe("Core htmx tokenizer tests", function(){
     });
 
     function tokenize(str) {
-        return htmx._("tokenizeString")(str);
+        return htmx.internalAPI.tokenizeString(str);
     }
 
     function tokenizeTest(str, result) {
@@ -34,7 +34,7 @@ describe("Core htmx tokenizer tests", function(){
     it('generates conditionals property', function()
     {
         var tokens = tokenize("[code==4||(code==5&&foo==true)]");
-        var conditional = htmx._("maybeGenerateConditional")(null, tokens);
+        var conditional = htmx.internalAPI.maybeGenerateConditional(null, tokens);
         var func = eval(conditional);
         func({code: 5, foo: true}).should.equal(true);
         func({code: 5, foo: false}).should.equal(false);

--- a/test/ext/loading-states.js
+++ b/test/ext/loading-states.js
@@ -159,7 +159,7 @@ describe("loading states extension", function () {
         this.server.respond();
         workArea.textContent.should.equal("test2")
 
-        htmx._('restoreHistory')("/test1")
+        htmx.internalAPI.restoreHistory("/test1")
 
         var el = byId("d2");
         el.disabled.should.be.false;

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -1,5 +1,12 @@
 /* Test Utilities */
 
+// expose internal api
+htmx.defineExtension('expose-internal-api', {
+    init: function (api) {
+        htmx.internalAPI = api;
+    }
+});
+
 function byId(id) {
     return document.getElementById(id);
 }


### PR DESCRIPTION
This removes the underscore function (`htmx._`) and thus the internal eval stuff from the public API and the codebase. This function is only used to access internal functions in tests, but this can also be achieved by exposing the internal API via a pseudo-extension (see `test/util/util.js`).

**Motivation**
[MDN eval()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval?retiredLocale=de#never_use_eval!):

>Warning: Executing JavaScript from a string is an enormous security risk. It is far too easy for a bad actor to run arbitrary code when you use eval(). See [Never use eval()!](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval?retiredLocale=de#never_use_eval!), below.

and

[Vite](https://vitejs.dev/) build warning:

>Use of eval in "node_modules/htmx.org/dist/htmx.min.js" is strongly discouraged as it poses security risks and may cause issues with minification.

@1cg would you mind taking a look.