### PR TITLE
fix incorrect config types

### DIFF
--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -407,9 +407,9 @@ export interface HtmxConfig {
     inlineScriptNonce?: string;
     /**
      * The type of binary data being received over the WebSocket connection
-     * @default blob
+     * @default 'blob'
      */
-    wsBinaryType?: Blob; 
+    wsBinaryType?: 'blob' | 'arraybuffer'; 
     /**
      * If set to true htmx will include a cache-busting parameter in GET requests to avoid caching partial responses by the browser
      * @default false 
@@ -424,7 +424,7 @@ export interface HtmxConfig {
      * htmx will format requests with these methods by encoding their parameters in the URL, not the request body
      * @default ["get"] 
      */
-    methodsThatUseUrlParams?: string[];
+    methodsThatUseUrlParams?: ('get' | 'head' | 'post' | 'put' | 'delete' | 'connect' | 'options' | 'trace' | 'patch' )[];
     /**
      * If set to true htmx will not update the title of the document when a title tag is found in new content
      * @default false 


### PR DESCRIPTION
## Description
This fixes the incorrect type definitions for `wsBinaryType` introduced in [#2026](https://github.com/bigskysoftware/htmx/pull/2026).

It also improves the strictness of the `methodsThatUseUrlParams` option to be a list of only valid HTTP Methods (as lowercase). 


Corresponding issue:
[#2026](https://github.com/bigskysoftware/htmx/pull/2026).

## Testing
N/A

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
