### PR TITLE
Fix: Make the SSE extension work properly and adhere to tests

### DIFF
--- a/src/ext/sse.js
+++ b/src/ext/sse.js
@@ -5,311 +5,322 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 
 */
 
-(function(){
+(function() {
 
-	/** @type {import("../htmx").HtmxInternalApi} */
-	var api;
+    /** @type {import("../htmx").HtmxInternalApi} */
+    var api;
 
-	htmx.defineExtension("sse", {
+    htmx.defineExtension("sse", {
 
-		/**
-		 * Init saves the provided reference to the internal HTMX API.
-		 * 
-		 * @param {import("../htmx").HtmxInternalApi} api 
-		 * @returns void
-		 */
-		init: function(apiRef) {
-			// store a reference to the internal API.
-			api = apiRef;
+        /**
+         * Init saves the provided reference to the internal HTMX API.
+         * 
+         * @param {import("../htmx").HtmxInternalApi} api 
+         * @returns void
+         */
+        init: function(apiRef) {
+            // store a reference to the internal API.
+            api = apiRef;
 
-			// set a function in the public API for creating new EventSource objects
-			if (htmx.createEventSource == undefined) {
-				htmx.createEventSource = createEventSource;
-			}
-		},
+            // set a function in the public API for creating new EventSource objects
+            if (htmx.createEventSource == undefined) {
+                htmx.createEventSource = createEventSource;
+            }
+        },
 
-		/**
-		 * onEvent handles all events passed to this extension.
-		 * 
-		 * @param {string} name 
-		 * @param {Event} evt 
-		 * @returns void
-		 */
-		onEvent: function(name, evt) {
+        /**
+         * onEvent handles all events passed to this extension.
+         * 
+         * @param {string} name 
+         * @param {Event} evt 
+         * @returns void
+         */
+        onEvent: function(name, evt) {
 
-			switch (name) {
+            switch (name) {
 
-			// Try to remove remove an EventSource when elements are removed
-			case "htmx:beforeCleanupElement":
-				var internalData = api.getInternalData(evt.target)
-				if (internalData.sseEventSource) {
-					internalData.sseEventSource.close();
-				}
-				return;
+                // Try to remove remove an EventSource when elements are removed
+                case "htmx:beforeCleanupElement":
+                    var internalData = api.getInternalData(evt.target)
+                    if (internalData.sseEventSource) {
+                        internalData.sseEventSource.close();
+                    }
+                    var swapValue = api.getAttributeValue(evt.target, "sse-swap") || getLegacySSESwaps(evt.target)
+                    if (swapValue) {
 
-			// Try to create EventSources when elements are processed
-			case "htmx:afterProcessNode":
-				createEventSourceOnElement(evt.target);
-			}
-		}
-	});
+                    }
 
-	///////////////////////////////////////////////
-	// HELPER FUNCTIONS
-	///////////////////////////////////////////////
+                    if (api.hasAttribute(evt.target, "sse-swap")) {
+                        var sourceElement = api.getClosestMatch(elt, function(node) {
+                            return api.getInternalData(node).sseEventSource != null;
+                        })
+                        var eventName = api.getAttributeValue(evt.target, "sse-swap");
+                    }
+                    return;
+
+                // Try to create EventSources when elements are processed
+                case "htmx:afterProcessNode":
+                    createEventSourceOnElement(evt.target);
+            }
+        }
+    });
+
+    ///////////////////////////////////////////////
+    // HELPER FUNCTIONS
+    ///////////////////////////////////////////////
 
 
-	/**
-	 * createEventSource is the default method for creating new EventSource objects.
-	 * it is hoisted into htmx.config.createEventSource to be overridden by the user, if needed.
-	 * 
-	 * @param {string} url 
-	 * @returns EventSource
-	 */
-	 function createEventSource(url) {
-		return new EventSource(url, {withCredentials:true});
-	}
+    /**
+     * createEventSource is the default method for creating new EventSource objects.
+     * it is hoisted into htmx.config.createEventSource to be overridden by the user, if needed.
+     * 
+     * @param {string} url 
+     * @returns EventSource
+     */
+    function createEventSource(url) {
+        return new EventSource(url, { withCredentials: true });
+    }
 
-	function splitOnWhitespace(trigger) {
-		return trigger.trim().split(/\s+/);
-	}
+    function splitOnWhitespace(trigger) {
+        return trigger.trim().split(/\s+/);
+    }
 
-	function getLegacySSEURL(elt) {
-		var legacySSEValue = api.getAttributeValue(elt, "hx-sse");
-		if (legacySSEValue) {
-			var values = splitOnWhitespace(legacySSEValue);
-			for (var i = 0; i < values.length; i++) {
-				var value = values[i].split(/:(.+)/);
-				if (value[0] === "connect") {
-					return value[1];
-				}
-			}
-		}
-	}
+    function getLegacySSEURL(elt) {
+        var legacySSEValue = api.getAttributeValue(elt, "hx-sse");
+        if (legacySSEValue) {
+            var values = splitOnWhitespace(legacySSEValue);
+            for (var i = 0; i < values.length; i++) {
+                var value = values[i].split(/:(.+)/);
+                if (value[0] === "connect") {
+                    return value[1];
+                }
+            }
+        }
+    }
 
-	function getLegacySSESwaps(elt) {
-		var legacySSEValue = api.getAttributeValue(elt, "hx-sse");
-		var returnArr = [];
-		if (legacySSEValue) {
-			var values = splitOnWhitespace(legacySSEValue);
-			for (var i = 0; i < values.length; i++) {
-				var value = values[i].split(/:(.+)/);
-				if (value[0] === "swap") {
-					returnArr.push(value[1]);
-				}
-			}
-		}
-		return returnArr;
-	}
+    function getLegacySSESwaps(elt) {
+        var legacySSEValue = api.getAttributeValue(elt, "hx-sse");
+        var returnArr = [];
+        if (legacySSEValue) {
+            var values = splitOnWhitespace(legacySSEValue);
+            for (var i = 0; i < values.length; i++) {
+                var value = values[i].split(/:(.+)/);
+                if (value[0] === "swap") {
+                    returnArr.push(value[1]);
+                }
+            }
+        }
+        return returnArr;
+    }
 
-	/**
-	 * createEventSourceOnElement creates a new EventSource connection on the provided element.
-	 * If a usable EventSource already exists, then it is returned.  If not, then a new EventSource
-	 * is created and stored in the element's internalData.
-	 * @param {HTMLElement} elt
-	 * @param {number} retryCount
-	 * @returns {EventSource | null}
-	 */
-	function createEventSourceOnElement(elt, retryCount) {
+    /**
+     * createEventSourceOnElement creates a new EventSource connection on the provided element.
+     * If a usable EventSource already exists, then it is returned.  If not, then a new EventSource
+     * is created and stored in the element's internalData.
+     * @param {HTMLElement} elt
+     * @param {number} retryCount
+     * @returns {EventSource | null}
+     */
+    function createEventSourceOnElement(elt, retryCount) {
 
-		if (elt == null) {
-			return null;
-		}
+        if (elt == null) {
+            return null;
+        }
 
-		// get URL from element's attribute
-		var sseURL = api.getAttributeValue(elt, "sse-connect") || getLegacySSEURL(elt);
+        // get URL from element's attribute
+        var sseURL = api.getAttributeValue(elt, "sse-connect") || getLegacySSEURL(elt);
         var sourceElement; // elt is not always the element with the "sse-connect" attribute
-		var internalData; // internal data for the sourceElement 
-		var source; // event source
-		if (sseURL) {
+        var internalData; // internal data for the sourceElement 
+        var source; // event source
+        if (sseURL) {
             sourceElement = elt; // set sourceElement to elt when it has the "sse-connect" attribute
-			// Create event new event source first
-			internalData = api.getInternalData(elt);
-			// Connect to the EventSource
-			source = htmx.createEventSource(sseURL);
-			internalData.sseEventSource = source;
+            // Create event new event source first
+            internalData = api.getInternalData(elt);
+            // Connect to the EventSource
+            source = htmx.createEventSource(sseURL);
+            internalData.sseEventSource = source;
 
-			// Create event handlers
-			source.onerror = function (err) {
+            // Create event handlers
+            source.onerror = function(err) {
 
-				// Log an error event
-				api.triggerErrorEvent(elt, "htmx:sseError", {error:err, source:source});
+                // Log an error event
+                api.triggerErrorEvent(elt, "htmx:sseError", { error: err, source: source });
 
-				// If parent no longer exists in the document, then clean up this EventSource
-				if (maybeCloseSSESource(elt)) {
-					return;
-				}
+                // If parent no longer exists in the document, then clean up this EventSource
+                if (maybeCloseSSESource(elt)) {
+                    return;
+                }
 
-				// Otherwise, try to reconnect the EventSource
-				if (source.readyState === EventSource.CLOSED) {
-					retryCount = retryCount || 0;
-					var timeout = Math.random() * (2 ^ retryCount) * 500;
-					window.setTimeout(function() {
-						createEventSourceOnElement(elt, Math.min(7, retryCount+1));
-					}, timeout);
-				}
-			};
+                // Otherwise, try to reconnect the EventSource
+                if (source.readyState === EventSource.CLOSED) {
+                    retryCount = retryCount || 0;
+                    var timeout = Math.random() * (2 ^ retryCount) * 500;
+                    window.setTimeout(function() {
+                        createEventSourceOnElement(elt, Math.min(7, retryCount + 1));
+                    }, timeout);
+                }
+            };
 
-			source.onopen = function (evt) {
-				api.triggerEvent(elt, "htmx:sseOpen", {source: source});
-			}
-		} else {
-			// Find closest existing event source
-			sourceElement = api.getClosestMatch(elt, function(node){
-				return api.getInternalData(node).sseEventSource != null;
-			})
-			if (sourceElement == null) {
-				return null; // no eventsource in parentage, orphaned element
-			}
+            source.onopen = function(evt) {
+                api.triggerEvent(elt, "htmx:sseOpen", { source: source });
+            }
+        } else {
+            // Find closest existing event source
+            sourceElement = api.getClosestMatch(elt, function(node) {
+                return api.getInternalData(node).sseEventSource != null;
+            })
+            if (sourceElement == null) {
+                return null; // no eventsource in parentage, orphaned element
+            }
 
-			// Set internalData and source
-			internalData = api.getInternalData(sourceElement);
-			source = internalData.sseEventSource;
-	    }
+            // Set internalData and source
+            internalData = api.getInternalData(sourceElement);
+            source = internalData.sseEventSource;
+        }
 
-		// Add message handlers for every `sse-swap` attribute
-		queryAttributeOnThisOrChildren(elt, "sse-swap").forEach(function(child) {
+        // Add message handlers for every `sse-swap` attribute
+        queryAttributeOnThisOrChildren(elt, "sse-swap").forEach(function(child) {
 
-			var sseSwapAttr = api.getAttributeValue(child, "sse-swap");
-			if (sseSwapAttr) {
-				var sseEventNames = sseSwapAttr.split(",");
-			} else {
-				var sseEventNames = getLegacySSESwaps(child);
-			}
+            var sseSwapAttr = api.getAttributeValue(child, "sse-swap");
+            if (sseSwapAttr) {
+                var sseEventNames = sseSwapAttr.split(",");
+            } else {
+                var sseEventNames = getLegacySSESwaps(child);
+            }
 
-			for (var i = 0 ; i < sseEventNames.length ; i++) {
-				var sseEventName = sseEventNames[i].trim();
-				var listener = function(event) {
+            for (var i = 0; i < sseEventNames.length; i++) {
+                var sseEventName = sseEventNames[i].trim();
+                var listener = function(event) {
 
-					// If the parent is missing then close SSE and remove listener
-					if (maybeCloseSSESource(sourceElement)) {
-						source.removeEventListener(sseEventName, listener);
-						return;
-					}
+                    // If the sourceElement is missing then close SSE and remove listener
+                    if (maybeCloseSSESource(sourceElement)) {
+                        source.removeEventListener(sseEventName, listener);
+                        return;
+                    }
 
-					// swap the response into the DOM and trigger a notification
-					swap(child, event.data);
-					api.triggerEvent(elt, "htmx:sseMessage", event);
-				};
+                    // swap the response into the DOM and trigger a notification
+                    swap(child, event.data);
+                    api.triggerEvent(elt, "htmx:sseMessage", event);
+                };
 
-				// Register the new listener
-				api.getInternalData(elt).sseEventListener = listener;
-				source.addEventListener(sseEventName, listener);
-			}
-		});
+                // Register the new listener
+                api.getInternalData(child).sseEventListener = listener;
+                source.addEventListener(sseEventName, listener);
+            }
+        });
 
-		// Add message handlers for every `hx-trigger="sse:*"` attribute
-		queryAttributeOnThisOrChildren(elt, "hx-trigger").forEach(function(child) {
+        // Add message handlers for every `hx-trigger="sse:*"` attribute
+        queryAttributeOnThisOrChildren(elt, "hx-trigger").forEach(function(child) {
 
-			var sseEventName = api.getAttributeValue(child, "hx-trigger");
-			if (sseEventName == null) {
-				return;
-			}
+            var sseEventName = api.getAttributeValue(child, "hx-trigger");
+            if (sseEventName == null) {
+                return;
+            }
 
-			// Only process hx-triggers for events with the "sse:" prefix
-			if (sseEventName.slice(0, 4) != "sse:") {
-				return;
-			}
-            
+            // Only process hx-triggers for events with the "sse:" prefix
+            if (sseEventName.slice(0, 4) != "sse:") {
+                return;
+            }
+
             // Revisit with htmx2
-            api.addTriggerHandler(child, {trigger:'sse', sseEvent: trigger.substr(4)}, api.getInternalData(child), function() {});
-		});
-	}
+            api.addTriggerHandler(child, { trigger: 'sse', sseEvent: trigger.substr(4) }, api.getInternalData(child), function() { });
+        });
+    }
 
-	/**
-	 * maybeCloseSSESource confirms that the parent element still exists.
-	 * If not, then any associated SSE source is closed and the function returns true.
-	 * 
-	 * @param {HTMLElement} elt 
-	 * @returns boolean
-	 */
-	function maybeCloseSSESource(elt) {
-		if (!api.bodyContains(elt)) {
-			var source = api.getInternalData(elt).sseEventSource;
-			if (source != undefined) {
-				source.close();
-				// source = null
-				return true;
-			}
-		}
-		return false;
-	}
+    /**
+     * maybeCloseSSESource confirms that the parent element still exists.
+     * If not, then any associated SSE source is closed and the function returns true.
+     * 
+     * @param {HTMLElement} elt 
+     * @returns boolean
+     */
+    function maybeCloseSSESource(elt) {
+        if (!api.bodyContains(elt)) {
+            var source = api.getInternalData(elt).sseEventSource;
+            if (source != undefined) {
+                source.close();
+                // source = null
+                return true;
+            }
+        }
+        return false;
+    }
 
-	/**
-	 * queryAttributeOnThisOrChildren returns all nodes that contain the requested attributeName, INCLUDING THE PROVIDED ROOT ELEMENT.
-	 * 
-	 * @param {HTMLElement} elt 
-	 * @param {string} attributeName 
-	 */
-	function queryAttributeOnThisOrChildren(elt, attributeName) {
+    /**
+     * queryAttributeOnThisOrChildren returns all nodes that contain the requested attributeName, INCLUDING THE PROVIDED ROOT ELEMENT.
+     * 
+     * @param {HTMLElement} elt 
+     * @param {string} attributeName 
+     */
+    function queryAttributeOnThisOrChildren(elt, attributeName) {
 
-		var result = [];
+        var result = [];
 
-		// If the parent element also contains the requested attribute, then add it to the results too.
-		if (api.hasAttribute(elt, attributeName) || api.hasAttribute(elt, "hx-sse")) {
-			result.push(elt);
-		}
+        // If the parent element also contains the requested attribute, then add it to the results too.
+        if (api.hasAttribute(elt, attributeName) || api.hasAttribute(elt, "hx-sse")) {
+            result.push(elt);
+        }
 
-		// Search all child nodes that match the requested attribute
-		elt.querySelectorAll("[" + attributeName + "], [data-" + attributeName + "], [hx-sse], [data-hx-sse]").forEach(function(node) {
-			result.push(node);
-		});
+        // Search all child nodes that match the requested attribute
+        elt.querySelectorAll("[" + attributeName + "], [data-" + attributeName + "], [hx-sse], [data-hx-sse]").forEach(function(node) {
+            result.push(node);
+        });
 
-		return result;
-	}
+        return result;
+    }
 
-	/**
-	 * @param {HTMLElement} elt
-	 * @param {string} content 
-	 */
-	function swap(elt, content) {
+    /**
+     * @param {HTMLElement} elt
+     * @param {string} content 
+     */
+    function swap(elt, content) {
 
-		api.withExtensions(elt, function(extension) {
-			content = extension.transformResponse(content, null, elt);
-		});
+        api.withExtensions(elt, function(extension) {
+            content = extension.transformResponse(content, null, elt);
+        });
 
-		var swapSpec = api.getSwapSpecification(elt);
-		var target = api.getTarget(elt);
-		var settleInfo = api.makeSettleInfo(elt);
+        var swapSpec = api.getSwapSpecification(elt);
+        var target = api.getTarget(elt);
+        var settleInfo = api.makeSettleInfo(elt);
 
-		api.selectAndSwap(swapSpec.swapStyle, target, elt, content, settleInfo);
+        api.selectAndSwap(swapSpec.swapStyle, target, elt, content, settleInfo);
 
-		settleInfo.elts.forEach(function (elt) {
-			if (elt.classList) {
-				elt.classList.add(htmx.config.settlingClass);
-			}
-			api.triggerEvent(elt, 'htmx:beforeSettle');
-		});
+        settleInfo.elts.forEach(function(elt) {
+            if (elt.classList) {
+                elt.classList.add(htmx.config.settlingClass);
+            }
+            api.triggerEvent(elt, 'htmx:beforeSettle');
+        });
 
-		// Handle settle tasks (with delay if requested)
-		if (swapSpec.settleDelay > 0) {
-			setTimeout(doSettle(settleInfo), swapSpec.settleDelay);
-		} else {
-			doSettle(settleInfo)();
-		}
-	}
+        // Handle settle tasks (with delay if requested)
+        if (swapSpec.settleDelay > 0) {
+            setTimeout(doSettle(settleInfo), swapSpec.settleDelay);
+        } else {
+            doSettle(settleInfo)();
+        }
+    }
 
-	/**
-	 * doSettle mirrors much of the functionality in htmx that 
-	 * settles elements after their content has been swapped.
-	 * TODO: this should be published by htmx, and not duplicated here
-	 * @param {import("../htmx").HtmxSettleInfo} settleInfo 
-	 * @returns () => void
-	 */
-	function doSettle(settleInfo) {
+    /**
+     * doSettle mirrors much of the functionality in htmx that 
+     * settles elements after their content has been swapped.
+     * TODO: this should be published by htmx, and not duplicated here
+     * @param {import("../htmx").HtmxSettleInfo} settleInfo 
+     * @returns () => void
+     */
+    function doSettle(settleInfo) {
 
-		return function() {
-			settleInfo.tasks.forEach(function (task) {
-				task.call();
-			});
+        return function() {
+            settleInfo.tasks.forEach(function(task) {
+                task.call();
+            });
 
-			settleInfo.elts.forEach(function (elt) {
-				if (elt.classList) {
-					elt.classList.remove(htmx.config.settlingClass);
-				}
-				api.triggerEvent(elt, 'htmx:afterSettle');
-			});
-		}
-	}
+            settleInfo.elts.forEach(function(elt) {
+                if (elt.classList) {
+                    elt.classList.remove(htmx.config.settlingClass);
+                }
+                api.triggerEvent(elt, 'htmx:afterSettle');
+            });
+        }
+    }
 
 })();

--- a/src/ext/sse.js
+++ b/src/ext/sse.js
@@ -119,52 +119,52 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 		// get URL from element's attribute
 		var sseURL = api.getAttributeValue(elt, "sse-connect") || getLegacySSEURL(elt);
 
-        var source; // event source for this element
-        var internalData; // internal data for the element the event source is attached to 
+		var internalData; // internal data for the element the event source is attached to 
+		var source; // event source for this element
 		if (sseURL) {
-            // Create event new event source first
-		    internalData = api.getInternalData(elt);
-            // Connect to the EventSource
-            source = htmx.createEventSource(sseURL);
-            internalData.sseEventSource = source;
+			// Create event new event source first
+			internalData = api.getInternalData(elt);
+			// Connect to the EventSource
+			source = htmx.createEventSource(sseURL);
+			internalData.sseEventSource = source;
 
-            // Create event handlers
-            source.onerror = function (err) {
+			// Create event handlers
+			source.onerror = function (err) {
 
-                // Log an error event
-                api.triggerErrorEvent(elt, "htmx:sseError", {error:err, source:source});
+				// Log an error event
+				api.triggerErrorEvent(elt, "htmx:sseError", {error:err, source:source});
 
-                // If parent no longer exists in the document, then clean up this EventSource
-                if (maybeCloseSSESource(elt)) {
-                    return;
-                }
+				// If parent no longer exists in the document, then clean up this EventSource
+				if (maybeCloseSSESource(elt)) {
+					return;
+				}
 
-                // Otherwise, try to reconnect the EventSource
-                if (source.readyState === EventSource.CLOSED) {
-                    retryCount = retryCount || 0;
-                    var timeout = Math.random() * (2 ^ retryCount) * 500;
-                    window.setTimeout(function() {
-                        createEventSourceOnElement(elt, Math.min(7, retryCount+1));
-                    }, timeout);
-                }			
-            };
+				// Otherwise, try to reconnect the EventSource
+				if (source.readyState === EventSource.CLOSED) {
+					retryCount = retryCount || 0;
+					var timeout = Math.random() * (2 ^ retryCount) * 500;
+					window.setTimeout(function() {
+						createEventSourceOnElement(elt, Math.min(7, retryCount+1));
+					}, timeout);
+				}
+			};
 
-            source.onopen = function (evt) {
-                api.triggerEvent(elt, "htmx:sseOpen", {source: source});
-            }
+			source.onopen = function (evt) {
+				api.triggerEvent(elt, "htmx:sseOpen", {source: source});
+			}
 		} else {
 			// Find closest existing event source
-            var sseSourceElt = api.getClosestMatch(elt, function(node){
-                return api.getInternalData(node).sseEventSource != null;
-            })
-            if (sseSourceElt == null) {
-                return null; // no eventsource in parentage, orphaned element
-            }
-            
-            // Set internalData and source
-            internalData = api.getInternalData(sseSourceElt);
-            source = internalData.sseEventSource;
-	    }	
+			var sseSourceElt = api.getClosestMatch(elt, function(node){
+				return api.getInternalData(node).sseEventSource != null;
+			})
+			if (sseSourceElt == null) {
+				return null; // no eventsource in parentage, orphaned element
+			}
+
+			// Set internalData and source
+			internalData = api.getInternalData(sseSourceElt);
+			source = internalData.sseEventSource;
+	    }
 
 		// Add message handlers for every `sse-swap` attribute
 		queryAttributeOnThisOrChildren(elt, "sse-swap").forEach(function(child) {

--- a/src/ext/sse.js
+++ b/src/ext/sse.js
@@ -5,322 +5,311 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 
 */
 
-(function() {
+(function(){
 
-    /** @type {import("../htmx").HtmxInternalApi} */
-    var api;
+	/** @type {import("../htmx").HtmxInternalApi} */
+	var api;
 
-    htmx.defineExtension("sse", {
+	htmx.defineExtension("sse", {
 
-        /**
-         * Init saves the provided reference to the internal HTMX API.
-         * 
-         * @param {import("../htmx").HtmxInternalApi} api 
-         * @returns void
-         */
-        init: function(apiRef) {
-            // store a reference to the internal API.
-            api = apiRef;
+		/**
+		 * Init saves the provided reference to the internal HTMX API.
+		 * 
+		 * @param {import("../htmx").HtmxInternalApi} api 
+		 * @returns void
+		 */
+		init: function(apiRef) {
+			// store a reference to the internal API.
+			api = apiRef;
 
-            // set a function in the public API for creating new EventSource objects
-            if (htmx.createEventSource == undefined) {
-                htmx.createEventSource = createEventSource;
-            }
-        },
+			// set a function in the public API for creating new EventSource objects
+			if (htmx.createEventSource == undefined) {
+				htmx.createEventSource = createEventSource;
+			}
+		},
 
-        /**
-         * onEvent handles all events passed to this extension.
-         * 
-         * @param {string} name 
-         * @param {Event} evt 
-         * @returns void
-         */
-        onEvent: function(name, evt) {
+		/**
+		 * onEvent handles all events passed to this extension.
+		 * 
+		 * @param {string} name 
+		 * @param {Event} evt 
+		 * @returns void
+		 */
+		onEvent: function(name, evt) {
 
-            switch (name) {
+			switch (name) {
 
-                // Try to remove remove an EventSource when elements are removed
-                case "htmx:beforeCleanupElement":
-                    var internalData = api.getInternalData(evt.target)
-                    if (internalData.sseEventSource) {
-                        internalData.sseEventSource.close();
-                    }
-                    var swapValue = api.getAttributeValue(evt.target, "sse-swap") || getLegacySSESwaps(evt.target)
-                    if (swapValue) {
+			// Try to remove remove an EventSource when elements are removed
+			case "htmx:beforeCleanupElement":
+				var internalData = api.getInternalData(evt.target)
+				if (internalData.sseEventSource) {
+					internalData.sseEventSource.close();
+				}
+				return;
 
-                    }
+			// Try to create EventSources when elements are processed
+			case "htmx:afterProcessNode":
+				createEventSourceOnElement(evt.target);
+			}
+		}
+	});
 
-                    if (api.hasAttribute(evt.target, "sse-swap")) {
-                        var sourceElement = api.getClosestMatch(elt, function(node) {
-                            return api.getInternalData(node).sseEventSource != null;
-                        })
-                        var eventName = api.getAttributeValue(evt.target, "sse-swap");
-                    }
-                    return;
-
-                // Try to create EventSources when elements are processed
-                case "htmx:afterProcessNode":
-                    createEventSourceOnElement(evt.target);
-            }
-        }
-    });
-
-    ///////////////////////////////////////////////
-    // HELPER FUNCTIONS
-    ///////////////////////////////////////////////
+	///////////////////////////////////////////////
+	// HELPER FUNCTIONS
+	///////////////////////////////////////////////
 
 
-    /**
-     * createEventSource is the default method for creating new EventSource objects.
-     * it is hoisted into htmx.config.createEventSource to be overridden by the user, if needed.
-     * 
-     * @param {string} url 
-     * @returns EventSource
-     */
-    function createEventSource(url) {
-        return new EventSource(url, { withCredentials: true });
-    }
+	/**
+	 * createEventSource is the default method for creating new EventSource objects.
+	 * it is hoisted into htmx.config.createEventSource to be overridden by the user, if needed.
+	 * 
+	 * @param {string} url 
+	 * @returns EventSource
+	 */
+	 function createEventSource(url) {
+		return new EventSource(url, {withCredentials:true});
+	}
 
-    function splitOnWhitespace(trigger) {
-        return trigger.trim().split(/\s+/);
-    }
+	function splitOnWhitespace(trigger) {
+		return trigger.trim().split(/\s+/);
+	}
 
-    function getLegacySSEURL(elt) {
-        var legacySSEValue = api.getAttributeValue(elt, "hx-sse");
-        if (legacySSEValue) {
-            var values = splitOnWhitespace(legacySSEValue);
-            for (var i = 0; i < values.length; i++) {
-                var value = values[i].split(/:(.+)/);
-                if (value[0] === "connect") {
-                    return value[1];
-                }
-            }
-        }
-    }
+	function getLegacySSEURL(elt) {
+		var legacySSEValue = api.getAttributeValue(elt, "hx-sse");
+		if (legacySSEValue) {
+			var values = splitOnWhitespace(legacySSEValue);
+			for (var i = 0; i < values.length; i++) {
+				var value = values[i].split(/:(.+)/);
+				if (value[0] === "connect") {
+					return value[1];
+				}
+			}
+		}
+	}
 
-    function getLegacySSESwaps(elt) {
-        var legacySSEValue = api.getAttributeValue(elt, "hx-sse");
-        var returnArr = [];
-        if (legacySSEValue) {
-            var values = splitOnWhitespace(legacySSEValue);
-            for (var i = 0; i < values.length; i++) {
-                var value = values[i].split(/:(.+)/);
-                if (value[0] === "swap") {
-                    returnArr.push(value[1]);
-                }
-            }
-        }
-        return returnArr;
-    }
+	function getLegacySSESwaps(elt) {
+		var legacySSEValue = api.getAttributeValue(elt, "hx-sse");
+		var returnArr = [];
+		if (legacySSEValue) {
+			var values = splitOnWhitespace(legacySSEValue);
+			for (var i = 0; i < values.length; i++) {
+				var value = values[i].split(/:(.+)/);
+				if (value[0] === "swap") {
+					returnArr.push(value[1]);
+				}
+			}
+		}
+		return returnArr;
+	}
 
-    /**
-     * createEventSourceOnElement creates a new EventSource connection on the provided element.
-     * If a usable EventSource already exists, then it is returned.  If not, then a new EventSource
-     * is created and stored in the element's internalData.
-     * @param {HTMLElement} elt
-     * @param {number} retryCount
-     * @returns {EventSource | null}
-     */
-    function createEventSourceOnElement(elt, retryCount) {
+	/**
+	 * createEventSourceOnElement creates a new EventSource connection on the provided element.
+	 * If a usable EventSource already exists, then it is returned.  If not, then a new EventSource
+	 * is created and stored in the element's internalData.
+	 * @param {HTMLElement} elt
+	 * @param {number} retryCount
+	 * @returns {EventSource | null}
+	 */
+	function createEventSourceOnElement(elt, retryCount) {
 
-        if (elt == null) {
-            return null;
-        }
+		if (elt == null) {
+			return null;
+		}
 
-        // get URL from element's attribute
-        var sseURL = api.getAttributeValue(elt, "sse-connect") || getLegacySSEURL(elt);
+		// get URL from element's attribute
+		var sseURL = api.getAttributeValue(elt, "sse-connect") || getLegacySSEURL(elt);
         var sourceElement; // elt is not always the element with the "sse-connect" attribute
-        var internalData; // internal data for the sourceElement 
-        var source; // event source
-        if (sseURL) {
+		var internalData; // internal data for the sourceElement 
+		var source; // event source
+		if (sseURL) {
             sourceElement = elt; // set sourceElement to elt when it has the "sse-connect" attribute
-            // Create event new event source first
-            internalData = api.getInternalData(elt);
-            // Connect to the EventSource
-            source = htmx.createEventSource(sseURL);
-            internalData.sseEventSource = source;
+			// Create event new event source first
+			internalData = api.getInternalData(elt);
+			// Connect to the EventSource
+			source = htmx.createEventSource(sseURL);
+			internalData.sseEventSource = source;
 
-            // Create event handlers
-            source.onerror = function(err) {
+			// Create event handlers
+			source.onerror = function (err) {
 
-                // Log an error event
-                api.triggerErrorEvent(elt, "htmx:sseError", { error: err, source: source });
+				// Log an error event
+				api.triggerErrorEvent(elt, "htmx:sseError", {error:err, source:source});
 
-                // If parent no longer exists in the document, then clean up this EventSource
-                if (maybeCloseSSESource(elt)) {
-                    return;
-                }
+				// If parent no longer exists in the document, then clean up this EventSource
+				if (maybeCloseSSESource(elt)) {
+					return;
+				}
 
-                // Otherwise, try to reconnect the EventSource
-                if (source.readyState === EventSource.CLOSED) {
-                    retryCount = retryCount || 0;
-                    var timeout = Math.random() * (2 ^ retryCount) * 500;
-                    window.setTimeout(function() {
-                        createEventSourceOnElement(elt, Math.min(7, retryCount + 1));
-                    }, timeout);
-                }
-            };
+				// Otherwise, try to reconnect the EventSource
+				if (source.readyState === EventSource.CLOSED) {
+					retryCount = retryCount || 0;
+					var timeout = Math.random() * (2 ^ retryCount) * 500;
+					window.setTimeout(function() {
+						createEventSourceOnElement(elt, Math.min(7, retryCount+1));
+					}, timeout);
+				}
+			};
 
-            source.onopen = function(evt) {
-                api.triggerEvent(elt, "htmx:sseOpen", { source: source });
-            }
-        } else {
-            // Find closest existing event source
-            sourceElement = api.getClosestMatch(elt, function(node) {
-                return api.getInternalData(node).sseEventSource != null;
-            })
-            if (sourceElement == null) {
-                return null; // no eventsource in parentage, orphaned element
-            }
+			source.onopen = function (evt) {
+				api.triggerEvent(elt, "htmx:sseOpen", {source: source});
+			}
+		} else {
+			// Find closest existing event source
+			sourceElement = api.getClosestMatch(elt, function(node){
+				return api.getInternalData(node).sseEventSource != null;
+			})
+			if (sourceElement == null) {
+				return null; // no eventsource in parentage, orphaned element
+			}
 
-            // Set internalData and source
-            internalData = api.getInternalData(sourceElement);
-            source = internalData.sseEventSource;
-        }
+			// Set internalData and source
+			internalData = api.getInternalData(sourceElement);
+			source = internalData.sseEventSource;
+	    }
 
-        // Add message handlers for every `sse-swap` attribute
-        queryAttributeOnThisOrChildren(elt, "sse-swap").forEach(function(child) {
+		// Add message handlers for every `sse-swap` attribute
+		queryAttributeOnThisOrChildren(elt, "sse-swap").forEach(function(child) {
 
-            var sseSwapAttr = api.getAttributeValue(child, "sse-swap");
-            if (sseSwapAttr) {
-                var sseEventNames = sseSwapAttr.split(",");
-            } else {
-                var sseEventNames = getLegacySSESwaps(child);
-            }
+			var sseSwapAttr = api.getAttributeValue(child, "sse-swap");
+			if (sseSwapAttr) {
+				var sseEventNames = sseSwapAttr.split(",");
+			} else {
+				var sseEventNames = getLegacySSESwaps(child);
+			}
 
-            for (var i = 0; i < sseEventNames.length; i++) {
-                var sseEventName = sseEventNames[i].trim();
-                var listener = function(event) {
+			for (var i = 0 ; i < sseEventNames.length ; i++) {
+				var sseEventName = sseEventNames[i].trim();
+				var listener = function(event) {
 
-                    // If the sourceElement is missing then close SSE and remove listener
-                    if (maybeCloseSSESource(sourceElement)) {
-                        source.removeEventListener(sseEventName, listener);
-                        return;
-                    }
+					// If the parent is missing then close SSE and remove listener
+					if (maybeCloseSSESource(sourceElement)) {
+						source.removeEventListener(sseEventName, listener);
+						return;
+					}
 
-                    // swap the response into the DOM and trigger a notification
-                    swap(child, event.data);
-                    api.triggerEvent(elt, "htmx:sseMessage", event);
-                };
+					// swap the response into the DOM and trigger a notification
+					swap(child, event.data);
+					api.triggerEvent(elt, "htmx:sseMessage", event);
+				};
 
-                // Register the new listener
-                api.getInternalData(child).sseEventListener = listener;
-                source.addEventListener(sseEventName, listener);
-            }
-        });
+				// Register the new listener
+				api.getInternalData(elt).sseEventListener = listener;
+				source.addEventListener(sseEventName, listener);
+			}
+		});
 
-        // Add message handlers for every `hx-trigger="sse:*"` attribute
-        queryAttributeOnThisOrChildren(elt, "hx-trigger").forEach(function(child) {
+		// Add message handlers for every `hx-trigger="sse:*"` attribute
+		queryAttributeOnThisOrChildren(elt, "hx-trigger").forEach(function(child) {
 
-            var sseEventName = api.getAttributeValue(child, "hx-trigger");
-            if (sseEventName == null) {
-                return;
-            }
+			var sseEventName = api.getAttributeValue(child, "hx-trigger");
+			if (sseEventName == null) {
+				return;
+			}
 
-            // Only process hx-triggers for events with the "sse:" prefix
-            if (sseEventName.slice(0, 4) != "sse:") {
-                return;
-            }
-
+			// Only process hx-triggers for events with the "sse:" prefix
+			if (sseEventName.slice(0, 4) != "sse:") {
+				return;
+			}
+            
             // Revisit with htmx2
-            api.addTriggerHandler(child, { trigger: 'sse', sseEvent: trigger.substr(4) }, api.getInternalData(child), function() { });
-        });
-    }
+            api.addTriggerHandler(child, {trigger:'sse', sseEvent: trigger.substr(4)}, api.getInternalData(child), function() {});
+		});
+	}
 
-    /**
-     * maybeCloseSSESource confirms that the parent element still exists.
-     * If not, then any associated SSE source is closed and the function returns true.
-     * 
-     * @param {HTMLElement} elt 
-     * @returns boolean
-     */
-    function maybeCloseSSESource(elt) {
-        if (!api.bodyContains(elt)) {
-            var source = api.getInternalData(elt).sseEventSource;
-            if (source != undefined) {
-                source.close();
-                // source = null
-                return true;
-            }
-        }
-        return false;
-    }
+	/**
+	 * maybeCloseSSESource confirms that the parent element still exists.
+	 * If not, then any associated SSE source is closed and the function returns true.
+	 * 
+	 * @param {HTMLElement} elt 
+	 * @returns boolean
+	 */
+	function maybeCloseSSESource(elt) {
+		if (!api.bodyContains(elt)) {
+			var source = api.getInternalData(elt).sseEventSource;
+			if (source != undefined) {
+				source.close();
+				// source = null
+				return true;
+			}
+		}
+		return false;
+	}
 
-    /**
-     * queryAttributeOnThisOrChildren returns all nodes that contain the requested attributeName, INCLUDING THE PROVIDED ROOT ELEMENT.
-     * 
-     * @param {HTMLElement} elt 
-     * @param {string} attributeName 
-     */
-    function queryAttributeOnThisOrChildren(elt, attributeName) {
+	/**
+	 * queryAttributeOnThisOrChildren returns all nodes that contain the requested attributeName, INCLUDING THE PROVIDED ROOT ELEMENT.
+	 * 
+	 * @param {HTMLElement} elt 
+	 * @param {string} attributeName 
+	 */
+	function queryAttributeOnThisOrChildren(elt, attributeName) {
 
-        var result = [];
+		var result = [];
 
-        // If the parent element also contains the requested attribute, then add it to the results too.
-        if (api.hasAttribute(elt, attributeName) || api.hasAttribute(elt, "hx-sse")) {
-            result.push(elt);
-        }
+		// If the parent element also contains the requested attribute, then add it to the results too.
+		if (api.hasAttribute(elt, attributeName) || api.hasAttribute(elt, "hx-sse")) {
+			result.push(elt);
+		}
 
-        // Search all child nodes that match the requested attribute
-        elt.querySelectorAll("[" + attributeName + "], [data-" + attributeName + "], [hx-sse], [data-hx-sse]").forEach(function(node) {
-            result.push(node);
-        });
+		// Search all child nodes that match the requested attribute
+		elt.querySelectorAll("[" + attributeName + "], [data-" + attributeName + "], [hx-sse], [data-hx-sse]").forEach(function(node) {
+			result.push(node);
+		});
 
-        return result;
-    }
+		return result;
+	}
 
-    /**
-     * @param {HTMLElement} elt
-     * @param {string} content 
-     */
-    function swap(elt, content) {
+	/**
+	 * @param {HTMLElement} elt
+	 * @param {string} content 
+	 */
+	function swap(elt, content) {
 
-        api.withExtensions(elt, function(extension) {
-            content = extension.transformResponse(content, null, elt);
-        });
+		api.withExtensions(elt, function(extension) {
+			content = extension.transformResponse(content, null, elt);
+		});
 
-        var swapSpec = api.getSwapSpecification(elt);
-        var target = api.getTarget(elt);
-        var settleInfo = api.makeSettleInfo(elt);
+		var swapSpec = api.getSwapSpecification(elt);
+		var target = api.getTarget(elt);
+		var settleInfo = api.makeSettleInfo(elt);
 
-        api.selectAndSwap(swapSpec.swapStyle, target, elt, content, settleInfo);
+		api.selectAndSwap(swapSpec.swapStyle, target, elt, content, settleInfo);
 
-        settleInfo.elts.forEach(function(elt) {
-            if (elt.classList) {
-                elt.classList.add(htmx.config.settlingClass);
-            }
-            api.triggerEvent(elt, 'htmx:beforeSettle');
-        });
+		settleInfo.elts.forEach(function (elt) {
+			if (elt.classList) {
+				elt.classList.add(htmx.config.settlingClass);
+			}
+			api.triggerEvent(elt, 'htmx:beforeSettle');
+		});
 
-        // Handle settle tasks (with delay if requested)
-        if (swapSpec.settleDelay > 0) {
-            setTimeout(doSettle(settleInfo), swapSpec.settleDelay);
-        } else {
-            doSettle(settleInfo)();
-        }
-    }
+		// Handle settle tasks (with delay if requested)
+		if (swapSpec.settleDelay > 0) {
+			setTimeout(doSettle(settleInfo), swapSpec.settleDelay);
+		} else {
+			doSettle(settleInfo)();
+		}
+	}
 
-    /**
-     * doSettle mirrors much of the functionality in htmx that 
-     * settles elements after their content has been swapped.
-     * TODO: this should be published by htmx, and not duplicated here
-     * @param {import("../htmx").HtmxSettleInfo} settleInfo 
-     * @returns () => void
-     */
-    function doSettle(settleInfo) {
+	/**
+	 * doSettle mirrors much of the functionality in htmx that 
+	 * settles elements after their content has been swapped.
+	 * TODO: this should be published by htmx, and not duplicated here
+	 * @param {import("../htmx").HtmxSettleInfo} settleInfo 
+	 * @returns () => void
+	 */
+	function doSettle(settleInfo) {
 
-        return function() {
-            settleInfo.tasks.forEach(function(task) {
-                task.call();
-            });
+		return function() {
+			settleInfo.tasks.forEach(function (task) {
+				task.call();
+			});
 
-            settleInfo.elts.forEach(function(elt) {
-                if (elt.classList) {
-                    elt.classList.remove(htmx.config.settlingClass);
-                }
-                api.triggerEvent(elt, 'htmx:afterSettle');
-            });
-        }
-    }
+			settleInfo.elts.forEach(function (elt) {
+				if (elt.classList) {
+					elt.classList.remove(htmx.config.settlingClass);
+				}
+				api.triggerEvent(elt, 'htmx:afterSettle');
+			});
+		}
+	}
 
 })();

--- a/src/ext/sse.js
+++ b/src/ext/sse.js
@@ -209,23 +209,8 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 			if (sseEventName.slice(0, 4) != "sse:") {
 				return;
 			}
-
-			var listener = function(event) {
-
-				// If parent is missing, then close SSE and remove listener
-				if (maybeCloseSSESource(elt)) {
-					source.removeEventListener(sseEventName, listener);
-					return;
-				}
-
-				// Trigger events to be handled by the rest of htmx
-				htmx.trigger(child, sseEventName, event);
-				htmx.trigger(child, "htmx:sseMessage", event);
-			}
-
-			// Register the new listener
-			api.getInternalData(elt).sseEventListener = listener;
-			source.addEventListener(sseEventName.slice(4), listener);
+            
+            api.addTriggerHandler(child, {trigger:'sse', sseEvent: trigger.substr(4)}, api.getInternalData(child), function() {});
 		});
 	}
 

--- a/src/ext/sse.js
+++ b/src/ext/sse.js
@@ -118,10 +118,11 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 
 		// get URL from element's attribute
 		var sseURL = api.getAttributeValue(elt, "sse-connect") || getLegacySSEURL(elt);
-
-		var internalData; // internal data for the element the event source is attached to 
-		var source; // event source for this element
+        var sourceElement; // elt is not always the element with the "sse-connect" attribute
+		var internalData; // internal data for the sourceElement 
+		var source; // event source
 		if (sseURL) {
+            sourceElement = elt; // set sourceElement to elt when it has the "sse-connect" attribute
 			// Create event new event source first
 			internalData = api.getInternalData(elt);
 			// Connect to the EventSource
@@ -154,15 +155,15 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 			}
 		} else {
 			// Find closest existing event source
-			var sseSourceElt = api.getClosestMatch(elt, function(node){
+			sourceElement = api.getClosestMatch(elt, function(node){
 				return api.getInternalData(node).sseEventSource != null;
 			})
-			if (sseSourceElt == null) {
+			if (sourceElement == null) {
 				return null; // no eventsource in parentage, orphaned element
 			}
 
 			// Set internalData and source
-			internalData = api.getInternalData(sseSourceElt);
+			internalData = api.getInternalData(sourceElement);
 			source = internalData.sseEventSource;
 	    }
 
@@ -181,7 +182,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 				var listener = function(event) {
 
 					// If the parent is missing then close SSE and remove listener
-					if (maybeCloseSSESource(elt)) {
+					if (maybeCloseSSESource(sourceElement)) {
 						source.removeEventListener(sseEventName, listener);
 						return;
 					}
@@ -210,6 +211,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 				return;
 			}
             
+            // Revisit with htmx2
             api.addTriggerHandler(child, {trigger:'sse', sseEvent: trigger.substr(4)}, api.getInternalData(child), function() {});
 		});
 	}

--- a/test/attributes/hx-sse.js
+++ b/test/attributes/hx-sse.js
@@ -4,43 +4,53 @@ describe("hx-sse attribute", function() {
         var listeners = {};
         var wasClosed = false;
         var mockEventSource = {
-            removeEventListener: function(name) {
-                delete listeners[name];
+            removeEventListener: function(name, l) {
+                listeners[name] = listeners[name].filter(function(elt, idx, arr) {
+                    if (arr[idx] === l) {
+                        return false;
+                    }
+                    return true;
+                })
             },
-            addEventListener: function (message, l) {
-                listeners[message] = l;
+            addEventListener: function(message, l) {
+                if (listeners == undefined) {
+                    listeners[message] = [];
+                }
+                listeners[message].push(l)
             },
-            sendEvent: function (eventName, data) {
-                var listener = listeners[eventName];
-                if (listener) {
-                    var event = htmx._("makeEvent")(eventName);
-                    event.data = data;
-                    listener(event);
+            sendEvent: function(eventName, data) {
+                var listeners = listeners[eventName];
+                if (listeners) {
+                    listeners.forEach(function(listener) {
+                        var event = htmx._("makeEvent")(eventName);
+                        event.data = data;
+                        listener(event);
+                    }
                 }
             },
-            close: function () {
+            close: function() {
                 wasClosed = true;
             },
-            wasClosed: function () {
+            wasClosed: function() {
                 return wasClosed;
             }
         };
         return mockEventSource;
     }
 
-    beforeEach(function () {
+    beforeEach(function() {
         this.server = makeServer();
         var eventSource = mockEventSource();
         this.eventSource = eventSource;
         clearWorkArea();
-        htmx.createEventSource = function(){ return eventSource };
+        htmx.createEventSource = function() { return eventSource };
     });
-    afterEach(function () {
+    afterEach(function() {
         this.server.restore();
         clearWorkArea();
     });
 
-    it('handles basic sse triggering', function () {
+    it('handles basic sse triggering', function() {
 
         this.server.respondWith("GET", "/d1", "div1 updated");
         this.server.respondWith("GET", "/d2", "div2 updated");
@@ -61,7 +71,7 @@ describe("hx-sse attribute", function() {
         byId("d2").innerHTML.should.equal("div2 updated");
     })
 
-    it('does not trigger events that arent named', function () {
+    it('does not trigger events that arent named', function() {
 
         this.server.respondWith("GET", "/d1", "div1 updated");
 
@@ -82,7 +92,7 @@ describe("hx-sse attribute", function() {
         byId("d1").innerHTML.should.equal("div1 updated");
     })
 
-    it('does not trigger events not on descendents', function () {
+    it('does not trigger events not on descendents', function() {
 
         this.server.respondWith("GET", "/d1", "div1 updated");
 
@@ -102,7 +112,7 @@ describe("hx-sse attribute", function() {
         byId("d1").innerHTML.should.equal("div1");
     })
 
-    it('is closed after removal', function () {
+    it('is closed after removal', function() {
         this.server.respondWith("GET", "/test", "Clicked!");
         var div = make('<div hx-get="/test" hx-swap="outerHTML" hx-sse="connect:/foo">' +
             '<div id="d1" hx-trigger="sse:e1" hx-get="/d1">div1</div>' +
@@ -112,7 +122,7 @@ describe("hx-sse attribute", function() {
         this.eventSource.wasClosed().should.equal(true)
     })
 
-    it('is closed after removal with no close and activity', function () {
+    it('is closed after removal with no close and activity', function() {
         var div = make('<div hx-get="/test" hx-swap="outerHTML" hx-sse="connect:/foo">' +
             '<div id="d1" hx-trigger="sse:e1" hx-get="/d1">div1</div>' +
             '</div>');
@@ -121,7 +131,7 @@ describe("hx-sse attribute", function() {
         this.eventSource.wasClosed().should.equal(true)
     })
 
-    it('swaps content properly on SSE swap', function () {
+    it('swaps content properly on SSE swap', function() {
         var div = make('<div hx-sse="connect:/event_stream">\n' +
             '  <div id="d1" hx-sse="swap:e1"></div>\n' +
             '  <div id="d2" hx-sse="swap:e2"></div>\n' +

--- a/test/attributes/hx-sse.js
+++ b/test/attributes/hx-sse.js
@@ -136,5 +136,15 @@ describe("hx-sse attribute", function() {
         byId("d2").innerText.should.equal("Event 2")
     })
 
+    it('swaps swapped in content', function() {
+        var div = make('<div hx-sse="connect:/event_stream">\n' +
+            '<div id="d1" hx-sse="swap:e1" hx-swap="outerHTML"></div>\n' +
+            '</div>\n'
+        )
+
+        this.eventSource.sendEvent("e1", '<div id="d2" hx-sse="swap:e2"></div>')
+        this.eventSource.sendEvent("e2", 'Event 2')
+        byId("d2").innerText.should.equal("Event 2")
+    })
 });
 

--- a/test/ext/sse.js
+++ b/test/ext/sse.js
@@ -1,0 +1,140 @@
+describe("sse extension", function() {
+
+    function mockEventSource() {
+        var listeners = {};
+        var wasClosed = false;
+        var mockEventSource = {
+            removeEventListener: function(name) {
+                delete listeners[name];
+            },
+            addEventListener: function(message, l) {
+                listeners[message] = l;
+            },
+            sendEvent: function(eventName, data) {
+                var listener = listeners[eventName];
+                if (listener) {
+                    var event = htmx._("makeEvent")(eventName);
+                    event.data = data;
+                    listener(event);
+                }
+            },
+            close: function() {
+                wasClosed = true;
+            },
+            wasClosed: function() {
+                return wasClosed;
+            }
+        };
+        return mockEventSource;
+    }
+
+    beforeEach(function() {
+        this.server = makeServer();
+        var eventSource = mockEventSource();
+        this.eventSource = eventSource;
+        clearWorkArea();
+        htmx.createEventSource = function() { return eventSource };
+    });
+    afterEach(function() {
+        this.server.restore();
+        clearWorkArea();
+    });
+
+    it('handles basic sse triggering', function() {
+
+        this.server.respondWith("GET", "/d1", "div1 updated");
+        this.server.respondWith("GET", "/d2", "div2 updated");
+
+        var div = make('<div hx-ext="sse" sse-connect="/foo">' +
+            '<div id="d1" hx-trigger="sse:e1" hx-get="/d1">div1</div>' +
+            '<div id="d2" hx-trigger="sse:e2" hx-get="/d2">div2</div>' +
+            '</div>');
+
+        this.eventSource.sendEvent("e1");
+        this.server.respond();
+        byId("d1").innerHTML.should.equal("div1 updated");
+        byId("d2").innerHTML.should.equal("div2");
+
+        this.eventSource.sendEvent("e2");
+        this.server.respond();
+        byId("d1").innerHTML.should.equal("div1 updated");
+        byId("d2").innerHTML.should.equal("div2 updated");
+    })
+
+    it('does not trigger events that arent named', function() {
+
+        this.server.respondWith("GET", "/d1", "div1 updated");
+
+        var div = make('<div hx-ext="sse" sse-connect="/foo">' +
+            '<div id="d1" hx-trigger="sse:e1" hx-get="/d1">div1</div>' +
+            '</div>');
+
+        this.eventSource.sendEvent("foo");
+        this.server.respond();
+        byId("d1").innerHTML.should.equal("div1");
+
+        this.eventSource.sendEvent("e2");
+        this.server.respond();
+        byId("d1").innerHTML.should.equal("div1");
+
+        this.eventSource.sendEvent("e1");
+        this.server.respond();
+        byId("d1").innerHTML.should.equal("div1 updated");
+    })
+
+    it('does not trigger events not on descendents', function() {
+
+        this.server.respondWith("GET", "/d1", "div1 updated");
+
+        var div = make('<div hx-ext="sse" sse-connect="/foo"></div>' +
+            '<div id="d1" hx-trigger="sse:e1" hx-get="/d1">div1</div>');
+
+        this.eventSource.sendEvent("foo");
+        this.server.respond();
+        byId("d1").innerHTML.should.equal("div1");
+
+        this.eventSource.sendEvent("e2");
+        this.server.respond();
+        byId("d1").innerHTML.should.equal("div1");
+
+        this.eventSource.sendEvent("e1");
+        this.server.respond();
+        byId("d1").innerHTML.should.equal("div1");
+    })
+
+    it('is closed after removal', function() {
+        this.server.respondWith("GET", "/test", "Clicked!");
+        var div = make('<div hx-get="/test" hx-swap="outerHTML" hx-ext="sse" sse-connect="/foo">' +
+            '<div id="d1" hx-trigger="sse:e1" hx-get="/d1">div1</div>' +
+            '</div>');
+        div.click();
+        this.server.respond();
+        this.eventSource.wasClosed().should.equal(true)
+    })
+
+    it('is closed after removal with no close and activity', function() {
+        var div = make('<div hx-get="/test" hx-swap="outerHTML" hx-ext="sse" sse-connect="/foo">' +
+            '<div id="d1" hx-trigger="sse:e1" hx-get="/d1">div1</div>' +
+            '</div>');
+        div.parentElement.removeChild(div);
+        this.eventSource.sendEvent("e1")
+        this.eventSource.wasClosed().should.equal(true)
+    })
+
+    it('swaps content properly on SSE swap', function() {
+        var div = make('<div hx-ext="sse" sse-connect="/event_stream">\n' +
+            '  <div id="d1" sse-swap="e1"></div>\n' +
+            '  <div id="d2" sse-swap="e2"></div>\n' +
+            '</div>\n');
+        byId("d1").innerText.should.equal("")
+        byId("d2").innerText.should.equal("")
+        this.eventSource.sendEvent("e1", "Event 1")
+        byId("d1").innerText.should.equal("Event 1")
+        byId("d2").innerText.should.equal("")
+        this.eventSource.sendEvent("e2", "Event 2")
+        byId("d1").innerText.should.equal("Event 1")
+        byId("d2").innerText.should.equal("Event 2")
+    })
+
+});
+

--- a/test/ext/sse.js
+++ b/test/ext/sse.js
@@ -136,5 +136,16 @@ describe("sse extension", function() {
         byId("d2").innerText.should.equal("Event 2")
     })
 
+    it('swaps swapped in content', function() {
+        var div = make('<div hx-ext="sse" sse-connect="/event_stream">\n' +
+            '<div id="d1" sse-swap="e1" hx-swap="outerHTML"></div>\n' +
+            '</div>\n'
+        )
+
+        this.eventSource.sendEvent("e1", '<div id="d2" sse-swap="e2"></div>')
+        this.eventSource.sendEvent("e2", 'Event 2')
+        byId("d2").innerText.should.equal("Event 2")
+    })
+
 });
 

--- a/test/ext/sse.js
+++ b/test/ext/sse.js
@@ -112,12 +112,22 @@ describe("sse extension", function() {
         this.eventSource.wasClosed().should.equal(true)
     })
 
-    it('is closed after removal with no close and activity', function() {
+    it('is closed after removal with no close and activity, hx-trigger', function() {
         var div = make('<div hx-get="/test" hx-swap="outerHTML" hx-ext="sse" sse-connect="/foo">' +
             '<div id="d1" hx-trigger="sse:e1" hx-get="/d1">div1</div>' +
             '</div>');
         div.parentElement.removeChild(div);
         this.eventSource.sendEvent("e1")
+        this.eventSource.wasClosed().should.equal(true)
+    })
+
+    // sse and hx-trigger handlers are distinct
+    it('is closed after removal with no close and activity, sse-swap', function() {
+        var div = make('<div hx-get="/test" hx-swap="outerHTML" hx-ext="sse" sse-connect="/foo">' +
+            '<div id="d1" sse-swap="e1" hx-get="/d1">div1</div>' +
+            '</div>');
+        div.parentElement.removeChild(div);
+        this.eventSource.sendEvent("e1", "div1.2")
         this.eventSource.wasClosed().should.equal(true)
     })
 

--- a/test/ext/sse.js
+++ b/test/ext/sse.js
@@ -1,3 +1,5 @@
+const { assert } = require("chai");
+
 describe("sse extension", function() {
 
     function mockEventSource() {
@@ -5,18 +7,28 @@ describe("sse extension", function() {
         var wasClosed = false;
         var url;
         var mockEventSource = {
-            removeEventListener: function(name) {
-                delete listeners[name];
+            removeEventListener: function(name, l) {
+                listeners[name] = listeners[name].filter(function(elt, idx, arr) {
+                    if (arr[idx] === l) {
+                        return false;
+                    }
+                    return true;
+                })
             },
             addEventListener: function(message, l) {
-                listeners[message] = l;
+                if (listeners == undefined) {
+                    listeners[message] = [];
+                }
+                listeners[message].push(l)
             },
             sendEvent: function(eventName, data) {
-                var listener = listeners[eventName];
-                if (listener) {
-                    var event = htmx._("makeEvent")(eventName);
-                    event.data = data;
-                    listener(event);
+                var listeners = listeners[eventName];
+                if (listeners) {
+                    listeners.forEach(function(listener) {
+                        var event = htmx._("makeEvent")(eventName);
+                        event.data = data;
+                        listener(event);
+                    }
                 }
             },
             close: function() {

--- a/test/index.html
+++ b/test/index.html
@@ -178,7 +178,7 @@
 </script>
 <em>Work Area</em>
 <hr/>
-<div id="work-area" hx-history-elt hx-ext="sse">
+<div id="work-area" hx-history-elt>
 </div>
 </body>
 </html>

--- a/test/index.html
+++ b/test/index.html
@@ -158,8 +158,12 @@
 <script src="../src/ext/ws.js"></script>
 <script src="ext/ws.js"></script>
 
+<script src="../src/ext/sse.js"></script>
+<script src="ext/sse.js"></script>
+
 <script src="../src/ext/response-targets.js"></script>
 <script src="ext/response-targets.js"></script>
+
 
 <!-- events last so they don't screw up other tests -->
 <script src="core/events.js"></script>


### PR DESCRIPTION
## Description

- Add: tests for the sse extension
- Partially Fix: `sse:*` inside of hx-trigger <sup>[(1)](#note-1)</sup>
- Fix: `sse-swap` events inside of previously swapped content

Previously `sse-swap` were only processed when `sse-connect` was on the root of what was being swapped in.
This is now fixed so that the closest sseEventSource is found and used as the event source.

While fixing this issue I ported the existing sse tests (`attributes/hx-sse.js`) to the sse extension, and while running those realized that the sse extension was not compliant with those tests, the change was one line so I decided to add it and make this a general sse extension fix pull request.

In some ways this is similar to the #1764 which seems to be stalled. However, it fixes a few more bugs, adds the missing testing. 

Corresponding issues: #2023 #916 

<a name="note-1"></a>(1) I'm calling this a partial fix because actually supporting the full `hx-trigger` functionality for sse might not be possible without a substantial refactor of the trigger functionality in htmx itself. Right now the most basic usage of `hx-trigger` with sse events is supported (i.e. `hx-trigger="sse:<event name>"`) however, comma separation of events, etc are not supported and can't really be supported unless there htmx allows new keywords and behavior to be added to `hx-trigger` by extensions. Or I copy the entirety of the behavior of `hx-trigger` into the sse extension which seems deeply silly and a real pain for the future maintainability of the sse extension.

## Testing

I initially used the code in this [gist](https://gist.github.com/fhp-mec/5dc1980b8b77b062de3435c64b9734e9) to test this manually as there are no tests for the sse backend that I could find

I then realized that there were test cases in `attributes/hx-sse.js` so I copied those, edited them to work with the sse extension.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
