### PR TITLE
Fix ready state for htmx:load listeners bound on DOMContentLoaded

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3752,15 +3752,22 @@ return (function () {
         //====================================================================
         // Initialization
         //====================================================================
+        var isReady = false
         /**
          * We want to initialize the page elements after DOMContentLoaded
          * fires, but there isn't always a good way to tell whether
          * it has already fired when we get here or not.
          */
         function ready(functionToCall) {
+            if (isReady) {
+                functionToCall()
+                return
+            }
+
             // call the function exactly once no matter how many times this is called
             var callReadyFunction = function() {
                 if (!functionToCall) return;
+                isReady = true
                 functionToCall();
                 functionToCall = null;
             };


### PR DESCRIPTION
## Description
So we introduced [a commit](https://github.com/bigskysoftware/htmx/commit/78a9ecf17079fcdfa3d674700d8338b60f14a058) recently to fix the ready state detection when loading htmx as an async script.
Seems we missed it at that time but we actually introduced a regression for that specific behaviour:
- htmx.js is included, binds itself to `DOMContentLoaded` via its internal `ready` function
- Client's custom script binds to `DOMContentLoaded` to wait for htmx to be initialized
- `DOMContentLoaded` fires, htmx initializes itselfs thanks to its initial `ready` listener that has been called back, queues a setTimeout that will fire `htmx:load`
- Client's custom script binds to `htmx:load` event using `htmx.onLoad`, which itself calls `htmx.on`
- Since `htmx.on` internally also [calls that `ready` function](https://github.com/bigskysoftware/htmx/blob/master/src/htmx.js#L674), it now goes through that new logic we introduced in the commit mentioned above. This is where lies the problem:
  - is the document state `complete`? Not yet. So the callback won't be called right away
  - So `ready` queues the callback for both `DOMContentLoaded` and `readystatechange`.
    - `DOMContentLoaded` has already been fired at this point, so `readystatechange` would catch it, but not now since the page has to reach the `complete` state first (when all assets are downloaded)
    - Meanwhile, the `setTimeout` that had been queued is executed, and `htmx:load` is fired on the body
    - When the document reaches the `complete` state, the `htmx.on` listener is called back, thus the client's custom script that binds a listener function to `htmx:load`. However, `htmx:load` has already been fired at this point, and this listener won't be called since it missed that initial `htmx:load` event.

Hope the description of the problem is clear, let me know!

As for the fix, this PR introduces _again_ (that boolean variable is a mechanism we had prior to the commit mentioned above) a boolean variable, that is set to true the first time a `ready` callback is called. When a `ready` listener is called, we know that no matter what the state of the document is, htmx is now initialized and can bind events right away. Because this variable would be set to true in the steps described above, the client's `hx.onLoad` call wouldn't be bound to the document events but called right away instead. Thus, its load listener would be called when htmx fires `htmx:load`

Corresponding issue: #2033

## Testing
First, to reproduce the issue:
- See [this JSFiddle](https://jsfiddle.net/53prdnma/) with htmx 1.9.8, that works as expected _(I just copied the code provided in the discussion linked above)_
- See [this JSFiddle](https://jsfiddle.net/de019nc5/) with htmx 1.9.9 for which the htmx load listener is never called
- See [this JSFiddle](https://jsfiddle.net/qv9tgh7k/) with this PR's fix in it, where it works as it used to in 1.9.8

I don't know how to write a test in the test suite for it, since it really relies on this timing between `DOMContentLoaded` and `load` events with the initial `htmx:load` event, and the test suite only runs on `DOMContentLoaded`, by the time this test runs, the `complete` state would very likely already been reached

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
