### PR TITLE
use wildcard (*) to match "revealed" trigger when scrolling

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1578,7 +1578,7 @@ return (function () {
                 setInterval(function() {
                     if (windowIsScrolling) {
                         windowIsScrolling = false;
-                        forEach(getDocument().querySelectorAll("[hx-trigger='revealed'],[data-hx-trigger='revealed']"), function (elt) {
+                        forEach(getDocument().querySelectorAll("[hx-trigger*='revealed'],[data-hx-trigger*='revealed']"), function (elt) {
                             maybeReveal(elt);
                         })
                     }

--- a/test/manual/scroll-test-eventHandler.html
+++ b/test/manual/scroll-test-eventHandler.html
@@ -102,6 +102,9 @@
 <div class="panel" hx-get="/more_content" hx-trigger="revealed"></div>
 <div class="panel" hx-get="/more_content" hx-trigger="revealed"></div>
 <div class="panel" hx-get="/more_content" hx-trigger="revealed"></div>
+<div class="panel" hx-get="/more_content" hx-trigger="revealed, click"></div>
+<div class="panel" hx-get="/more_content" hx-trigger="click, revealed"></div>
+<div class="panel" hx-get="/more_content" hx-trigger="click, revealed, mouseenter"></div>
 
 </body>
 </html>


### PR DESCRIPTION
## Description
Fixes #2233, using wildcard to match "revealed" trigger when collecting elements to execute `maybeReveal` on while scrolling allows using more events in the same hx-trigger attribute (i.e. click, mouseenter, custom events, etc)

A minimal example to reproduce the bug is included in the original issue.

Corresponding issue: #2233 

## Testing
The only way to test this is to have an element with `hx-trigger="revealed, anyOtherEvent"` below the fold (so that the initial `maybeReveal` function would not trigger the request)

I've updated `scroll-test-eventHandler.html` manual test to include 3 cases (at the very bottom), when the reveal event appears first, when it's last and when it's in the middle. All of them working after applying the fix.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded