### PR TITLE
rewrite the HX-Retarget header to use extended query selectors

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3453,7 +3453,11 @@ return (function () {
             }
 
             if (hasHeader(xhr,/HX-Retarget:/i)) {
-                responseInfo.target = getDocument().querySelector(xhr.getResponseHeader("HX-Retarget"));
+                if (xhr.getResponseHeader("HX-Retarget") === "this") {
+                    responseInfo.target = elt;
+                } else {
+                    responseInfo.target = querySelectorExt(elt, xhr.getResponseHeader("HX-Retarget"));
+                }
             }
 
             var historyUpdate = determineHistoryUpdates(elt, responseInfo);


### PR DESCRIPTION
## Description
I modified the HX-Retarget header handling to use extended css selectors.

Corresponding issue:
#1962 

## Testing
I made a quick webserver and html site using golang echo.
```go
package main

import (
	"github.com/labstack/echo/v4"
)

func main() {
	e := echo.New()
	e.GET("/", func(c echo.Context) error {
		return c.File("idx.html")
	})
	e.GET("/htmx", func(c echo.Context) error {
		return c.File("../../htmx/src/htmx.js")
	})
	e.POST("/changethis", func(c echo.Context) error {
		c.Response().Header().Add("HX-Retarget", "this")
		return c.String(200, "changed")
	})
	e.POST("/changehi", func(c echo.Context) error {
		c.Response().Header().Add("HX-Retarget", "#hi")
		return c.String(200, "bye")
	})
	e.POST("/changepreviousp", func(c echo.Context) error {
		c.Response().Header().Add("HX-Retarget", "previous p")
		return c.String(200, "prev")
	})
	e.POST("/changenextp", func(c echo.Context) error {
		c.Response().Header().Add("HX-Retarget", "next p")
		return c.String(200, "next")
	})
	e.Logger.Fatal(e.Start(":1323"))
}
```
with the index page
```html
<!DOCTYPE html>
<html lang="en">

<head>
    <title>hxtest</title>
    <meta charset="UTF-8">
    <meta name="viewport" content="width=device-width, initial-scale=1">
    <link href="css/style.css" rel="stylesheet">
    <script src="htmx"></script>
</head>

<body>
    <div id="hi">
        hi
    </div>
    <p>1</p>
    <p>2</p>


    <button hx-post="changethis">
        click
    </button>
    <button hx-post="changehi">
        change hi
    </button>
    <button hx-post="changenextp">
        change next
    </button>
    <button hx-post="changepreviousp">
        change previous
    </button>
    <p>3</p>
    <p>4</p>
</body>

</html>
```
I then tested the buttons and they worked as expected

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
