### PR TITLE
loading states: add support for filtering on verb

### DIFF
--- a/src/ext/loading-states.js
+++ b/src/ext/loading-states.js
@@ -20,6 +20,15 @@
 		return pathElt.getAttribute('data-loading-path') === requestPath
 	}
 
+	function mayProcessLoadingStateByVerb(elt, verb) {
+		const verbElt = htmx.closest(elt, '[data-loading-verb]')
+		if (!verbElt) {
+			return true
+		}
+
+		return verbElt.getAttribute('data-loading-verb') === verb
+	}
+
 	function queueLoadingState(sourceElt, targetElt, doCallback, undoCallback) {
 		const delayElt = htmx.closest(sourceElt, '[data-loading-delay]')
 		if (delayElt) {
@@ -44,9 +53,11 @@
 		}
 	}
 
-	function getLoadingStateElts(loadingScope, type, path) {
+	function getLoadingStateElts(loadingScope, type, path, verb) {
 		return Array.from(htmx.findAll(loadingScope, "[" + type + "]")).filter(
-			function (elt) { return mayProcessLoadingStateByPath(elt, path) }
+			function (elt) {
+				return mayProcessLoadingStateByPath(elt, path) && mayProcessLoadingStateByVerb(elt, verb)
+			}
 		)
 	}
 
@@ -78,7 +89,8 @@
 					loadingStateEltsByType[type] = getLoadingStateElts(
 						container,
 						type,
-						evt.detail.pathInfo.requestPath
+						evt.detail.pathInfo.requestPath,
+						evt.detail.requestConfig.verb
 					)
 				})
 

--- a/test/ext/loading-states.js
+++ b/test/ext/loading-states.js
@@ -129,6 +129,20 @@ describe("loading states extension", function () {
         btn.innerHTML.should.equal("Clicked!");
     });
 
+    it('works with verb filters', function () {
+        this.server.respondWith("POST", "/test", "Clicked!");
+        var btn = make('<button hx-post="/test" hx-ext="loading-states" >Click Me!</button>');
+        var matchingRequestElement = make('<div data-loading-class="test" data-loading-verb="post">');
+        var nonMatchingPathElement = make('<div data-loading-class="test" data-loading-verb="get">');
+        btn.click();
+        matchingRequestElement.should.have.class("test");
+        nonMatchingPathElement.should.not.have.class("test");
+        this.server.respond();
+        matchingRequestElement.should.not.have.class("test");
+        nonMatchingPathElement.should.not.have.class("test");
+        btn.innerHTML.should.equal("Clicked!");
+    });
+
     it('works with scopes', function () {
         this.server.respondWith("GET", "/test", "Clicked!");
         var btn = make('<div data-loading-states><button hx-get="/test" hx-ext="loading-states" >Click Me!</button></div>');

--- a/www/content/extensions/loading-states.md
+++ b/www/content/extensions/loading-states.md
@@ -99,7 +99,8 @@ Add the following class to your stylesheet to make sure elements are hidden by d
 
 - `data-loading-path`
 
-  Allows filtering the processing of loading states only for specific requests based on the request path.
+  Allows filtering the processing of loading states only for specific requests based on the request path. Can be
+  combined with `data-loading-verb` to additionally filter based on the request verb.
 
   ```html
   <form hx-post="/save">
@@ -111,6 +112,27 @@ Add the following class to your stylesheet to make sure elements are hidden by d
 
   ```html
   <form hx-post="/save" data-loading-path="/save">
+    <button type="submit" data-loading-disable>Submit</button>
+  </form>
+  ```
+
+- `data-loading-verb`
+
+  Allows filtering the processing of loading states only for specific requests based on the request verb ('get', 'post', 'put', 'delete', 'patch').
+
+  ```html
+  <form hx-post="/user">
+    <button type="submit" data-loading-disable data-loading-verb="post">Create</button>
+  </form>
+  <form hx-delete="/user">
+    <button type="submit" data-loading-disable data-loading-verb="delete">Delete</button>
+  </form>
+  ```
+
+   You can place the `data-loading-verb` attribute directly on the loading state element, or in any parent element.
+
+  ```html
+  <form hx-post="/save" data-loading-path="/save" data-loading-verb="post">
     <button type="submit" data-loading-disable>Submit</button>
   </form>
   ```


### PR DESCRIPTION
## Description
This is a small feature added to the loading states extension for being able to filter based on request verb, either by itself or combined with the existing path filter. Useful when using RESTful URLs.

Corresponding issue: Didn't create one since this was such a minor change, sorry!

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [X] I ran the test suite locally (`npm run test`) and verified that it succeeded
