### PR TITLE
introduce types.ts; improve types for internal functions with focus on hx-swap

### DIFF
--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -442,6 +442,7 @@ export interface HtmxConfig {
  * https://htmx.org/extensions/#defining
  */
 export interface HtmxExtension {
+    init(apiRef: HtmxInternalApi): void;
     onEvent?: (name: string, evt: CustomEvent) => any;
     transformResponse?: (text: any, xhr: XMLHttpRequest, elt: any) => any;
     isInlineSwap?: (swapStyle: any) => any;

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -92,7 +92,7 @@ return (function () {
             version: "1.9.10"
         };
 
-        /** @type {import("./htmx").HtmxInternalApi} */
+        /** @type {import("./types").HtmxInternalApi} */
         var internalAPI = {
             addTriggerHandler: addTriggerHandler,
             bodyContains: bodyContains,
@@ -2547,6 +2547,7 @@ return (function () {
          */
         function getInputValues(elt, verb) {
             var processed = [];
+            /** @type {Object<string, any>} */
             var values = {};
             var formValues = {};
             var errors = [];

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -50,7 +50,7 @@ return (function () {
                 historyEnabled:true,
                 historyCacheSize:10,
                 refreshOnHistoryMiss:false,
-                defaultSwapStyle:'innerHTML',
+                defaultSwapStyle: /** @type{import("./types").SwapStyle} */('innerHTML'),
                 defaultSwapDelay:0,
                 defaultSettleDelay:20,
                 includeIndicatorStyles:true,
@@ -404,6 +404,7 @@ return (function () {
             }
         }
 
+        /** @type {import("./types").splitOnWhitespace} */
         function splitOnWhitespace(trigger) {
             return trigger.trim().split(/\s+/);
         }
@@ -2707,14 +2708,10 @@ return (function () {
           return getRawAttribute(elt, 'href') && getRawAttribute(elt, 'href').indexOf("#") >=0
         }
 
-        /**
-         *
-         * @param {HTMLElement} elt
-         * @param {string} swapInfoOverride
-         * @returns {import("./htmx").HtmxSwapSpecification}
-         */
+        /** @type {import("./types").HtmxInternalApi['getSwapSpecification']} */
         function getSwapSpecification(elt, swapInfoOverride) {
             var swapInfo = swapInfoOverride ? swapInfoOverride : getClosestAttributeValue(elt, "hx-swap");
+            /** @type {import("./types").HtmxSwapSpecification} */
             var swapSpec = {
                 "swapStyle" : getInternalData(elt).boosted ? 'innerHTML' : htmx.config.defaultSwapStyle,
                 "swapDelay" : htmx.config.defaultSwapDelay,
@@ -2741,20 +2738,20 @@ return (function () {
                             var splitSpec = scrollSpec.split(":");
                             var scrollVal = splitSpec.pop();
                             var selectorVal = splitSpec.length > 0 ? splitSpec.join(":") : null;
-                            swapSpec["scroll"] = scrollVal;
+                            swapSpec["scroll"] = /** @type {"top" | "bottom"} */(scrollVal);
                             swapSpec["scrollTarget"] = selectorVal;
                         } else if (value.indexOf("show:") === 0) {
                             var showSpec = value.substr(5);
                             var splitSpec = showSpec.split(":");
                             var showVal = splitSpec.pop();
                             var selectorVal = splitSpec.length > 0 ? splitSpec.join(":") : null;
-                            swapSpec["show"] = showVal;
+                            swapSpec["show"] = /** @type {"top" | "bottom"} */(showVal);
                             swapSpec["showTarget"] = selectorVal;
                         } else if (value.indexOf("focus-scroll:") === 0) {
                             var focusScrollVal = value.substr("focus-scroll:".length);
                             swapSpec["focusScroll"] = focusScrollVal == "true";
                         } else if (i == 0) {
-                            swapSpec["swapStyle"] = value;
+                            swapSpec["swapStyle"] = /** @type {any} */(value);
                         } else {
                             logError('Unknown modifier in hx-swap: ' + value);
                         }
@@ -2796,6 +2793,7 @@ return (function () {
             return {tasks: [], elts: [target]};
         }
 
+        /** @type {import("./types").updateScrollState} */
         function updateScrollState(content, swapSpec) {
             var first = content[0];
             var last = content[content.length - 1];
@@ -3461,6 +3459,7 @@ return (function () {
             if (hasHeader(xhr, /HX-Location:/i)) {
                 saveCurrentPageToHistory();
                 var redirectPath = xhr.getResponseHeader("HX-Location");
+                /** @type {import("./types").HtmxSwapSpecification} */
                 var swapSpec;
                 if (redirectPath.indexOf("{") === 0) {
                     swapSpec = parseJSON(redirectPath);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,151 @@
+interface HtmxTriggerSpecification {
+  sseEvent?: string;
+  trigger: string;
+  root?: Element | Document | null;
+  threshold?: string;
+  delay?: number;
+  pollInterval?: number;
+}
+
+interface HtmxSwapSpecification {
+  swapStyle: SwapStyle;
+  swapDelay: number;
+  settleDelay: number;
+}
+
+interface HtmxSettleInfo {
+  title?: string;
+  tasks?: (() => void)[];
+  elts?: Element[];
+}
+
+interface ListenerInfo {
+  listener: EventListener;
+  on: HTMLElement;
+  trigger: string;
+}
+
+/** the http verb used in the request (lowercase) */
+type Verb = "get" | "post" | "put" | "delete" | "patch";
+
+interface KnownInternalData {
+  initHash?: number | null;
+  listenerInfos?: ListenerInfo[];
+  path?: string;
+  streamPaused?: boolean;
+  streamReader?: ReadableStreamDefaultReader;
+  verb?: Verb;
+  lastButtonClicked?: Element | null;
+  timeout?: number;
+  webSocket?: WebSocket;
+  sseEventSource?: EventSource;
+  onHandlers?: { event: string; listener: EventListener }[];
+  xhr?: XMLHttpRequest;
+  requestCount?: number;
+}
+
+type InternalData = KnownInternalData & Record<PropertyKey, any>;
+
+interface InputValues {
+  errors: any[];
+  values: Record<string, string>;
+}
+
+interface Pollable {
+  polling: boolean;
+}
+
+interface TriggerHandler {
+  (elt: Element, evt: Event): void;
+  (): void;
+}
+
+type SwapStyle =
+  | "innerHTML"
+  | "outerHTML"
+  | "afterbegin"
+  | "beforebegin"
+  | "afterend"
+  | "beforeend"
+  | "none"
+  | "delete";
+
+interface HtmxInternalApi {
+  addTriggerHandler(
+    elt: Element,
+    triggerSpec: HtmxTriggerSpecification,
+    nodeData: Pollable,
+    handler: TriggerHandler
+  ): void;
+  bodyContains(elt: Node): boolean;
+  canAccessLocalStorage(): boolean;
+  findThisElement(elt: HTMLElement, attribute: string): HTMLElement | null;
+  filterValues(
+    inputValues: Record<string, string>,
+    elt: HTMLElement
+  ): Record<string, string>;
+  hasAttribute(
+    elt: { hasAttribute: (arg0: string) => boolean },
+    qualifiedName: string
+  ): boolean;
+  getAttributeValue(elt: HTMLElement, qualifiedName: string): string | null;
+  getClosestAttributeValue(
+    elt: HTMLElement,
+    attributeName: string
+  ): string | null;
+  getClosestMatch(
+    elt: HTMLElement,
+    condition: (e: HTMLElement) => boolean
+  ): HTMLElement | null;
+  getExpressionVars(elt: HTMLElement): Record<string, string>;
+  getHeaders(
+    elt: HTMLElement,
+    target: HTMLElement,
+    prompt: string
+  ): Record<string, string>;
+  getInputValues(elt: HTMLElement, verb: string): InputValues;
+  getInternalData(elt: HTMLElement): InternalData;
+  getSwapSpecification(
+    elt: HTMLElement,
+    swapInfoOverride?: string
+  ): HtmxSwapSpecification;
+  getTriggerSpecs(elt: HTMLElement): HtmxTriggerSpecification[];
+  getTarget(elt: HTMLElement): Element | null;
+  makeFragment(resp: any): Element | DocumentFragment;
+  mergeObjects<A extends object, B extends object>(obj1: A, obj2: B): A & B;
+  makeSettleInfo(target: Element): HtmxSettleInfo;
+  oobSwap(
+    oobValue: string,
+    oobElement: HTMLElement,
+    settleInfo: HtmxSettleInfo
+  ): string;
+  querySelectorExt(eltOrSelector: any, selector: string): Element | null;
+  selectAndSwap(
+    swapStyle: SwapStyle,
+    target: Element | null,
+    elt: Element | null,
+    responseText: string,
+    settleInfo: HtmxSettleInfo,
+    selectOverride?: string | null
+  ): void;
+  settleImmediately(tasks: { call: () => void }[]): void;
+  shouldCancel(evt: Event, elt: HTMLElement): boolean;
+  triggerEvent(
+    elt: Element | null,
+    eventName: string,
+    detail?: EventDetail
+  ): boolean;
+  triggerErrorEvent(
+    elt: HTMLElement,
+    eventName: string,
+    detail?: EventDetail
+  ): void;
+  withExtensions(
+    elt: HTMLElement,
+    toDo: (extension: HtmxExtension) => void
+  ): void;
+}
+
+type EventDetail = {
+  [key: PropertyKey]: unknown;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,9 @@
+/**
+ * @fileoverview Internal types used inside htmx.js but are not part of
+ * the public API. The main benefit of having this file is that you can
+ * have better DX defining types in TypeScript and then just import them
+ * into the JsDoc comments in the htmx.js file. */
+
 interface HtmxTriggerSpecification {
   sseEvent?: string;
   trigger: string;
@@ -7,10 +13,20 @@ interface HtmxTriggerSpecification {
   pollInterval?: number;
 }
 
-interface HtmxSwapSpecification {
+export interface HtmxSwapSpecification {
   swapStyle: SwapStyle;
   swapDelay: number;
   settleDelay: number;
+
+  scroll?: "top" | "bottom";
+  scrollTarget?: string | null;
+
+  show?: "top" | "bottom";
+  showTarget?: string | null;
+
+  transition?: boolean;
+  ignoreTitle?: boolean;
+  focusScroll?: boolean;
 }
 
 interface HtmxSettleInfo {
@@ -60,17 +76,17 @@ interface TriggerHandler {
   (): void;
 }
 
-type SwapStyle =
+export type SwapStyle =
   | "innerHTML"
   | "outerHTML"
-  | "afterbegin"
   | "beforebegin"
-  | "afterend"
+  | "afterbegin"
   | "beforeend"
-  | "none"
-  | "delete";
+  | "afterend"
+  | "delete"
+  | "none";
 
-interface HtmxInternalApi {
+export interface HtmxInternalApi {
   addTriggerHandler(
     elt: Element,
     triggerSpec: HtmxTriggerSpecification,
@@ -142,10 +158,17 @@ interface HtmxInternalApi {
   ): void;
   withExtensions(
     elt: HTMLElement,
-    toDo: (extension: HtmxExtension) => void
+    toDo: (extension: import("./htmx").HtmxExtension) => void
   ): void;
 }
 
 type EventDetail = {
   [key: PropertyKey]: unknown;
 };
+
+export declare function updateScrollState(
+  content,
+  swapSpec: HtmxSwapSpecification
+): void;
+
+export declare function splitOnWhitespace(trigger: string): string[];


### PR DESCRIPTION
## Description

> previous [PR](https://github.com/bigskysoftware/htmx/pull/2038)

- Add `HtmxExtension.init type` (src/htmx.d.ts)
- create new file `src/types.ts` based on code form @trvswgnr https://gist.github.com/trvswgnr/7239fa78cd12cee986384623a29b9b89
  - it has a lot of `any`s but it's better than nothing :)
- improve types for hx-swap, this brings the number of errors in `test-types` from 21 to 15
- add types to `internalAPI` (the ones that @trvswgnr wrote)

This PR will introduce a new file `dist/types.ts` into the mix, I'm not 100% sure if that's good or bad :)
So let's talk a bit about alternatives:
 - inline everything in `.js` file with jsdoc syntax --- that's what we were doing so far, not the best ergonomics
 - write types inside `htmx.d.ts` --- that works great for external types like `HtmxConfig` or `html.addClass`, but you don't want to put `splitOnWhitespace` there
 - write types inside `types.d.ts` --- this is what [SvelteKit](https://github.com/sveltejs/kit/blob/master/packages/kit/src/runtime/client/types.d.ts) is doing and I first started with that approach when I started doing JsDoc projects, but I found it a bit clumsy, the biggest issue for me was how confusing it would work in case if you have both `something.js` and `something.d.ts` file
 - write types inside `types.ts` --- that's what someone recommended to me to try instead of doing `.d.ts` and I was happy ever since :D (but I'm not married to that)

So most of this PR is done, there are two outstanding things that I wanted to discuss before I turn this PR from Draft to Ready:
- `HtmxExtension.init` --- this method takes `HtmxInternalApi` as first argument, so that means that `HtmxInternalApi` kind of have to be public API now, and if we are adding types of `HtmxInternalApi` to `htmx.d.ts` then you have to add all additional types like `HtmxTriggerSpecification` or `TriggerHandler` to it and so on.
  - so we could just use the type `init(apiRef: import("./types").HtmxInternalApi): void;` which works, but sends a signal that "there will be dragons"
  - I'm looking for feedback in terms of do we expect 3rd party extensions to consume those types (as in an npm module that will be written in TS that imports internal types to work) or even rewrite existing extensions to use those types, right now there's basically no type checkin in src/ext 
- how much of the stuff from `src/types.ts` should actually be in `htmx.d.ts`? In the original gist it feels like it was intended to be a part of public api https://gist.github.com/trvswgnr/7239fa78cd12cee986384623a29b9b89

## Testing
     npm run test-types

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
