### PR TITLE
Keep the loading state when the response is a HX-Redirect

### DIFF
--- a/src/ext/loading-states.js
+++ b/src/ext/loading-states.js
@@ -173,7 +173,7 @@
 				)
 			}
 
-			if (name === 'htmx:beforeOnLoad') {
+			if (name === 'htmx:beforeOnLoad' && !evt.detail.xhr.getResponseHeader('HX-Redirect')) {
 				while (loadingStatesUndoQueue.length > 0) {
 					loadingStatesUndoQueue.shift()()
 				}

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -291,7 +291,7 @@ var htmx = (function() {
 
   function duplicateScript(script) {
     const newScript = getDocument().createElement('script')
-    forEach(script.attributes, function (attr) {
+    forEach(script.attributes, function(attr) {
       newScript.setAttribute(attr.name, attr.value)
     })
     newScript.textContent = script.textContent
@@ -299,21 +299,21 @@ var htmx = (function() {
     if (htmx.config.inlineScriptNonce) {
       newScript.nonce = htmx.config.inlineScriptNonce
     }
-    return newScript;
+    return newScript
   }
 
   function isJavaScriptScriptNode(script) {
-    return script.matches('script') && (script.type === 'text/javascript' || script.type === 'module' || script.type === '');
+    return script.matches('script') && (script.type === 'text/javascript' || script.type === 'module' || script.type === '')
   }
 
   // we have to make new copies of script tags that we are going to insert because
   // SOME browsers (not saying who, but it involves an element and an animal) don't
   // execute scripts created in <template> tags when they are inserted into the DOM
-// and all the others do lmao
+  // and all the others do lmao
   function normalizeScriptTags(fragment) {
     Array.from(fragment.querySelectorAll('script')).forEach((script) => {
       if (isJavaScriptScriptNode(script)) {
-        const newScript = duplicateScript(script);
+        const newScript = duplicateScript(script)
         const parent = script.parentNode
         try {
           parent.insertBefore(newScript, script)
@@ -1301,7 +1301,7 @@ var htmx = (function() {
       })
 
       if (swapOptions.anchor) {
-        const anchorTarget = resolveTarget("#" + swapOptions.anchor)
+        const anchorTarget = resolveTarget('#' + swapOptions.anchor)
         if (anchorTarget) {
           anchorTarget.scrollIntoView({ block: 'start', behavior: 'auto' })
         }
@@ -1380,9 +1380,9 @@ var htmx = (function() {
           if (triggerEvent(document.body, 'htmx:addingHeadElement', { headElement: node }) !== false) {
             // make a copy of script nodes so they will execute properly
             if (isJavaScriptScriptNode(node)) {
-              node = duplicateScript(node);
+              node = duplicateScript(node)
             }
-            currentHead.appendChild(node);
+            currentHead.appendChild(node)
           }
         }
 


### PR DESCRIPTION
## Description
When we do a HX request and the response is a redirect the loading state should be kept - if it doesn't the application will "flick" before loading the new page.

Corresponding issue:
#2146

## Testing
Have a simple form that submits to an endpoint that responds with a HX-Redirect header - the loading state should be kept until the redirect is successfully done:
```
<form hx-post="/test">
    <button type="submit" data-loading-disable>
        Submit!
    </button>
</form>
```

## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [X] I ran the test suite locally (`npm run test`) and verified that it succeeded
