### PR TITLE
Add Scala http4s example to docs (server-examples)

### DIFF
--- a/www/content/server-examples.md
+++ b/www/content/server-examples.md
@@ -114,6 +114,11 @@ These examples may make it a bit easier to get started using htmx with your plat
 - <https://github.com/libsyz/htmx-to-do-app>
 - <https://github.com/beechnut/pokebutt-htmx>
 
+## Scala
+  
+### http4s
+- <https://github.com/martinprobson/http4s-htmx-demo>
+
 ## Kotlin
 
 ### Ktor


### PR DESCRIPTION
## Description
Documentation update only - Added Scala (http4s) example to server examples page.
 

## Testing
website checked locally with Zola

## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
