### PR TITLE
typo: dahs -> dash

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -1288,7 +1288,7 @@ If we wanted to respond to the `click` event using an `hx-on` attribute, we woul
 </button>
 ```
 
-So, the string `hx-on`, followed by a colon (or a dahs), then by the name of the event.
+So, the string `hx-on`, followed by a colon (or a dash), then by the name of the event.
 
 For a `click` event, of course, we would recommend sticking with the standard `onclick` attribute.  However, consider an 
 htmx-powered button that wishes to add a parameter to a request using the `htmx:config-request` event.  This would not 


### PR DESCRIPTION
## Description
Fixes typo in `dahs` to `dash` in `content/docs.md`

Corresponding issue:
NA.

## Testing
NA.

## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [X] I ran the test suite locally (`npm run test`) and verified that it succeeded
