### PR TITLE
Fixes issue 1537 - OOB does not escape query selector

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -799,7 +799,7 @@ return (function () {
          * @returns
          */
         function oobSwap(oobValue, oobElement, settleInfo) {
-            var selector = "#" + getRawAttribute(oobElement, "id");
+            var selector = '[id="' + getRawAttribute(oobElement, "id") + '"]';
             var swapStyle = "outerHTML";
             if (oobValue === "true") {
                 // do nothing


### PR DESCRIPTION
## Description

This change alters how the oobSwap function builds the query selector string. Rather than simply prefixing it with a `#` it uses the  `'[id="raw_id"]'` format. Where `raw_id` is the value obtained from `getRawAttribute(oobElement, "id")`

Ideally this could be done more cleanly with template literals (backtick strings) - but as I understand it you want to support IE11. 

This fix allows the call querySelectorAll to return the nodelist of all elements with the id "raw_id" - without getting "Failed to execute 'querySelectorAll' on 'Document': 'raw_id' is not a valid selector, and whilst not limiting the selection to the first matching id in the document.

Corresponding issue:
https://github.com/bigskysoftware/htmx/issues/1537

## Testing

I ran the htmx.js test suite Version: 1.9.10 and got passes: 679 failures: 0

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
