### PR TITLE
Add missing '})' in core ajax tests

### DIFF
--- a/test/core/ajax.js
+++ b/test/core/ajax.js
@@ -1284,6 +1284,8 @@ describe("Core htmx AJAX Tests", function(){
         byId("submit").click();
         this.server.respond();
         responded.should.equal(true);
+    })
+
     it("can associate submit buttons from outside a form with the current version of the form after swap", function(){
         const template = '<form ' +
               'id="hello" ' +


### PR DESCRIPTION
Found while working on improving the js support of HtmlUnit.

This replaces [#1990](https://github.com/bigskysoftware/htmx/pull/1990)