### PR TITLE
Fix wildcard hx-on search's root node

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1898,22 +1898,33 @@ return (function () {
             return document.querySelector("[hx-boost], [data-hx-boost]");
         }
 
+        function shouldProcessHxOn(elt) {
+            var attributes = elt.attributes
+            for (var j = 0; j < attributes.length; j++) {
+                var attrName = attributes[j].name
+                if (startsWith(attrName, "hx-on:") || startsWith(attrName, "data-hx-on:")) {
+                    return true
+                }
+            }
+            return false
+        }
+
         function findHxOnWildcardElements(elt) {
             var node = null
             var elements = []
 
+            if (shouldProcessHxOn(elt)) {
+                elements.push(elt)
+            }
+
             if (document.evaluate) {
-                var iter = document.evaluate('//*[@*[ starts-with(name(), "hx-on:") or starts-with(name(), "data-hx-on:") ]]', elt)
+                var iter = document.evaluate('.//*[@*[ starts-with(name(), "hx-on:") or starts-with(name(), "data-hx-on:") ]]', elt)
                 while (node = iter.iterateNext()) elements.push(node)
             } else {
-                var allElements = document.getElementsByTagName("*")
+                var allElements = elt.getElementsByTagName("*")
                 for (var i = 0; i < allElements.length; i++) {
-                    var attributes = allElements[i].attributes
-                    for (var j = 0; j < attributes.length; j++) {
-                        var attrName = attributes[j].name
-                        if (startsWith(attrName, "hx-on:") || startsWith(attrName, "data-hx-on:")) {
-                            elements.push(allElements[i])
-                        }
+                    if (shouldProcessHxOn(allElements[i])) {
+                        elements.push(allElements[i])
                     }
                 }
             }


### PR DESCRIPTION
## Description
As @svenberkvens pointed out in #2019, the XPATH query run to find hx-on wildcard elements to process, as well as its IE11 compatible code counterpart, didn't take the root node parameter into account, resulting in scanning the whole DOM to find such elements.
This was causing a huge performance impact for each individual node processed later on by htmx on a initially large DOM.

This PR fixes this issue by looking for hx-on wildcard elements from the root element parameter, instead of from the document itself.

Corresponding issues: #2019 and #2051

## Testing
Ran a performance test using htmx version before the introduction of that hx-on wildcard attribute (i.e. 1.9.2), one with the current version, and another one with this PR's changes
The test creates 100 000 links in the DOM, then adds a dummy element and calls `htmx.process` on it
- In [this JSFiddle using 1.9.2](https://jsfiddle.net/nxb23ky7/), I get the following:
> Took 7.3 ms to process node
- In [this JSFiddle using 1.9.9](https://jsfiddle.net/Lrz0ek8a/), I get the following:
> Took 591 ms to process node
- In this [this JSFiddle using this PR's changes](https://jsfiddle.net/Lrz0ek8a/1/), I get the following:
> Took 7.9 ms to process node

So it looks like we're back to the initial performance of processing an individual node with a very large DOM around.

Also ran the test suite locally which works, no no regression seems to be introduced by this change

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
