### PR TITLE
Clarify hx-validate documentation

### DIFF
--- a/www/content/attributes/hx-validate.md
+++ b/www/content/attributes/hx-validate.md
@@ -5,7 +5,7 @@ title = "hx-validate"
 The `hx-validate` attribute will cause an element to validate itself by way of the [HTML5 Validation API](@/docs.md#validation)
 before it submits a request.
 
-Form elements do this by default, but other elements do not.
+Only `<form>` elements validate data by default, but other elements do not. Adding `hx-validate="true"` to `<input>`, `<textarea>` or `<select>` enables validation before sending requests.
 
 ## Notes
 


### PR DESCRIPTION
Fixes #2185

## Description
The [hx-validate](https://htmx.org/attributes/hx-validate/) documentation says "Form elements do this by default, but other elements do not" which is quite confusing, I interpreted this to also mean `<input>` elements validate by default. This PR solves that confusion and also makes it clear that hx-validate must be set to "true".   

This change has not been explicitly approved by the maintainers via the issue, hope that's ok. If not, please let me know and I won't make a PR next time until it's approved. 

Corresponding issue: #2185 

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
