### PR TITLE
Fix broken oob swap error handling.

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -811,7 +811,7 @@ return (function () {
             }
 
             var targets = getDocument().querySelectorAll(selector);
-            if (targets) {
+            if (targets.length !== 0) {
                 forEach(
                     targets,
                     function (target) {

--- a/test/attributes/hx-swap-oob.js
+++ b/test/attributes/hx-swap-oob.js
@@ -128,5 +128,27 @@ describe("hx-swap-oob attribute", function () {
         this.server.respond();
         should.equal(byId("d1"), null);
     });
+
+    it('oob swap error handling on missing element', function()
+    {
+        this.server.respondWith("GET", "/test", '<div hx-swap-oob="d2" id="d2">new</div>');
+        var errorEvent = null;
+        var handler = htmx.on("htmx:oobErrorNoTarget", function (event) {
+            errorEvent = event;
+        });
+
+        try {
+            var div = make('<div id="d1" hx-get="/test">initial</div>')
+            div.click();
+            this.server.respond();
+
+            should.not.equal(null, errorEvent);
+            should.not.equal(null, errorEvent.detail);
+            should.not.equal(null, errorEvent.detail.content);
+            should.equal('d2', errorEvent.detail.content.id);
+        } finally {
+            htmx.off("htmx:oobErrorNoTarget", handler);
+        }
+    });
 });
 


### PR DESCRIPTION
## Description
For missing target on oob swap the event `htmx:oobErrorNoTarget` must be triggered (see https://htmx.org/events/#htmx:oobErrorNoTarget)

Corresponding issue:


## Testing
1. Added a new test
2. via `npm run test`

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
