### PR TITLE
Improve head tag parsing on template fragments

### DIFF
--- a/test/manual/hxboost_partial_template_parsing/index-partial.html
+++ b/test/manual/hxboost_partial_template_parsing/index-partial.html
@@ -1,0 +1,8 @@
+<head>
+    <title>Index content</title>
+</head>
+<h1># Index</h1>
+<ul>
+    <li><code>&lt;title&gt;</code> <b>should not</b> spawn inside <code>&lt;main&gt;</code></li>
+    <li><code>&lt;title&gt;</code> <b>should be</b> <em>index content</em></li>
+</ul>

--- a/test/manual/hxboost_partial_template_parsing/index.html
+++ b/test/manual/hxboost_partial_template_parsing/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" hx-preserve="true">
+    <meta name="htmx-config" content='{"useTemplateFragments": true}' hx-preserve="true">
+
+    <title>Index content</title>
+
+    <style hx-preserve="true">
+        * {
+            font-family: Arial, sans-serif;
+            font-size: 24px;
+        }
+        code {
+            font-family: monospace;
+            font-size: 20px;
+        }
+        hr { border: 1px solid black; }
+    </style>
+
+    <script src="../../../src/htmx.js" hx-preserve="true"></script>
+    <script src="../../../src/ext/head-support.js" hx-preserve="true"></script>
+</head>
+<body hx-ext="head-support" hx-boost="true">
+    <header hx-push-url="false" hx-target="main" hx-swap="innerHTML">
+        <nav>
+            <ul>
+                <li><a href="./index-partial.html">Index</a></li>
+                <li><a href="./other-content.html">See other content</a></li>
+            </ul>
+        </nav><hr>
+    </header>
+    <main>
+        <h1># Index</h1>
+        <ul>
+            <li><code>&lt;title&gt;</code> <b>should not</b> spawn inside <code>&lt;main&gt;</code></li>
+            <li><code>&lt;title&gt;</code> <b>should be</b> <em>index content</em></li>
+        </ul>
+    </main>
+</body>
+</html>

--- a/test/manual/hxboost_partial_template_parsing/other-content.html
+++ b/test/manual/hxboost_partial_template_parsing/other-content.html
@@ -1,0 +1,16 @@
+<head>
+    <title>Other content</title>
+    <style>
+        body {
+            background: lightgreen;
+        }
+    </style>
+</head>
+<h1># Swapped content</h1>
+<ul>
+    <li><code>&lt;title&gt;</code> and &lt;style&gt;
+        <b>should not</b> spawn inside <code>&lt;main&gt;</code></li>
+    <li><code>&lt;title&gt;</code> <b>should be</b> <em>other content</em></li>
+    <li>Background <b>should be</b> green</li>
+</ul>
+

--- a/test/manual/index.html
+++ b/test/manual/index.html
@@ -41,6 +41,7 @@
         <ul>
             <li><a href="hxboost_relative_resources">Relative Resources</a></li>
             <li><a href="hxboost_template_parsing">Template Parsing</a></li>
+            <li><a href="hxboost_partial_template_parsing">Partial Template Parsing</a></li>
         </ul>
     </li>
 </ul>


### PR DESCRIPTION
## Description

**This PR:**
* Fix the duplication of head's children tags inside the content when parsing fragments regardless of the status of `useTemplateFragments` configuration.
* These modifications are applied for both parsers: template fragment and plain HTML (default). The new strategy is to skip head tag parsing on the `makeFragment(response)` function as head-support extension already implemented a proper merging algorithm for that.
* Added a manual .html test: `hxboost_partial_template_parsing/index.html, index-partial.html & other-content.html`.
* Also added an array with similar regular expressions to be compiled only once and not for every execution (**edit:** replaced the array approach by constants).

**Corresponding issue:** https://github.com/bigskysoftware/htmx/issues/2018

**This PR needs a review.** For knowledge: @1cg @alexpetros 

## Testing
* If the template fragment is parsed incorrectly and end up including head's children tags inside the template body, the manual test won't have the expected behaviour.
* In order to make the manual test fail just execute it without the modifications or uncomment the following line on htmx.js:
  `content = content.replace(regexPatterns.HEAD, '');`

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded


