### PR TITLE
fix typo

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -829,7 +829,7 @@ server and the browser than websockets.
 If you want an element to respond to a Server Sent Event via htmx, you need to do two things:
 
 1. Define an SSE source.  To do this, add a [hx-sse](@/attributes/hx-sse.md) attribute on a parent element with
-a `connect <url>` declaration that specifies the URL from which Server Sent Events will be received.
+a `connect:<url>` declaration that specifies the URL from which Server Sent Events will be received.
 
 2. Define elements that are descendents of this element that are triggered by server sent events using the
 `hx-trigger="sse:<event_name>"` syntax


### PR DESCRIPTION
connect:<url> instead of connect <url>

## Description
https://htmx.org/docs/#websockets-and-sse
says use `connect <url>` (with a space) when example below that use `connect:<url>` (with a colon)

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
