### PR TITLE
Fix form validation docs example

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -991,12 +991,15 @@ Here is an example of an input that uses the `htmx:validation:validate` event to
 `foo`, using hyperscript:
 
 ```html
-<form hx-post="/test">
+<form id="foo-form" hx-post="/test">
     <input _="on htmx:validation:validate
                 if my.value != 'foo'
                     call me.setCustomValidity('Please enter the value foo')
-                else
-                    call me.setCustomValidity('')"
+                    call #foo-form.reportValidity()
+                end
+                
+                on keyup
+                call me.setCustomValidity('')"
         name="example"
     >
 </form>


### PR DESCRIPTION
## Description
The [form example](https://htmx.org/docs/#validation-example) provided in the docs had 2 issues.
1. The custom validation message would not show on first submit because `reportValidity` wasn't called. Forcing the user to press a `submit` button 2x before seeing the message.
2. You couldn't submit the form after fixing the input because `setCustomValidity` was locked to the first error message. It needed to be cleared on `keyup`.

Corresponding issue:

## Testing
Tested on chrome and brave with a form / submit button on the form.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [] I ran the test suite locally (`npm run test`) and verified that it succeeded
