### PR TITLE
#2056 Updated the tracking of changed values to record the value against th…

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1442,6 +1442,10 @@ return (function () {
             return false;
         }
 
+        function uniqueId(length = 16){
+            return parseInt(Math.ceil(Math.random() * Date.now()).toPrecision(length).toString().replace(".", ""));
+        }
+
         function addEventListener(elt, handler, nodeData, triggerSpec, explicitCancel) {
             var elementData = getInternalData(elt);
             var eltsToListenOn;
@@ -1454,7 +1458,18 @@ return (function () {
             if (triggerSpec.changed) {
                 eltsToListenOn.forEach(function (eltToListenOn) {
                     var eltToListenOnData = getInternalData(eltToListenOn);
-                    eltToListenOnData.lastValue = eltToListenOn.value;
+                  
+                    //give each target element a unique ID
+                    if(!eltToListenOnData.id){
+                        eltToListenOnData.id = uniqueId();
+                    }
+
+                    if(!elementData[eltToListenOnData.id]){
+                        elementData[eltToListenOnData.id] = {};
+                    }
+
+                    //save the target elements value against the source element
+                    elementData[eltToListenOnData.id].lastValue = eltToListenOn.value;
                 })
             }
             forEach(eltsToListenOn, function (eltToListenOn) {
@@ -1495,11 +1510,14 @@ return (function () {
                             }
                         }
                         if (triggerSpec.changed) {
-                            var eltToListenOnData = getInternalData(eltToListenOn)
-                            if (eltToListenOnData.lastValue === eltToListenOn.value) {
-                                return;
-                            }
-                            eltToListenOnData.lastValue = eltToListenOn.value
+                           //compare the new target element value against the value the source element last recorded.                        
+                           var eltToListenOnData = getInternalData(eltToListenOn);
+
+                           if (elementData[eltToListenOnData.id].lastValue === eltToListenOn.value) {
+                               return;
+                           }
+
+                           elementData[eltToListenOnData.id].lastValue = eltToListenOn.value;
                         }
                         if (elementData.delayed) {
                             clearTimeout(elementData.delayed);


### PR DESCRIPTION
## Description

Updated the tracking of changed values to record the value against the source element instead of the target element.
This allows multiple source elements to listen to a single target for a change.

Corresponding issue:

#2056 

## Testing

*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

I tested this against the example in the issue. With the fix both triggers were fired, not just the one.

I also performed a couple of tests against other HTMX components I had written to check I hadn't broken anything else. This wasn't extensive testing.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
