### PR TITLE
removed leftover @param

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -275,7 +275,6 @@ var htmx = (function() {
   /**
    *
    * @param {string} resp
-   * @param {number} depth
    * @returns {Document}
    */
   function parseHTML(resp) {


### PR DESCRIPTION
## Description
Tiny JSDoc fix: 'depth' parameter was removed from parseHTML signature, but not from its JSDoc.

Corresponding issue:
n/a

## Testing
n/a

## Checklist

* [x] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
