### PR TITLE
Trigger specs cache indentation fix + documentation & tests

### DIFF
--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -430,6 +430,12 @@ export interface HtmxConfig {
      * @default false 
      */
     ignoreTitle:? boolean;
+    /**
+     * The cache to store evaluated trigger specifications into.
+     * You may define a simple object to use a never-clearing cache, or implement your own system using a [proxy object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy)
+     * @default null
+     */
+    triggerSpecsCache?: {[trigger: string]: HtmxTriggerSpecification[]};
 }
 
 /**

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1259,89 +1259,89 @@ return (function () {
          */
         function parseAndCacheTrigger(elt, explicitTrigger, cache) {
             var triggerSpecs = [];
-                var tokens = tokenizeString(explicitTrigger);
-                do {
-                    consumeUntil(tokens, NOT_WHITESPACE);
-                    var initialLength = tokens.length;
-                    var trigger = consumeUntil(tokens, /[,\[\s]/);
-                    if (trigger !== "") {
-                        if (trigger === "every") {
-                            var every = {trigger: 'every'};
-                            consumeUntil(tokens, NOT_WHITESPACE);
-                            every.pollInterval = parseInterval(consumeUntil(tokens, /[,\[\s]/));
-                            consumeUntil(tokens, NOT_WHITESPACE);
-                            var eventFilter = maybeGenerateConditional(elt, tokens, "event");
-                            if (eventFilter) {
-                                every.eventFilter = eventFilter;
-                            }
-                            triggerSpecs.push(every);
-                        } else if (trigger.indexOf("sse:") === 0) {
-                            triggerSpecs.push({trigger: 'sse', sseEvent: trigger.substr(4)});
-                        } else {
-                            var triggerSpec = {trigger: trigger};
-                            var eventFilter = maybeGenerateConditional(elt, tokens, "event");
-                            if (eventFilter) {
-                                triggerSpec.eventFilter = eventFilter;
-                            }
-                            while (tokens.length > 0 && tokens[0] !== ",") {
-                                consumeUntil(tokens, NOT_WHITESPACE)
-                                var token = tokens.shift();
-                                if (token === "changed") {
-                                    triggerSpec.changed = true;
-                                } else if (token === "once") {
-                                    triggerSpec.once = true;
-                                } else if (token === "consume") {
-                                    triggerSpec.consume = true;
-                                } else if (token === "delay" && tokens[0] === ":") {
-                                    tokens.shift();
-                                    triggerSpec.delay = parseInterval(consumeUntil(tokens, WHITESPACE_OR_COMMA));
-                                } else if (token === "from" && tokens[0] === ":") {
-                                    tokens.shift();
-                                    if (COMBINED_SELECTOR_START.test(tokens[0])) {
-                                        var from_arg = consumeCSSSelector(tokens);
-                                    } else {
-                                        var from_arg = consumeUntil(tokens, WHITESPACE_OR_COMMA);
-                                        if (from_arg === "closest" || from_arg === "find" || from_arg === "next" || from_arg === "previous") {
-                                            tokens.shift();
-                                            var selector = consumeCSSSelector(tokens);
-                                            // `next` and `previous` allow a selector-less syntax
-                                            if (selector.length > 0) {
-                                                from_arg += " " + selector;
-                                            }
+            var tokens = tokenizeString(explicitTrigger);
+            do {
+                consumeUntil(tokens, NOT_WHITESPACE);
+                var initialLength = tokens.length;
+                var trigger = consumeUntil(tokens, /[,\[\s]/);
+                if (trigger !== "") {
+                    if (trigger === "every") {
+                        var every = {trigger: 'every'};
+                        consumeUntil(tokens, NOT_WHITESPACE);
+                        every.pollInterval = parseInterval(consumeUntil(tokens, /[,\[\s]/));
+                        consumeUntil(tokens, NOT_WHITESPACE);
+                        var eventFilter = maybeGenerateConditional(elt, tokens, "event");
+                        if (eventFilter) {
+                            every.eventFilter = eventFilter;
+                        }
+                        triggerSpecs.push(every);
+                    } else if (trigger.indexOf("sse:") === 0) {
+                        triggerSpecs.push({trigger: 'sse', sseEvent: trigger.substr(4)});
+                    } else {
+                        var triggerSpec = {trigger: trigger};
+                        var eventFilter = maybeGenerateConditional(elt, tokens, "event");
+                        if (eventFilter) {
+                            triggerSpec.eventFilter = eventFilter;
+                        }
+                        while (tokens.length > 0 && tokens[0] !== ",") {
+                            consumeUntil(tokens, NOT_WHITESPACE)
+                            var token = tokens.shift();
+                            if (token === "changed") {
+                                triggerSpec.changed = true;
+                            } else if (token === "once") {
+                                triggerSpec.once = true;
+                            } else if (token === "consume") {
+                                triggerSpec.consume = true;
+                            } else if (token === "delay" && tokens[0] === ":") {
+                                tokens.shift();
+                                triggerSpec.delay = parseInterval(consumeUntil(tokens, WHITESPACE_OR_COMMA));
+                            } else if (token === "from" && tokens[0] === ":") {
+                                tokens.shift();
+                                if (COMBINED_SELECTOR_START.test(tokens[0])) {
+                                    var from_arg = consumeCSSSelector(tokens);
+                                } else {
+                                    var from_arg = consumeUntil(tokens, WHITESPACE_OR_COMMA);
+                                    if (from_arg === "closest" || from_arg === "find" || from_arg === "next" || from_arg === "previous") {
+                                        tokens.shift();
+                                        var selector = consumeCSSSelector(tokens);
+                                        // `next` and `previous` allow a selector-less syntax
+                                        if (selector.length > 0) {
+                                            from_arg += " " + selector;
                                         }
                                     }
-                                    triggerSpec.from = from_arg;
-                                } else if (token === "target" && tokens[0] === ":") {
-                                    tokens.shift();
-                                    triggerSpec.target = consumeCSSSelector(tokens);
-                                } else if (token === "throttle" && tokens[0] === ":") {
-                                    tokens.shift();
-                                    triggerSpec.throttle = parseInterval(consumeUntil(tokens, WHITESPACE_OR_COMMA));
-                                } else if (token === "queue" && tokens[0] === ":") {
-                                    tokens.shift();
-                                    triggerSpec.queue = consumeUntil(tokens, WHITESPACE_OR_COMMA);
-                                } else if (token === "root" && tokens[0] === ":") {
-                                    tokens.shift();
-                                    triggerSpec[token] = consumeCSSSelector(tokens);
-                                } else if (token === "threshold" && tokens[0] === ":") {
-                                    tokens.shift();
-                                    triggerSpec[token] = consumeUntil(tokens, WHITESPACE_OR_COMMA);
-                                } else {
-                                    triggerErrorEvent(elt, "htmx:syntax:error", {token:tokens.shift()});
                                 }
+                                triggerSpec.from = from_arg;
+                            } else if (token === "target" && tokens[0] === ":") {
+                                tokens.shift();
+                                triggerSpec.target = consumeCSSSelector(tokens);
+                            } else if (token === "throttle" && tokens[0] === ":") {
+                                tokens.shift();
+                                triggerSpec.throttle = parseInterval(consumeUntil(tokens, WHITESPACE_OR_COMMA));
+                            } else if (token === "queue" && tokens[0] === ":") {
+                                tokens.shift();
+                                triggerSpec.queue = consumeUntil(tokens, WHITESPACE_OR_COMMA);
+                            } else if (token === "root" && tokens[0] === ":") {
+                                tokens.shift();
+                                triggerSpec[token] = consumeCSSSelector(tokens);
+                            } else if (token === "threshold" && tokens[0] === ":") {
+                                tokens.shift();
+                                triggerSpec[token] = consumeUntil(tokens, WHITESPACE_OR_COMMA);
+                            } else {
+                                triggerErrorEvent(elt, "htmx:syntax:error", {token:tokens.shift()});
                             }
-                            triggerSpecs.push(triggerSpec);
                         }
+                        triggerSpecs.push(triggerSpec);
                     }
-                    if (tokens.length === initialLength) {
-                        triggerErrorEvent(elt, "htmx:syntax:error", {token:tokens.shift()});
-                    }
-                    consumeUntil(tokens, NOT_WHITESPACE);
-                } while (tokens[0] === "," && tokens.shift())
-                if (cache) {
-                    cache[explicitTrigger] = triggerSpecs
                 }
-                return triggerSpecs
+                if (tokens.length === initialLength) {
+                    triggerErrorEvent(elt, "htmx:syntax:error", {token:tokens.shift()});
+                }
+                consumeUntil(tokens, NOT_WHITESPACE);
+            } while (tokens[0] === "," && tokens.shift())
+            if (cache) {
+                cache[explicitTrigger] = triggerSpecs
+            }
+            return triggerSpecs
         }
 
         /**

--- a/test/attributes/hx-trigger.js
+++ b/test/attributes/hx-trigger.js
@@ -954,5 +954,56 @@ describe("hx-trigger attribute", function(){
         make('<div hx-trigger="intersect root:{form input}" hx-get="/test">Not Called</div>');
     });
 
+    it("uses trigger specs cache if defined", function () {
+        var initialCacheConfig = htmx.config.triggerSpecsCache
+        htmx.config.triggerSpecsCache = {}
 
+        var specExamples = {
+            "every 1s": [{trigger: 'every', pollInterval: 1000}],
+            "click": [{trigger: 'click'}],
+            "customEvent": [{trigger: 'customEvent'}],
+            "event changed": [{trigger: 'event', changed: true}],
+            "event once": [{trigger: 'event', once: true}],
+            "event delay:1s": [{trigger: 'event', delay: 1000}],
+            "event throttle:1s": [{trigger: 'event', throttle: 1000}],
+            "event delay:1s, foo": [{trigger: 'event', delay: 1000}, {trigger: 'foo'}],
+            "event throttle:1s, foo": [{trigger: 'event', throttle: 1000}, {trigger: 'foo'}],
+            "event changed once delay:1s": [{trigger: 'event', changed: true, once: true, delay: 1000}],
+            "event1,event2": [{trigger: 'event1'}, {trigger: 'event2'}],
+            "event1, event2": [{trigger: 'event1'}, {trigger: 'event2'}],
+            "event1 once, event2 changed": [{trigger: 'event1', once: true}, {trigger: 'event2', changed: true}],
+        }
+
+        for (var specString in specExamples) {
+            var div = make("<div hx-trigger='" + specString + "'></div>");
+            var spec = htmx._('getTriggerSpecs')(div);
+            spec.should.deep.equal(specExamples[specString], "Found : " + JSON.stringify(spec) + ", expected : " + JSON.stringify(specExamples[specString]) + " for spec: " + specString);
+        }
+
+        Object.keys(htmx.config.triggerSpecsCache).length.should.greaterThan(0)
+        Object.keys(htmx.config.triggerSpecsCache).length.should.equal(Object.keys(specExamples).length)
+
+        htmx.config.triggerSpecsCache = initialCacheConfig
+    })
+
+    it("correctly reuses trigger specs from the cache if defined", function () {
+        var initialCacheConfig = htmx.config.triggerSpecsCache
+        htmx.config.triggerSpecsCache = {}
+
+        var triggerStr = "event changed once delay:1s"
+        var expectedSpec = [{trigger: 'event', changed: true, once: true, delay: 1000}]
+
+        var div = make("<div hx-trigger='event changed once delay:1s'></div>");
+        var spec = htmx._('getTriggerSpecs')(div);
+        spec.should.deep.equal(expectedSpec, "Found : " + JSON.stringify(spec) + ", expected : " + JSON.stringify(expectedSpec) + " for spec: " + triggerStr);
+        spec.push("This should be carried to further identical specs thanks to the cache")
+
+        var div2 = make("<div hx-trigger='event changed once delay:1s'></div>");
+        var spec2 = htmx._('getTriggerSpecs')(div2);
+        spec2.should.deep.equal(spec, "Found : " + JSON.stringify(spec) + ", expected : " + JSON.stringify(spec2) + " for cached spec: " + triggerStr);
+
+        Object.keys(htmx.config.triggerSpecsCache).length.should.equal(1)
+
+        htmx.config.triggerSpecsCache = initialCacheConfig
+    })
 })

--- a/www/content/api.md
+++ b/www/content/api.md
@@ -134,6 +134,7 @@ Note that using a [meta tag](@/docs.md#config) is the preferred mechanism for se
 * `selfRequestsOnly:false` - boolean: if set to `true` will only allow AJAX requests to the same domain as the current document
 * `ignoreTitle:false` - boolean: if set to `true` htmx will not update the title of the document when a `title` tag is found in new content
 * `scrollIntoViewOnBoost:true` - boolean: whether or not the target of a boosted element is scrolled into the viewport. If `hx-target` is omitted on a boosted element, the target defaults to `body`, causing the page to scroll to the top.
+* `triggerSpecsCache:null` - object: the cache to store evaluated trigger specifications into, improving parsing performance at the cost of more memory usage. You may define a simple object to use a never-clearing cache, or implement your own system using a [proxy object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy) |
 
 ##### Example
 

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -1655,6 +1655,7 @@ listed below:
 | `htmx.config.methodsThatUseUrlParams` | defaults to `["get"]`, htmx will format requests with this method by encoding their parameters in the URL, not the request body                                            |
 | `htmx.config.selfRequestsOnly`        | defaults to `false`, if set to `true` will only allow AJAX requests to the same domain as the current document                                                             |
 | `htmx.config.ignoreTitle`             | defaults to `false`, if set to `true` htmx will not update the title of the document when a `title` tag is found in new content                                            |
+| `htmx.config.triggerSpecsCache`       | defaults to `null`, the cache to store evaluated trigger specifications into, improving parsing performance at the cost of more memory usage. You may define a simple object to use a never-clearing cache, or implement your own system using a [proxy object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy) |
 
 </div>
 

--- a/www/content/reference.md
+++ b/www/content/reference.md
@@ -248,6 +248,7 @@ listed below:
 | `htmx.config.selfRequestsOnly`        | defaults to `false`, if set to `true` will only allow AJAX requests to the same domain as the current document                                                             |
 | `htmx.config.ignoreTitle`             | defaults to `false`, if set to `true` htmx will not update the title of the document when a `title` tag is found in new content                                            |
 | `htmx.config.scrollIntoViewOnBoost`   | defaults to `true`, whether or not the target of a boosted element is scrolled into the viewport. If `hx-target` is omitted on a boosted element, the target defaults to `body`, causing the page to scroll to the top. |
+| `htmx.config.triggerSpecsCache`       | defaults to `null`, the cache to store evaluated trigger specifications into, improving parsing performance at the cost of more memory usage. You may define a simple object to use a never-clearing cache, or implement your own system using a [proxy object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy) |
 
 </div>
 


### PR DESCRIPTION
## Description
Following up on #1540

1) Indentation fix, as @1cg had suggested in the linked PR,
> is it possible to eliminate the whitespace changes here to make the actual change clearer and then submit a whitespace fix in a separate PR?
2) Added documentation & tests that I had omitted in the other PR

## Testing
Added 2 tests
- One that evaluates the same trigger strings as the `parses spec strings` test, but enables the cache, and make sure the cache was indeed used, expecting it to hold the same keys count as the evaluated example specs list
- A second one that makes sure the cached specs are actually reused. It adds a dummy value to the evaluated specs, then evaluates trigger specs for a new element with the same trigger string, and makes sure the returned object is the same as the first one (i.e. was correctly cached and reused)

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
