### PR TITLE
Add TypeScript union string type for custom event names

### DIFF
--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -438,11 +438,54 @@ export interface HtmxConfig {
     triggerSpecsCache?: {[trigger: string]: HtmxTriggerSpecification[]};
 }
 
+export type HtmxEvent = "htmx:abort"
+    | "htmx:afterOnLoad"
+    | "htmx:afterProcessNode"
+    | "htmx:afterRequest"
+    | "htmx:afterSettle"
+    | "htmx:afterSwap"
+    | "htmx:beforeCleanupElement"
+    | "htmx:beforeOnLoad"
+    | "htmx:beforeProcessNode"
+    | "htmx:beforeRequest"
+    | "htmx:beforeSwap"
+    | "htmx:beforeSend"
+    | "htmx:configRequest"
+    | "htmx:confirm"
+    | "htmx:historyCacheError"
+    | "htmx:historyCacheMiss"
+    | "htmx:historyCacheMissError"
+    | "htmx:historyCacheMissLoad"
+    | "htmx:historyRestore"
+    | "htmx:load"
+    | "htmx:noSSESourceError"
+    | "htmx:onLoadError"
+    | "htmx:oobAfterSwap"
+    | "htmx:oobBeforeSwap"
+    | "htmx:oobErrorNoTarget"
+    | "htmx:prompt"
+    | "htmx:pushedIntoHistory"
+    | "htmx:responseError"
+    | "htmx:sendError"
+    | "htmx:sseError"
+    | "htmx:sseOpen"
+    | "htmx:swapError"
+    | "htmx:targetError"
+    | "htmx:timeout"
+    | "htmx:validation:validate"
+    | "htmx:validation:failed"
+    | "htmx:validation:halted"
+    | "htmx:xhr:abort"
+    | "htmx:xhr:loadend"
+    | "htmx:xhr:loadstart"
+    | "htmx:xhr:progress"
+;
+
 /**
  * https://htmx.org/extensions/#defining
  */
 export interface HtmxExtension {
-    onEvent?: (name: string, evt: CustomEvent) => any;
+    onEvent?: (name: HtmxEvent, evt: CustomEvent) => any;
     transformResponse?: (text: any, xhr: XMLHttpRequest, elt: any) => any;
     isInlineSwap?: (swapStyle: any) => any;
     handleSwap?: (swapStyle: any, target: any, fragment: any, settleInfo: any) => any;


### PR DESCRIPTION
## Description
This adds more type-safety to extension developers, since the event name in `onEvent` is now no longer of type `string`, but uses a. new union-type of all available event names as string.

The type and the available events are based on [what's written in the docs](https://htmx.org/reference/#events).

Corresponding issue: _there is no issue atm. please let me know when I should create one._

## Testing
This only changes the type definition, not the actual source-code, therefore no tests are provided.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
