### PR TITLE
[Website]: Fix cut off list items in demo-server-info panel

### DIFF
--- a/www/templates/shortcodes/demoenv.html
+++ b/www/templates/shortcodes/demoenv.html
@@ -25,6 +25,10 @@
       vertical-align: top
   }
 
+  #demo-activity ol li {
+      list-style-position: inside;
+  }
+
   #demo-canvas {
       margin-bottom: 500px;
       padding-top: 12px;


### PR DESCRIPTION
## Description

This PR resolves #2189 

Fixes a small visual bug on the docs site where list items in the demo-server-info panel overflow are cut off because they overflow past the edge of the viewport.

Before fix:

<img width="243" alt="Screen Shot 2024-01-13 at 2 34 24 PM" src="https://github.com/bigskysoftware/htmx/assets/39639992/650a383b-1d50-42e6-b6f3-97cf62abdce4">

After fix:

<img width="253" alt="Screen Shot 2024-01-13 at 2 34 45 PM" src="https://github.com/bigskysoftware/htmx/assets/39639992/f8308b62-0988-4d7a-9b94-6a225e52a28e">

Again, (as I mentioned in #2188), apologies if I'm jumping the gun by sending this PR before explicit approval of the associated issue. This was also a one-line CSS fix, so I thought it wouldn't hurt to just send in a PR at the same time as the issue.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
