### PR TITLE
www: mention hx-preserve on hx-boost

### DIFF
--- a/www/content/attributes/hx-boost.md
+++ b/www/content/attributes/hx-boost.md
@@ -44,3 +44,4 @@ This form will issue an ajax `POST` to the given URL and replace the body's inne
 * All requests are done via AJAX, so keep that in mind when doing things like redirects
 * To find out if the request results from a boosted anchor or form, look for [`HX-Boosted`](@/reference.md#request_headers) in the request header
 * Selectively disable boost on child elements with `hx-boost="false"`
+* Disable the replacement of elements via boost, and their children, with [`hx-preserve="true"`](@/attributes/hx-preserve.md)


### PR DESCRIPTION
## Description

This note would have really helped me when I was working on avoiding my maplibre canvas div from being overwritten when using hx-boost. I was initially confused by the hx-boost=false note thinking that is what I needed.


## Testing

This is untested.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
