### PR TITLE
Fix Server Side Event Interrupted while the page was loading error message

### DIFF
--- a/src/ext/sse.js
+++ b/src/ext/sse.js
@@ -136,12 +136,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 		internalData.sseEventSource = source;
 
     // Don't forget to disconnect the EventSource on page unload
-    window.addEventListener("beforeunload", function () {
-      var source = api.getInternalData(elt).sseEventSource;
-      if (source != undefined) {
-        source.close();
-      }
-    });
+    window.addEventListener("beforeunload", closeSSESourceBeforePageUnload);
 
 		// Create event handlers
 		source.onerror = function (err) {
@@ -232,6 +227,16 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 	}
 
 	/**
+	 * closeSSESourceBeforePageUnload close any associated SSE source if present.
+	 */
+	function closeSSESourceBeforePageUnload() {
+      var source = api.getInternalData(elt).sseEventSource;
+      if (source != undefined) {
+        source.close();
+      }
+	}
+
+	/**
 	 * maybeCloseSSESource confirms that the parent element still exists.
 	 * If not, then any associated SSE source is closed and the function returns true.
 	 * 
@@ -240,6 +245,8 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 	 */
 	function maybeCloseSSESource(elt) {
 		if (!api.bodyContains(elt)) {
+      // We don't need anymore to disconnect the EventSource on page unload when disconnecting
+      removeEventListener("beforeunload", closeSSESourceBeforePageUnload)
 			var source = api.getInternalData(elt).sseEventSource;
 			if (source != undefined) {
 				source.close();

--- a/src/ext/sse.js
+++ b/src/ext/sse.js
@@ -135,13 +135,13 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 		var source = htmx.createEventSource(sseURL);
 		internalData.sseEventSource = source;
 
-    // Don't forget to disconnect the EventSource on page unload
-    window.addEventListener("beforeunload", function () {
-      var source = api.getInternalData(elt).sseEventSource;
-      if (source != undefined) {
-        source.close();
-      }
-    });
+		// Don't forget to disconnect the EventSource on page unload
+		window.addEventListener("beforeunload", function () {
+			var source = api.getInternalData(elt).sseEventSource;
+			if (source != undefined) {
+				source.close();
+			}
+		});
 
 		// Create event handlers
 		source.onerror = function (err) {

--- a/src/ext/sse.js
+++ b/src/ext/sse.js
@@ -136,7 +136,12 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 		internalData.sseEventSource = source;
 
     // Don't forget to disconnect the EventSource on page unload
-    window.addEventListener("beforeunload", closeSSESourceBeforePageUnload);
+    window.addEventListener("beforeunload", function () {
+      var source = api.getInternalData(elt).sseEventSource;
+      if (source != undefined) {
+        source.close();
+      }
+    });
 
 		// Create event handlers
 		source.onerror = function (err) {
@@ -227,16 +232,6 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 	}
 
 	/**
-	 * closeSSESourceBeforePageUnload close any associated SSE source if present.
-	 */
-	function closeSSESourceBeforePageUnload() {
-      var source = api.getInternalData(elt).sseEventSource;
-      if (source != undefined) {
-        source.close();
-      }
-	}
-
-	/**
 	 * maybeCloseSSESource confirms that the parent element still exists.
 	 * If not, then any associated SSE source is closed and the function returns true.
 	 * 
@@ -245,8 +240,6 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 	 */
 	function maybeCloseSSESource(elt) {
 		if (!api.bodyContains(elt)) {
-      // We don't need anymore to disconnect the EventSource on page unload when disconnecting
-      removeEventListener("beforeunload", closeSSESourceBeforePageUnload)
 			var source = api.getInternalData(elt).sseEventSource;
 			if (source != undefined) {
 				source.close();

--- a/src/ext/sse.js
+++ b/src/ext/sse.js
@@ -135,6 +135,14 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 		var source = htmx.createEventSource(sseURL);
 		internalData.sseEventSource = source;
 
+    // Don't forget to disconnect the EventSource on page unload
+    window.addEventListener("beforeunload", () => {
+      var source = api.getInternalData(elt).sseEventSource;
+      if (source != undefined) {
+        source.close();
+      }
+    });
+
 		// Create event handlers
 		source.onerror = function (err) {
 

--- a/src/ext/sse.js
+++ b/src/ext/sse.js
@@ -136,7 +136,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 		internalData.sseEventSource = source;
 
     // Don't forget to disconnect the EventSource on page unload
-    window.addEventListener("beforeunload", () => {
+    window.addEventListener("beforeunload", function () {
       var source = api.getInternalData(elt).sseEventSource;
       if (source != undefined) {
         source.close();

--- a/src/ext/sse.js
+++ b/src/ext/sse.js
@@ -137,7 +137,6 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 
 		// Don't forget to disconnect the EventSource on page unload
 		window.addEventListener("beforeunload", function () {
-			var source = api.getInternalData(elt).sseEventSource;
 			if (source != undefined) {
 				source.close();
 			}


### PR DESCRIPTION
## Description
I love `HTMX`, it's for me the return of the good old way of think and I'm so glad to be here.
But nothing is perfect, there is an annoying bug in Firefox with the Server Side Event Extension.

There is an issue with the way the `EventSource` is closed on Firefox. When you have a currently connected `EventSource` and you refresh the page without closing it, you got those errors :
```
The connection to http://localhost:5000/stream was interrupted while the page was loading. htmx.org:1:1349
error { target: EventSource, isTrusted: true, srcElement: EventSource, currentTarget: EventSource, eventPhase: 2, bubbles: false, cancelable: false, returnValue: true, defaultPrevented: false, composed: false, … }
htmx.org:1:25781
```
With some search on the internet I found this is an old bug from Firefox and *this is not fixed yet*. https://bugzilla.mozilla.org/show_bug.cgi?id=833462

By chance a workaround was found, if the JavaScript close the `EventSource` before the page unload. There is no more error on the page unload.

*Note : There is a bug very similar on Chromium where the is also a similar error message except it appear for a fraction of time before vanish to the oblivion ! Closing the `EventSource` solve this too.*

## Testing
I know it's bad but I didn't manage a way to test my change. What my PR do is I close the `EventSource` on the windows `beforeunload`, this event make me force in my test to close the window. But if I close the window my test stop...
I don't know how I can still use `beforeunload` but simulate a window close in my test.
So I no my PR is not conform yet to the standard of PR but if someone can suggest a way to test `beforeunload`, I will update this PR to include a test to verify the `EventSource` is closed when the window close.

## Replicate 
I didn't create an Issue since It's written in the review guideline "Correspondingly, it is fine to directly PR bugfixes for behavior that htmx already guarantees", but I will still write here a small example to get those error I show in Firefox.

You need a server with SSE. (here an example in python with Flask)
```python
from flask import Flask, render_template, Response
import time

app = Flask(__name__)

def generate_sse():
    count = 0
    while True:
        time.sleep(0.001)
        count += 1
        yield f"data: {count}\n\n"

@app.route('/stream')
def stream():
    return Response(generate_sse(), mimetype='text/event-stream')

@app.route('/')
def home():
    return render_template('index.html')

if __name__ == '__main__':
    app.run(debug=True)
```

And you need to use the HTMX SSE extension.
```html
<!DOCTYPE html>
<html lang="fr">
<head>
    <meta charset="UTF-8">
    <title>Exemple HTMX SSE</title>
    <script src="https://unpkg.com/htmx.org"></script>
    <script src="https://unpkg.com/htmx.org/dist/ext/sse.js"></script>
</head>
<body>
    <h1>Compteur SSE avec HTMX</h1>
    <div hx-ext="sse" sse-connect="/stream" sse-swap="message">
        Waiting for data...
    </div>
</body>
</html>
```

When you reload the page, you got those errors in Firefox
