### PR TITLE
Removed outdated note in oob swap documentation

### DIFF
--- a/www/content/attributes/hx-swap-oob.md
+++ b/www/content/attributes/hx-swap-oob.md
@@ -34,4 +34,3 @@ If a selector is given, all elements matched by that selector will be swapped.  
 ## Notes
 
 * `hx-swap-oob` is not inherited
-* Out of band elements must be in the top level of the response, and not children of the top level elements.

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -601,8 +601,6 @@ would be swapped into the target in the normal manner.
 
 You can use this technique to "piggy-back" updates on other requests.
 
-Note that out of band elements must be in the top level of the response, and not children of the top level elements.
-
 #### Selecting Content To Swap
 
 If you want to select a subset of the response HTML to swap into the target, you can use the [hx-select](@/attributes/hx-select.md)


### PR DESCRIPTION
## Description
3 years ago, @1cg pushed [this commit](https://github.com/bigskysoftware/htmx/commit/b96e5e771ef83d284af6a5fdd11a2c37abc855f9)
> allow `hx-swap-oob` to be at any level in returned content

Yet 3 years later, the [hx-swap-oob](https://htmx.org/attributes/hx-swap-oob/) documentation still states the following:
> Out of band elements must be in the top level of the response, and not children of the top level elements.

which doesn't seem to be true anymore, given that the commit mentioned above introduced a [test case](https://github.com/bigskysoftware/htmx/commit/b96e5e771ef83d284af6a5fdd11a2c37abc855f9#diff-7089bd70f59ce011095405d0fa57ee13073d0a8317209d95a9a26f353abaff36R73) for the nested elements scenario.

_Btw, this also seems to make the `multi-swap` extension kinda obsolete now as its reason to exist [as per its doc](https://htmx.org/extensions/multi-swap/) was:_
> Multi-swap can help in cases where OOB ([Out of Band Swaps](https://htmx.org/docs/#oob_swaps)) is not enough for you. OOB requires HTML tags marked with hx-swap-oob attributes to be at the TOP level of HTML, which significantly limited its use. With OOB, it’s impossible to swap multiple elements arbitrarily placed and nested in the DOM tree.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
