### PR TITLE
[DOC] clarify SSE hx-swap docs to note #784

### DIFF
--- a/www/content/extensions/server-sent-events.md
+++ b/www/content/extensions/server-sent-events.md
@@ -12,7 +12,7 @@ Use the following attributes to configure how SSE connections behave:
 
 * `sse-connect="<url>"` - The URL of the SSE server.
 * `sse-swap="<message-name>"` - The name of the message to swap into the DOM.
-* `hx-swap` - You can control the swap strategy by using the [hx-swap](@/attributes/hx-swap.md) attribute.
+* `hx-swap` - You can control the swap strategy by using the [hx-swap](@/attributes/hx-swap.md) attribute, though note that modifiers like `scroll` are not supported.
 * `hx-trigger="sse:<message-name>"` - SSE messages can also trigger HTTP callbacks using the [`hx-trigger`](@/attributes/hx-trigger.md) attribute.
 
 ## Install


### PR DESCRIPTION
## Description

The SSE extension docs suggest that `hx-swap` works, which it sort of does, except that (as noted in #784) the modifier functionality documented on the `hx-swap` attribute is silently ignored.

Corresponding issue: #784

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded

(I'm not a node developer and don't have all the dependencies to run the test suite -- if you're concerned that this Markdown wording change might have broken the tests, lmk and I can look into it.)