### PR TITLE
Remove incorrect external script info from client-side-templates docs

### DIFF
--- a/www/content/extensions/client-side-templates.md
+++ b/www/content/extensions/client-side-templates.md
@@ -58,9 +58,6 @@ To use the client side template, you will need to include htmx, the extension, a
 Here is an example of this setup for Mustache using
 a [`<template>` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template).
 
-If you wish to put a template into another file, you can use a directive such as
- `<script src="my-template" id="template-id" type="text/mustache">`
-
 ```html
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION
I don't know why this was in here in the first place, it's just outright false. Neither Mustache nor the CST extension have any sort of code to enable using `<script type="text/mustache">` like this. The `<object>`-based example for XSLT templates should probably be double-checked too.

## Description
Removed erroneous text from https://htmx.org/extensions/client-side-templates/

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
