### PR TITLE
[docs] Clarify htmx:afterRequest in www/.../events.md

### DIFF
--- a/www/content/events.md
+++ b/www/content/events.md
@@ -38,8 +38,8 @@ This event is triggered after htmx has initialized a DOM node.  It can be useful
 
 ### Event - `htmx:afterRequest` {#htmx:afterRequest}
 
-This event is triggered after an AJAX request has finished either in the case of a successful request (although
-one that may have returned a remote error code such as a `404`) or in a network error situation.  This event
+This event is triggered after an AJAX request has finished — either in the case of a completed request (regardless
+of the HTTP status code such as 200 or 400) or in a network error situation.  This event
 can be paired with [`htmx:beforeRequest`](#htmx:beforeRequest) to wrap behavior around a request cycle.
 
 ##### Details


### PR DESCRIPTION
I found the concept of a “successful” request with a 404 status code distracting. So this is my attempt to smooth this out.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
