### PR TITLE
Docs: hx-swap-oob clarity. Removed excess from hx-swap short desc.

### DIFF
--- a/www/content/attributes/hx-select-oob.md
+++ b/www/content/attributes/hx-select-oob.md
@@ -2,8 +2,8 @@
 title = "hx-select-oob"
 +++
 
-The `hx-select-oob` attribute allows you to select content from a response to be swapped in via an out-of-band swap.  
-The value of this attribute is comma separated list of elements to be swapped out of band.  This attribute is almost
+The `hx-select-oob` attribute allows you to select content from a response to be swapped in via an "out of band" swap.
+The value of this attribute is a comma separated list of elements to swap in. This attribute is almost
 always paired with [hx-select](@/attributes/hx-select.md).
 
 Here is an example that selects a subset of the response content:

--- a/www/content/attributes/hx-swap-oob.md
+++ b/www/content/attributes/hx-swap-oob.md
@@ -2,8 +2,8 @@
 title = "hx-swap-oob"
 +++
 
-The `hx-swap-oob` attribute allows you to specify that some content in a response should be 
-swapped into the DOM somewhere other than the target, that is "Out of Band".  This allows you to piggy back updates to other element updates on a response.
+The `hx-swap-oob` attribute allows you to mark an element to swap in from a response via an "out of band" swap.
+This allows you to piggy back updates to other elements during a response.
 
 Consider the following response HTML: 
 

--- a/www/content/reference.md
+++ b/www/content/reference.md
@@ -28,7 +28,7 @@ The most common attributes when using htmx.
 | [`hx-push-url`](@/attributes/hx-push-url.md)     | push a URL into the browser location bar to create history                                                         |
 | [`hx-select`](@/attributes/hx-select.md)         | select content to swap in from a response                                                                          |
 | [`hx-select-oob`](@/attributes/hx-select-oob.md) | select content to swap in from a response, somewhere other than the target (out of band)                           |
-| [`hx-swap`](@/attributes/hx-swap.md)             | controls how content will swap in (`outerHTML`, `beforeend`, `afterend`, ...)                                      |
+| [`hx-swap`](@/attributes/hx-swap.md)             | controls how content will swap in                                                                                  |
 | [`hx-swap-oob`](@/attributes/hx-swap-oob.md)     | mark element to swap in from a response (out of band)                                                              |
 | [`hx-target`](@/attributes/hx-target.md)         | specifies the target element to be swapped                                                                         |
 | [`hx-trigger`](@/attributes/hx-trigger.md)       | specifies the event that triggers the request                                                                      |


### PR DESCRIPTION
Before / After

* Clarified `hx-swap-oob` vs `hx-select-oob`
* Consistent wording of "out of band" in `hx-swap-oob` and `hx-select-oob`
* Removed excess information from `hx-swap` short description.

![image](https://github.com/bigskysoftware/htmx/assets/24665/cc9c3342-f267-4a63-bacc-7542821a012e)

![image](https://github.com/bigskysoftware/htmx/assets/24665/35c55b2c-0f1c-4454-8cf4-60cf252181de)

