### PR TITLE
fix src/htmx.js(3842,25): error TS2769: No overload matches this call.

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3827,7 +3827,9 @@ return (function () {
                     internalData.xhr.abort();
                 }
             });
-            var originalPopstate = window.onpopstate;
+            /** @type {(ev: PopStateEvent) => any} */
+            const originalPopstate = window.onpopstate ? window.onpopstate.bind(window) : null;
+            /** @type {(ev: PopStateEvent) => any} */
             window.onpopstate = function (event) {
                 if (event.state && event.state.htmx) {
                     restoreHistory();


### PR DESCRIPTION
## Description

This fixes one of the typescript issues that I see when I run `test-types` command

```
src/htmx.js(3842,25): error TS2769: No overload matches this call.
  Overload 1 of 2, '(this: WindowEventHandlers, ev: PopStateEvent): any', gave the following error.
    The 'this' context of type 'void' is not assignable to method's 'this' of type 'WindowEventHandlers'.
  Overload 2 of 2, '(this: Window, ev: PopStateEvent): any', gave the following error.
    The 'this' context of type 'void' is not assignable to method's 'this' of type 'Window'.
```
 
<img width="854" alt="image" src="https://github.com/bigskysoftware/htmx/assets/7026/10271db5-193f-4073-88e1-911e23d44560">


Corresponding issue:

I couldn't find it

## Testing

I was running `test-types` before and after this change I saw that issue is not there anymore

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
  - this PR has very strong `Refactors that do not make functional changes will be automatically closed, unless explicitly solicited. Imagine someone came into your house unannounced, rearranged a bunch of furniture, and left.` vibe, I'm doing this just to gauge if I can help with type improvements in this repo :)
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded