### PR TITLE
Fix typo in Hyperscript Tabs docs

### DIFF
--- a/www/content/examples/tabs-javascript.md
+++ b/www/content/examples/tabs-javascript.md
@@ -24,9 +24,9 @@ when the content is swapped into the DOM.
                                let newTab = event.target
                                newTab.setAttribute('aria-selected', 'true')
                                newTab.classList.add('selected')">
-    <button role="tab" aria-controls="tab-content" aria-selected="true" hx-get="/tab1" class="selected">Tab 1</button>
-    <button role="tab" aria-controls="tab-content" aria-selected="false" hx-get="/tab2">Tab 2</button>
-    <button role="tab" aria-controls="tab-content" aria-selected="false" hx-get="/tab3">Tab 3</button>
+    <button role="tab" aria-controls="tab-contents" aria-selected="true" hx-get="/tab1" class="selected">Tab 1</button>
+    <button role="tab" aria-controls="tab-contents" aria-selected="false" hx-get="/tab2">Tab 2</button>
+    <button role="tab" aria-controls="tab-contents" aria-selected="false" hx-get="/tab3">Tab 3</button>
 </div>
 
 <div id="tab-contents" role="tabpanel" hx-get="/tab1" hx-trigger="load"></div>
@@ -42,9 +42,9 @@ when the content is swapped into the DOM.
                                           let newTab = event.target
                                           newTab.setAttribute('aria-selected', 'true')
                                           newTab.classList.add('selected')">
-	<button role="tab" aria-controls="tab-content" aria-selected="true" hx-get="/tab1" class="selected">Tab 1</button>
-	<button role="tab" aria-controls="tab-content" aria-selected="false" hx-get="/tab2">Tab 2</button>
-	<button role="tab" aria-controls="tab-content" aria-selected="false" hx-get="/tab3">Tab 3</button>
+	<button role="tab" aria-controls="tab-contents" aria-selected="true" hx-get="/tab1" class="selected">Tab 1</button>
+	<button role="tab" aria-controls="tab-contents" aria-selected="false" hx-get="/tab2">Tab 2</button>
+	<button role="tab" aria-controls="tab-contents" aria-selected="false" hx-get="/tab3">Tab 3</button>
 </div>
 
 <div id="tab-contents" role="tabpanel" hx-get="/tab1" hx-trigger="load"></div>


### PR DESCRIPTION
## Description
Fix typo in tabs-hyperscript by making the `aria-controls` property of the tabs (buttons) point to `<div id="tab-contents" ...>`

Corresponding issue:
https://github.com/bigskysoftware/htmx/issues/2163

## Testing
(not applicable)

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
