### PR TITLE
[Website]: Fix demo-server-info panel rendering issue

### DIFF
--- a/www/templates/shortcodes/demoenv.html
+++ b/www/templates/shortcodes/demoenv.html
@@ -11,6 +11,7 @@
       border-top: 2px solid gray;
       overflow: hide;
       margin: 0px;
+      z-index: 1;
   }
   #demo-server-info.show {
       max-height: 45vh;


### PR DESCRIPTION
## Description

This PR resolves #2187 

Fixes a tiny visual bug on the docs website where the demo-server-info panel is not rendering above some example page content (namely the link emoji).

Before fix:

<img width="400" alt="Screen Shot 2024-01-13 at 1 53 59 PM" src="https://github.com/bigskysoftware/htmx/assets/39639992/7361edf5-ea79-42be-83e2-9d7fd52df569">
<img width="400" alt="Screen Shot 2024-01-13 at 1 54 08 PM" src="https://github.com/bigskysoftware/htmx/assets/39639992/4c45b713-a0b0-443b-b043-e59049969671">

After fix:

<img width="400" alt="Screen Shot 2024-01-13 at 1 54 41 PM" src="https://github.com/bigskysoftware/htmx/assets/39639992/c8eb3356-4082-480c-805b-580981073492">
<img width="400" alt="Screen Shot 2024-01-13 at 1 54 53 PM" src="https://github.com/bigskysoftware/htmx/assets/39639992/49ff14f0-2539-4611-99f8-70c6d061c79c">


Also, apologies if I'm jumping the gun by sending this PR before explicit approval of the issue I submitted. Since this was a one-line CSS fix, I thought it wouldn't hurt to just send in a PR at the same time as the issue. 

If, in the future, you would like me to wait for explicit approval please let me know 😊

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
