### PR TITLE
Show element used for hx-indicator in value-select example code

### DIFF
--- a/www/content/examples/value-select.md
+++ b/www/content/examples/value-select.md
@@ -25,6 +25,7 @@ Here is the code:
       <option value="a1">A1</option>
       ...
     </select>
+    <img class="htmx-indicator" width="20" src="/img/bars.svg">
 </div>
 ```
 


### PR DESCRIPTION
## Description
Code examples does not include element with class `.htmx-indicator` used for hx-indicator attribute

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
