### PR TITLE
fix sse-swap removal handling in ext/sse.js

### DIFF
--- a/src/ext/sse.js
+++ b/src/ext/sse.js
@@ -145,6 +145,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 					// If the body no longer contains the element, remove the listener
 					if (!api.bodyContains(child)) {
 						source.removeEventListener(sseEventName, listener);
+						return;
 					}
 
 					// swap the response into the DOM and trigger a notification

--- a/test/ext/sse.js
+++ b/test/ext/sse.js
@@ -5,6 +5,7 @@ describe("sse extension", function() {
         var wasClosed = false;
         var url;
         var mockEventSource = {
+            _listeners: listeners,
             removeEventListener: function(name, l) {
                 listeners[name] = listeners[name].filter(function(elt, idx, arr) {
                     if (arr[idx] === l) {
@@ -147,6 +148,16 @@ describe("sse extension", function() {
         div.parentElement.removeChild(div);
         this.eventSource.sendEvent("e1")
         this.eventSource.wasClosed().should.equal(true)
+    })
+
+    it('is not listening for events after hx-swap element removed', function() {
+        var div = make('<div hx-ext="sse" sse-connect="/foo">' +
+            '<div id="d1" hx-swap="outerHTML" sse-swap="e1">div1</div>' +
+            '</div>');
+        this.eventSource._listeners["e1"].should.be.lengthOf(1)
+        div.removeChild(byId("d1"));
+        this.eventSource.sendEvent("e1", "Test")
+        this.eventSource._listeners["e1"].should.be.empty
     })
 
     // sse and hx-trigger handlers are distinct


### PR DESCRIPTION
## Description

sse.js was not returning from handler after removing event listeners when sse-swap element was replaced/removed from the DOM. This lead to errors when removed element was target for swapping

Corresponding issue: https://discord.com/channels/725789699527933952/1200403330254520320

## Testing
I added new test case to test/ext/sse.js and also ran manual tests with the test server

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
