### PR TITLE
SSE Ext #2225: reinstantiate EventSource listeners upon reconnection logic

### DIFF
--- a/src/ext/sse.js
+++ b/src/ext/sse.js
@@ -111,19 +111,18 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 	 * @param {HTMLElement} elt
 	 */
 	function registerSSE(elt) {
-		// Find closest existing event source
-		var sourceElement = api.getClosestMatch(elt, hasEventSource);
-		if (sourceElement == null) {
-			// api.triggerErrorEvent(elt, "htmx:noSSESourceError")
-			return null; // no eventsource in parentage, orphaned element
-		}
-
-		// Set internalData and source
-		var internalData = api.getInternalData(sourceElement);
-		var source = internalData.sseEventSource;
-
 		// Add message handlers for every `sse-swap` attribute
-		queryAttributeOnThisOrChildren(elt, "sse-swap").forEach(function(child) {
+		queryAttributeOnThisOrChildren(elt, "sse-swap").forEach(function (child) {
+			// Find closest existing event source
+			var sourceElement = api.getClosestMatch(child, hasEventSource);
+			if (sourceElement == null) {
+				// api.triggerErrorEvent(elt, "htmx:noSSESourceError")
+				return null; // no eventsource in parentage, orphaned element
+			}
+
+			// Set internalData and source
+			var internalData = api.getInternalData(sourceElement);
+			var source = internalData.sseEventSource;
 
 			var sseSwapAttr = api.getAttributeValue(child, "sse-swap");
 			if (sseSwapAttr) {
@@ -162,6 +161,16 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 
 		// Add message handlers for every `hx-trigger="sse:*"` attribute
 		queryAttributeOnThisOrChildren(elt, "hx-trigger").forEach(function(child) {
+			// Find closest existing event source
+			var sourceElement = api.getClosestMatch(child, hasEventSource);
+			if (sourceElement == null) {
+				// api.triggerErrorEvent(elt, "htmx:noSSESourceError")
+				return null; // no eventsource in parentage, orphaned element
+			}
+
+			// Set internalData and source
+			var internalData = api.getInternalData(sourceElement);
+			var source = internalData.sseEventSource;
 
 			var sseEventName = api.getAttributeValue(child, "hx-trigger");
 			if (sseEventName == null) {

--- a/src/ext/sse.js
+++ b/src/ext/sse.js
@@ -51,7 +51,6 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 				// Try to create EventSources when elements are processed
 				case "htmx:afterProcessNode":
 					ensureEventSourceOnElement(evt.target);
-					registerSSE(evt.target);
 			}
 		}
 	});
@@ -223,6 +222,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 			ensureEventSource(child, sseURL, retryCount);
 		});
 
+		registerSSE(elt);
 	}
 
 	function ensureEventSource(elt, url, retryCount) {

--- a/test/ext/sse.js
+++ b/test/ext/sse.js
@@ -190,7 +190,8 @@ describe("sse extension", function() {
             '<div id="d1" sse-connect="/event_stream" sse-swap="e1">div1</div>\n' +
             '</div>\n'
         )
-        this.eventSource.url = "/event_stream"
+        this.eventSource.sendEvent("e1", "Event 1")
+        byId("d1").innerText.should.equal("Event 1")
     })
 
     it('only adds sseEventSource to elements with sse-connect', function() {


### PR DESCRIPTION
## Description
*Please describe what changes you made, and why you feel they are necessary. Make sure to include
code examples, where applicable.*

Currently when EventSource loses connection with the server, e.g. when server restarts and later SSE ext reconnects it creates new EventSource, but is not adding any previously registered listeners. As a result while server issues new events, SSE ext no longer consumes them.

Corresponding issue:

Refs: #2225

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

Tested on a real application by using the exact changes and patching the npm package with `patch-package` module first.
All the existing tests are passing:

<img width="593" alt="Screenshot 2024-02-02 at 10 26 56" src="https://github.com/bigskysoftware/htmx/assets/8940850/0da97122-b7ac-474f-a7f9-1d9e9c54500a">

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded

Last isn't checked, as it fails to start on my machine even on a clean `dev` branch.