### PR TITLE
Add init function to description of default extension points.

### DIFF
--- a/www/content/extensions/_index.md
+++ b/www/content/extensions/_index.md
@@ -108,6 +108,7 @@ Extensions can override the following default extension points to add or change 
 
 ```javascript
 {
+    init: function(api) {return null;},
     onEvent : function(name, evt) {return true;},
     transformResponse : function(text, xhr, elt) {return text;},
     isInlineSwap : function(swapStyle) {return false;},


### PR DESCRIPTION
## Description

Add `init` function to description of default extension points in the extension document.
The relevant code can be found at the following:
https://github.com/bigskysoftware/htmx/blob/145627a5792520b10f35e86eea23ce5c388e0fb0/src/htmx.js#L3741

## Testing

This PR has just changed the document. There is no need for testing.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] ~~I ran the test suite locally (`npm run test`) and verified that it succeeded~~. This PR has just changed the document. There is no need for testing.
