### PR TITLE
docs(headers): add `select` to HX-Location

### DIFF
--- a/www/content/headers/hx-location.md
+++ b/www/content/headers/hx-location.md
@@ -27,3 +27,4 @@ Path is required and is url to load the response from. The rest of the data mirr
 * `swap` - how the response will be swapped in relative to the target
 * `values` - values to submit with the request
 * `headers` - headers to submit with the request
+* `select` - allows you to select the content you want swapped from a response


### PR DESCRIPTION
## Description
The `select` option was added into `htmx.ajax()` a few days ago according to this commit https://github.com/bigskysoftware/htmx/commit/cabff5db1445a2ee525caddec0f9bfa6f046ee9d, but the documentation for `HX-Location` which to my understanding uses `htmx.ajax()` does not yet have that option, so I added it there.

Corresponding issue: https://github.com/bigskysoftware/htmx/pull/1985

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
