### PR TITLE
fix conflicting function names in sse.js

### DIFF
--- a/src/ext/sse.js
+++ b/src/ext/sse.js
@@ -187,7 +187,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 	}
 
 	/**
-	 * createEventSourceOnElement creates a new EventSource connection on the provided element.
+	 * ensureEventSourceOnElement creates a new EventSource connection on the provided element.
 	 * If a usable EventSource already exists, then it is returned.  If not, then a new EventSource
 	 * is created and stored in the element's internalData.
 	 * @param {HTMLElement} elt

--- a/src/ext/sse.js
+++ b/src/ext/sse.js
@@ -50,7 +50,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 
 				// Try to create EventSources when elements are processed
 				case "htmx:afterProcessNode":
-					createEventSourceOnElement(evt.target);
+					ensureEventSourceOnElement(evt.target);
 					registerSSE(evt.target);
 			}
 		}

--- a/src/ext/sse.js
+++ b/src/ext/sse.js
@@ -14,8 +14,8 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 
 		/**
 		 * Init saves the provided reference to the internal HTMX API.
-		 * 
-		 * @param {import("../htmx").HtmxInternalApi} api 
+		 *
+		 * @param {import("../htmx").HtmxInternalApi} api
 		 * @returns void
 		 */
 		init: function(apiRef) {
@@ -30,9 +30,9 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 
 		/**
 		 * onEvent handles all events passed to this extension.
-		 * 
-		 * @param {string} name 
-		 * @param {Event} evt 
+		 *
+		 * @param {string} name
+		 * @param {Event} evt
 		 * @returns void
 		 */
 		onEvent: function(name, evt) {
@@ -50,7 +50,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 
 				// Try to create EventSources when elements are processed
 				case "htmx:afterProcessNode":
-					createEventSourceOnElement(evt.target);
+					ensureEventSourceOnElement(evt.target);
 					registerSSE(evt.target);
 			}
 		}
@@ -64,8 +64,8 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 	/**
 	 * createEventSource is the default method for creating new EventSource objects.
 	 * it is hoisted into htmx.config.createEventSource to be overridden by the user, if needed.
-	 * 
-	 * @param {string} url 
+	 *
+	 * @param {string} url
 	 * @returns EventSource
 	 */
 	function createEventSource(url) {
@@ -105,7 +105,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 	}
 
 	/**
-	 * registerSSE looks for attributes that can contain sse events, right 
+	 * registerSSE looks for attributes that can contain sse events, right
 	 * now hx-trigger and sse-swap and adds listeners based on these attributes too
 	 * the closest event source
 	 *
@@ -170,7 +170,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 			if (sseEventName.slice(0, 4) != "sse:") {
 				return;
 			}
-			
+
 			// remove the sse: prefix from here on out
 			sseEventName = sseEventName.substr(4);
 
@@ -194,7 +194,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 	 * @param {number} retryCount
 	 * @returns {EventSource | null}
 	 */
-	function createEventSourceOnElement(elt, retryCount) {
+	function ensureEventSourceOnElement(elt, retryCount) {
 
 		if (elt == null) {
 			return null;
@@ -207,7 +207,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 				return;
 			}
 
-			createEventSource(child, sseURL, retryCount);
+			ensureEventSource(child, sseURL, retryCount);
 		});
 
 		// handle legacy sse, remove for HTMX2
@@ -217,12 +217,12 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 				return;
 			}
 
-			createEventSource(child, sseURL, retryCount);
+			ensureEventSource(child, sseURL, retryCount);
 		});
 
 	}
 
-	function createEventSource(elt, url, retryCount) {
+	function ensureEventSource(elt, url, retryCount) {
 		var source = htmx.createEventSource(url);
 
 		source.onerror = function(err) {
@@ -240,7 +240,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 				retryCount = retryCount || 0;
 				var timeout = Math.random() * (2 ^ retryCount) * 500;
 				window.setTimeout(function() {
-					createEventSourceOnElement(elt, Math.min(7, retryCount + 1));
+					ensureEventSourceOnElement(elt, Math.min(7, retryCount + 1));
 				}, timeout);
 			}
 		};
@@ -254,9 +254,9 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 
 	/**
 	 * maybeCloseSSESource confirms that the parent element still exists.
-	 * If not, then any associated SSE source is closed and the function returns true.
-	 * 
-	 * @param {HTMLElement} elt 
+	 *If not, then any associated SSE source is closed and the function returns true.
+	 *
+	 * @param {HTMLElement} elt
 	 * @returns boolean
 	 */
 	function maybeCloseSSESource(elt) {
@@ -272,10 +272,10 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 	}
 
 	/**
-	 * queryAttributeOnThisOrChildren returns all nodes that contain the requested attributeName, INCLUDING THE PROVIDED ROOT ELEMENT.
-	 * 
-	 * @param {HTMLElement} elt 
-	 * @param {string} attributeName 
+	 *queryAttributeOnThisOrChildren returns all nodes that contain the requested attributeName, INCLUDING THE PROVIDED ROOT ELEMENT.
+	 *
+	 * @param {HTMLElement} elt
+	 * @param {string} attributeName
 	 */
 	function queryAttributeOnThisOrChildren(elt, attributeName) {
 
@@ -295,8 +295,8 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 	}
 
 	/**
-	 * @param {HTMLElement} elt
-	 * @param {string} content 
+	 * @param {HTMLElement} el
+	 * @param {string} content
 	 */
 	function swap(elt, content) {
 
@@ -326,10 +326,10 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 	}
 
 	/**
-	 * doSettle mirrors much of the functionality in htmx that 
+	 * doSettle mirrors much of the functionality in htmx that
 	 * settles elements after their content has been swapped.
-	 * TODO: this should be published by htmx, and not duplicated here
-	 * @param {import("../htmx").HtmxSettleInfo} settleInfo 
+	 * TODO: this should be published by htmx, and not duplcated here
+	 * @param {import("../htmx").HtmxSettleInfo} settleInfo
 	 * @returns () => void
 	 */
 	function doSettle(settleInfo) {

--- a/src/ext/sse.js
+++ b/src/ext/sse.js
@@ -14,8 +14,8 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 
 		/**
 		 * Init saves the provided reference to the internal HTMX API.
-		 *
-		 * @param {import("../htmx").HtmxInternalApi} api
+		 * 
+		 * @param {import("../htmx").HtmxInternalApi} api 
 		 * @returns void
 		 */
 		init: function(apiRef) {
@@ -30,9 +30,9 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 
 		/**
 		 * onEvent handles all events passed to this extension.
-		 *
-		 * @param {string} name
-		 * @param {Event} evt
+		 * 
+		 * @param {string} name 
+		 * @param {Event} evt 
 		 * @returns void
 		 */
 		onEvent: function(name, evt) {
@@ -50,7 +50,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 
 				// Try to create EventSources when elements are processed
 				case "htmx:afterProcessNode":
-					ensureEventSourceOnElement(evt.target);
+					createEventSourceOnElement(evt.target);
 					registerSSE(evt.target);
 			}
 		}
@@ -64,8 +64,8 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 	/**
 	 * createEventSource is the default method for creating new EventSource objects.
 	 * it is hoisted into htmx.config.createEventSource to be overridden by the user, if needed.
-	 *
-	 * @param {string} url
+	 * 
+	 * @param {string} url 
 	 * @returns EventSource
 	 */
 	function createEventSource(url) {
@@ -105,7 +105,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 	}
 
 	/**
-	 * registerSSE looks for attributes that can contain sse events, right
+	 * registerSSE looks for attributes that can contain sse events, right 
 	 * now hx-trigger and sse-swap and adds listeners based on these attributes too
 	 * the closest event source
 	 *
@@ -170,7 +170,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 			if (sseEventName.slice(0, 4) != "sse:") {
 				return;
 			}
-
+			
 			// remove the sse: prefix from here on out
 			sseEventName = sseEventName.substr(4);
 
@@ -254,9 +254,9 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 
 	/**
 	 * maybeCloseSSESource confirms that the parent element still exists.
-	 *If not, then any associated SSE source is closed and the function returns true.
-	 *
-	 * @param {HTMLElement} elt
+	 * If not, then any associated SSE source is closed and the function returns true.
+	 * 
+	 * @param {HTMLElement} elt 
 	 * @returns boolean
 	 */
 	function maybeCloseSSESource(elt) {
@@ -272,10 +272,10 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 	}
 
 	/**
-	 *queryAttributeOnThisOrChildren returns all nodes that contain the requested attributeName, INCLUDING THE PROVIDED ROOT ELEMENT.
-	 *
-	 * @param {HTMLElement} elt
-	 * @param {string} attributeName
+	 * queryAttributeOnThisOrChildren returns all nodes that contain the requested attributeName, INCLUDING THE PROVIDED ROOT ELEMENT.
+	 * 
+	 * @param {HTMLElement} elt 
+	 * @param {string} attributeName 
 	 */
 	function queryAttributeOnThisOrChildren(elt, attributeName) {
 
@@ -295,8 +295,8 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 	}
 
 	/**
-	 * @param {HTMLElement} el
-	 * @param {string} content
+	 * @param {HTMLElement} elt
+	 * @param {string} content 
 	 */
 	function swap(elt, content) {
 
@@ -326,10 +326,10 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 	}
 
 	/**
-	 * doSettle mirrors much of the functionality in htmx that
+	 * doSettle mirrors much of the functionality in htmx that 
 	 * settles elements after their content has been swapped.
-	 * TODO: this should be published by htmx, and not duplcated here
-	 * @param {import("../htmx").HtmxSettleInfo} settleInfo
+	 * TODO: this should be published by htmx, and not duplicated here
+	 * @param {import("../htmx").HtmxSettleInfo} settleInfo 
 	 * @returns () => void
 	 */
 	function doSettle(settleInfo) {


### PR DESCRIPTION
## Description

There was a function naming conflict after #2025. I missed it because it worked on current dev since htmx.js initialized createEventSource parameter, but after removing it for 2.0, it led to infinite recursion and errors

Corresponding issue: discovered when updating #2095 to latest dev

## Testing

I applied the patch to WS/SSE removal branch and ensured that recursion error was gone 

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
