### PR TITLE
Handle non-existent HX-Retarget element

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3506,10 +3506,17 @@ return (function () {
             }
 
             if (hasHeader(xhr,/HX-Retarget:/i)) {
-                if (xhr.getResponseHeader("HX-Retarget") === "this") {
+                var targetValue = xhr.getResponseHeader("HX-Retarget");
+
+                if (targetValue === "this") {
                     responseInfo.target = elt;
                 } else {
-                    responseInfo.target = querySelectorExt(elt, xhr.getResponseHeader("HX-Retarget"));
+                    responseInfo.target = querySelectorExt(elt, targetValue);
+                }
+
+                if (responseInfo.target == null || responseInfo.target == DUMMY_ELT) {
+                    triggerErrorEvent(elt, 'htmx:targetError', {target: targetValue});
+                    return;
                 }
             }
 

--- a/test/core/headers.js
+++ b/test/core/headers.js
@@ -251,6 +251,26 @@ describe("Core htmx AJAX headers", function () {
         div2.innerHTML.should.equal("Result");
     })
 
+    it("should handle HX-Retarget that targets a non-existent element", function() {
+        this.server.respondWith('GET', '/test', [200, {'HX-Retarget': 'closest #d2'}, 'Result']);
+
+        var div1 = make('<div id="d1" hx-get="/test"></div>');
+        var invokedEventTargetError = false;
+        var eventTargetErrorDetails = {};
+        div1.addEventListener('htmx:targetError', function(evt) {
+            console.error(evt);
+            invokedEventTargetError = true;
+            eventTargetErrorDetails = evt.detail;
+        });
+
+        div1.click();
+        this.server.respond();
+
+        invokedEventTargetError.should.equal(true);
+        eventTargetErrorDetails.error.should.equal('htmx:targetError');
+        eventTargetErrorDetails.target.should.equal('closest #d2');
+    })
+
     it("should handle HX-Reswap", function () {
         this.server.respondWith("GET", "/test", [200, {"HX-Reswap": "innerHTML"}, "Result"]);
 


### PR DESCRIPTION
## Description

As per the issue, HX-Retarget performed no handling of whether the resultant target element actually existed or not. This PR adds error handling seen in other places and gracefully returns from the function. 

Corresponding issue: Resolves #2216 

## Testing

Tested via an automated test and manually with the reproduction steps in the original issue.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
