### PR TITLE
Enable Node CI for v2.0v2.0 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Node CI
 
 on:
   push:
-    branches: [ master, dev, htmx-2.0 ]
+    branches: [ master, dev, htmx-2.0, v2.0v2.0 ]
   pull_request:
-    branches: [ master, dev, htmx-2.0 ]
+    branches: [ master, dev, htmx-2.0, v2.0v2.0 ]
 
 jobs:
   test_suite:


### PR DESCRIPTION
So we can spot mistakes during htmx2 development too