### PR TITLE
Inherit support include indicator - correction

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -632,6 +632,14 @@ return (function () {
                 return [window];
             } else if (selector === 'body') {
                 return [document.body];
+            } else if (selector.indexOf("inherit") === 0) {
+                var result = [...Array.prototype.slice.call(getDocument().querySelectorAll(normalizeSelector(selector)))]
+                var attrTarget = getAttributeValue(elt, 'hx-indicator') || getAttributeValue(elt, 'hx-include')
+                if (attrTarget){
+                    result.push(...Array.prototype.slice.call(querySelectorAllExt(elt.parentNode, attrTarget)))
+                    result.filter((value, index, array) => array.indexOf(value) === index)
+                }
+                return result;
             } else {
                 return getDocument().querySelectorAll(normalizeSelector(selector));
             }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -634,7 +634,7 @@ return (function () {
                 return [document.body];
             } else if (selector.indexOf("inherit") === 0) {
                 var result = [...Array.prototype.slice.call(getDocument().querySelectorAll(normalizeSelector(selector)))]
-                var attrTarget = getAttributeValue(elt, 'hx-indicator') || getAttributeValue(elt, 'hx-include')
+                var attrTarget = getAttributeValue(elt, 'hx-include')
                 if (attrTarget){
                     result.push(...Array.prototype.slice.call(querySelectorAllExt(elt.parentNode, attrTarget)))
                     result.filter((value, index, array) => array.indexOf(value) === index)

--- a/test/attributes/hx-include.js
+++ b/test/attributes/hx-include.js
@@ -212,7 +212,6 @@ describe("hx-include attribute", function() {
     it('The `inherit` modifier can be used in the hx-include selector', function () {
         this.server.respondWith("POST", "/include", function (xhr) {
             var params = getParameters(xhr);
-            console.log('1', params)
             params['i1'].should.equal("test");
             params['i2'].should.equal("test");
             xhr.respond(200, {}, "Clicked!")

--- a/test/attributes/hx-include.js
+++ b/test/attributes/hx-include.js
@@ -209,7 +209,23 @@ describe("hx-include attribute", function() {
         this.server.respond();
         btn.innerHTML.should.equal("Clicked!");
     })
-
+    it('The `inherit` modifier can be used in the hx-include selector', function () {
+        this.server.respondWith("POST", "/include", function (xhr) {
+            var params = getParameters(xhr);
+            console.log('1', params)
+            params['i1'].should.equal("test");
+            params['i2'].should.equal("test");
+            xhr.respond(200, {}, "Clicked!")
+        });
+        make('<input id="i2" name="i2" value="test"/>');
+        var div = make('<div hx-include="#i2" hx-target="this">'+
+        '<input id="i1" name="i1" value="test" hx-post="/include" hx-trigger="click" hx-include="inherit, #i1"/>'+
+        '</div>');
+        var input = byId("i1")
+        input.click();
+        this.server.respond();
+        div.innerHTML.should.equal("Clicked!");
+    })
     it('The `this` modifier can be used in the hx-include selector', function () {
         this.server.respondWith("POST", "/include", function (xhr) {
             var params = getParameters(xhr);


### PR DESCRIPTION
## Description
I have added Inheritence for include indicators as described in issue https://github.com/bigskysoftware/htmx/issues/1754.
