### PR TITLE
Add trailing slash to manual tests link

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -24,7 +24,7 @@
 </ul>
 
 <h2>Manual Tests</h2>
-<a href="manual">Here</a>
+<a href="manual/">Here</a>
 
 <h2>Mocha Test Suite</h2>
 <a href="index.html">[ALL]</a>


### PR DESCRIPTION
## Description

When trying to contribute, [docs suggest](https://github.com/bigskysoftware/htmx/?tab=readme-ov-file#hacking-guide) to use `npx serve` and then go to http://0.0.0.0:3000/test/ to see all tests, in this file there's a link to the manual tests, but if you have followed the steps on the guide you will realize that the links for the individual manual tests are not working, all files will throw a 404, the first time I saw this I didn't know if I had something misconfigured, then I realized that the links were relative and since the link to "manual" didn't have a trailing slash, all individual manual tests were pointed to the root of tests folder (i.e. `http://localhost:3000/test/aborting-request` instead of `http://localhost:3000/test/manual/aborting-request`)

The "correct" way to fix this would be to add a `serve.json` as stated here: https://github.com/vercel/serve/issues/628, but not sure about adding a new config file and also, on my first test that approach worked for the test files links but broke relative image paths so I would need to review all tests and fix all affected. (not to mention that we need to make sure that paths works when open the files "locally" without `npx serve`)

Instead, I'm submitting this PR which only adds a trailing slash to the manual tests link on `http://0.0.0.0:3000/test/` this way a newcomer would not get immediately confused when trying to run and explore tests. 

I've made sure that this approach also works when opening the files "locally".

**Screenshot of the issue:**
<img width="1840" alt="image" src="https://github.com/bigskysoftware/htmx/assets/2120107/e7bd8a1f-652e-4a4e-80ca-4b25c085efaa">

Corresponding issue:

## Testing
NA

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
