### PR TITLE
Fix hx-on anchor in the docs

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -1258,7 +1258,7 @@ Scripting solutions that pair well with htmx include:
   team that created htmx.  It is designed to embed well in HTML and both respond to and create events, and pairs very well
   with htmx.
 
-### <a name="hx-on"></a>[The `hx-on` Attribute](#hyperscript)
+### The `hx-on` Attribute{#hx-on}
 
 HTML allows the embedding of inline scripts via the [`onevent` properties](https://developer.mozilla.org/en-US/docs/Web/Events/Event_handlers#using_onevent_properties),
 such as `onClick`:

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -38,6 +38,7 @@ custom_classes = "wide-content"
 * [events & logging](#events)
 * [debugging](#debugging)
 * [scripting](#scripting)
+  * [hx-on attribute](#hx-on)
   * [hyperscript](#hyperscript)
 * [3rd party integration](#3rd-party)
 * [caching](#caching)

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -38,7 +38,7 @@ custom_classes = "wide-content"
 * [events & logging](#events)
 * [debugging](#debugging)
 * [scripting](#scripting)
-  * [hx-on attribute](#hx-on)
+  * [hx-on attribute](#the-hx-on-attribute)
   * [hyperscript](#hyperscript)
 * [3rd party integration](#3rd-party)
 * [caching](#caching)
@@ -1259,7 +1259,7 @@ Scripting solutions that pair well with htmx include:
   team that created htmx.  It is designed to embed well in HTML and both respond to and create events, and pairs very well
   with htmx.
 
-### The `hx-on` Attribute{#hx-on}
+### <a name="hx-on"></a>The `hx-on` Attribute{#the-hx-on-attribute}
 
 HTML allows the embedding of inline scripts via the [`onevent` properties](https://developer.mozilla.org/en-US/docs/Web/Events/Event_handlers#using_onevent_properties),
 such as `onClick`:


### PR DESCRIPTION
## Description

Current version of the site has a weird heading on the section about hx-on, which is not only different from the rest, but also points to `#hyperscript` instead. This PR puts this in order

Also add `hx-on` to the table of contents in the docs


## Testing
N/A

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a **documentation update**, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
