### PR TITLE
chore: add missing options to HtmxConfig type

### DIFF
--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -400,6 +400,36 @@ export interface HtmxConfig {
      * @default true
      */
     scrollIntoViewOnBoost?: boolean;
+    /**
+     * If set, the nonce will be added to inline scripts.
+     * @default ''
+     */
+    inlineScriptNonce?: string;
+    /**
+     * The type of binary data being received over the WebSocket connection
+     * @default blob
+     */
+    wsBinaryType?: Blob; 
+    /**
+     * If set to true htmx will include a cache-busting parameter in GET requests to avoid caching partial responses by the browser
+     * @default false 
+     */
+    getCacheBusterParam?: boolean;
+    /**
+     * If set to true, htmx will use the View Transition API when swapping in new content.
+     * @default false 
+     */
+    globalViewTransitions?: boolean;
+    /**
+     * htmx will format requests with these methods by encoding their parameters in the URL, not the request body
+     * @default ["get"] 
+     */
+    methodsThatUseUrlParams?: string[];
+    /**
+     * If set to true htmx will not update the title of the document when a title tag is found in new content
+     * @default false 
+     */
+    ignoreTitle:? boolean;
 }
 
 /**


### PR DESCRIPTION
## Description
When playing around with View Transitions, I noticed that the `globalViewTransitions` property, as well as some other options, were missing from the `HtmxConfig` type. This PR aligns the `HtmkConfig` with the options listed on [htmx.org](https://htmx.org/reference/#config).

Corresponding issue:

## Testing

None

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
