### PR TITLE
Refactor and expose `swap` in public API

### DIFF
--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -438,6 +438,22 @@ export interface HtmxConfig {
     triggerSpecsCache?: {[trigger: string]: HtmxTriggerSpecification[]};
 }
 
+type HtmxSwapStyle = "innerHTML" | "outerHTML" | "beforebegin" | "afterbegin" | "beforeend" | "afterend" | "delete" | "none" | string
+
+export interface HtmxSwapSpecification {
+    swapStyle: HtmxSwapStyle;
+    swapDelay?: number;
+    settleDelay?: number;
+    transition?: boolean;
+    ignoreTitle?: boolean;
+    head?: string;
+    scroll?: string;
+    scrollTarget?: string;
+    show?: string;
+    showTarget?: string;
+    focusScroll?: boolean;
+}
+
 /**
  * https://htmx.org/extensions/#defining
  */

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -25,7 +25,7 @@ var htmx = (function() {
     removeClass: removeClassFromElement,
     toggleClass: toggleClassOnElement,
     takeClass: takeClassForElement,
-    swap: swap,
+    swap,
     /* Extension entrypoints */
     defineExtension,
     removeExtension,
@@ -405,8 +405,8 @@ var htmx = (function() {
    */
   /**
    * @template T
-   * @param {{[index: number]: T, length: number}} arr 
-   * @param {forEachCallback<T>} func 
+   * @param {{[index: number]: T, length: number}} arr
+   * @param {forEachCallback<T>} func
    */
   function forEach(arr, func) {
     if (arr) {
@@ -1145,7 +1145,7 @@ var htmx = (function() {
       swapOptions = {}
     }
 
-    target = resolveTarget(target);
+    target = resolveTarget(target)
 
     // preserve focus and selection
     const activeElt = document.activeElement
@@ -1161,9 +1161,9 @@ var htmx = (function() {
     } catch (e) {
       // safari issue - see https://github.com/microsoft/playwright/issues/5894
     }
-    let settleInfo = makeSettleInfo(target);
+    const settleInfo = makeSettleInfo(target)
 
-    let fragment = makeFragment(content);
+    let fragment = makeFragment(content)
 
     settleInfo.title = fragment.title
     settleInfo.head = fragment.head
@@ -1202,8 +1202,8 @@ var htmx = (function() {
       })
       fragment = newFragment
     }
-    handlePreservedElements(fragment);
-    swapWithStyle(swapSpec.swapStyle, swapOptions.contextElement, target, fragment, settleInfo);
+    handlePreservedElements(fragment)
+    swapWithStyle(swapSpec.swapStyle, swapOptions.contextElement, target, fragment, settleInfo)
 
     // apply saved focus and selection information to swapped content
     if (selectionInfo.elt &&
@@ -1233,15 +1233,15 @@ var htmx = (function() {
       triggerEvent(elt, 'htmx:afterSwap', swapOptions.eventInfo)
     })
     if (swapOptions.afterSwapCallback) {
-      swapOptions.afterSwapCallback();
+      swapOptions.afterSwapCallback()
     }
 
     // merge in new head after swap but before settle
     if (!swapSpec.ignoreTitle) {
-      handleTitle(settleInfo.title);
+      handleTitle(settleInfo.title)
     }
-    if (triggerEvent(document.body, "htmx:beforeHeadMerge", {head: settleInfo.head})) {
-      handleHeadTag(settleInfo.head, swapSpec.head);
+    if (triggerEvent(document.body, 'htmx:beforeHeadMerge', { head: settleInfo.head })) {
+      handleHeadTag(settleInfo.head, swapSpec.head)
     }
 
     // settle
@@ -1257,7 +1257,7 @@ var htmx = (function() {
       })
 
       if (swapOptions.anchor) {
-        const anchorTarget = resolveTarget(swapOptions.anchor);
+        const anchorTarget = resolveTarget(swapOptions.anchor)
         if (anchorTarget) {
           anchorTarget.scrollIntoView({ block: 'start', behavior: 'auto' })
         }
@@ -3637,7 +3637,7 @@ var htmx = (function() {
                 handleTriggerHeader(xhr, 'HX-Trigger-After-Settle', finalElt)
               }
               maybeCall(settleResolve)
-            },
+            }
           })
         } catch (e) {
           triggerErrorEvent(elt, 'htmx:swapError', responseInfo)

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -87,6 +87,7 @@ var htmx = (function() {
     canAccessLocalStorage,
     findThisElement,
     filterValues,
+    fullSwap,
     hasAttribute,
     getAttributeValue,
     getClosestAttributeValue,

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1122,12 +1122,12 @@ var htmx = (function() {
    * @property {SwapSpecification} spec
    * @property {?string} select
    * @property {?string} selectOOB
-   * @property {boolean} ignoreTitle
-   * @property {*} responseInfo
-   * @property {*} headStrategy
+   * @property {?boolean} ignoreTitle
+   * @property {?*} responseInfo
+   * @property {?*} headStrategy
    * @property {?Element} contextElement
-   * @property {swapCallback} afterSwapCallback
-   * @property {swapCallback} afterSettleCallback
+   * @property {?swapCallback} afterSwapCallback
+   * @property {?swapCallback} afterSettleCallback
    */
 
   /**
@@ -1225,7 +1225,9 @@ var htmx = (function() {
       }
       triggerEvent(elt, 'htmx:afterSwap', swapOptions.responseInfo)
     })
-    swapOptions.afterSwapCallback();
+    if (swapOptions.afterSwapCallback) {
+      swapOptions.afterSwapCallback();
+    }
 
     // merge in new head after swap but before settle
     if (!swapOptions.ignoreTitle) {
@@ -1247,7 +1249,7 @@ var htmx = (function() {
         triggerEvent(elt, 'htmx:afterSettle', swapOptions.responseInfo)
       })
 
-      if (swapOptions.responseInfo.pathInfo.anchor) {
+      if (swapOptions.responseInfo && swapOptions.responseInfo.pathInfo.anchor) {
         const anchorTarget = getDocument().getElementById(swapOptions.responseInfo.pathInfo.anchor)
         if (anchorTarget) {
           anchorTarget.scrollIntoView({ block: 'start', behavior: 'auto' })
@@ -1255,7 +1257,9 @@ var htmx = (function() {
       }
 
       updateScrollState(settleInfo.elts, swapOptions.spec)
-      swapOptions.afterSettleCallback()
+      if (swapOptions.afterSettleCallback) {
+        swapOptions.afterSettleCallback()
+      }
     }
 
     if (swapOptions.spec.settleDelay > 0) {

--- a/test/core/api.js
+++ b/test/core/api.js
@@ -375,4 +375,32 @@ describe('Core htmx API test', function() {
     htmx.trigger(div, 'myEvent')
     myEventCalled.should.equal(true)
   })
+
+  it('swaps content properly (basic)', function() {
+    var output = make('<output id="output"/>')
+    htmx.swap('#output', '<div>Swapped!</div>', {swapStyle: 'innerHTML'});
+    output.innerHTML.should.be.equal('<div>Swapped!</div>');
+  })
+
+  it('swaps content properly (with select)', function() {
+    var output = make('<output id="output"/>')
+    htmx.swap('#output', '<div><p id="select-me">Swapped!</p></div>', {swapStyle: 'innerHTML'}, {select: '#select-me'});
+    output.innerHTML.should.be.equal('<p id="select-me">Swapped!</p>');
+  })
+
+  it('swaps content properly (with oob)', function() {
+    var output = make('<output id="output"/>')
+    var oobDiv = make('<div id="oob"/>')
+    htmx.swap('#output', '<div id="oob" hx-swap-oob="innerHTML">OOB Swapped!</div><div>Swapped!</div>', {swapStyle: 'innerHTML'});
+    output.innerHTML.should.be.equal('<div>Swapped!</div>');
+    oobDiv.innerHTML.should.be.equal('OOB Swapped!');
+  })
+
+  it('swaps content properly (with select oob)', function() {
+    var output = make('<output id="output"/>')
+    var oobDiv = make('<div id="oob"/>')
+    htmx.swap('#output', '<div id="oob">OOB Swapped!</div><div>Swapped!</div>', {swapStyle: 'innerHTML'}, {selectOOB: '#oob:innerHTML'});
+    output.innerHTML.should.be.equal('<div>Swapped!</div>');
+    oobDiv.innerHTML.should.be.equal('OOB Swapped!');
+  })
 })

--- a/test/core/api.js
+++ b/test/core/api.js
@@ -378,29 +378,29 @@ describe('Core htmx API test', function() {
 
   it('swaps content properly (basic)', function() {
     var output = make('<output id="output"/>')
-    htmx.swap('#output', '<div>Swapped!</div>', {swapStyle: 'innerHTML'});
-    output.innerHTML.should.be.equal('<div>Swapped!</div>');
+    htmx.swap('#output', '<div>Swapped!</div>', { swapStyle: 'innerHTML' })
+    output.innerHTML.should.be.equal('<div>Swapped!</div>')
   })
 
   it('swaps content properly (with select)', function() {
     var output = make('<output id="output"/>')
-    htmx.swap('#output', '<div><p id="select-me">Swapped!</p></div>', {swapStyle: 'innerHTML'}, {select: '#select-me'});
-    output.innerHTML.should.be.equal('<p id="select-me">Swapped!</p>');
+    htmx.swap('#output', '<div><p id="select-me">Swapped!</p></div>', { swapStyle: 'innerHTML' }, { select: '#select-me' })
+    output.innerHTML.should.be.equal('<p id="select-me">Swapped!</p>')
   })
 
   it('swaps content properly (with oob)', function() {
     var output = make('<output id="output"/>')
     var oobDiv = make('<div id="oob"/>')
-    htmx.swap('#output', '<div id="oob" hx-swap-oob="innerHTML">OOB Swapped!</div><div>Swapped!</div>', {swapStyle: 'innerHTML'});
-    output.innerHTML.should.be.equal('<div>Swapped!</div>');
-    oobDiv.innerHTML.should.be.equal('OOB Swapped!');
+    htmx.swap('#output', '<div id="oob" hx-swap-oob="innerHTML">OOB Swapped!</div><div>Swapped!</div>', { swapStyle: 'innerHTML' })
+    output.innerHTML.should.be.equal('<div>Swapped!</div>')
+    oobDiv.innerHTML.should.be.equal('OOB Swapped!')
   })
 
   it('swaps content properly (with select oob)', function() {
     var output = make('<output id="output"/>')
     var oobDiv = make('<div id="oob"/>')
-    htmx.swap('#output', '<div id="oob">OOB Swapped!</div><div>Swapped!</div>', {swapStyle: 'innerHTML'}, {selectOOB: '#oob:innerHTML'});
-    output.innerHTML.should.be.equal('<div>Swapped!</div>');
-    oobDiv.innerHTML.should.be.equal('OOB Swapped!');
+    htmx.swap('#output', '<div id="oob">OOB Swapped!</div><div>Swapped!</div>', { swapStyle: 'innerHTML' }, { selectOOB: '#oob:innerHTML' })
+    output.innerHTML.should.be.equal('<div>Swapped!</div>')
+    oobDiv.innerHTML.should.be.equal('OOB Swapped!')
   })
 })

--- a/www/content/api.md
+++ b/www/content/api.md
@@ -448,6 +448,37 @@ Removes the given extension from htmx
   htmx.removeExtension("my-extension");
 ```
 
+### Method - `htmx.swap()` {#swap}
+
+Performs swapping (and settling) of HTML content
+
+##### Parameters
+
+* `target` - the HTML element or string selector of swap target
+* `content` - string representation of content to be swapped
+* `swapSpec` - swapping specification, representing parameters from `hx-swap`
+  * `swapStyle` (required) - swapping style (`innerHTML`, `outerHTML`, `beforebegin` etc)
+  * `swapDelay`, `settleDelay` (number) - delays before swapping and settling respectively
+  * `transition` (bool) - whether to use HTML transitions for swap
+  * `ignoreTitle` (bool) - disables page title updates
+  * `head` (string) - specifies `head` tag handling strategy (`merge` or `append`). Leave empty to disable head handling
+  * `scroll`, `scrollTarget`, `show`, `showTarget`, `focusScroll` - specifies scroll handling after swap
+* `swapOptions` - additional *optional* parameters for swapping
+  * `select` - selector for the content to be swapped (equivalent of `hx-select`)
+  * `selectOOB` - selector for the content to be swapped out-of-band (equivalent of `hx-select-oob`)
+  * `eventInfo` - an object to be attached to `htmx:afterSwap` and `htmx:afterSettle` elements
+  * `anchor` - an anchor element that triggered scroll, will be scrolled into view on settle. Provides simple alternative to full scroll handling
+  * `contextElement` - DOM element that serves as context to swapping operation. Currently used to find extensions enabled for specific element
+  * `afterSwapCallback`, `afterSettleCallback` - callback functions called after swap and settle respectively. Take no arguments
+
+
+##### Example
+
+```js
+    // swap #output element inner HTML with div element with "Swapped!" text
+    htmx.swap("#output", "<div>Swapped!</div>", {swapStyle: 'innerHTML'});
+```
+
 ### Method - `htmx.takeClass()` {#takeClass}
 
 Takes the given class from its siblings, so that among its siblings, only the given element will have the class.

--- a/www/content/reference.md
+++ b/www/content/reference.md
@@ -202,6 +202,7 @@ The table below lists all other attributes available in htmx.
 | [`htmx.remove()`](@/api.md#remove)  | Removes the given element
 | [`htmx.removeClass()`](@/api.md#removeClass)  | Removes a class from the given element
 | [`htmx.removeExtension()`](@/api.md#removeExtension)  | Removes an htmx [extension](@/extensions/_index.md)
+| [`htmx.swap()`](@/api.md#swap)  | Performs swapping (and settling) of HTML content
 | [`htmx.takeClass()`](@/api.md#takeClass)  | Takes a class from other elements for the given element
 | [`htmx.toggleClass()`](@/api.md#toggleClass)  | Toggles a class from the given element
 | [`htmx.trigger()`](@/api.md#trigger)  | Triggers an event on an element


### PR DESCRIPTION
## Description
This PR includes `swap` method in htmx public API. This feature has been requested on multiple occasions, was proposed for 2.0 and finally delivered. To make it possible, I did a bit of a refactoring by gathering every swap-related piece of code in `fullSwap` method (name is up for discussion), which handles

* focus and selection preservation
* title updates
* head merging
* scroll
* OOB swapping
* normal swapping
* settling

This means that any extension and custom script can use full power of htmx's swapping features. I also anticipate that this change should significantly simplify maintenance of swapping in the future

**This is a breaking change, as extensions no longer have access to `selectAndSwap` method**. The new method fully covers the needs for swapping, while also removing responsibility of managing settling info.

The old method covered very specific part of swapping process and had a tricky signature which I struggle to keep untouched.

On the plus side, this is the entire code that's required to perform swapping from SSE extension

```js
let target = api.getTarget(child);
let swapSpec = api.getSwapSpecification(child);
htmx.swap(target, event.data, {spec: swapSpec});
```

To be done/decided:

- [x] exposure of `SwapSpecification` type to the public world (are we ok with it? need to document it) - added to htmx.d.ts and documented in JS API section
- [x] documentation - documented
- [x] naming of the method - renamed to `swap`
- [ ] upgrading official extensions (ws, sse) - TBD
- [ ] handling view transitions from this method - TBD

Corresponding issue: 2.0

## Testing
I ensured that this refactor did not affect existing tests at all. I also intend to write tests specifically for this method, if the team agrees that this approach works for us
