### PR TITLE
Add support for hx-swap-oob-source as "firstChild" (or "innerHTML")

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -819,7 +819,7 @@ return (function () {
                         var oobElementClone = oobElement.cloneNode(true);
                         fragment = getDocument().createDocumentFragment();
                         fragment.appendChild(oobElementClone);
-                        if (!isInlineSwap(swapStyle, target)) {
+                        if (!isInlineSwap(swapStyle, target) || getAttributeValue(oobElement, "hx-swap-oob-source") === "firstChild") {
                             fragment = oobElementClone; // if this is not an inline swap, we use the content of the node, not the node itself
                         }
 

--- a/test/attributes/hx-swap-oob.js
+++ b/test/attributes/hx-swap-oob.js
@@ -128,5 +128,16 @@ describe("hx-swap-oob attribute", function () {
         this.server.respond();
         should.equal(byId("d1"), null);
     });
+
+    it('handles hx-swap-oob-source properly', function()
+    {
+        this.server.respondWith("GET", "/test", '<div hx-swap-oob="true" hx-swap-oob-source="firstChild" id="d1"><div id="d2">Swapped</div></div>');
+
+        var div = make('<div id="d1" hx-get="/test">Foo</div>')
+        div.click();
+        this.server.respond();
+        should.equal(byId("d1"), null);
+        byId("d2").innerHTML.should.equal("Swapped");
+    });
 });
 


### PR DESCRIPTION
## Description

Added support for a new `hx-swap-oob-source` attribute which presently can only take one value, `firstChild` (in line with the DocumentFragment API.) If set to `firstChild`, the swapped node is not the node with the `hx-swap-oob` attribute but its first child.

At the moment this silently fails if no child node is passed, but it might be desirable to throw an error, which I'd be happy to implement.

Corresponding issue: https://github.com/bigskysoftware/htmx/issues/423

## Testing

I added one test to the hx-swap-oob suite.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue **No, but the change is so minimal that I thought I'd offer an actual PR** 
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
