### PR TITLE
Keep the loading state when the response is a HX-Redirect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
   "name": "htmx.org",
-  "version": "1.9.6",
+  "version": "1.9.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "htmx.org",
-      "version": "1.9.6",
+      "version": "1.9.10",
       "license": "BSD 2-Clause",
-      "dependencies": {
-        "ws": "^8.14.2"
-      },
       "devDependencies": {
         "chai": "^4.3.7",
         "chai-dom": "^1.11.0",
@@ -21,7 +18,8 @@
         "mock-socket": "^9.2.1",
         "sinon": "^9.2.4",
         "typescript": "^4.9.5",
-        "uglify-js": "^3.17.4"
+        "uglify-js": "^3.17.4",
+        "ws": "^8.14.2"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -2264,6 +2262,7 @@
       "version": "8.14.2",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
       "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -4141,6 +4140,7 @@
       "version": "8.14.2",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
       "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "dev": true,
       "requires": {}
     },
     "y18n": {

--- a/src/ext/loading-states.js
+++ b/src/ext/loading-states.js
@@ -173,7 +173,7 @@
 				)
 			}
 
-			if (name === 'htmx:beforeOnLoad') {
+			if (name === 'htmx:beforeOnLoad' && !evt.detail.xhr.getResponseHeader('HX-Redirect')) {
 				while (loadingStatesUndoQueue.length > 0) {
 					loadingStatesUndoQueue.shift()()
 				}


### PR DESCRIPTION
## Description
When we do a HX request and the response is a redirect the loading state should be kept - if it doesn't the application will "flick" before loading the new page.

Corresponding issue:
#2146

## Testing
Have a simple form that submits to an endpoint that responds with a HX-Redirect header - the loading state should be kept until the redirect is successfully done:
```
<form hx-post="/test">
    <button type="submit" data-loading-disable>
        Submit!
    </button>
</form>
```

## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [X] I ran the test suite locally (`npm run test`) and verified that it succeeded
