### PR TITLE
Preload header

### DIFF
--- a/src/ext/preload.js
+++ b/src/ext/preload.js
@@ -49,6 +49,7 @@ htmx.defineExtension("preload", {
 				var hxGet = node.getAttribute("hx-get") || node.getAttribute("data-hx-get")
 				if (hxGet) {
 					htmx.ajax("GET", hxGet, {
+						headers: {"HX-Preload-Request": "true"},
 						source: node,
 						handler:function(elt, info) {
 							done(info.xhr.responseText);
@@ -63,6 +64,7 @@ htmx.defineExtension("preload", {
 				if (node.getAttribute("href")) {
 					var r = new XMLHttpRequest();
 					r.open("GET", node.getAttribute("href"));
+					r.setRequestHeader("HX-Preload-Request", "true");
 					r.onload = function() {done(r.responseText);};
 					r.send();
 					return;


### PR DESCRIPTION
## Description

This is a proposal to add a header specific to `preload` requests so that the server can recognize them as `preload` and act accordingly.
In our case, we were trying to set a different cache header and cache TTL when using `preload` but couldn't find a way to distinguish a `preload` request from a standard one.


Corresponding [issue](https://github.com/bigskysoftware/htmx/issues/2218)

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
