### PR TITLE
Improve active-search example by not using chrome-only event "search"

### DIFF
--- a/www/content/examples/active-search.md
+++ b/www/content/examples/active-search.md
@@ -41,7 +41,7 @@ we add the `changed` modifier to the trigger to ensure we don't send new queries
 value of the input (e.g. they hit an arrow key, or pasted the same value).
 
 We can use multiple triggers by separating them with a comma, this way we add 2 more triggers:
-- `keyup[key=='Enter']` triggers once enter is pressed. We use [event filters](/attributes/hx-trigger#standard-event-filters) here to check for [key property in the KeyboardEvent object](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key).
+- `keyup[key=='Enter']` triggers once enter is pressed. We use [event filters](/attributes/hx-trigger#standard-event-filters) here to check for [the key property in the KeyboardEvent object](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key).
 - `load` in order to show all results initially on load.
 
 Finally, we show an indicator when the search is in flight with the `hx-indicator` attribute.

--- a/www/content/examples/active-search.md
+++ b/www/content/examples/active-search.md
@@ -5,20 +5,20 @@ template = "demo.html"
 
 This example actively searches a contacts database as the user enters text.
 
-We start with a search input and an empty table:
+We start with a text input and an empty table:
 
 ```html
-<h3> 
-  Search Contacts 
-  <span class="htmx-indicator"> 
-    <img src="/img/bars.svg"/> Searching... 
-   </span> 
+<h3>
+  Search Contacts
+  <span class="htmx-indicator">
+    <img src="/img/bars.svg"/> Searching...
+   </span>
 </h3>
-<input class="form-control" type="search" 
-       name="search" placeholder="Begin Typing To Search Users..." 
-       hx-post="/search" 
-       hx-trigger="input changed delay:500ms, search" 
-       hx-target="#search-results" 
+<input class="form-control" type="text"
+       name="search" placeholder="Begin Typing To Search Users..."
+       hx-post="/search"
+       hx-trigger="input changed delay:500ms, keyup[key=='Enter'], load"
+       hx-target="#search-results"
        hx-indicator=".htmx-indicator">
 
 <table class="table">
@@ -34,18 +34,17 @@ We start with a search input and an empty table:
 </table>
 ```
 
-The input issues a `POST` to `/search` on the [`input`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) event and sets the body of the table to be the resulting content. Note that the `keyup` event could be used as well, but would not fire if the user pasted text with their mouse (or any other non-keyboard method).
+The input issues a `POST` to `/search` on the [`input`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) event and sets the body of the table to be the resulting content.
 
 We add the `delay:500ms` modifier to the trigger to delay sending the query until the user stops typing.  Additionally,
 we add the `changed` modifier to the trigger to ensure we don't send new queries when the user doesn't change the
-value of the input (e.g. they hit an arrow key, or pasted the same value).  
+value of the input (e.g. they hit an arrow key, or pasted the same value).
 
-Since we use a `search` type input we will get an `x` in the input field to clear the input. 
-To make this trigger a new `POST` we have to specify another trigger. We specify another trigger by using a comma to 
-separate them. The `search` trigger will be run when the field is cleared but it also makes it possible to override 
-the 500 ms `input` event delay by just pressing enter.
+We can use multiple triggers by separating them with a comma, this way we add 2 more triggers:
+- `keyup[key=='Enter']` triggers once enter is pressed. We use [event filters](/attributes/hx-trigger#standard-event-filters) here to check for [key property in the KeyboardEvent object](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key).
+- `load` in order to show all results initially on load.
 
-Finally, we show an indicator when the search is in flight with the `hx-indicator` attribute. 
+Finally, we show an indicator when the search is in flight with the `hx-indicator` attribute.
 
 {{ demoenv() }}
 
@@ -75,11 +74,11 @@ Search Contacts
 </span>
 </h3>
 
-<input class="form-control" type="search" 
-       name="search" placeholder="Begin Typing To Search Users..." 
-       hx-post="/search" 
-       hx-trigger="input changed delay:500ms, search" 
-       hx-target="#search-results" 
+<input class="form-control" type="text"
+       name="search" placeholder="Begin Typing To Search Users..."
+       hx-post="/search"
+       hx-trigger="input changed delay:500ms, keyup[key=='Enter'], load"
+       hx-target="#search-results"
        hx-indicator=".htmx-indicator">
 
 <table class="table">

--- a/www/content/examples/active-search.md
+++ b/www/content/examples/active-search.md
@@ -5,7 +5,7 @@ template = "demo.html"
 
 This example actively searches a contacts database as the user enters text.
 
-We start with a text input and an empty table:
+We start with a search input and an empty table:
 
 ```html
 <h3>
@@ -14,7 +14,7 @@ We start with a text input and an empty table:
     <img src="/img/bars.svg"/> Searching...
    </span>
 </h3>
-<input class="form-control" type="text"
+<input class="form-control" type="search"
        name="search" placeholder="Begin Typing To Search Users..."
        hx-post="/search"
        hx-trigger="input changed delay:500ms, keyup[key=='Enter'], load"
@@ -74,7 +74,7 @@ Search Contacts
 </span>
 </h3>
 
-<input class="form-control" type="text"
+<input class="form-control" type="search"
        name="search" placeholder="Begin Typing To Search Users..."
        hx-post="/search"
        hx-trigger="input changed delay:500ms, keyup[key=='Enter'], load"


### PR DESCRIPTION
Fixes #1569
Fixes #2126

## Description
The active search example uses [the chrome-only event "search"](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/search_event) which is not supported in Safari and Firefox. This PR solves that  by using the `keyup[key=='Enter']` trigger. 

I also fixed #2126 so it won't show an empty table on load, it now shows all data initially. I think this better reflects how a real table search would work, but please let me know if you don't agree with that change and I'll remove the `load` trigger.

Corresponding issue: #1569 #2126

## Testing
Tested on latest the latest version of Firefox and Chromium.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
