### PR TITLE
Prevent references to nodes swapped out of the dom accumulating as detached elements in memory

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -972,6 +972,9 @@ return (function () {
             if (element.children) { // IE
                 forEach(element.children, function(child) { cleanUpElement(child) });
             }
+            if (element.hasOwnProperty('htmx-internal-data')) {
+                delete element['htmx-internal-data'];
+            }
         }
 
         function swapOuterHTML(target, fragment, settleInfo) {
@@ -987,7 +990,6 @@ return (function () {
                 } else {
                     newElt = eltBeforeNewContent.nextSibling;
                 }
-                getInternalData(target).replacedWith = newElt; // tuck away so we can fire events on it later
                 settleInfo.elts = settleInfo.elts.filter(function(e) { return e != target });
                 while(newElt && newElt !== target) {
                     if (newElt.nodeType === Node.ELEMENT_NODE) {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -960,10 +960,8 @@ return (function () {
                     }
                 });
             }
-            if (internalData.initHash) {
-                internalData.initHash = null
-            }
             deInitOnHandlers(element);
+            forEach(Object.keys(internalData), function(key) { delete internalData[key] });
         }
 
         function cleanUpElement(element) {
@@ -971,9 +969,6 @@ return (function () {
             deInitNode(element);
             if (element.children) { // IE
                 forEach(element.children, function(child) { cleanUpElement(child) });
-            }
-            if (element.hasOwnProperty('htmx-internal-data')) {
-                delete element['htmx-internal-data'];
             }
         }
 


### PR DESCRIPTION
## Description
I noticed that detached nodes accumulated in a project after multiple swaps. Memory heap snapshots contained detached elements with references to `htmx-internal-data` and a `replacedWith` property caused by this line:

Ref:
https://github.com/bigskysoftware/htmx/blob/206912b71d355477377aade60d06ea013c8e5455/src/htmx.js#L990

Important notes: 
* I do not understand the purpose of the `replacedWith`  property, there are no other references to it in the source code.
* I am also deleting the element's `htmx-internal-data` in `cleanUpElement()` because some elements would retain content in this structure (with references to elements no longer in the dom) _despite_ the preceding cleanup - I did not investigate why, or determine if there is ever a reason to retain data in `htmx-internal-data` when an element is "cleaned up".

## Testing
Observed manually using Chrome's developer tools to take heap snapshots while performing a sequence of typical user tasks on a complex htmx application. And checked with Microsoft Edge which has a useful 'Detached Elements' feature. These changes prevented detached nodes accumulating.

Passes htmx automated tests.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
