### PR TITLE
Improve performance of lib during initialization phase

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1894,7 +1894,7 @@ return (function () {
             });
         }
 
-        function hasChanceOfBeingBoosted() {
+        function getBoostedWrappers() {
             return document.querySelector("[hx-boost], [data-hx-boost]");
         }
 
@@ -1934,10 +1934,17 @@ return (function () {
 
         function findElementsToProcess(elt) {
             if (elt.querySelectorAll) {
-                var boostedElts = hasChanceOfBeingBoosted() ? ", a" : "";
-                var results = elt.querySelectorAll(VERB_SELECTOR + boostedElts + ", form, [type='submit'], [hx-sse], [data-hx-sse], [hx-ws]," +
+                var boostedWrappers = getBoostedWrappers();
+                var boostedElts = [];
+                boostedWrappers.forEach(boostWrapper => {
+                    boostedElts.push(...boostWrapper.querySelectorAll('a'))
+                });
+                var results = elt.querySelectorAll(VERB_SELECTOR + ", form, [type='submit'], [hx-sse], [data-hx-sse], [hx-ws]," +
                     " [data-hx-ws], [hx-ext], [data-hx-ext], [hx-trigger], [data-hx-trigger], [hx-on], [data-hx-on]");
-                return results;
+                return [
+                    ...results,
+                    ...boostedElts,
+                ];
             } else {
                 return [];
             }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1894,10 +1894,6 @@ return (function () {
             });
         }
 
-        function getBoostedWrappers() {
-            return document.querySelector("[hx-boost], [data-hx-boost]");
-        }
-
         function shouldProcessHxOn(elt) {
             var attributes = elt.attributes
             for (var j = 0; j < attributes.length; j++) {
@@ -1934,10 +1930,10 @@ return (function () {
 
         function findElementsToProcess(elt) {
             if (elt.querySelectorAll) {
-                var boostedElts = document.querySelectorAll("[hx-boost] a, [data-hx-boost] a, a[hx-boost], a[data-hx-boost]");
-                var results = elt.querySelectorAll(VERB_SELECTOR + ", form, [type='submit'], [hx-sse], [data-hx-sse], [hx-ws]," +
+                var boostedSelector = ", [hx-boost] a, [data-hx-boost] a, a[hx-boost], a[data-hx-boost]";
+                var results = elt.querySelectorAll(VERB_SELECTOR + boostedSelector + ", form, [type='submit'], [hx-sse], [data-hx-sse], [hx-ws]," +
                     " [data-hx-ws], [hx-ext], [data-hx-ext], [hx-trigger], [data-hx-trigger], [hx-on], [data-hx-on]");
-                return toArray(results).concat(toArray(boostedElts));
+                return results;
             } else {
                 return [];
             }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1934,13 +1934,10 @@ return (function () {
 
         function findElementsToProcess(elt) {
             if (elt.querySelectorAll) {
-                var boostedElts = document.querySelectorAll("[hx-boost] a, [data-hx-boost] a");
+                var boostedElts = document.querySelectorAll("[hx-boost] a, [data-hx-boost] a, [hx-boost]a, [data-hx-boost]a");
                 var results = elt.querySelectorAll(VERB_SELECTOR + ", form, [type='submit'], [hx-sse], [data-hx-sse], [hx-ws]," +
                     " [data-hx-ws], [hx-ext], [data-hx-ext], [hx-trigger], [data-hx-trigger], [hx-on], [data-hx-on]");
-                return [
-                    ...results,
-                    ...boostedElts,
-                ];
+                return toArray(results).concat(toArray(boostedElts));
             } else {
                 return [];
             }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1934,7 +1934,7 @@ return (function () {
 
         function findElementsToProcess(elt) {
             if (elt.querySelectorAll) {
-                var boostedElts = document.querySelectorAll("[hx-boost] a, [data-hx-boost] a, [hx-boost]a, [data-hx-boost]a");
+                var boostedElts = document.querySelectorAll("[hx-boost] a, [data-hx-boost] a, a[hx-boost], a[data-hx-boost]");
                 var results = elt.querySelectorAll(VERB_SELECTOR + ", form, [type='submit'], [hx-sse], [data-hx-sse], [hx-ws]," +
                     " [data-hx-ws], [hx-ext], [data-hx-ext], [hx-trigger], [data-hx-trigger], [hx-on], [data-hx-on]");
                 return toArray(results).concat(toArray(boostedElts));

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1934,11 +1934,7 @@ return (function () {
 
         function findElementsToProcess(elt) {
             if (elt.querySelectorAll) {
-                var boostedWrappers = getBoostedWrappers();
-                var boostedElts = [];
-                boostedWrappers.forEach(boostWrapper => {
-                    boostedElts.push(...boostWrapper.querySelectorAll('a'))
-                });
+                var boostedElts = document.querySelectorAll("[hx-boost] a, [data-hx-boost] a");
                 var results = elt.querySelectorAll(VERB_SELECTOR + ", form, [type='submit'], [hx-sse], [data-hx-sse], [hx-ws]," +
                     " [data-hx-ws], [hx-ext], [data-hx-ext], [hx-trigger], [data-hx-trigger], [hx-on], [data-hx-on]");
                 return [


### PR DESCRIPTION
## Description
If I have following page:
```
<div hx-boost="true">
    <a href="https://htmx.org/">asdasdasd</a>
</div>
<a href="https://www.google.com/">test</a>
... thousand of same link
<a href="https://www.google.com/">test</a> 
```
htmx on load will init all of the links on the page. However, it's necessary to init htmx only on one link inside hx-boost wrapper. This can result in poor performance on pages with lot of "plain" links.

Performance on page with 1K links (6 x slowdown):
Before:
![image](https://github.com/bigskysoftware/htmx/assets/10236315/adb9bc83-8455-4e6b-9463-f8e921782b2c)

After:
![image](https://github.com/bigskysoftware/htmx/assets/10236315/58596d5c-37f3-4e46-bb21-502a9548a14b)

## Testing
I have test the performance and simple boosted link.

## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue - **I hope that it's bugfix**
* [X] I ran the test suite locally (`npm run test`) and verified that it succeeded
