### PR TITLE
Add dark mode toggle button

### DIFF
--- a/www/content/_index.md
+++ b/www/content/_index.md
@@ -7,7 +7,7 @@ insert_anchor_links = "left"
   <sub class="no-mobile"><i>high power tools for HTML</i></sub>
 </div>
 
-<div style="border: 1px solid lightgrey; margin:24px;padding:12px;border-radius: 8px; background-color: whitesmoke; filter: drop-shadow(3px 3px darkgray)">
+<div class="note" >
 <b>NEWS:</b> htmx finished 2nd in the <a href="https://risingstars.js.org/2023/en#section-framework">2023 
 JavaScript Rising Stars</a> "Front-end Frameworks" category, just behind React (htmx is a library, btw) and <a href="https://risingstars.js.org/2023/en#section-all">#10 overall</a>!
 Thank you to everyone who <a href="https://github.com/bigskysoftware/htmx">starred</a> us!
@@ -62,7 +62,7 @@ We are happy to announce the release of [Hypermedia Systems](https://hypermedia.
 <a href="https://www.amazon.com/dp/B0C9S88QV6/ref=sr_1_1?crid=1P0I3GXQK32TN"><img src="/img/hypermedia-systems.png" alt="hypermedia systems"></a>
 </div>
 
-<h2>sponsors <iframe src="https://github.com/sponsors/bigskysoftware/button" title="Sponsor htmx" height="32" width="114" style="border: 1px solid gray; border-radius: 12px; float:right"></iframe></h2>
+<h2>sponsors <iframe src="https://github.com/sponsors/bigskysoftware/button" title="Sponsor htmx" height="32" width="114" style="border: 1px solid rgba(var(--fg-color),0.7); border-radius: 12px; float:right"></iframe></h2>
 
 
 htmx development can be supported via [GitHub Sponsors](https://github.com/sponsors/bigskysoftware?o=esb)
@@ -128,7 +128,7 @@ Thank you to all our generous <a href="https://github.com/sponsors/bigskysoftwar
         </a>
 </td>
 <td>
-      <a href="https://twitter.com/sekunho_/"><img src="/img/sekun-doggo.jpg" alt="Hiro The Doggo" style="border: 2px solid lightgray; border-radius:20px; width:100%;max-width:150px"></a>
+      <a href="https://twitter.com/sekunho_/"><img src="/img/sekun-doggo.jpg" alt="Hiro The Doggo" style="border: 2px solid rgba(var(--bg-color), 0.25); border-radius:20px; width:100%;max-width:150px"></a>
 </td>
 <td>
         <a href="https://www.dasfilter.shop/">

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -788,7 +788,7 @@ htmx has experimental support for declarative use of both
 [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_client_applications)
 and  [Server Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events).
 
-<div style="border: 1px solid whitesmoke; background-color: #e4f0ff; padding: 8px; border-radius: 8px">
+<div class="note">
 
 **Note:** In htmx 2.0, these features will be migrated to extensions.  These new extensions are already available in
 htmx 1.7+ and, if you are writing new code, you are encouraged to use the extensions instead.  All new feature work for

--- a/www/content/essays/hateoas.md
+++ b/www/content/essays/hateoas.md
@@ -226,7 +226,7 @@ necessity for building RESTful systems.
     display: block;
     margin-bottom: 32px;
     text-align: center;
-    color: #aaa;
+    color: rgba(var(--bg-color),0.33);
     font-weight: bold;
     letter-spacing: .5em;
   }

--- a/www/content/examples/tabs-hateoas.md
+++ b/www/content/examples/tabs-hateoas.md
@@ -124,11 +124,11 @@ Subsequent tab pages display all tabs and highlight the selected one accordingly
 	}
 
 	#tabs > .tab-list button:hover {
-		color: var(--midBlue);
+		color: rgb(var(--accent-color));
 	}
 
 	#tabs > .tab-list button.selected {
-		background-color: #eee;
+		background-color: rgba(var(--bg-color),0.05);
 	}
 
 	#tabs > .tab-content {

--- a/www/content/examples/tabs-javascript.md
+++ b/www/content/examples/tabs-javascript.md
@@ -101,11 +101,11 @@ when the content is swapped into the DOM.
 	}
 
 	#tabs > button:hover {
-		color: var(--midBlue);
+		color: rgb(var(--accent-color));
 	}
 
 	#tabs > button.selected {
-		background-color: #eee;
+		background-color: rgba(var(--bg-color),0.05);
 	}
 
 	#tab-contents {

--- a/www/content/webring.md
+++ b/www/content/webring.md
@@ -22,20 +22,20 @@ title = "htmx webring"
 
 <div id="webring-div">
 
-<table id="nav-table" style="border: black 4px double; text-align: center">
+<table id="nav-table" style="border: rgb(var(--bg-alt)) 4px double; text-align: center">
 <tr>
-  <td class="built-with-tds" style="border: 1px black solid">
+  <td class="built-with-tds" style="border: 1px rgb(var(--bg-alt)) solid">
     <img width="200px" src="/img/createdwith.jpeg">
   </td>
-  <td  width="70%" style="text-align: center; font-size: 20px; border: 1px black solid">
+  <td  width="70%" style="text-align: center; font-size: 20px; border: 1px rgb(var(--bg-alt)) solid">
      This Great <a href="https://htmx.org">htmx</a> Webring site is owned by <a href="https://bigsky.software">Your Name Here</a>.
   </td>
-  <td class="built-with-tds" style="; border: 1px black solid"">
+  <td class="built-with-tds" style="; border: 1px rgb(var(--bg-alt)) solid"">
     <img width="200px" src="/img/createdwith.jpeg">
   </td>
 </tr>
 <tr>
-<td colspan="3" style="text-align: center; ; border: 1px black solid; position: relative">
+<td colspan="3" style="text-align: center; ; border: 1px rgb(var(--bg-alt)) solid; position: relative">
     [<a
          class="nav-link"
          href="#" 

--- a/www/themes/htmx-theme/static/css/site.css
+++ b/www/themes/htmx-theme/static/css/site.css
@@ -1,6 +1,32 @@
-:root {
+/* :root {
   --midBlue: #3366cc;
   --lightBlue: #3d72d7;
+} */
+body:not(.dark) {
+
+  --bg-alt: 233, 233, 239;
+  --fg-color: 42, 42, 42;
+  --accent-color: 61, 114, 215;
+
+  /* Color of 'x' is important brand color */
+  /* a11y contrast isn't great so we only use it there in dark mode */
+  --x-color: 61, 114, 215;
+
+  --fg-alt: 0, 0, 0;
+  --bg-color: 255, 255, 255;
+  --accent-alt: 116, 155, 232;
+}
+
+body.dark {
+
+  --fg-color: 233, 233, 239;
+  --bg-color: 42, 42, 42;
+  --accent-color: 116, 155, 232;
+  --x-color: 61, 114, 215;
+
+  --bg-alt: 0, 0, 0;
+  --fg-alt: 255, 255, 255;
+  --accent-alt: 61, 114, 215;
 }
 
 body {
@@ -8,8 +34,8 @@ body {
   margin: 0px;
   line-height: 1.5em;
   font-size: 16px;
-  color: #111;
-  background-color: white;
+  color: rgb(var(--fg-color));
+  background-color: rgb(var(--bg-color));
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
     "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif !important;
 }
@@ -35,9 +61,18 @@ table {
   font-weight: bold;
 
 }
+
+a.logo:hover {
+  color: rgba(var(--fg-color), 0.6);
+}
+
+a.logo:hover b {
+  color: rgba(var(--x-color), 0.6);
+}
+
 .logo b {
   font-weight: inherit;
-  color: var(--midBlue);
+  color: rgb(var(--x-color));
 }
 
 /*
@@ -50,11 +85,13 @@ table {
 
 .top-nav {
   line-height: 30px;
-  border-bottom: 1px solid #d0d0d0;
+  border-bottom: 1px solid rgba(var(--bg-color), 0.25);
   margin: 0px;
-  background-image: linear-gradient(#fff, #f4f5f5);
-  box-shadow: 0px 4px 15px 0px rgb(239, 239, 239);
-  margin-bottom:1em;
+
+  /* background-image: linear-gradient(rgb(var(--bg-alt)), rgb(var(--bg-color))); */
+  background-color: rgba(var(--fg-alt), 0.05);
+  box-shadow: 0px 4px 15px 0px rgba(var(--bg-color), 0.05);
+  margin-bottom: 1em;
 }
 
 .hide {
@@ -70,50 +107,88 @@ body .content code {
 }
 
 code:not(code[class*="language-"]) {
-  background: #3465a41f;
+  background: rgb(var(--accent-alt), 0.2);
   border-radius: 2px;
   padding: 2px 5px;
 }
 
+
+.content {
+  position: relative;
+}
+
 .dark-hero {
-  background: url(/img/topo.svg), linear-gradient(#1f1f1f, #2d2d2d) ;
   height: 240px;
   line-height: 240px;
   text-align: center;
-  vertical-align: center;
-  color: whitesmoke;
   margin-top: -2em;
+  position: relative;
+  background: url(/img/topo.svg), linear-gradient(rgba(var(--fg-color), 1), rgba(var(--fg-color), 1)); 
+
+  color: rgba(var(--bg-color), 1);
   box-shadow:
-          inset 0px 11px 8px -10px #262626,
-          inset 0px -11px 8px -10px #262626;
-  border-bottom: 1px solid whitesmoke;
+    inset 0px 11px 8px -10px rgba(var(--bg-color), 0.33),
+    inset 0px -11px 8px -10px rgba(var(--bg-color), 0.33);
+  border-bottom: 1px solid rgba(var(--bg-color), 1);
+  z-index: 2;
 }
-  .dark-hero * {
-      opacity: 0;
-      transition: all 500ms ease-in;
-  }
-  .dark-hero sub {
-      display: inline-block;
-      position: relative;
-      top: 40px;
-  }
-  .dark-hero.appear * {
-      opacity: 1;
-      top: 10px;
-  }
-  .dark-hero .logo {
-      font-size: 100px;
-  }
-  .dark-hero .blue {
-      color: var(--lightBlue);
-  }
+
+/* makes the hero bg texture pop */
+
+/* 
+.dark-hero {
+  background-image: linear-gradient(rgba(var(--fg-color), 1), rgba(var(--fg-color), 1));
+}
+
+.dark-hero::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-image: url(/img/topo.svg);
+  opacity: 0.1;
+  z-index: -1;
+}
+
+body.dark .dark-hero::before {
+  filter: invert(1);
+} 
+*/
+
+.dark-hero * {
+  opacity: 0;
+  /* ease in made the main text flop in like a fish when the dark mode toggled */
+  transition: all 500ms ease-in;
+  transition: color 500ms ease-out;
+}
+
+.dark-hero sub {
+  display: inline-block;
+  position: relative;
+  top: 40px;
+}
+
+.dark-hero.appear * {
+  opacity: 1;
+  top: 10px;
+}
+
+.dark-hero .logo {
+  font-size: 100px;
+}
+
+.dark-hero .blue {
+  color: rgb(var(--x-color));
+}
 
 p {
   margin: 0.5em 0;
 }
 
 blockquote {
-  border-left: 4px solid whitesmoke;
+  border-left: 4px solid rgb(var(--bg-alt));
   margin: 1em;
   padding-left: 0.5em;
 }
@@ -134,8 +209,8 @@ time {
 }
 
 a {
-text-decoration: none;
-color: var(--midBlue)
+  text-decoration: none;
+  color: rgb(var(--accent-color));
 }
 
 .center {
@@ -145,10 +220,11 @@ color: var(--midBlue)
 .nav {
   margin-bottom: 1em;
 }
-  .nav ul {
-      list-style: none;
-      padding-left: 12px;
-  }
+
+.nav ul {
+  list-style: none;
+  padding-left: 12px;
+}
 
 .hamburger {
   display: none;
@@ -157,9 +233,11 @@ color: var(--midBlue)
 h2:not(:first-child) {
   margin-top: 42px;
 }
+
 h3 {
   margin-top: 32px;
 }
+
 h4 {
   margin-top: 16px;
 }
@@ -171,83 +249,88 @@ h4 {
 }
 
 ul {
-    margin-left: 12px;
+  margin-left: 12px;
 }
 
 ul li {
-    padding: 4px;
-}
-
-ol {
-    margin-left: 12px;
-}
-
-ol li {
-    padding: 4px;
+  padding: 4px;
 }
 
 @media(max-width:45rem) {
   #nav {
-      height: 0px;
-      overflow: hidden;
-      text-align: center;
-      font-size: 22px;
+    height: 0px;
+    overflow: hidden;
+    text-align: center;
+    font-size: 22px;
   }
+
   #nav.show {
-      height: initial;
-      overflow: visible;
+    height: initial;
+    overflow: visible;
   }
+
   .hero {
-      font-size: 2.5em;
+    font-size: 2.5em;
   }
-  pre[class*="language-"]  {
-      overflow-x: scroll !important;
-      border-radius: 0 !important;
+
+  pre[class*="language-"] {
+    overflow-x: scroll !important;
+    border-radius: 0 !important;
   }
-  .info-table  {
-      overflow-x: scroll !important;
+
+  .info-table {
+    overflow-x: scroll !important;
   }
+
   .no-mobile {
-      display: none !important;
+    display: none !important;
   }
+
   .hamburger {
-      display: revert;
-      float: right;
+    display: revert;
+    float: right;
   }
+
   .nav {
-      text-align: center;
-      font-size: 1.2em;
-      line-height: 1.3em;
+    text-align: center;
+    font-size: 1.2em;
+    line-height: 1.3em;
   }
 }
 
 @media(min-width:45em) {
   .col {
-      display: table-cell;
+    display: table-cell;
   }
+
   .\31 {
-      width: 5%;
+    width: 5%;
   }
+
   .\33 {
-      width: 22%;
+    width: 22%;
   }
+
   .\34 {
-      width: 30%;
+    width: 30%;
   }
+
   .\35 {
-      width: 40%;
+    width: 40%;
   }
+
   .\32 {
-      width: 15%;
+    width: 15%;
   }
-  .content .row .nav,
-  .logo-wrapper{
-      width:12rem;
+
+  .content .row .nav {
+    width: 12rem;
   }
+
   .row {
-      display: table;
-      table-layout: fixed;
-      /* border-spacing: 1em 0; */
+    display: table;
+    table-layout: fixed;
+    /* border-spacing: 1em 0; */
   }
 }
 
@@ -258,7 +341,7 @@ ol li {
 
 .card:focus {
   outline: 0;
-  border: solid var(--midBlue);
+  border: solid rgb(var(--accent-color));
 }
 
 hr {
@@ -267,11 +350,12 @@ hr {
 
 .card {
   padding: 1em;
-  border: solid #eee;
+  border: solid rgba(var(--bg-color), 0.05);
 }
 
-a[href]:hover, .btn:hover {
-  opacity: .6;
+a[href]:not(.logo):hover,
+.btn:hover {
+  color: rgb(var(--accent-alt));
 }
 
 .c {
@@ -286,76 +370,88 @@ a[href]:hover, .btn:hover {
 
 .btn.primary {
   color: white;
-  background: var(--midBlue);
-  border: solid var(--midBlue);
+  background: rgb(var(--accent-color));
+  border: solid rgb(var(--accent-color));
 }
 
 td {
   padding: 0.2em 0.2em 0.2em 0;
   text-align: left;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid rgba(var(--bg-color), 0.05);
 }
 
 th {
   padding: 0.2em 0.2em 0.2em 0;
   text-align: left;
-  border-bottom: 2px solid #eee;
+  border-bottom: 2px solid rgba(var(--bg-color), 0.05);
 }
 
 .btn {
   padding: 1em;
   letter-spacing: .1em;
   text-transform: uppercase;
-  background: white;
+  background: rgb(var(--bg-alt));
   border: solid;
-  cursor:pointer;
+  cursor: pointer;
   border-radius: 8px;
 }
 
 pre {
   overflow: auto;
   font-size: 0.9em;
-  background-color: #272822;
+  background-color: rgba(var(--fg-color), 0.1);
 }
 
 table.delete-row-example .htmx-swapping {
-opacity: 0;
-transition: visibility 0s 1s, opacity 1s linear;
+  opacity: 0;
+  transition: visibility 0s 1s, opacity 1s linear;
 }
 
 /* MENU */
 
-.menu{
-  padding:1em 0;
+.menu {
+  padding: 1em 0;
 }
 
-.github-stars iframe{
-  max-width:95px
+.github-stars iframe {
+  max-width: 52px;
+  overflow: hidden;
 }
 
 /* Content */
 
 .content {
-  padding-top:1em;
+  padding-top: 1em;
 }
 
-h1,h2,h3,h4{
+h1,h2,h3,h4 {
   margin-bottom: .65em;
   font-weight: 600;
   line-height: 1em;
 }
 
 /* UL in content */
-:not(.nav) ul{
+:not(.nav) ul {
   padding-left: 1em;
 }
 
-.nav ul{
+.nav ul {
   padding-left: 0;
 }
 
 .nav ul ul {
-  padding-left:12px;
+  padding-left: 12px;
+}
+
+.navigation-items {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.33rem;
+}
+
+.navigation-items > * {
+  line-height: 22px;
 }
 
 
@@ -363,135 +459,158 @@ h1,h2,h3,h4{
 
   /* Menu */
   .menu,
-  .navigation > div{
-      display:flex;
-      align-items:center;
+  .navigation > div {
+    display: flex;
+    align-items: center;
   }
-  .navigation{
-     flex:1;
-     display:flex;
-     justify-content: space-between;
-     padding-left: calc(1em + 1.5vw);
+
+  .navigation {
+    flex: 1;
+    display: flex;
+    justify-content: space-between;
+    padding-left: calc(1em + 1.5vw);
   }
-  .navigation-items > *:not(:last-child){
-      margin-right: calc(.5em + .7vw);
-  }
-  .github-stars{
-      display:flex;
-      align-items:center;
-  }
-  .github-stars a{
-      margin:0 calc(.5em + .7vw);
-  }
+.navigation-items {
+  flex-direction: row;
+  justify-content: space-evenly;
+}
 
   /* Content */
   .content .col:not(:nth-child(1)):not(.nav) {
-      padding-left: calc(1em + 1.5vw);
+    padding-left: calc(1em + 1.5vw);
   }
+
   .content .nav > p,
-  .content .nav #contents{
-      position: sticky;
+  .content .nav #contents {
+    position: sticky;
 
   }
 
-  .content .nav #contents{
-      top: 3.5em;
+  .content .nav #contents {
+    top: 3.5em;
   }
+
   .content .nav #contents > ul {
-      max-height: calc(100vh - 5rem);
-      overflow-y: scroll;
+    max-height: calc(100vh - 5rem);
+    overflow-y: scroll;
   }
 
-  .content .nav > p
-  {
-      position: sticky;
-      top: 2vh;
+  .content .nav > p {
+    position: sticky;
+    top: 2vh;
   }
 
   .shift-up-img {
-      position:relative;
-      top:-120px
+    position: relative;
+    top: -120px
   }
 
 }
 
 @media(max-width:45rem) {
-  .github-stars{
-      text-align:center;
-      margin-top:1em;
+  
+    .navigation-items {
+      flex-direction: column;
+      justify-content: center;
+      gap: 0.5rem;
+    }
+  .github-stars {
+    height: 30px;
+    text-align: center;
+    margin: 0.5rem 0;
+
   }
-  .github-stars a{
-      display:block;
+
+  .github-stars a {
+    display: block;
   }
 }
 
 
 .logo-wrapper {
-white-space: nowrap;
+  white-space: nowrap;
 }
 
 table td:first-child code {
-display: block;
-background: none;
+  display: block;
+  background: none;
 }
 
-
 .search-box {
-    transition: all .2s ease-in-out;
-    width: 2.5rem;
-    padding: 4px 6px;
-    border: 2px solid #eee;
-    border-radius: 10px;
-    margin-right: 10px;
-    outline: 0;
+  transition: all .2s ease-in-out;
+  width: 2.5rem;
+  padding: 4px 6px;
+  border: 2px solid rgba(var(--bg-color), 0.05);
+  border-radius: 10px;
+  margin-right: 10px;
+  outline: 0;
 }
 
 .search-box::placeholder {
-    text-align: right;
+  text-align: right;
 }
 
-.search-box:hover, .search-box:not(:placeholder-shown) {
-    border: 2px solid var(--midBlue);
+.search-box:hover,
+.search-box:not(:placeholder-shown) {
+  border: 2px solid rgb(var(--accent-color));
 }
 
-.search-box:active, .search-box:focus, .search-box:not(:placeholder-shown) {
-    width: 10rem;
+.search-box:active,
+.search-box:focus,
+.search-box:not(:placeholder-shown) {
+  width: 10rem;
 }
 
 footer {
-margin-top: 2em;
-padding-top: 2em;
-padding-bottom: 5em;
-background-color: #f6f6f6;
+  margin-top: 2em;
+  padding-top: 2em;
+  padding-bottom: 5em;
+  background-color: rgba(var(--fg-alt), 0.05);
 }
 
 footer .footer-menu {
-text-align: right;
+  text-align: right;
 }
 
 @media(max-width:45rem) {
-footer .footer-haiku {
-  margin-bottom: 3em;
+  footer .footer-haiku {
+    margin-bottom: 3em;
+  }
+
+  footer .footer-menu {
+    padding-top: 3em;
+    border-top: 1px solid rgba(var(--bg-color), 0.05);
+    text-align: left;
+  }
 }
 
-footer .footer-menu {
-  padding-top: 3em;
-  border-top: 1px solid #eee;
-  text-align: left;
-}
-}
 pre[class|="language"] {
   line-height: 1.3;
   padding: .5rem;
   margin: .5rem 0;
   border-radius: .25rem;
-  color: lightgray;
+  color: rgba(var(--bg-color), 0.25);
 }
+
 .zola-anchor {
   margin-left: -1.3rem;
   margin-right: .3rem;
   opacity: 40%;
 }
+
 .zola-anchor:hover {
-    opacity: 95%;
+  opacity: 95%;
+}
+
+
+/* extracting css from .md */
+
+.note {
+  box-shadow: 0px 4px 15px 0px rgba(var(--fg-color), 0.1);
+  margin: 24px;
+  padding: 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(var(--fg-color), 0.77);
+  background-color: rgba(var(--fg-color), 0.05);
+  /* filter: drop-shadow(3px 3px var(--gray-004)) */
 }

--- a/www/themes/htmx-theme/static/js/dark-mode-toggle.js
+++ b/www/themes/htmx-theme/static/js/dark-mode-toggle.js
@@ -1,0 +1,78 @@
+class CustomComponent extends HTMLElement {
+
+  // Adds a button to the top right
+  // Click event adds '.dark' class to body element
+
+  constructor() {
+    super();
+
+    this.attachShadow({
+      mode: 'open'
+    });
+
+    const button = document.createElement('button');
+
+    button.setAttribute('id', 'toggle-btn')
+    button.addEventListener('click', this.toggleDarkMode.bind(this));
+
+    button.innerHTML = `<i class="icon-moon"><svg width="24px" height="24px" stroke-width="1.49" viewBox="0 0 24 24" fill="none" color="var(--color-light, #0f0)"><path d="M3 11.507a9.493 9.493 0 0018 4.219c-8.507 0-12.726-4.22-12.726-12.726A9.494 9.494 0 003 11.507z" stroke="var(--color-light, #ccc)" stroke-width="1.49" stroke-linecap="round" stroke-linejoin="round"></path></svg></i><i class="icon-sun"><svg width="24px" height="24px" stroke-width="1.49" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" color="var(--color-dark, #333)"><path d="M12 18a6 6 0 100-12 6 6 0 000 12zM22 12h1M12 2V1M12 23v-1M20 20l-1-1M20 4l-1 1M4 20l1-1M4 4l1 1M1 12h1" stroke="var(--color-dark, #333)" stroke-width="1.49" stroke-linecap="round" stroke-linejoin="round"  fill="var(--color-dark, #333)"></path></svg></i>`
+
+    this.shadowRoot.appendChild(button);
+
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const isDarkMode = localStorage.getItem('darkMode') === 'true';
+
+    if (prefersDark || isDarkMode) {
+      document.body.classList.add('dark');
+      button.classList.add('dark');
+    }
+
+    const style = document.createElement('style');
+
+    style.textContent = `
+      :host {
+
+          // --color-light: #f0f;
+          // --color-dark: #0f0;
+      }
+
+      @media(max-width:45rem) {
+        :host {
+          position: relative;
+          margin: 10px;
+        }
+      }
+      @media(min-width:45em) {
+        :host {
+          position: absolute;
+          top: 20px;
+          right: 20px;
+        }
+      }
+      #toggle-btn {
+          background: none;
+          border: 0;
+          cursor: pointer;
+          padding: 0px;
+      }
+     .dark .icon-sun,  .icon-moon {
+          display: none;
+      }
+     .dark .icon-moon,  .icon-sun {
+          display: block;
+      }
+    `;
+    this.shadowRoot.appendChild(style);
+  }
+
+  toggleDarkMode() {
+    const isDark = document.body.classList.toggle('dark');
+    localStorage.setItem('darkMode', isDark);
+
+    const btn = this.shadowRoot.querySelector('#toggle-btn')
+    btn.classList.toggle('dark')
+  }
+
+}
+
+customElements.define('dark-mode-toggle', CustomComponent);

--- a/www/themes/htmx-theme/templates/base.html
+++ b/www/themes/htmx-theme/templates/base.html
@@ -17,6 +17,7 @@
     <script src="/js/class-tools.js"></script>
     <script src="/js/preload.js"></script>
     <script src="/js/_hyperscript.js"></script>
+    <script src="/js/dark-mode-toggle.js"></script>
     <meta name="generator" content="Zola v.TODO">
 </head>
 <body hx-ext="class-tools, preload">
@@ -56,6 +57,7 @@
                 <div class="github-stars">
                     <iframe style="margin:auto;" src="https://ghbtns.com/github-btn.html?user=bigskysoftware&repo=htmx&type=star&count=true" frameborder="0" scrolling="0" width="150" height="20" title="Star htmx on GitHub"></iframe>
                 </div>
+                <dark-mode-toggle></dark-mode-toggle>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Description

I've added a dark mode toggle web component to add a dark mode to the htmx.org website.   The web component just adds `.dark` to the body element, but it also checks for user preference (via `prefers-color-scheme: dark` and LocalStorage; it also adds the dark mode state to LocalStorage.  

The preference checks enable dark mode to persist across page navigation, and they are the reason the toggle was not implemented in hyperscript.  The body element class toggle is easy enough to do in hyperscript, but it's also the least complicated part of a dark mode toggle; handling persistence is the hard(er) part -- and, afaik, is out of scope for hyperscript?  Since javascript is required to handle persistence, I felt it was worth it to use the web component for the entire toggle (I've heard locality of behavior is popular here).

I refactored the CSS colors into variables to ease the swap.  I normalized the (wide variety!) of shades of gray into 2 foreground and 2 background colors, and handled variations using alpha.  I retained the "brand" blue in the logos (`var(--x-color)`), but I switched to a lighter blue in dark mode for links, to keep the site in happy a11y territory.  

I noticed a few places where other CSS normalization and optimization could occur, but I tried to keep those out of this PR.  (If y'all express an interest in that, I'd be happy to add those as another PR.) The only "optimization" that I didn't remove is the addition of a `note` class (used in the index's news and in the docs page); I don't want to remove the ability of the content author to add css directly in the .md files, but this particular repetition seemed like something that could be extracted -- the author only needs to remember one class.  I did NOT add the `note` class to anywhere else in the *.md files, since they didn't have that styling, but that seems like something worth trying.

Corresponding issue:

No issue, just my own screeching

## Testing

- Verified that the dark mode toggle functions correctly on (both) major browsers (firefox, chrome, brave)
- Tested the website's responsiveness with the new styles.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded (I didn't really; I only touched CSS.  It was like that when I got here!)
