### PR TITLE
Add a HTMX CEO's website

### DIFF
--- a/www/content/webring.md
+++ b/www/content/webring.md
@@ -107,6 +107,7 @@ title = "htmx webring"
   <tr><td><a rel="nofollow" target="_blank" href="https://xrss.infogulch.com">XRSS</a></td><td>A simple RSS reader inspired by Google Reader</td></tr>
   <tr><td><a rel="nofollow" target="_blank" href="https://openunited.com/">OpenUnited</a></td><td>A Digital Talent match-making platform</td></tr>
   <tr><td><a rel="nofollow" target="_blank" href="https://gophemeral.com">Gophemeral</a></td><td>Share secrets securely!</td></tr>
+  <tr><td><a rel="nofollow" target="_blank" href="https://www.thomasricci.dev">thomasricci.dev</a></td><td>Super fast portfolio website</td></tr>
 </tbody>
 </table>
 </div>


### PR DESCRIPTION
## Description
This is a personal site. It seems like personal sites aren't allowed as per #2186, however it was closed because it was "Not exactly an htmx showcase." so I'm not exactly sure if it's that personal sites aren't allowed, or it's that the site didn't showcase HTMX.

I'd argue my site is webring-worthy because it relies nearly completely on HTMX and hyperscript, shows that HTMX and hyperscript can create very [fast](https://pagespeed.web.dev/analysis/https-thomasricci-dev/6tey5ptzsx?form_factor=desktop) websites, and has had (some) popularity w/ [HTMX on twitter](https://twitter.com/RudRecciah/status/1749007532734235134).

I'd love for it to be added, but if that's not an option it's okay.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue (i guess this is a documentation update? not sure)
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded (no, but the issue template allows ignoring testing for website updates)
