### PR TITLE
[DOC] Adds a reference to `hx-swap` from SSE extension

### DIFF
--- a/www/content/extensions/server-sent-events.md
+++ b/www/content/extensions/server-sent-events.md
@@ -12,6 +12,7 @@ Use the following attributes to configure how SSE connections behave:
 
 * `sse-connect="<url>"` - The URL of the SSE server.
 * `sse-swap="<message-name>"` - The name of the message to swap into the DOM.
+* `hx-swap` - You can control the swap strategy by using the [hx-swap](@/attributes/hx-swap.md) attribute.
 * `hx-trigger="sse:<message-name>"` - SSE messages can also trigger HTTP callbacks using the [`hx-trigger`](@/attributes/hx-trigger.md) attribute.
 
 ## Install


### PR DESCRIPTION
Fixes #2197

## Description
Adds a reference to `hx-swap` from the SSE extension doc page.

Corresponding issue:

#2197

## Testing
N/A

## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
