### PR TITLE
Support encapsulating oob swap elements in templates in response

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -829,6 +829,15 @@ var htmx = (function() {
     return oobValue
   }
 
+  function findAndSwapOobElements(fragment, settleInfo) {
+    forEach(findAll(fragment, '[hx-swap-oob], [data-hx-swap-oob]'), function (oobElement) {
+      const oobValue = getAttributeValue(oobElement, "hx-swap-oob");
+      if (oobValue != null) {
+        oobSwap(oobValue, oobElement, settleInfo);
+      }
+    });
+  }
+
   function handleOutOfBandSwaps(elt, fragment, settleInfo) {
     const oobSelects = getClosestAttributeValue(elt, 'hx-select-oob')
     if (oobSelects) {
@@ -846,10 +855,12 @@ var htmx = (function() {
         }
       }
     }
-    forEach(findAll(fragment, '[hx-swap-oob], [data-hx-swap-oob]'), function(oobElement) {
-      const oobValue = getAttributeValue(oobElement, 'hx-swap-oob')
-      if (oobValue != null) {
-        oobSwap(oobValue, oobElement, settleInfo)
+    findAndSwapOobElements(fragment, settleInfo)
+    forEach(findAll(fragment, 'template'), function (template) {
+      findAndSwapOobElements(template.content, settleInfo)
+      if (template.content.childElementCount === 0) {
+        // Avoid polluting the DOM with empty templates that were only used to encapsulate oob swap
+        template.remove()
       }
     })
   }

--- a/test/attributes/hx-swap-oob.js
+++ b/test/attributes/hx-swap-oob.js
@@ -127,4 +127,39 @@ describe('hx-swap-oob attribute', function() {
     this.server.respond()
     should.equal(byId('d1'), null)
   })
+
+  it("oob swap supports table row in fragment along other oob swap elements", function () {
+    this.server.respondWith("GET", "/test",
+      `Clicked
+      <div hx-swap-oob="innerHTML" id="d1">Test</div>
+      <button type="button" hx-swap-oob="true" id="b2">Another button</button>
+      <template>
+        <tr hx-swap-oob="true" id="r1"><td>bar</td></tr>
+      </template>
+      <template>
+        <td hx-swap-oob="true" id="td1">hey</td>
+      </template>`)
+
+    make(`<div id="d1">Bar</div>
+      <button id="b2">Foo</button>
+      <table id="table">
+        <tbody id="tbody">
+          <tr id="r1">
+           <td>foo</td>
+          </tr>
+          <tr>
+            <td id="td1">Bar</td>
+          </tr>
+        </tbody>
+      </table>`)
+
+    var btn = make('<button id="b1" type="button" hx-get="/test">Click me</button>')
+    btn.click()
+    this.server.respond()
+    btn.innerText.should.equal("Clicked")
+    byId("r1").innerHTML.should.equal(`<td>bar</td>`)
+    byId("b2").innerHTML.should.equal(`Another button`)
+    byId("d1").innerHTML.should.equal(`Test`)
+    byId("td1").innerHTML.should.equal(`hey`)
+  })
 })

--- a/www/content/attributes/hx-swap-oob.md
+++ b/www/content/attributes/hx-swap-oob.md
@@ -31,6 +31,22 @@ If a swap value is given, that swap strategy will be used.
 
 If a selector is given, all elements matched by that selector will be swapped.  If not, the element with an ID matching the new content will be swapped.
 
+You should use a `template` tag to encapsulate elements that by the spec can't stand on their own in the DOM _(`tr` or `td` for example that must be children of respectively `tbody` and `tr`)_
+
+```html
+<div>
+    ...
+</div>
+<div id="alerts" hx-swap-oob="true">
+    ...
+</div>
+<template>
+    <tr id="row" hx-swap-oob="true">
+        ...
+    </tr>
+</template>
+```
+
 ## Notes
 
 * `hx-swap-oob` is not inherited


### PR DESCRIPTION
As discussed in the Discord, here's a template-based suggestion to work around the annoying scenario of oob-swapping the lone `tr` or `td` to, which by default won't work if there are any elements before it in the response, because of the way the DOM parser works.

Updated the docs to mention that scenario and the way we would now recommend to address it.