### PR TITLE
Fix SSE tests and emit new "beforeMessage" event for SSE Extension

### DIFF
--- a/src/ext/sse.js
+++ b/src/ext/sse.js
@@ -148,6 +148,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 					}
 
 					// swap the response into the DOM and trigger a notification
+					api.triggerEvent(elt, "htmx:sseBeforeMessage", event);
 					swap(child, event.data);
 					api.triggerEvent(elt, "htmx:sseMessage", event);
 				};

--- a/src/ext/sse.js
+++ b/src/ext/sse.js
@@ -148,7 +148,9 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 					}
 
 					// swap the response into the DOM and trigger a notification
-					api.triggerEvent(elt, "htmx:sseBeforeMessage", event);
+					if(!api.triggerEvent(elt, "htmx:sseBeforeMessage", event)) {
+						return;
+					}
 					swap(child, event.data);
 					api.triggerEvent(elt, "htmx:sseMessage", event);
 				};

--- a/test/attributes/hx-sse.js
+++ b/test/attributes/hx-sse.js
@@ -13,15 +13,15 @@ describe("hx-sse attribute", function() {
                 })
             },
             addEventListener: function(message, l) {
-                if (listeners == undefined) {
+                if (listeners[message] === undefined) {
                     listeners[message] = [];
                 }
                 listeners[message].push(l)
             },
             sendEvent: function(eventName, data) {
-                var listeners = listeners[eventName];
-                if (listeners) {
-                    listeners.forEach(function(listener) {
+                var eventListeners = listeners[eventName];
+                if (eventListeners) {
+                    eventListeners.forEach(function(listener) {
                         var event = htmx._("makeEvent")(eventName);
                         event.data = data;
                         listener(event);
@@ -47,6 +47,7 @@ describe("hx-sse attribute", function() {
     });
     afterEach(function() {
         this.server.restore();
+        this.eventSource = mockEventSource();
         clearWorkArea();
     });
 

--- a/test/attributes/hx-sse.js
+++ b/test/attributes/hx-sse.js
@@ -25,7 +25,7 @@ describe("hx-sse attribute", function() {
                         var event = htmx._("makeEvent")(eventName);
                         event.data = data;
                         listener(event);
-                    }
+                    })
                 }
             },
             close: function() {

--- a/test/ext/sse.js
+++ b/test/ext/sse.js
@@ -1,5 +1,3 @@
-const { assert } = require("chai");
-
 describe("sse extension", function() {
 
     function mockEventSource() {
@@ -28,7 +26,7 @@ describe("sse extension", function() {
                         var event = htmx._("makeEvent")(eventName);
                         event.data = data;
                         listener(event);
-                    }
+                    })
                 }
             },
             close: function() {

--- a/test/ext/sse.js
+++ b/test/ext/sse.js
@@ -228,5 +228,63 @@ describe("sse extension", function() {
 
     })
 
+    it('raises htmx:sseBeforeMessage when receiving message from the server', function () {
+        var myEventCalled = false;
+
+        function handle(evt) {
+            myEventCalled = true;
+        }
+
+        htmx.on("htmx:sseBeforeMessage", handle)
+
+        var div = make('<div hx-ext="sse" sse-connect="/event_stream" sse-swap="e1"></div>');
+
+        this.eventSource.sendEvent("e1", '<div id="d1"></div>')
+
+        myEventCalled.should.be.true;
+
+        htmx.off("htmx:sseBeforeMessage", handle)
+    })
+
+    it('cancels swap when htmx:sseBeforeMessage was cancelled', function () {
+        var myEventCalled = false;
+
+        function handle(evt) {
+            myEventCalled = true;
+            evt.preventDefault();
+        }
+
+        htmx.on("htmx:sseBeforeMessage", handle)
+
+        var div = make('<div hx-ext="sse" sse-connect="/event_stream" sse-swap="e1"><div id="d1">div1</div></div>');
+
+        this.eventSource.sendEvent("e1", '<div id="d1">replaced</div>')
+
+        myEventCalled.should.be.true;
+
+        byId("d1").innerHTML.should.equal("div1");
+
+        htmx.off("htmx:sseBeforeMessage", handle)
+    })
+
+    it('raises htmx:sseMessage when message was completely processed', function () {
+        var myEventCalled = false;
+
+        function handle(evt) {
+            myEventCalled = true;
+        }
+
+        htmx.on("htmx:sseMessage", handle)
+
+        var div = make('<div hx-ext="sse" sse-connect="/event_stream" sse-swap="e1"><div id="d1">div1</div></div>');
+
+        this.eventSource.sendEvent("e1", '<div id="d1">replaced</div>')
+
+        myEventCalled.should.be.true;
+        byId("d1").innerHTML.should.equal("replaced");
+
+        htmx.off("htmx:sseMessage", handle)
+    })
+
 });
 

--- a/test/ext/sse.js
+++ b/test/ext/sse.js
@@ -14,15 +14,15 @@ describe("sse extension", function() {
                 })
             },
             addEventListener: function(message, l) {
-                if (listeners == undefined) {
+                if (listeners[message] === undefined) {
                     listeners[message] = [];
                 }
                 listeners[message].push(l)
             },
             sendEvent: function(eventName, data) {
-                var listeners = listeners[eventName];
-                if (listeners) {
-                    listeners.forEach(function(listener) {
+                var eventListeners = listeners[eventName];
+                if (eventListeners) {
+                    eventListeners.forEach(function(listener) {
                         var event = htmx._("makeEvent")(eventName);
                         event.data = data;
                         listener(event);
@@ -54,6 +54,7 @@ describe("sse extension", function() {
     });
     afterEach(function() {
         this.server.restore();
+        this.eventSource = mockEventSource();
         clearWorkArea();
     });
 


### PR DESCRIPTION
## Description
I'm building a toy chat app with HTMX + the SSE extension. I have some custom JS that I want to run **before and after** new SSE messages are swapped in from the server.

For a regular request with HTMX, I could add listeners to the `htmx:beforeSwap` and `htmx:afterSwap` events. Similarly, the WS extension emits `htmx:wsBeforeMessage` and `htmx:wsAfterMessage`, but there is no corresponding ability to listen to "before swap" messages with the SSE extension.

This PR introduces a new event, `htmx:sseBeforeMessage`, that is emitted before the SSE extension swaps in content from the server. Open to feedback on naming convention!

## Testing
I tested this change manually by applying this patch to my local copy of the SSE extension.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
