### PR TITLE
Add hyperlink to HTML standards for data- prefix

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -96,7 +96,7 @@ within the [original web programming model](https://www.ics.uci.edu/~fielding/pu
 using [Hypertext As The Engine Of Application State](https://en.wikipedia.org/wiki/HATEOAS)
 without even needing to really understand that concept.
 
-It's worth mentioning that, if you prefer, you can use the `data-` prefix when using htmx:
+It's worth mentioning that, if you prefer, you can use the [`data-`](https://html.spec.whatwg.org/multipage/dom.html#attr-data-*) prefix when using htmx:
 
 ```html
 <a data-hx-post="/click">Click Me!</a>


### PR DESCRIPTION
Fixes #2071

## Description
Adds hyperlink to WHATWG HTML standards for our mention of `data-` prefix to help explain more.

Corresponding issue:
Fixes #2071

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
