### PR TITLE
Fix TypeScript types

### DIFF
--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -429,13 +429,7 @@ export interface HtmxConfig {
      * If set to true htmx will not update the title of the document when a title tag is found in new content
      * @default false 
      */
-    ignoreTitle:? boolean;
-    /**
-     * The cache to store evaluated trigger specifications into.
-     * You may define a simple object to use a never-clearing cache, or implement your own system using a [proxy object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy)
-     * @default null
-     */
-    triggerSpecsCache?: {[trigger: string]: HtmxTriggerSpecification[]};
+    ignoreTitle?: boolean;
 }
 
 export type HtmxEvent = "htmx:abort"


### PR DESCRIPTION
## Description

This PR fixes the TypeScript types in `src/htmx.d.ts`. There were two separate issues:

- Line 432 contained invalid syntax.
- `triggerSpecsCache` referenced a `HtmxTriggerSpecification` type the doesn't exist

Given the guidance in https://github.com/bigskysoftware/htmx/pull/2107#issuecomment-1866499625, I opted to remove the types for `triggerSpecCache` entirely.

Interestingly, there are other parts of the code (JSDoc comments) that reference `HtmxTriggerSpecification`:

- https://github.com/bigskysoftware/htmx/blob/7f3d114269d423ac8e77c64e988d6f4cf60325b1/src/htmx.js#L1273
- https://github.com/bigskysoftware/htmx/blob/7f3d114269d423ac8e77c64e988d6f4cf60325b1/src/htmx.js#L1364

This leads me to believe that this type did exist at one point, but I couldn't immediately find it in the Git history. It seems like a type that should exist though!

Corresponding issue: https://github.com/bigskysoftware/htmx/issues/2148

## Testing

I installed these types into my project and verified that `tsc` could now successfully parse the types.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
