### PR TITLE
chore: upgrade actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
   test_suite:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '15.x'
       - run: npm ci


### PR DESCRIPTION
## Description
Upgrade these github actions to v4:
- checkout
- setup-node

