### PR TITLE
Fix path-params title (preventing zola from building)

### DIFF
--- a/www/content/extensions/path-params.md
+++ b/www/content/extensions/path-params.md
@@ -1,5 +1,5 @@
 +++
-title = path-params
+title = "path-params"
 +++
 
 This extension uses request parameters to populate path variables. Used parameters are removed so they won't be sent in the query string or body anymore.


### PR DESCRIPTION
## Description
The `path-params` doc didn't have quotes around its title, resulting in the following error when attempting to execute `zola serve` to run the htmx website locally
```
Building site...
Error: Failed to serve the site
Error: Error when parsing front matter of section `\\?\D:\workspace\git\htmx\www\content\extensions\path-params.md`        
Error: Reason: TOML parse error at line 2, column 9
  |
2 | title = path-params
  |         ^
invalid string
expected `"`, `'`
```

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
