### PR TITLE
Use faster `regexp.test` over `string.match` for testing against regex

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -274,7 +274,7 @@ return (function () {
         }
 
         function aFullPageResponse(resp) {
-            return resp.match(/<body/);
+            return /<body/.test(resp)
         }
 
         /**
@@ -448,7 +448,7 @@ return (function () {
                     path = url.pathname + url.search;
                 }
                 // remove trailing slash, unless index page
-                if (!path.match('^/$')) {
+                if (!(/^\/$/.test(path))) {
                     path = path.replace(/\/+$/, '');
                 }
                 return path;
@@ -1226,7 +1226,7 @@ return (function () {
 
         function consumeUntil(tokens, match) {
             var result = "";
-            while (tokens.length > 0 && !tokens[0].match(match)) {
+            while (tokens.length > 0 && !match.test(tokens[0])) {
                 result += tokens.shift();
             }
             return result;
@@ -2871,7 +2871,7 @@ return (function () {
         }
 
         function hasHeader(xhr, regexp) {
-            return xhr.getAllResponseHeaders().match(regexp);
+            return regexp.test(xhr.getAllResponseHeaders())
         }
 
         function ajaxHelper(verb, path, context) {


### PR DESCRIPTION
## Description
As was mentioned by @xhaggi [in this code review](https://github.com/bigskysoftware/htmx/pull/1913/files/2389b43a399ff62b14ec9c9fa71bab6d46ad5fe9#r1388211677), `regex.test` is faster than `string.match` if the goal is to check if a string matches a regular expression. `string.match` is only necessary if the goal is to extract a substring.

Out of the six places in HTMX where `string.match` is used, four of them can be replaced by `regexp.test`.

Corresponding issue: None, suppose that's not necessary for this small change, but correct me if I'm wrong.

## Testing
I ran the testing suite and everything came out green.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
