### PR TITLE
Update `htmx.ajax` type signature to make the `element` argument optional

### DIFF
--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -21,7 +21,7 @@ export function addClass(elt: Element, clazz: string, delay?: number): void;
  * @param element the element to target (defaults to the **body**)
  * @returns Promise that resolves immediately if no request is sent, or when the request is complete
  */
-export function ajax(verb: string, path: string, element: Element): Promise<void>;
+export function ajax(verb: string, path: string, element?: Element): Promise<void>;
 
 /**
  * Issues an htmx-style AJAX request


### PR DESCRIPTION
I updated the type signature of `htmx.ajax` to allow the user to not provide a value to the `element` argument and just use the default documented value, `body`.