### PR TITLE
Added Handlebars implementation

### DIFF
--- a/www/content/extensions/client-side-templates.md
+++ b/www/content/extensions/client-side-templates.md
@@ -123,6 +123,79 @@ Here's a working example using the `mustache-array-template` working against an 
 </html>
 ```
 
+
+### Full Handlebars HTML Example
+
+To use the client side template, you will need to include htmx, the extension, and the rendering engine.
+Here is an example of this setup for Mustache using
+a [`<template>` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template).
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>JS Bin</title>
+  <script src="https://unpkg.com/htmx.org"></script>
+  <script src="https://unpkg.com/htmx.org/dist/ext/client-side-templates.js"></script>
+  <script src="https://unpkg.com/handlebars@latest/dist/handlebars.min.js"></script>
+</head>
+<body>
+  <div hx-ext="client-side-templates">
+    <button hx-get="https://jsonplaceholder.typicode.com/todos/1"
+            hx-swap="innerHTML"
+            hx-target="#content"
+            handlebars-template="foo">
+      Click Me
+    </button>
+
+    <p id="content">Start</p>
+
+    <template id="foo">
+      <p> {{{userID}}} and {{{id}}} and {{{title}}} and {{{completed}}}</p>
+    </template>
+  </div>
+</body>
+</html>
+```
+
+<!-- Here is a [jsbin](https://jsbin.com/qonutovico/edit?html,output) playground to try this out. -->
+
+Here's a working example using the `handlebars-array-template` working against an API that returns an array:
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>JS Bin</title>
+  <script src="https://unpkg.com/htmx.org"></script>
+  <script src="https://unpkg.com/htmx.org/dist/ext/client-side-templates.js"></script>
+  <script src="https://unpkg.com/handlebars@latest/dist/handlebars.min.js"></script>
+</head>
+<body>
+  <div hx-ext="client-side-templates">
+    <button hx-get="https://jsonplaceholder.typicode.com/users"
+            hx-swap="innerHTML"
+            hx-target="#content"
+            handlebars-array-template="foo">
+      Click Me
+    </button>
+
+    <p id="content">Start</p>
+
+    <template id="foo">
+      {{#each this}}
+      <p> {{name}} at {{email}} is with {{company.name}}</p>
+      {{/each}}
+    </template>
+  </div>
+</body>
+</html>
+```
+
+
 ### Full XSLT HTML Example
 
 To use the client side template, you will need to include htmx and the extension.


### PR DESCRIPTION
## Description

Handlebars says itself to be "Mustache compatible" on their [website](https://handlebarsjs.com) but its implementation with HTMX [client-side-template](https://htmx.org/extensions/client-side-templates/) extension is slightly different and breaks when migrating to Handlebars from Mustache

I've added the Different implementation from mustache, needed to be followed when using handlebars

### Significantly two explicit changes are needed
1. Use the CDN upkg.com `/handlebars@latest/dist/handlebars.min.js` instead of `/handlebars@latest`
2. Use `{#each this}` for looping instead of `{#each data}` or `{#data}` inspired from mustache example

Corresponding issue:


## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
