### PR TITLE
JSdoc in htmx.js + generated TypeScript definition

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,14 +1,19 @@
 {
-    "compilerOptions": {
-        "target": "es5",
-        "noEmit": true,
-        "checkJs": true,
-        "jsx": "react",
-        "strict": false,
-        "lib": [ "dom" ]
-    },
-    "include": [
-        "./src/htmx.js"
-    ],
-    "verbose": true
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outFile": "src/htmx.d.ts",
+    "target": "es6",
+    "checkJs": true,
+    "lib": [
+      "dom",
+      "dom.iterable"
+    ]
+  },
+  "include": [
+    "./src/htmx.js"
+  ],
+  "verbose": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "htmx.org",
-  "version": "1.9.10",
+  "version": "2.0.0-alpha2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "htmx.org",
-      "version": "1.9.10",
-      "license": "BSD 2-Clause",
+      "version": "2.0.0-alpha2",
+      "license": "0BSD",
       "devDependencies": {
         "chai": "^4.3.10",
         "chai-dom": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint-fix": "eslint src/htmx.js test/attributes/ test/core/ test/util/ --fix",
     "format": "eslint --fix src/htmx.js test/attributes/ test/core/ test/util/",
     "test": "npm run lint && mocha-chrome test/index.html",
-    "test-types": "tsc --project ./jsconfig.json",
+    "type-declarations": "tsc --project ./jsconfig.json",
     "ws-tests": "cd ./test/ws-sse && node ./server.js",
     "www": "bash ./scripts/www.sh"
   },

--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -1,466 +1,193 @@
-// https://htmx.org/reference/#api
-
-/**
- * This method adds a class to the given element.
- *
- * https://htmx.org/api/#addClass
- *
- * @param elt the element to add the class to
- * @param clazz the class to add
- * @param delay the delay (in milliseconds before class is added)
- */
-export function addClass(elt: Element, clazz: string, delay?: number): void;
-
-/**
- * Issues an htmx-style AJAX request
- *
- * https://htmx.org/api/#ajax
- *
- * @param verb 'GET', 'POST', etc.
- * @param path the URL path to make the AJAX
- * @param element the element to target (defaults to the **body**)
- * @returns Promise that resolves immediately if no request is sent, or when the request is complete
- */
-export function ajax(verb: string, path: string, element: Element): Promise<void>;
-
-/**
- * Issues an htmx-style AJAX request
- *
- * https://htmx.org/api/#ajax
- *
- * @param verb 'GET', 'POST', etc.
- * @param path the URL path to make the AJAX
- * @param selector a selector for the target
- * @returns Promise that resolves immediately if no request is sent, or when the request is complete
- */
-export function ajax(verb: string, path: string, selector: string): Promise<void>;
-
-/**
- * Issues an htmx-style AJAX request
- *
- * https://htmx.org/api/#ajax
- *
- * @param verb 'GET', 'POST', etc.
- * @param path the URL path to make the AJAX
- * @param context a context object that contains any of the following
- * @returns Promise that resolves immediately if no request is sent, or when the request is complete
- */
-export function ajax(
-    verb: string,
-    path: string,
-    context: Partial<{ source: any; event: any; handler: any; target: any; swap: any; values: any; headers: any; select: any }>
-): Promise<void>;
-
-/**
- * Finds the closest matching element in the given elements parentage, inclusive of the element
- *
- * https://htmx.org/api/#closest
- *
- * @param elt the element to find the selector from
- * @param selector the selector to find
- */
-export function closest(elt: Element, selector: string): Element | null;
-
-/**
- * A property holding the configuration htmx uses at runtime.
- *
- * Note that using a [meta tag](https://htmx.org/docs/#config) is the preferred mechanism for setting these properties.
- *
- * https://htmx.org/api/#config
- */
-export var config: HtmxConfig;
-
-/**
- * A property used to create new [Server Sent Event](https://htmx.org/docs/#sse) sources. This can be updated to provide custom SSE setup.
- *
- * https://htmx.org/api/#createEventSource
- */
-export var createEventSource: (url: string) => EventSource;
-
-/**
- * A property used to create new [WebSocket](https://htmx.org/docs/#websockets). This can be updated to provide custom WebSocket setup.
- *
- * https://htmx.org/api/#createWebSocket
- */
-export var createWebSocket: (url: string) => WebSocket;
-
-/**
- * Defines a new htmx [extension](https://htmx.org/extensions).
- *
- * https://htmx.org/api/#defineExtension
- *
- * @param name the extension name
- * @param ext the extension definition
- */
-export function defineExtension(name: string, ext: HtmxExtension): void;
-
-/**
- * Finds an element matching the selector
- *
- * https://htmx.org/api/#find
- *
- * @param selector the selector to match
- */
-export function find(selector: string): Element | null;
-
-/**
- * Finds an element matching the selector
- *
- * https://htmx.org/api/#find
- *
- * @param elt the root element to find the matching element in, inclusive
- * @param selector the selector to match
- */
-export function find(elt: Element, selector: string): Element | null;
-
-/**
- * Finds all elements matching the selector
- *
- * https://htmx.org/api/#findAll
- *
- * @param selector the selector to match
- */
-export function findAll(selector: string): NodeListOf<Element>;
-
-/**
- * Finds all elements matching the selector
- *
- * https://htmx.org/api/#findAll
- *
- * @param elt the root element to find the matching elements in, inclusive
- * @param selector the selector to match
- */
-export function findAll(elt: Element, selector: string): NodeListOf<Element>;
-
-/**
- * Log all htmx events, useful for debugging.
- *
- * https://htmx.org/api/#logAll
- */
-export function logAll(): void;
-
-/**
- * The logger htmx uses to log with
- *
- * https://htmx.org/api/#logger
- */
-export var logger: (elt: Element, eventName: string, detail: any) => void | null;
-
-/**
- * Removes an event listener from an element
- *
- * https://htmx.org/api/#off
- *
- * @param eventName the event name to remove the listener from
- * @param listener the listener to remove
- */
-export function off(eventName: string, listener: (evt: Event) => void): (evt: Event) => void;
-
-/**
- * Removes an event listener from an element
- *
- * https://htmx.org/api/#off
- *
- * @param target the element to remove the listener from
- * @param eventName the event name to remove the listener from
- * @param listener the listener to remove
- */
-export function off(target: string, eventName: string, listener: (evt: Event) => void): (evt: Event) => void;
-
-/**
- * Adds an event listener to an element
- *
- * https://htmx.org/api/#on
- *
- * @param eventName the event name to add the listener for
- * @param listener the listener to add
- */
-export function on(eventName: string, listener: (evt: Event) => void): (evt: Event) => void;
-
-/**
- * Adds an event listener to an element
- *
- * https://htmx.org/api/#on
- *
- * @param target the element to add the listener to
- * @param eventName the event name to add the listener for
- * @param listener the listener to add
- */
-export function on(target: string, eventName: string, listener: (evt: Event) => void): (evt: Event) => void;
-
-/**
- * Adds a callback for the **htmx:load** event. This can be used to process new content, for example initializing the content with a javascript library
- *
- * https://htmx.org/api/#onLoad
- *
- * @param callback the callback to call on newly loaded content
- */
-export function onLoad(callback: (element: Element) => void): void;
-
-/**
- * Parses an interval string consistent with the way htmx does. Useful for plugins that have timing-related attributes.
- *
- * Caution: Accepts an int followed by either **s** or **ms**. All other values use **parseFloat**
- *
- * https://htmx.org/api/#parseInterval
- *
- * @param str timing string
- */
-export function parseInterval(str: string): number;
-
-/**
- * Processes new content, enabling htmx behavior. This can be useful if you have content that is added to the DOM outside of the normal htmx request cycle but still want htmx attributes to work.
- *
- * https://htmx.org/api/#process
- *
- * @param element element to process
- */
-export function process(element: Element): void;
-
-/**
- * Removes an element from the DOM
- *
- * https://htmx.org/api/#remove
- *
- * @param elt element to remove
- * @param delay the delay (in milliseconds before element is removed)
- */
-export function remove(elt: Element, delay?: number): void;
-
-/**
- * Removes a class from the given element
- *
- * https://htmx.org/api/#removeClass
- *
- * @param elt element to remove the class from
- * @param clazz the class to remove
- * @param delay the delay (in milliseconds before class is removed)
- */
-export function removeClass(elt: Element, clazz: string, delay?: number): void;
-
-/**
- * Removes the given extension from htmx
- *
- * https://htmx.org/api/#removeExtension
- *
- * @param name the name of the extension to remove
- */
-export function removeExtension(name: string): void;
-
-/**
- * Takes the given class from its siblings, so that among its siblings, only the given element will have the class.
- *
- * https://htmx.org/api/#takeClass
- *
- * @param elt the element that will take the class
- * @param clazz the class to take
- */
-export function takeClass(elt: Element, clazz: string): void;
-
-/**
- * Toggles the given class on an element
- *
- * https://htmx.org/api/#toggleClass
- *
- * @param elt the element to toggle the class on
- * @param clazz the class to toggle
- */
-export function toggleClass(elt: Element, clazz: string): void;
-
-/**
- * Triggers a given event on an element
- *
- * https://htmx.org/api/#trigger
- *
- * @param elt the element to trigger the event on
- * @param name the name of the event to trigger
- * @param detail details for the event
- */
-export function trigger(elt: Element, name: string, detail: any): void;
-
-/**
- * Returns the input values that would resolve for a given element via the htmx value resolution mechanism
- *
- * https://htmx.org/api/#values
- *
- * @param elt the element to resolve values on
- * @param requestType the request type (e.g. **get** or **post**) non-GET's will include the enclosing form of the element. Defaults to **post**
- */
-export function values(elt: Element, requestType?: string): any;
-
-export const version: string;
-
-export interface HtmxConfig {
-    /**
-     * The attributes to settle during the settling phase.
-     * @default ["class", "style", "width", "height"]
-     */
-    attributesToSettle?: ["class", "style", "width", "height"] | string[];
-    /**
-     * If the focused element should be scrolled into view.
-     * @default false
-    */
-    defaultFocusScroll?: boolean;
-    /**
-     * The default delay between completing the content swap and settling attributes.
-     * @default 20
-     */
-    defaultSettleDelay?: number;
-    /**
-     * The default delay between receiving a response from the server and doing the swap.
-     * @default 0
-     */
-    defaultSwapDelay?: number;
-    /**
-     * The default swap style to use if **[hx-swap](https://htmx.org/attributes/hx-swap)** is omitted.
-     * @default "innerHTML"
-     */
-    defaultSwapStyle?: "innerHTML" | string;
-    /**
-     * The number of pages to keep in **localStorage** for history support.
-     * @default 10
-     */
-    historyCacheSize?: number;
-    /**
-     * Whether or not to use history.
-     * @default true
-     */
-    historyEnabled?: boolean;
-    /**
-     * If true, htmx will inject a small amount of CSS into the page to make indicators invisible unless the **htmx-indicator** class is present.
-     * @default true
-     */
-    includeIndicatorStyles?: boolean;
-    /**
-     * The class to place on indicators when a request is in flight.
-     * @default "htmx-indicator"
-     */
-    indicatorClass?: "htmx-indicator" | string;
-    /**
-     * The class to place on triggering elements when a request is in flight.
-     * @default "htmx-request"
-     */
-    requestClass?: "htmx-request" | string;
-    /**
-     * The class to temporarily place on elements that htmx has added to the DOM.
-     * @default "htmx-added"
-     */
-    addedClass?: "htmx-added" | string;
-    /**
-     * The class to place on target elements when htmx is in the settling phase.
-     * @default "htmx-settling"
-     */
-    settlingClass?: "htmx-settling" | string;
-    /**
-     * The class to place on target elements when htmx is in the swapping phase.
-     * @default "htmx-swapping"
-     */
-    swappingClass?: "htmx-swapping" | string;
-    /**
-     * Allows the use of eval-like functionality in htmx, to enable **hx-vars**, trigger conditions & script tag evaluation. Can be set to **false** for CSP compatibility.
-     * @default true
-     */
-    allowEval?: boolean;
-    /**
-     * Use HTML template tags for parsing content from the server. This allows you to use Out of Band content when returning things like table rows, but it is *not* IE11 compatible.
-     * @default false
-     */
-    useTemplateFragments?: boolean;
-    /**
-     * Allow cross-site Access-Control requests using credentials such as cookies, authorization headers or TLS client certificates.
-     * @default false
-     */
-    withCredentials?: boolean;
-    /**
-     * The default implementation of **getWebSocketReconnectDelay** for reconnecting after unexpected connection loss by the event code **Abnormal Closure**, **Service Restart** or **Try Again Later**.
-     * @default "full-jitter"
-     */
-    wsReconnectDelay?: "full-jitter" | string | ((retryCount: number) => number);
-    // following don't appear in the docs
-    /** @default false */
-    refreshOnHistoryMiss?: boolean;
-    /** @default 0 */
-    timeout?: number;
-    /** @default "[hx-disable], [data-hx-disable]" */
-    disableSelector?: "[hx-disable], [data-hx-disable]" | string;
-    /** @default "smooth" */
-    scrollBehavior?: "smooth" | "auto";
-    /**
-     * If set to false, disables the interpretation of script tags.
-     * @default true
-     */
-    allowScriptTags?: boolean;
-    /**
-     * If set to true, disables htmx-based requests to non-origin hosts.
-     * @default false
-     */
-    selfRequestsOnly?: boolean;
-    /**
-     * Whether or not the target of a boosted element is scrolled into the viewport.
-     * @default true
-     */
-    scrollIntoViewOnBoost?: boolean;
-    /**
-     * If set, the nonce will be added to inline scripts.
-     * @default ''
-     */
-    inlineScriptNonce?: string;
-    /**
-     * The type of binary data being received over the WebSocket connection
-     * @default 'blob'
-     */
-    wsBinaryType?: 'blob' | 'arraybuffer'; 
-    /**
-     * If set to true htmx will include a cache-busting parameter in GET requests to avoid caching partial responses by the browser
-     * @default false 
-     */
-    getCacheBusterParam?: boolean;
-    /**
-     * If set to true, htmx will use the View Transition API when swapping in new content.
-     * @default false 
-     */
-    globalViewTransitions?: boolean;
-    /**
-     * htmx will format requests with these methods by encoding their parameters in the URL, not the request body
-     * @default ["get"] 
-     */
-    methodsThatUseUrlParams?: ('get' | 'head' | 'post' | 'put' | 'delete' | 'connect' | 'options' | 'trace' | 'patch' )[];
-    /**
-     * If set to true htmx will not update the title of the document when a title tag is found in new content
-     * @default false 
-     */
-    ignoreTitle:? boolean;
-    /**
-     * The cache to store evaluated trigger specifications into.
-     * You may define a simple object to use a never-clearing cache, or implement your own system using a [proxy object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy)
-     * @default null
-     */
-    triggerSpecsCache?: {[trigger: string]: HtmxTriggerSpecification[]};
+declare namespace htmx {
+    function onLoad(callback: (elt: Node) => void): EventListener;
+    function process(elt: string | Element): void;
+    function on(arg1: string | EventTarget, arg2: string | EventListener, arg3?: EventListener): EventListener;
+    function off(arg1: string | EventTarget, arg2: string | EventListener, arg3?: EventListener): EventListener;
+    function trigger(elt: string | EventTarget, eventName: string, detail?: any): boolean;
+    function ajax(verb: HttpVerb, path: string, context: string | Element | HtmxAjaxHelperContext): Promise<void>;
+    function find(eltOrSelector: string | (Element | Document | DocumentFragment), selector?: string): Element;
+    function findAll(eltOrSelector: string | (Element | Document | DocumentFragment), selector?: string): NodeListOf<Element>;
+    function closest(elt: string | Element, selector: string): Element;
+    function values(elt: Element, type: HttpVerb): any;
+    function remove(elt: Node, delay?: number): void;
+    function addClass(elt: string | Element, clazz: string, delay?: number): void;
+    function removeClass(node: string | Node, clazz: string, delay?: number): void;
+    function toggleClass(elt: string | Element, clazz: string): void;
+    function takeClass(elt: string | Node, clazz: string): void;
+    function swap(target: string | Element, content: string, swapSpec: HtmxSwapSpecification, swapOptions?: SwapOptions): void;
+    function defineExtension(name: string, extension: any): void;
+    function removeExtension(name: string): void;
+    function logAll(): void;
+    function logNone(): void;
+    const logger: any;
+    namespace config {
+        const historyEnabled: boolean;
+        const historyCacheSize: number;
+        const refreshOnHistoryMiss: boolean;
+        const defaultSwapStyle: HtmxSwapStyle;
+        const defaultSwapDelay: number;
+        const defaultSettleDelay: number;
+        const includeIndicatorStyles: boolean;
+        const indicatorClass: string;
+        const requestClass: string;
+        const addedClass: string;
+        const settlingClass: string;
+        const swappingClass: string;
+        const allowEval: boolean;
+        const allowScriptTags: boolean;
+        const inlineScriptNonce: string;
+        const attributesToSettle: string[];
+        const withCredentials: boolean;
+        const timeout: number;
+        const wsReconnectDelay: "full-jitter" | ((retryCount: number) => number);
+        const wsBinaryType: BinaryType;
+        const disableSelector: string;
+        const scrollBehavior: 'auto' | 'instant' | 'smooth';
+        const defaultFocusScroll: boolean;
+        const getCacheBusterParam: boolean;
+        const globalViewTransitions: boolean;
+        const methodsThatUseUrlParams: (HttpVerb)[];
+        const selfRequestsOnly: boolean;
+        const ignoreTitle: boolean;
+        const scrollIntoViewOnBoost: boolean;
+        const triggerSpecsCache: any | null;
+        const disableInheritance: boolean;
+        const responseHandling: HtmxResponseHandlingConfig[];
+    }
+    function parseInterval(str: string): number;
+    function _(str: string): any;
+    const version: string;
 }
-
-type HtmxSwapStyle = "innerHTML" | "outerHTML" | "beforebegin" | "afterbegin" | "beforeend" | "afterend" | "delete" | "none" | string
-
-export interface HtmxSwapSpecification {
+type HttpVerb = 'get' | 'head' | 'post' | 'put' | 'delete' | 'connect' | 'options' | 'trace' | 'patch';
+type SwapOptions = {
+    select?: string;
+    selectOOB?: string;
+    eventInfo?: any;
+    anchor?: string;
+    contextElement?: Element;
+    afterSwapCallback?: swapCallback;
+    afterSettleCallback?: swapCallback;
+};
+type swapCallback = () => any;
+type HtmxSwapStyle = 'innerHTML' | 'outerHTML' | 'beforebegin' | 'afterbegin' | 'beforeend' | 'afterend' | 'delete' | 'none' | string;
+type HtmxSwapSpecification = {
     swapStyle: HtmxSwapStyle;
-    swapDelay?: number;
-    settleDelay?: number;
+    swapDelay: number;
+    settleDelay: number;
     transition?: boolean;
     ignoreTitle?: boolean;
     head?: string;
-    scroll?: string;
+    scroll?: 'top' | 'bottom';
     scrollTarget?: string;
     show?: string;
     showTarget?: string;
     focusScroll?: boolean;
-}
-
-/**
- * https://htmx.org/extensions/#defining
- */
-export interface HtmxExtension {
-    onEvent?: (name: string, evt: CustomEvent) => any;
-    transformResponse?: (text: any, xhr: XMLHttpRequest, elt: any) => any;
-    isInlineSwap?: (swapStyle: any) => any;
-    handleSwap?: (swapStyle: any, target: any, fragment: any, settleInfo: any) => any;
-    encodeParameters?: (xhr: XMLHttpRequest, parameters: any, elt: any) => any;
-}
+};
+type ConditionalFunction = ((this: Node, evt: Event) => boolean) & {
+    source: string;
+};
+type HtmxTriggerSpecification = {
+    trigger: string;
+    pollInterval?: number;
+    eventFilter?: ConditionalFunction;
+    changed?: boolean;
+    once?: boolean;
+    consume?: boolean;
+    delay?: number;
+    from?: string;
+    target?: string;
+    throttle?: number;
+    queue?: string;
+    root?: string;
+    threshold?: string;
+};
+type HtmxElementValidationError = {
+    elt: Element;
+    message: string;
+    validity: ValidityState;
+};
+type HtmxHeaderSpecification = Record<string, string>;
+type HtmxAjaxHelperContext = {
+    source?: Element | string;
+    event?: Event;
+    handler?: HtmxAjaxHandler;
+    target: Element | string;
+    swap?: HtmxSwapStyle;
+    values?: any | FormData;
+    headers?: Record<string, string>;
+    select?: string;
+};
+type HtmxRequestConfig = {
+    boosted: boolean;
+    useUrlParams: boolean;
+    formData: FormData;
+    /**
+     * formData proxy
+     */
+    parameters: any;
+    unfilteredFormData: FormData;
+    /**
+     * unfilteredFormData proxy
+     */
+    unfilteredParameters: any;
+    headers: HtmxHeaderSpecification;
+    target: Element;
+    verb: HttpVerb;
+    errors: HtmxElementValidationError[];
+    withCredentials: boolean;
+    timeout: number;
+    path: string;
+    triggeringEvent: Event;
+};
+type HtmxResponseInfo = {
+    xhr: XMLHttpRequest;
+    target: Element;
+    requestConfig: HtmxRequestConfig;
+    etc: HtmxAjaxEtc;
+    boosted: boolean;
+    select: string;
+    pathInfo: {
+        requestPath: string;
+        finalRequestPath: string;
+        responsePath: string | null;
+        anchor: string;
+    };
+    failed?: boolean;
+    successful?: boolean;
+};
+type HtmxAjaxEtc = {
+    returnPromise?: boolean;
+    handler?: HtmxAjaxHandler;
+    select?: string;
+    targetOverride?: Element;
+    swapOverride?: HtmxSwapStyle;
+    headers?: Record<string, string>;
+    values?: any | FormData;
+    credentials?: boolean;
+    timeout?: number;
+};
+type HtmxResponseHandlingConfig = {
+    code?: string;
+    swap: boolean;
+    error?: boolean;
+    ignoreTitle?: boolean;
+    select?: string;
+    target?: string;
+    swapOverride?: string;
+    event?: string;
+};
+type HtmxBeforeSwapDetails = HtmxResponseInfo & {
+    shouldSwap: boolean;
+    serverResponse: any;
+    isError: boolean;
+    ignoreTitle: boolean;
+    selectOverride: string;
+};
+type HtmxAjaxHandler = (elt: Element, responseInfo: HtmxResponseInfo) => any;
+type HtmxSettleTask = (() => void);
+type HtmxSettleInfo = {
+    tasks: HtmxSettleTask[];
+    elts: Element[];
+    title?: string;
+};
+type HtmxExtension = any;

--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -1,24 +1,24 @@
 declare namespace htmx {
-    function onLoad(callback: (elt: Node) => void): EventListener;
-    function process(elt: string | Element): void;
-    function on(arg1: string | EventTarget, arg2: string | EventListener, arg3?: EventListener): EventListener;
-    function off(arg1: string | EventTarget, arg2: string | EventListener, arg3?: EventListener): EventListener;
-    function trigger(elt: string | EventTarget, eventName: string, detail?: any): boolean;
-    function ajax(verb: HttpVerb, path: string, context: string | Element | HtmxAjaxHelperContext): Promise<void>;
-    function find(eltOrSelector: string | (Element | Document | DocumentFragment), selector?: string): Element;
-    function findAll(eltOrSelector: string | (Element | Document | DocumentFragment), selector?: string): NodeListOf<Element>;
-    function closest(elt: string | Element, selector: string): Element;
+    const onLoad: (callback: (elt: Node) => void) => EventListener;
+    const process: (elt: string | Element) => void;
+    const on: (arg1: string | EventTarget, arg2: string | EventListener, arg3?: EventListener) => EventListener;
+    const off: (arg1: string | EventTarget, arg2: string | EventListener, arg3?: EventListener) => EventListener;
+    const trigger: (elt: string | EventTarget, eventName: string, detail?: any) => boolean;
+    const ajax: (verb: HttpVerb, path: string, context: string | Element | HtmxAjaxHelperContext) => Promise<void>;
+    const find: (eltOrSelector: string | (Element | DocumentFragment | Document), selector?: string) => Element;
+    const findAll: (eltOrSelector: string | (Element | DocumentFragment | Document), selector?: string) => NodeListOf<Element>;
+    const closest: (elt: string | Element, selector: string) => Element;
     function values(elt: Element, type: HttpVerb): any;
-    function remove(elt: Node, delay?: number): void;
-    function addClass(elt: string | Element, clazz: string, delay?: number): void;
-    function removeClass(node: string | Node, clazz: string, delay?: number): void;
-    function toggleClass(elt: string | Element, clazz: string): void;
-    function takeClass(elt: string | Node, clazz: string): void;
-    function swap(target: string | Element, content: string, swapSpec: HtmxSwapSpecification, swapOptions?: SwapOptions): void;
-    function defineExtension(name: string, extension: any): void;
-    function removeExtension(name: string): void;
-    function logAll(): void;
-    function logNone(): void;
+    const remove: (elt: Node, delay?: number) => void;
+    const addClass: (elt: string | Element, clazz: string, delay?: number) => void;
+    const removeClass: (node: string | Node, clazz: string, delay?: number) => void;
+    const toggleClass: (elt: string | Element, clazz: string) => void;
+    const takeClass: (elt: string | Node, clazz: string) => void;
+    const swap: (target: string | Element, content: string, swapSpec: HtmxSwapSpecification, swapOptions?: SwapOptions) => void;
+    const defineExtension: (name: string, extension: any) => void;
+    const removeExtension: (name: string) => void;
+    const logAll: () => void;
+    const logNone: () => void;
     const logger: any;
     namespace config {
         const historyEnabled: boolean;
@@ -54,8 +54,8 @@ declare namespace htmx {
         const disableInheritance: boolean;
         const responseHandling: HtmxResponseHandlingConfig[];
     }
-    function parseInterval(str: string): number;
-    function _(str: string): any;
+    const parseInterval: (str: string) => number;
+    const _: (str: string) => any;
     const version: string;
 }
 type HttpVerb = 'get' | 'head' | 'post' | 'put' | 'delete' | 'connect' | 'options' | 'trace' | 'patch';

--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -5,8 +5,8 @@ declare namespace htmx {
     const off: (arg1: string | EventTarget, arg2: string | EventListener, arg3?: EventListener) => EventListener;
     const trigger: (elt: string | EventTarget, eventName: string, detail?: any) => boolean;
     const ajax: (verb: HttpVerb, path: string, context: string | Element | HtmxAjaxHelperContext) => Promise<void>;
-    const find: (eltOrSelector: string | (Element | DocumentFragment | Document), selector?: string) => Element;
-    const findAll: (eltOrSelector: string | (Element | DocumentFragment | Document), selector?: string) => NodeListOf<Element>;
+    const find: (eltOrSelector: string | ParentNode, selector?: string) => Element;
+    const findAll: (eltOrSelector: string | ParentNode, selector?: string) => NodeListOf<Element>;
     const closest: (elt: string | Element, selector: string) => Element;
     function values(elt: Element, type: HttpVerb): any;
     const remove: (elt: Node, delay?: number) => void;

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2,88 +2,740 @@ var htmx = (function() {
   'use strict'
 
   // Public API
-  //* * @type {import("./htmx").HtmxApi} */
   const htmx = {
     /* Event processing */
-    onLoad: onLoadHelper,
-    process: processNode,
-    on: addEventListenerImpl,
-    off: removeEventListenerImpl,
-    trigger: triggerEvent,
-    ajax: ajaxHelper,
+    /**
+     * Adds a callback for the **htmx:load** event. This can be used to process new content, for example initializing the content with a javascript library
+     *
+     * @see https://htmx.org/api/#onLoad
+     *
+     * @param {(elt: Node) => void} callback the callback to call on newly loaded content
+     * @returns {EventListener}
+     */
+    onLoad: function(callback) {
+      const value = htmx.on('htmx:load', /** @param {CustomEvent} evt */ function(evt) {
+        callback(evt.detail.elt)
+      })
+      return value
+    },
+    /**
+     * Processes new content, enabling htmx behavior. This can be useful if you have content that is added to the DOM outside of the normal htmx request cycle but still want htmx attributes to work.
+     *
+     * @see https://htmx.org/api/#process
+     *
+     * @param {Element|string} elt element to process
+     */
+    process: function(elt) {
+      elt = resolveTarget(elt)
+      if (htmx.closest(elt, htmx.config.disableSelector)) {
+        cleanUpElement(elt)
+        return
+      }
+      initNode(elt)
+      forEach(findElementsToProcess(elt), function(child) { initNode(child) })
+      forEach(findHxOnWildcardElements(elt), processHxOnWildcard)
+    },
+    /**
+     * Adds an event listener to an element
+     *
+     * @see https://htmx.org/api/#on
+     *
+     * @param {EventTarget|string} arg1 the element to add the listener to | the event name to add the listener for
+     * @param {string|EventListener} arg2 the event name to add the listener for | the listener to add
+     * @param {EventListener} [arg3] the listener to add
+     * @returns {EventListener}
+     */
+    on: function on(arg1, arg2, arg3) {
+      ready(function() {
+        const eventArgs = processEventArgs(arg1, arg2, arg3)
+        eventArgs.target.addEventListener(eventArgs.event, eventArgs.listener)
+      })
+      const b = isFunction(arg2)
+      return b ? arg2 : arg3
+    },
+    /**
+     * Removes an event listener from an element
+     *
+     * @see https://htmx.org/api/#off
+     *
+     * @param {EventTarget|string} arg1 the element to remove the listener from | the event name to remove the listener from
+     * @param {string|EventListener} arg2 the event name to remove the listener from | the listener to remove
+     * @param {EventListener} [arg3] the listener to remove
+     * @returns {EventListener}
+     */
+    off: function(arg1, arg2, arg3) {
+      ready(function() {
+        const eventArgs = processEventArgs(arg1, arg2, arg3)
+        eventArgs.target.removeEventListener(eventArgs.event, eventArgs.listener)
+      })
+      return isFunction(arg2) ? arg2 : arg3
+    },
+    /**
+     * Triggers a given event on an element
+     *
+     * @see https://htmx.org/api/#trigger
+     *
+     * @param {EventTarget|string} elt the element to trigger the event on
+     * @param {string} eventName the name of the event to trigger
+     * @param {any=} detail details for the event
+     * @returns {boolean}
+     */
+    trigger: function(elt, eventName, detail) {
+      elt = resolveTarget(elt)
+      if (detail == null) {
+        detail = {}
+      }
+      detail.elt = elt
+      const event = makeEvent(eventName, detail)
+      if (htmx.logger && !ignoreEventForLogging(eventName)) {
+        htmx.logger(elt, eventName, detail)
+      }
+      if (detail.error) {
+        logError(detail.error)
+        htmx.trigger(elt, 'htmx:error', { errorInfo: detail })
+      }
+      let eventResult = elt.dispatchEvent(event)
+      const kebabName = kebabEventName(eventName)
+      if (eventResult && kebabName !== eventName) {
+        const kebabedEvent = makeEvent(kebabName, event.detail)
+        eventResult = eventResult && elt.dispatchEvent(kebabedEvent)
+      }
+      withExtensions(asElement(elt), function(extension) {
+        eventResult = eventResult && (extension.onEvent(eventName, event) !== false && !event.defaultPrevented)
+      })
+      return eventResult
+    },
+    /**
+     * Issues an htmx-style AJAX request
+     *
+     * @see https://htmx.org/api/#ajax
+     *
+     * @param {HttpVerb} verb
+     * @param {string} path the URL path to make the AJAX
+     * @param {Element|string|HtmxAjaxHelperContext} context the element to target (defaults to the **body**) | a selector for the target | a context object that contains any of the following
+     * @return {Promise<void>} Promise that resolves immediately if no request is sent, or when the request is complete
+     */
+    ajax: function(verb, path, context) {
+      verb = (/** @type HttpVerb */(verb.toLowerCase()))
+      if (context) {
+        if (context instanceof Element || typeof context === 'string') {
+          return issueAjaxRequest(verb, path, null, null, {
+            targetOverride: resolveTarget(context),
+            returnPromise: true
+          })
+        } else {
+          return issueAjaxRequest(verb, path, resolveTarget(context.source), context.event,
+            {
+              handler: context.handler,
+              headers: context.headers,
+              values: context.values,
+              targetOverride: resolveTarget(context.target),
+              swapOverride: context.swap,
+              select: context.select,
+              returnPromise: true
+            })
+        }
+      } else {
+        return issueAjaxRequest(verb, path, null, null, {
+          returnPromise: true
+        })
+      }
+    },
     /* DOM querying helpers */
-    find,
-    findAll,
-    closest,
+    /**
+     * Finds an element matching the selector
+     *
+     * @see https://htmx.org/api/#find
+     *
+     * @param {Queryable|string} eltOrSelector  the root element to find the matching element in, inclusive | the selector to match
+     * @param {string} [selector] the selector to match
+     * @returns {Element|null}
+     */
+    find: function(eltOrSelector, selector) {
+      if (typeof eltOrSelector !== 'string') {
+        return eltOrSelector.querySelector(selector)
+      } else {
+        return htmx.find(getDocument(), eltOrSelector)
+      }
+    },
+    /**
+     * Finds all elements matching the selector
+     *
+     * @see https://htmx.org/api/#findAll
+     *
+     * @param {Queryable|string} eltOrSelector the root element to find the matching elements in, inclusive | the selector to match
+     * @param {string} [selector] the selector to match
+     * @returns {NodeListOf<Element>}
+     */
+    findAll: function(eltOrSelector, selector) {
+      if (typeof eltOrSelector !== 'string') {
+        return eltOrSelector.querySelectorAll(selector)
+      } else {
+        return htmx.findAll(getDocument(), eltOrSelector)
+      }
+    },
+    /**
+     * Finds the closest matching element in the given elements parentage, inclusive of the element
+     *
+     * @see https://htmx.org/api/#closest
+     *
+     * @param {Element|string} elt the element to find the selector from
+     * @param {string} selector the selector to find
+     * @returns {Element|null}
+     */
+    closest: function(elt, selector) {
+      elt = asElement(resolveTarget(elt))
+      if (elt && elt.closest) {
+        return elt.closest(selector)
+      } else {
+        // TODO remove when IE goes away
+        do {
+          if (elt == null || matches(elt, selector)) {
+            return elt
+          }
+        }
+        while (elt = elt && asElement(parentElt(elt)))
+        return null
+      }
+    },
+    /**
+     * Returns the input values that would resolve for a given element via the htmx value resolution mechanism
+     *
+     * @see https://htmx.org/api/#values
+     *
+     * @param {Element} elt the element to resolve values on
+     * @param {HttpVerb} type the request type (e.g. **get** or **post**) non-GET's will include the enclosing form of the element. Defaults to **post**
+     * @returns {Object}
+     */
     values: function(elt, type) {
       const inputValues = getInputValues(elt, type || 'post')
       return inputValues.values
     },
     /* DOM manipulation helpers */
-    remove: removeElement,
-    addClass: addClassToElement,
-    removeClass: removeClassFromElement,
-    toggleClass: toggleClassOnElement,
-    takeClass: takeClassForElement,
-    swap,
+    /**
+     * Removes an element from the DOM
+     *
+     * @see https://htmx.org/api/#remove
+     *
+     * @param {Node} elt
+     * @param {number} [delay]
+     */
+    remove: function(elt, delay) {
+      elt = resolveTarget(elt)
+      if (delay) {
+        getWindow().setTimeout(function() {
+          htmx.remove(elt)
+          elt = null
+        }, delay)
+      } else {
+        parentElt(elt).removeChild(elt)
+      }
+    },
+    /**
+     * This method adds a class to the given element.
+     *
+     * @see https://htmx.org/api/#addClass
+     *
+     * @param {Element|string} elt the element to add the class to
+     * @param {string} clazz the class to add
+     * @param {number} [delay] the delay (in milliseconds) before class is added
+     */
+    addClass: function(elt, clazz, delay) {
+      elt = asElement(resolveTarget(elt))
+      if (!elt) {
+        return
+      }
+      if (delay) {
+        getWindow().setTimeout(function() {
+          htmx.addClass(elt, clazz)
+          elt = null
+        }, delay)
+      } else {
+        elt.classList && elt.classList.add(clazz)
+      }
+    },
+    /**
+     * Removes a class from the given element
+     *
+     * @see https://htmx.org/api/#removeClass
+     *
+     * @param {Node|string} node element to remove the class from
+     * @param {string} clazz the class to remove
+     * @param {number} [delay] the delay (in milliseconds before class is removed)
+     */
+    removeClass: function(node, clazz, delay) {
+      let elt = asElement(resolveTarget(node))
+      if (!elt) {
+        return
+      }
+      if (delay) {
+        getWindow().setTimeout(function() {
+          htmx.removeClass(elt, clazz)
+          elt = null
+        }, delay)
+      } else {
+        if (elt.classList) {
+          elt.classList.remove(clazz)
+          // if there are no classes left, remove the class attribute
+          if (elt.classList.length === 0) {
+            elt.removeAttribute('class')
+          }
+        }
+      }
+    },
+    /**
+     * Toggles the given class on an element
+     *
+     * @see https://htmx.org/api/#toggleClass
+     *
+     * @param {Element|string} elt the element to toggle the class on
+     * @param {string} clazz the class to toggle
+     */
+    toggleClass: function(elt, clazz) {
+      elt = resolveTarget(elt)
+      elt.classList.toggle(clazz)
+    },
+    /**
+     * Takes the given class from its siblings, so that among its siblings, only the given element will have the class.
+     *
+     * @see https://htmx.org/api/#takeClass
+     *
+     * @param {Node|string} elt the element that will take the class
+     * @param {string} clazz the class to take
+     */
+    takeClass: function(elt, clazz) {
+      elt = resolveTarget(elt)
+      forEach(elt.parentElement.children, function(child) {
+        htmx.removeClass(child, clazz)
+      })
+      htmx.addClass(asElement(elt), clazz)
+    },
+    /**
+     * Implements complete swapping pipeline, including: focus and selection preservation,
+     * title updates, scroll, OOB swapping, normal swapping and settling
+     * @param {string|Element} target
+     * @param {string} content
+     * @param {HtmxSwapSpecification} swapSpec
+     * @param {SwapOptions} [swapOptions]
+     */
+    swap: function(target, content, swapSpec, swapOptions) {
+      if (!swapOptions) {
+        swapOptions = {}
+      }
+
+      target = resolveTarget(target)
+
+      // preserve focus and selection
+      const activeElt = document.activeElement
+      let selectionInfo = {}
+      try {
+        selectionInfo = {
+          elt: activeElt,
+          // @ts-ignore
+          start: activeElt ? activeElt.selectionStart : null,
+          // @ts-ignore
+          end: activeElt ? activeElt.selectionEnd : null
+        }
+      } catch (e) {
+        // safari issue - see https://github.com/microsoft/playwright/issues/5894
+      }
+      const settleInfo = makeSettleInfo(target)
+
+      let fragment = makeFragment(content)
+
+      settleInfo.title = fragment.title
+
+      // select-oob swaps
+      if (swapOptions.selectOOB) {
+        const oobSelectValues = swapOptions.selectOOB.split(',')
+        for (let i = 0; i < oobSelectValues.length; i++) {
+          const oobSelectValue = oobSelectValues[i].split(':', 2)
+          let id = oobSelectValue[0].trim()
+          if (id.indexOf('#') === 0) {
+            id = id.substring(1)
+          }
+          const oobValue = oobSelectValue[1] || 'true'
+          const oobElement = fragment.querySelector('#' + id)
+          if (oobElement) {
+            oobSwap(oobValue, oobElement, settleInfo)
+          }
+        }
+      }
+      // oob swaps
+      findAndSwapOobElements(fragment, settleInfo)
+      forEach(htmx.findAll(fragment, 'template'), /** @param {HTMLTemplateElement} template */function(template) {
+        findAndSwapOobElements(template.content, settleInfo)
+        if (template.content.childElementCount === 0) {
+          // Avoid polluting the DOM with empty templates that were only used to encapsulate oob swap
+          template.remove()
+        }
+      })
+
+      // normal swap
+      if (swapOptions.select) {
+        const newFragment = getDocument().createDocumentFragment()
+        forEach(fragment.querySelectorAll(swapOptions.select), function(node) {
+          newFragment.appendChild(node)
+        })
+        fragment = newFragment
+      }
+      handlePreservedElements(fragment)
+      swapWithStyle(swapSpec.swapStyle, swapOptions.contextElement, target, fragment, settleInfo)
+
+      // apply saved focus and selection information to swapped content
+      if (selectionInfo.elt &&
+              !bodyContains(selectionInfo.elt) &&
+              getRawAttribute(selectionInfo.elt, 'id')) {
+        const newActiveElt = document.getElementById(getRawAttribute(selectionInfo.elt, 'id'))
+        const focusOptions = { preventScroll: swapSpec.focusScroll !== undefined ? !swapSpec.focusScroll : !htmx.config.defaultFocusScroll }
+        if (newActiveElt) {
+          // @ts-ignore
+          if (selectionInfo.start && newActiveElt.setSelectionRange) {
+            try {
+              // @ts-ignore
+              newActiveElt.setSelectionRange(selectionInfo.start, selectionInfo.end)
+            } catch (e) {
+              // the setSelectionRange method is present on fields that don't support it, so just let this fail
+            }
+          }
+          newActiveElt.focus(focusOptions)
+        }
+      }
+
+      target.classList.remove(htmx.config.swappingClass)
+      forEach(settleInfo.elts, function(elt) {
+        if (elt.classList) {
+          elt.classList.add(htmx.config.settlingClass)
+        }
+        htmx.trigger(elt, 'htmx:afterSwap', swapOptions.eventInfo)
+      })
+      if (swapOptions.afterSwapCallback) {
+        swapOptions.afterSwapCallback()
+      }
+
+      // merge in new title after swap but before settle
+      if (!swapSpec.ignoreTitle) {
+        handleTitle(settleInfo.title)
+      }
+
+      // settle
+      const doSettle = function() {
+        forEach(settleInfo.tasks, function(task) {
+          task.call()
+        })
+        forEach(settleInfo.elts, function(elt) {
+          if (elt.classList) {
+            elt.classList.remove(htmx.config.settlingClass)
+          }
+          htmx.trigger(elt, 'htmx:afterSettle', swapOptions.eventInfo)
+        })
+
+        if (swapOptions.anchor) {
+          const anchorTarget = asElement(resolveTarget('#' + swapOptions.anchor))
+          if (anchorTarget) {
+            anchorTarget.scrollIntoView({ block: 'start', behavior: 'auto' })
+          }
+        }
+
+        updateScrollState(settleInfo.elts, swapSpec)
+        if (swapOptions.afterSettleCallback) {
+          swapOptions.afterSettleCallback()
+        }
+      }
+
+      if (swapSpec.settleDelay > 0) {
+        getWindow().setTimeout(doSettle, swapSpec.settleDelay)
+      } else {
+        doSettle()
+      }
+    },
     /* Extension entrypoints */
-    defineExtension,
-    removeExtension,
+    /**
+     * defineExtension initializes the extension and adds it to the htmx registry
+     *
+     * @see https://htmx.org/api/#defineExtension
+     *
+     * @param {string} name the extension name
+     * @param {HtmxExtension} extension the extension definition
+     */
+    defineExtension: function(name, extension) {
+      if (extension.init) {
+        extension.init(internalAPI)
+      }
+      extensions[name] = mergeObjects(extensionBase(), extension)
+    },
+    /**
+     * removeExtension removes an extension from the htmx registry
+     *
+     * @see https://htmx.org/api/#removeExtension
+     *
+     * @param {string} name
+     */
+    removeExtension: function(name) {
+      delete extensions[name]
+    },
     /* Debugging */
-    logAll,
-    logNone,
+    /**
+     * Log all htmx events, useful for debugging.
+     *
+     * @see https://htmx.org/api/#logAll
+     */
+    logAll: function() {
+      htmx.logger = function(elt, event, data) {
+        if (console) {
+          console.log(event, elt, data)
+        }
+      }
+    },
+    logNone: function() {
+      htmx.logger = null
+    },
+    /**
+     * The logger htmx uses to log with
+     *
+     * @see https://htmx.org/api/#logger
+     */
     logger: null,
+    /**
+     * A property holding the configuration htmx uses at runtime.
+     *
+     * Note that using a [meta tag](https://htmx.org/docs/#config) is the preferred mechanism for setting these properties.
+     *
+     * @see https://htmx.org/api/#config
+     */
     config: {
+      /**
+       * Whether to use history.
+       * @type boolean
+       * @default true
+       */
       historyEnabled: true,
+      /**
+       * The number of pages to keep in **localStorage** for history support.
+       * @type number
+       * @default 10
+       */
       historyCacheSize: 10,
+      /**
+       * @type boolean
+       * @default false
+       */
       refreshOnHistoryMiss: false,
+      /**
+       * The default swap style to use if **[hx-swap](https://htmx.org/attributes/hx-swap)** is omitted.
+       * @type HtmxSwapStyle
+       * @default 'innerHTML'
+       */
       defaultSwapStyle: 'innerHTML',
+      /**
+       * The default delay between receiving a response from the server and doing the swap.
+       * @type number
+       * @default 0
+       */
       defaultSwapDelay: 0,
+      /**
+       * The default delay between completing the content swap and settling attributes.
+       * @type number
+       * @default 20
+       */
       defaultSettleDelay: 20,
+      /**
+       * If true, htmx will inject a small amount of CSS into the page to make indicators invisible unless the **htmx-indicator** class is present.
+       * @type boolean
+       * @default true
+       */
       includeIndicatorStyles: true,
+      /**
+       * The class to place on indicators when a request is in flight.
+       * @type string
+       * @default 'htmx-indicator'
+       */
       indicatorClass: 'htmx-indicator',
+      /**
+       * The class to place on triggering elements when a request is in flight.
+       * @type string
+       * @default 'htmx-request'
+       */
       requestClass: 'htmx-request',
+      /**
+       * The class to temporarily place on elements that htmx has added to the DOM.
+       * @type string
+       * @default 'htmx-added'
+       */
       addedClass: 'htmx-added',
+      /**
+       * The class to place on target elements when htmx is in the settling phase.
+       * @type string
+       * @default 'htmx-settling'
+       */
       settlingClass: 'htmx-settling',
+      /**
+       * The class to place on target elements when htmx is in the swapping phase.
+       * @type string
+       * @default 'htmx-swapping'
+       */
       swappingClass: 'htmx-swapping',
+      /**
+       * Allows the use of eval-like functionality in htmx, to enable **hx-vars**, trigger conditions & script tag evaluation. Can be set to **false** for CSP compatibility.
+       * @type boolean
+       * @default true
+       */
       allowEval: true,
+      /**
+       * If set to false, disables the interpretation of script tags.
+       * @type boolean
+       * @default true
+       */
       allowScriptTags: true,
+      /**
+       * If set, the nonce will be added to inline scripts.
+       * @type string
+       * @default ''
+       */
       inlineScriptNonce: '',
+      /**
+       * The attributes to settle during the settling phase.
+       * @type string[]
+       * @default ['class', 'style', 'width', 'height']
+       */
       attributesToSettle: ['class', 'style', 'width', 'height'],
+      /**
+       * Allow cross-site Access-Control requests using credentials such as cookies, authorization headers or TLS client certificates.
+       * @type boolean
+       * @default false
+       */
       withCredentials: false,
+      /**
+       * @type number
+       * @default 0
+       */
       timeout: 0,
+      /**
+       * The default implementation of **getWebSocketReconnectDelay** for reconnecting after unexpected connection loss by the event code **Abnormal Closure**, **Service Restart** or **Try Again Later**.
+       * @type {'full-jitter' | ((retryCount:number) => number)}
+       * @default "full-jitter"
+       */
       wsReconnectDelay: 'full-jitter',
+      /**
+       * The type of binary data being received over the WebSocket connection
+       * @type BinaryType
+       * @default 'blob'
+       */
       wsBinaryType: 'blob',
+      /**
+       * @type string
+       * @default '[hx-disable], [data-hx-disable]'
+       */
       disableSelector: '[hx-disable], [data-hx-disable]',
+      /**
+       * @type {'auto' | 'instant' | 'smooth'}
+       * @default 'smooth'
+       */
       scrollBehavior: 'instant',
+      /**
+       * If the focused element should be scrolled into view.
+       * @type boolean
+       * @default false
+       */
       defaultFocusScroll: false,
+      /**
+       * If set to true htmx will include a cache-busting parameter in GET requests to avoid caching partial responses by the browser
+       * @type boolean
+       * @default false
+       */
       getCacheBusterParam: false,
+      /**
+       * If set to true, htmx will use the View Transition API when swapping in new content.
+       * @type boolean
+       * @default false
+       */
       globalViewTransitions: false,
+      /**
+       * htmx will format requests with these methods by encoding their parameters in the URL, not the request body
+       * @type {(HttpVerb)[]}
+       * @default ['get', 'delete']
+       */
       methodsThatUseUrlParams: ['get', 'delete'],
+      /**
+       * If set to true, disables htmx-based requests to non-origin hosts.
+       * @type boolean
+       * @default false
+       */
       selfRequestsOnly: true,
+      /**
+       * If set to true htmx will not update the title of the document when a title tag is found in new content
+       * @type boolean
+       * @default false
+       */
       ignoreTitle: false,
+      /**
+       * Whether the target of a boosted element is scrolled into the viewport.
+       * @type boolean
+       * @default true
+       */
       scrollIntoViewOnBoost: true,
+      /**
+       * The cache to store evaluated trigger specifications into.
+       * You may define a simple object to use a never-clearing cache, or implement your own system using a [proxy object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy)
+       * @type {Object|null}
+       * @default null
+       */
       triggerSpecsCache: null,
+      /** @type boolean */
       disableInheritance: false,
+      /** @type HtmxResponseHandlingConfig[] */
       responseHandling: [
         { code: '204', swap: false },
         { code: '[23]..', swap: true },
         { code: '[45]..', swap: false, error: true }
       ]
     },
-    parseInterval,
-    _: internalEval,
+    /**
+     * Parses an interval string consistent with the way htmx does. Useful for plugins that have timing-related attributes.
+     *
+     * Caution: Accepts an int followed by either **s** or **ms**. All other values use **parseFloat**
+     *
+     * @see https://htmx.org/api/#parseInterval
+     *
+     * @param {string} str timing string
+     * @returns {number|undefined}
+     */
+    parseInterval: function(str) {
+      if (str == undefined) {
+        return undefined
+      }
+
+      let interval = NaN
+      if (str.slice(-2) == 'ms') {
+        interval = parseFloat(str.slice(0, -2))
+      } else if (str.slice(-1) == 's') {
+        interval = parseFloat(str.slice(0, -1)) * 1000
+      } else if (str.slice(-1) == 'm') {
+        interval = parseFloat(str.slice(0, -1)) * 1000 * 60
+      } else {
+        interval = parseFloat(str)
+      }
+      return isNaN(interval) ? undefined : interval
+    },
+    /**
+     * @param {string} str
+     * @returns {any}
+     */
+    _: function(str) {
+      return maybeEval(getDocument().body, function() {
+        return eval(str)
+      })
+    },
     version: '2.0a'
   }
 
-  /** @type {import("./htmx").HtmxInternalApi} */
   const internalAPI = {
     addTriggerHandler,
     bodyContains,
     canAccessLocalStorage,
     findThisElement,
     filterValues,
-    swap,
+    swap: htmx.swap,
     hasAttribute,
     getAttributeValue,
     getClosestAttributeValue,
@@ -102,7 +754,7 @@ var htmx = (function() {
     querySelectorExt,
     settleImmediately,
     shouldCancel,
-    triggerEvent,
+    triggerEvent: htmx.trigger,
     triggerErrorEvent,
     withExtensions
   }
@@ -128,42 +780,29 @@ var htmx = (function() {
       global ? 'gim' : 'im')
   }
 
-  function parseInterval(str) {
-    if (str == undefined) {
-      return undefined
-    }
-
-    let interval = NaN
-    if (str.slice(-2) == 'ms') {
-      interval = parseFloat(str.slice(0, -2))
-    } else if (str.slice(-1) == 's') {
-      interval = parseFloat(str.slice(0, -1)) * 1000
-    } else if (str.slice(-1) == 'm') {
-      interval = parseFloat(str.slice(0, -1)) * 1000 * 60
-    } else {
-      interval = parseFloat(str)
-    }
-    return isNaN(interval) ? undefined : interval
-  }
-
   /**
-   * @param {Element} elt
+   * @param {Node} elt
    * @param {string} name
    * @returns {(string | null)}
    */
   function getRawAttribute(elt, name) {
-    return elt.getAttribute && elt.getAttribute(name)
+    return elt instanceof Element && elt.getAttribute && elt.getAttribute(name)
   }
 
+  /**
+   * @param {Element} elt
+   * @param {string} qualifiedName
+   * @returns {boolean}
+   */
   // resolve with both hx and data-hx prefixes
   function hasAttribute(elt, qualifiedName) {
-    return elt.hasAttribute && (elt.hasAttribute(qualifiedName) ||
+    return !!elt.hasAttribute && (elt.hasAttribute(qualifiedName) ||
       elt.hasAttribute('data-' + qualifiedName))
   }
 
   /**
    *
-   * @param {HTMLElement} elt
+   * @param {Node} elt
    * @param {string} qualifiedName
    * @returns {(string | null)}
    */
@@ -172,8 +811,8 @@ var htmx = (function() {
   }
 
   /**
-   * @param {HTMLElement} elt
-   * @returns {HTMLElement | ShadowRoot | null}
+   * @param {Node} elt
+   * @returns {Node | null}
    */
   function parentElt(elt) {
     const parent = elt.parentElement
@@ -189,16 +828,18 @@ var htmx = (function() {
   }
 
   /**
-   * @returns {Document | ShadowRoot}
+   * @param {Node} elt
+   * @param {boolean} global
+   * @returns {Node|Document}
    */
   function getRootNode(elt, global) {
     return elt.getRootNode ? elt.getRootNode({ composed: global }) : getDocument()
   }
 
   /**
-   * @param {HTMLElement} elt
-   * @param {(e:HTMLElement) => boolean} condition
-   * @returns {HTMLElement | null}
+   * @param {Node} elt
+   * @param {(e:Node) => boolean} condition
+   * @returns {Node | null}
    */
   function getClosestMatch(elt, condition) {
     while (elt && !condition(elt)) {
@@ -208,6 +849,12 @@ var htmx = (function() {
     return elt || null
   }
 
+  /**
+   * @param {Element} initialElement
+   * @param {Element} ancestor
+   * @param {string} attributeName
+   * @returns {string|null}
+   */
   function getAttributeValueWithDisinheritance(initialElement, ancestor, attributeName) {
     const attributeValue = getAttributeValue(ancestor, attributeName)
     const disinherit = getAttributeValue(ancestor, 'hx-disinherit')
@@ -228,14 +875,14 @@ var htmx = (function() {
   }
 
   /**
-   * @param {HTMLElement} elt
+   * @param {Element} elt
    * @param {string} attributeName
    * @returns {string | null}
    */
   function getClosestAttributeValue(elt, attributeName) {
     let closestAttr = null
     getClosestMatch(elt, function(e) {
-      return closestAttr = getAttributeValueWithDisinheritance(elt, e, attributeName)
+      return !!(closestAttr = getAttributeValueWithDisinheritance(elt, asElement(e), attributeName))
     })
     if (closestAttr !== 'unset') {
       return closestAttr
@@ -243,15 +890,15 @@ var htmx = (function() {
   }
 
   /**
-   * @param {HTMLElement} elt
+   * @param {Node} elt
    * @param {string} selector
    * @returns {boolean}
    */
   function matches(elt, selector) {
     // @ts-ignore: non-standard properties for browser compatibility
     // noinspection JSUnresolvedVariable
-    const matchesFunction = elt.matches || elt.matchesSelector || elt.msMatchesSelector || elt.mozMatchesSelector || elt.webkitMatchesSelector || elt.oMatchesSelector
-    return matchesFunction && matchesFunction.call(elt, selector)
+    const matchesFunction = elt instanceof Element && (elt.matches || elt.matchesSelector || elt.msMatchesSelector || elt.mozMatchesSelector || elt.webkitMatchesSelector || elt.oMatchesSelector)
+    return !!matchesFunction && matchesFunction.call(elt, selector)
   }
 
   /**
@@ -269,9 +916,7 @@ var htmx = (function() {
   }
 
   /**
-   *
    * @param {string} resp
-   * @param {number} depth
    * @returns {Document}
    */
   function parseHTML(resp) {
@@ -279,12 +924,20 @@ var htmx = (function() {
     return parser.parseFromString(resp, 'text/html')
   }
 
+  /**
+   * @param {DocumentFragment} fragment
+   * @param {Node} elt
+   */
   function takeChildrenFor(fragment, elt) {
     while (elt.childNodes.length > 0) {
       fragment.append(elt.childNodes[0])
     }
   }
 
+  /**
+   * @param {HTMLScriptElement} script
+   * @returns {HTMLScriptElement}
+   */
   function duplicateScript(script) {
     const newScript = getDocument().createElement('script')
     forEach(script.attributes, function(attr) {
@@ -298,16 +951,23 @@ var htmx = (function() {
     return newScript
   }
 
+  /**
+   * @param {HTMLScriptElement} script
+   * @returns {boolean}
+   */
   function isJavaScriptScriptNode(script) {
     return script.matches('script') && (script.type === 'text/javascript' || script.type === 'module' || script.type === '')
   }
 
-  // we have to make new copies of script tags that we are going to insert because
-  // SOME browsers (not saying who, but it involves an element and an animal) don't
-  // execute scripts created in <template> tags when they are inserted into the DOM
-  // and all the others do lmao
+  /**
+   * we have to make new copies of script tags that we are going to insert because
+   * SOME browsers (not saying who, but it involves an element and an animal) don't
+   * execute scripts created in <template> tags when they are inserted into the DOM
+   * and all the others do lmao
+   * @param {DocumentFragment} fragment
+   */
   function normalizeScriptTags(fragment) {
-    Array.from(fragment.querySelectorAll('script')).forEach((script) => {
+    Array.from(fragment.querySelectorAll('script')).forEach(/** @param {HTMLScriptElement} script */ (script) => {
       if (isJavaScriptScriptNode(script)) {
         const newScript = duplicateScript(script)
         const parent = script.parentNode
@@ -323,31 +983,37 @@ var htmx = (function() {
   }
 
   /**
-   * @param {string} response HTML
-   * @returns {DocumentFragment & {title: string}} a document fragment representing the response HTML, including
+   * @typedef {DocumentFragment & {title?: string}} DocumentFragmentWithTitle
+   * @description  a document fragment representing the response HTML, including
    * a `title` property for any title information found
+   */
+
+  /**
+   * @param {string} response HTML
+   * @returns {DocumentFragmentWithTitle}
    */
   function makeFragment(response) {
     // strip head tag to determine shape of response we are dealing with
     const responseWithNoHead = response.replace(HEAD_TAG_REGEX, '')
     const startTag = getStartTag(responseWithNoHead)
-    let fragment = null
+    /** @type DocumentFragmentWithTitle */
+    let fragment
     if (startTag === 'html') {
       // if it is a full document, parse it and return the body
-      fragment = new DocumentFragment()
+      fragment = /** @type DocumentFragmentWithTitle */ (new DocumentFragment())
       const doc = parseHTML(response)
       takeChildrenFor(fragment, doc.body)
       fragment.title = doc.title
     } else if (startTag === 'body') {
       // parse body w/o wrapping in template
-      fragment = new DocumentFragment()
+      fragment = /** @type DocumentFragmentWithTitle */ (new DocumentFragment())
       const doc = parseHTML(responseWithNoHead)
       takeChildrenFor(fragment, doc.body)
       fragment.title = doc.title
     } else {
       // otherwise we have non-body partial HTML content, so wrap it in a template to maximize parsing flexibility
       const doc = parseHTML('<body><template class="internal-htmx-wrapper">' + responseWithNoHead + '</template></body>')
-      fragment = doc.querySelector('template').content
+      fragment = /** @type DocumentFragmentWithTitle */ (doc.querySelector('template').content)
       // extract title into fragment for later processing
       fragment.title = doc.title
 
@@ -392,7 +1058,7 @@ var htmx = (function() {
    * @returns {o is Function}
    */
   function isFunction(o) {
-    return isType(o, 'Function')
+    return typeof o === 'function'
   }
 
   /**
@@ -404,9 +1070,50 @@ var htmx = (function() {
   }
 
   /**
+   * @typedef {Object} OnHandler
+   * @property {(keyof HTMLElementEventMap)|string} event
+   * @property {EventListener} listener
+   */
+
+  /**
+   * @typedef {Object} ListenerInfo
+   * @property {string} trigger
+   * @property {EventListener} listener
+   * @property {EventTarget} on
+   */
+
+  /**
+   * @typedef {Object} HtmxNodeInternalData
+   * Element data
+   * @property {number} [initHash]
+   * @property {boolean} [boosted]
+   * @property {OnHandler[]} [onHandlers]
+   * @property {number} [timeout]
+   * @property {ListenerInfo[]} [listenerInfos]
+   * @property {boolean} [cancelled]
+   * @property {boolean} [triggeredOnce]
+   * @property {number} [delayed]
+   * @property {number|null} [throttle]
+   * @property {string} [lastValue]
+   * @property {boolean} [loaded]
+   * @property {string} [path]
+   * @property {string} [verb]
+   * @property {boolean} [polling]
+   * @property {HTMLButtonElement|HTMLInputElement|null} [lastButtonClicked]
+   * @property {number} [requestCount]
+   * @property {XMLHttpRequest} [xhr]
+   * @property {(() => void)[]} [queuedRequests]
+   * @property {boolean} [abortable]
+   *
+   * Event data
+   * @property {HtmxTriggerSpecification} [triggerSpec]
+   * @property {EventTarget[]} [handledFor]
+   */
+
+  /**
    * getInternalData retrieves "private" data stored by htmx within an element
-   * @param {HTMLElement} elt
-   * @returns {*}
+   * @param {EventTarget|Event} elt
+   * @returns {HtmxNodeInternalData}
    */
   function getInternalData(elt) {
     const dataProp = 'htmx-internal-data'
@@ -419,8 +1126,9 @@ var htmx = (function() {
 
   /**
    * toArray converts an ArrayLike object into a real array.
-   * @param {ArrayLike} arr
-   * @returns {any[]}
+   * @template T
+   * @param {ArrayLike<T>} arr
+   * @returns {T[]}
    */
   function toArray(arr) {
     const returnArr = []
@@ -434,13 +1142,8 @@ var htmx = (function() {
 
   /**
    * @template T
-   * @callback forEachCallback
-   * @param {T} value
-   */
-  /**
-   * @template T
-   * @param {{[index: number]: T, length: number}} arr
-   * @param {forEachCallback<T>} func
+   * @param {T[]|NamedNodeMap|HTMLCollection|HTMLFormControlsCollection|ArrayLike<T>} arr
+   * @param {(T) => void} func
    */
   function forEach(arr, func) {
     if (arr) {
@@ -450,6 +1153,10 @@ var htmx = (function() {
     }
   }
 
+  /**
+   * @param {Element} el
+   * @returns {boolean}
+   */
   function isScrolledIntoView(el) {
     const rect = el.getBoundingClientRect()
     const elemTop = rect.top
@@ -457,35 +1164,52 @@ var htmx = (function() {
     return elemTop < window.innerHeight && elemBottom >= 0
   }
 
+  /**
+   * @param {Node} elt
+   * @returns {boolean}
+   */
   function bodyContains(elt) {
     // IE Fix
-    if (elt.getRootNode && elt.getRootNode() instanceof window.ShadowRoot) {
-      return getDocument().body.contains(elt.getRootNode().host)
+    const rootNode = elt.getRootNode && elt.getRootNode()
+    if (rootNode && rootNode instanceof window.ShadowRoot) {
+      return getDocument().body.contains(rootNode.host)
     } else {
       return getDocument().body.contains(elt)
     }
   }
 
+  /**
+   * @param {string} trigger
+   * @returns {string[]}
+   */
   function splitOnWhitespace(trigger) {
     return trigger.trim().split(/\s+/)
   }
 
   /**
-   * mergeObjects takes all of the keys from
+   * mergeObjects takes all the keys from
    * obj2 and duplicates them into obj1
-   * @param {Object} obj1
-   * @param {Object} obj2
-   * @returns {Object}
+   * @template T1
+   * @template T2
+   * @param {T1} obj1
+   * @param {T2} obj2
+   * @returns {T1 & T2}
    */
   function mergeObjects(obj1, obj2) {
     for (const key in obj2) {
       if (obj2.hasOwnProperty(key)) {
+        // @ts-ignore tsc doesn't seem to properly handle types merging
         obj1[key] = obj2[key]
       }
     }
+    // @ts-ignore tsc doesn't seem to properly handle types merging
     return obj1
   }
 
+  /**
+   * @param {string} jString
+   * @returns {any|null}
+   */
   function parseJSON(jString) {
     try {
       return JSON.parse(jString)
@@ -495,6 +1219,9 @@ var htmx = (function() {
     }
   }
 
+  /**
+   * @returns {boolean}
+   */
   function canAccessLocalStorage() {
     const test = 'htmx:localStorageTest'
     try {
@@ -506,6 +1233,10 @@ var htmx = (function() {
     }
   }
 
+  /**
+   * @param {string} path
+   * @returns {string}
+   */
   function normalizePath(path) {
     try {
       const url = new URL(path)
@@ -527,126 +1258,71 @@ var htmx = (function() {
   // public API
   //= =========================================================================================
 
-  function internalEval(str) {
-    return maybeEval(getDocument().body, function() {
-      return eval(str)
-    })
+  /**
+   * @returns Window
+   */
+  function getWindow() {
+    return window
   }
 
-  function onLoadHelper(callback) {
-    const value = htmx.on('htmx:load', function(evt) {
-      callback(evt.detail.elt)
-    })
-    return value
+  /**
+   * @param {any} elt
+   * @return {Element|null}
+   */
+  function asElement(elt) {
+    return elt instanceof Element ? elt : null
   }
 
-  function logAll() {
-    htmx.logger = function(elt, event, data) {
-      if (console) {
-        console.log(event, elt, data)
-      }
-    }
+  /**
+   * @param {any} elt
+   * @return {HTMLElement|null}
+   */
+  function asHtmlElement(elt) {
+    return elt instanceof HTMLElement ? elt : null
   }
 
-  function logNone() {
-    htmx.logger = null
+  /**
+   * @param {any} value
+   * @return {string|null}
+   */
+  function asString(value) {
+    return typeof value === 'string' ? value : null
   }
 
-  function find(eltOrSelector, selector) {
-    if (selector) {
-      return eltOrSelector.querySelector(selector)
-    } else {
-      return find(getDocument(), eltOrSelector)
-    }
+  /**
+   * @typedef {Element|Document|DocumentFragment} Queryable
+   */
+
+  /**
+   * @param {EventTarget} elt
+   * @return {Queryable|null}
+   */
+  function asQueryable(elt) {
+    return elt instanceof Element || elt instanceof Document || elt instanceof DocumentFragment ? elt : null
   }
 
-  function findAll(eltOrSelector, selector) {
-    if (selector) {
-      return eltOrSelector.querySelectorAll(selector)
-    } else {
-      return findAll(getDocument(), eltOrSelector)
-    }
-  }
-
-  function removeElement(elt, delay) {
-    elt = resolveTarget(elt)
-    if (delay) {
-      setTimeout(function() {
-        removeElement(elt)
-        elt = null
-      }, delay)
-    } else {
-      parentElt(elt).removeChild(elt)
-    }
-  }
-
-  function addClassToElement(elt, clazz, delay) {
-    elt = resolveTarget(elt)
-    if (delay) {
-      setTimeout(function() {
-        addClassToElement(elt, clazz)
-        elt = null
-      }, delay)
-    } else {
-      elt.classList && elt.classList.add(clazz)
-    }
-  }
-
-  function removeClassFromElement(elt, clazz, delay) {
-    elt = resolveTarget(elt)
-    if (delay) {
-      setTimeout(function() {
-        removeClassFromElement(elt, clazz)
-        elt = null
-      }, delay)
-    } else {
-      if (elt.classList) {
-        elt.classList.remove(clazz)
-        // if there are no classes left, remove the class attribute
-        if (elt.classList.length === 0) {
-          elt.removeAttribute('class')
-        }
-      }
-    }
-  }
-
-  function toggleClassOnElement(elt, clazz) {
-    elt = resolveTarget(elt)
-    elt.classList.toggle(clazz)
-  }
-
-  function takeClassForElement(elt, clazz) {
-    elt = resolveTarget(elt)
-    forEach(elt.parentElement.children, function(child) {
-      removeClassFromElement(child, clazz)
-    })
-    addClassToElement(elt, clazz)
-  }
-
-  function closest(elt, selector) {
-    elt = resolveTarget(elt)
-    if (elt.closest) {
-      return elt.closest(selector)
-    } else {
-      // TODO remove when IE goes away
-      do {
-        if (elt == null || matches(elt, selector)) {
-          return elt
-        }
-      }
-      while (elt = elt && parentElt(elt))
-      return null
-    }
-  }
-
+  /**
+   * @param {string} str
+   * @param {string} prefix
+   * @returns {boolean}
+   */
   function startsWith(str, prefix) {
     return str.substring(0, prefix.length) === prefix
   }
 
+  /**
+   * @param {string} str
+   * @param {string} suffix
+   * @returns {boolean}
+   */
   function endsWith(str, suffix) {
     return str.substring(str.length - suffix.length) === suffix
   }
 
+  /**
+   * @param {string} selector
+   * @returns {string}
+   */
   function normalizeSelector(selector) {
     const trimmedSelector = selector.trim()
     if (startsWith(trimmedSelector, '<') && endsWith(trimmedSelector, '/>')) {
@@ -656,17 +1332,24 @@ var htmx = (function() {
     }
   }
 
+  /**
+   * @param {Node|Element|Document|string} elt
+   * @param {string} selector
+   * @param {boolean=} global
+   * @returns {(Node|Window)[]}
+   */
   function querySelectorAllExt(elt, selector, global) {
+    elt = resolveTarget(elt)
     if (selector.indexOf('closest ') === 0) {
-      return [closest(elt, normalizeSelector(selector.substr(8)))]
+      return [htmx.closest(asElement(elt), normalizeSelector(selector.substr(8)))]
     } else if (selector.indexOf('find ') === 0) {
-      return [find(elt, normalizeSelector(selector.substr(5)))]
+      return [htmx.find(asQueryable(elt), normalizeSelector(selector.substr(5)))]
     } else if (selector === 'next') {
-      return [elt.nextElementSibling]
+      return [asElement(elt).nextElementSibling]
     } else if (selector.indexOf('next ') === 0) {
       return [scanForwardQuery(elt, normalizeSelector(selector.substr(5)), !!global)]
     } else if (selector === 'previous') {
-      return [elt.previousElementSibling]
+      return [asElement(elt).previousElementSibling]
     } else if (selector.indexOf('previous ') === 0) {
       return [scanBackwardsQuery(elt, normalizeSelector(selector.substr(9)), !!global)]
     } else if (selector === 'document') {
@@ -680,12 +1363,18 @@ var htmx = (function() {
     } else if (selector.indexOf('global ') === 0) {
       return querySelectorAllExt(elt, selector.slice(7), true)
     } else {
-      return getRootNode(elt, !!global).querySelectorAll(normalizeSelector(selector))
+      return toArray(asQueryable(getRootNode(elt, !!global)).querySelectorAll(normalizeSelector(selector)))
     }
   }
 
+  /**
+   * @param {Node} start
+   * @param {string} match
+   * @param {boolean} global
+   * @returns {Element}
+   */
   var scanForwardQuery = function(start, match, global) {
-    const results = getRootNode(start, global).querySelectorAll(match)
+    const results = asQueryable(getRootNode(start, global)).querySelectorAll(match)
     for (let i = 0; i < results.length; i++) {
       const elt = results[i]
       if (elt.compareDocumentPosition(start) === Node.DOCUMENT_POSITION_PRECEDING) {
@@ -694,8 +1383,14 @@ var htmx = (function() {
     }
   }
 
+  /**
+   * @param {Node} start
+   * @param {string} match
+   * @param {boolean} global
+   * @returns {Element}
+   */
   var scanBackwardsQuery = function(start, match, global) {
-    const results = getRootNode(start, global).querySelectorAll(match)
+    const results = asQueryable(getRootNode(start, global)).querySelectorAll(match)
     for (let i = results.length - 1; i >= 0; i--) {
       const elt = results[i]
       if (elt.compareDocumentPosition(start) === Node.DOCUMENT_POSITION_FOLLOWING) {
@@ -704,8 +1399,13 @@ var htmx = (function() {
     }
   }
 
+  /**
+   * @param {Node|string} eltOrSelector
+   * @param {string=} selector
+   * @returns {Node|Window}
+   */
   function querySelectorExt(eltOrSelector, selector) {
-    if (selector) {
+    if (typeof eltOrSelector !== 'string') {
       return querySelectorAllExt(eltOrSelector, selector)[0]
     } else {
       return querySelectorAllExt(getDocument().body, eltOrSelector)[0]
@@ -713,51 +1413,50 @@ var htmx = (function() {
   }
 
   /**
-   *
-   * @param {string|Element} arg2
-   * @param {Element} [context]
-   * @returns {Element}
+   * @template {EventTarget} T
+   * @param {T|string} eltOrSelector
+   * @param {T} [context]
+   * @returns {Element|T|null}
    */
-  function resolveTarget(arg2, context) {
-    if (isType(arg2, 'String')) {
-      return find(context || document, arg2)
+  function resolveTarget(eltOrSelector, context) {
+    if (typeof eltOrSelector === 'string') {
+      return htmx.find(asQueryable(context) || document, eltOrSelector)
     } else {
-      // @ts-ignore
-      return arg2
+      return eltOrSelector
     }
   }
 
+  /**
+   * @typedef {keyof HTMLElementEventMap|string} AnyEventName
+   */
+
+  /**
+   * @typedef {Object} EventArgs
+   * @property {EventTarget} target
+   * @property {AnyEventName} event
+   * @property {EventListener} listener
+   */
+
+  /**
+   * @param {EventTarget|AnyEventName} arg1
+   * @param {AnyEventName|EventListener} arg2
+   * @param {EventListener} [arg3]
+   * @returns {EventArgs}
+   */
   function processEventArgs(arg1, arg2, arg3) {
     if (isFunction(arg2)) {
       return {
         target: getDocument().body,
-        event: arg1,
+        event: asString(arg1),
         listener: arg2
       }
     } else {
       return {
         target: resolveTarget(arg1),
-        event: arg2,
+        event: asString(arg2),
         listener: arg3
       }
     }
-  }
-
-  function addEventListenerImpl(arg1, arg2, arg3) {
-    ready(function() {
-      const eventArgs = processEventArgs(arg1, arg2, arg3)
-      eventArgs.target.addEventListener(eventArgs.event, eventArgs.listener)
-    })
-    const b = isFunction(arg2)
-    return b ? arg2 : arg3
-  }
-
-  function removeEventListenerImpl(arg1, arg2, arg3) {
-    ready(function() {
-      const eventArgs = processEventArgs(arg1, arg2, arg3)
-      eventArgs.target.removeEventListener(eventArgs.event, eventArgs.listener)
-    })
-    return isFunction(arg2) ? arg2 : arg3
   }
 
   //= ===================================================================
@@ -765,6 +1464,11 @@ var htmx = (function() {
   //= ===================================================================
 
   const DUMMY_ELT = getDocument().createElement('output') // dummy element for bad selectors
+  /**
+   * @param {Element} elt
+   * @param {string} attrName
+   * @returns {(Node|Window)[]}
+   */
   function findAttributeTargets(elt, attrName) {
     const attrTarget = getClosestAttributeValue(elt, attrName)
     if (attrTarget) {
@@ -782,12 +1486,21 @@ var htmx = (function() {
     }
   }
 
+  /**
+   * @param {Element} elt
+   * @param {string} attribute
+   * @returns {Element|null}
+   */
   function findThisElement(elt, attribute) {
-    return getClosestMatch(elt, function(elt) {
-      return getAttributeValue(elt, attribute) != null
-    })
+    return asElement(getClosestMatch(elt, function(elt) {
+      return getAttributeValue(asElement(elt), attribute) != null
+    }))
   }
 
+  /**
+   * @param {Element} elt
+   * @returns {Node|Window|null}
+   */
   function getTarget(elt) {
     const targetStr = getClosestAttributeValue(elt, 'hx-target')
     if (targetStr) {
@@ -806,6 +1519,10 @@ var htmx = (function() {
     }
   }
 
+  /**
+   * @param {string} name
+   * @returns {boolean}
+   */
   function shouldSettleAttribute(name) {
     const attributesToSettle = htmx.config.attributesToSettle
     for (let i = 0; i < attributesToSettle.length; i++) {
@@ -816,6 +1533,10 @@ var htmx = (function() {
     return false
   }
 
+  /**
+   * @param {Element} mergeTo
+   * @param {Element} mergeFrom
+   */
   function cloneAttributes(mergeTo, mergeFrom) {
     forEach(mergeTo.attributes, function(attr) {
       if (!mergeFrom.hasAttribute(attr.name) && shouldSettleAttribute(attr.name)) {
@@ -829,6 +1550,11 @@ var htmx = (function() {
     })
   }
 
+  /**
+   * @param {HtmxSwapStyle} swapStyle
+   * @param {Element} target
+   * @returns {boolean}
+   */
   function isInlineSwap(swapStyle, target) {
     const extensions = getExtensions(target)
     for (let i = 0; i < extensions.length; i++) {
@@ -845,14 +1571,14 @@ var htmx = (function() {
   }
 
   /**
-   *
    * @param {string} oobValue
    * @param {Element} oobElement
-   * @param {*} settleInfo
+   * @param {HtmxSettleInfo} settleInfo
    * @returns
    */
   function oobSwap(oobValue, oobElement, settleInfo) {
     let selector = '#' + getRawAttribute(oobElement, 'id')
+    /** @type HtmxSwapStyle */
     let swapStyle = 'outerHTML'
     if (oobValue === 'true') {
       // do nothing
@@ -873,18 +1599,18 @@ var htmx = (function() {
           fragment = getDocument().createDocumentFragment()
           fragment.appendChild(oobElementClone)
           if (!isInlineSwap(swapStyle, target)) {
-            fragment = oobElementClone // if this is not an inline swap, we use the content of the node, not the node itself
+            fragment = asQueryable(oobElementClone) // if this is not an inline swap, we use the content of the node, not the node itself
           }
 
           const beforeSwapDetails = { shouldSwap: true, target, fragment }
-          if (!triggerEvent(target, 'htmx:oobBeforeSwap', beforeSwapDetails)) return
+          if (!htmx.trigger(target, 'htmx:oobBeforeSwap', beforeSwapDetails)) return
 
           target = beforeSwapDetails.target // allow re-targeting
           if (beforeSwapDetails.shouldSwap) {
             swapWithStyle(swapStyle, target, target, fragment, settleInfo)
           }
           forEach(settleInfo.elts, function(elt) {
-            triggerEvent(elt, 'htmx:oobAfterSwap', beforeSwapDetails)
+            htmx.trigger(elt, 'htmx:oobAfterSwap', beforeSwapDetails)
           })
         }
       )
@@ -896,8 +1622,11 @@ var htmx = (function() {
     return oobValue
   }
 
+  /**
+   * @param {DocumentFragment} fragment
+   */
   function handlePreservedElements(fragment) {
-    forEach(findAll(fragment, '[hx-preserve], [data-hx-preserve]'), function(preservedElt) {
+    forEach(htmx.findAll(fragment, '[hx-preserve], [data-hx-preserve]'), function(preservedElt) {
       const id = getAttributeValue(preservedElt, 'id')
       const oldElt = getDocument().getElementById(id)
       if (oldElt != null) {
@@ -906,14 +1635,20 @@ var htmx = (function() {
     })
   }
 
+  /**
+   * @param {Node} parentNode
+   * @param {Queryable} fragment
+   * @param {HtmxSettleInfo} settleInfo
+   */
   function handleAttributes(parentNode, fragment, settleInfo) {
     forEach(fragment.querySelectorAll('[id]'), function(newNode) {
       const id = getRawAttribute(newNode, 'id')
       if (id && id.length > 0) {
         const normalizedId = id.replace("'", "\\'")
         const normalizedTag = newNode.tagName.replace(':', '\\:')
-        const oldNode = parentNode.querySelector(normalizedTag + "[id='" + normalizedId + "']")
-        if (oldNode && oldNode !== parentNode) {
+        const parentElt = asQueryable(parentNode)
+        const oldNode = parentElt && parentElt.querySelector(normalizedTag + "[id='" + normalizedId + "']")
+        if (oldNode && oldNode !== parentElt) {
           const newAttributes = newNode.cloneNode()
           cloneAttributes(newNode, oldNode)
           settleInfo.tasks.push(function() {
@@ -924,28 +1659,41 @@ var htmx = (function() {
     })
   }
 
+  /**
+   * @param {Node} child
+   * @returns {HtmxSettleTask}
+   */
   function makeAjaxLoadTask(child) {
     return function() {
-      removeClassFromElement(child, htmx.config.addedClass)
-      processNode(child)
-      processFocus(child)
-      triggerEvent(child, 'htmx:load')
+      htmx.removeClass(child, htmx.config.addedClass)
+      htmx.process(asElement(child))
+      processFocus(asQueryable(child))
+      htmx.trigger(child, 'htmx:load')
     }
   }
 
+  /**
+   * @param {Queryable} child
+   */
   function processFocus(child) {
     const autofocus = '[autofocus]'
-    const autoFocusedElt = matches(child, autofocus) ? child : child.querySelector(autofocus)
+    const autoFocusedElt = asHtmlElement(matches(child, autofocus) ? child : child.querySelector(autofocus))
     if (autoFocusedElt != null) {
       autoFocusedElt.focus()
     }
   }
 
+  /**
+   * @param {Node} parentNode
+   * @param {Node} insertBefore
+   * @param {Queryable} fragment
+   * @param {HtmxSettleInfo} settleInfo
+   */
   function insertNodesBefore(parentNode, insertBefore, fragment, settleInfo) {
     handleAttributes(parentNode, fragment, settleInfo)
     while (fragment.childNodes.length > 0) {
       const child = fragment.firstChild
-      addClassToElement(child, htmx.config.addedClass)
+      htmx.addClass(asElement(child), htmx.config.addedClass)
       parentNode.insertBefore(child, insertBefore)
       if (child.nodeType !== Node.TEXT_NODE && child.nodeType !== Node.COMMENT_NODE) {
         settleInfo.tasks.push(makeAjaxLoadTask(child))
@@ -953,8 +1701,13 @@ var htmx = (function() {
     }
   }
 
-  // based on https://gist.github.com/hyamamoto/fd435505d29ebfa3d9716fd2be8d42f0,
-  // derived from Java's string hashcode implementation
+  /**
+   * based on https://gist.github.com/hyamamoto/fd435505d29ebfa3d9716fd2be8d42f0,
+   * derived from Java's string hashcode implementation
+   * @param {string} string
+   * @param {number} hash
+   * @returns {number}
+   */
   function stringHash(string, hash) {
     let char = 0
     while (char < string.length) {
@@ -963,6 +1716,10 @@ var htmx = (function() {
     return hash
   }
 
+  /**
+   * @param {Element} elt
+   * @returns {number}
+   */
   function attributeHash(elt) {
     let hash = 0
     // IE fix
@@ -978,17 +1735,23 @@ var htmx = (function() {
     return hash
   }
 
+  /**
+   * @param {EventTarget} elt
+   */
   function deInitOnHandlers(elt) {
     const internalData = getInternalData(elt)
     if (internalData.onHandlers) {
       for (let i = 0; i < internalData.onHandlers.length; i++) {
         const handlerInfo = internalData.onHandlers[i]
-        elt.removeEventListener(handlerInfo.event, handlerInfo.listener)
+        htmx.off(elt, handlerInfo.event, handlerInfo.listener)
       }
       delete internalData.onHandlers
     }
   }
 
+  /**
+   * @param {Node} element
+   */
   function deInitNode(element) {
     const internalData = getInternalData(element)
     if (internalData.timeout) {
@@ -997,7 +1760,7 @@ var htmx = (function() {
     if (internalData.listenerInfos) {
       forEach(internalData.listenerInfos, function(info) {
         if (info.on) {
-          info.on.removeEventListener(info.trigger, info.listener)
+          htmx.off(info.on, info.trigger, info.listener)
         }
       })
     }
@@ -1005,16 +1768,27 @@ var htmx = (function() {
     forEach(Object.keys(internalData), function(key) { delete internalData[key] })
   }
 
+  /**
+   * @param {Node} element
+   */
   function cleanUpElement(element) {
-    triggerEvent(element, 'htmx:beforeCleanupElement')
+    htmx.trigger(element, 'htmx:beforeCleanupElement')
     deInitNode(element)
+    // @ts-ignore IE11 code
+    // noinspection JSUnresolvedReference
     if (element.children) { // IE
+      // @ts-ignore
       forEach(element.children, function(child) { cleanUpElement(child) })
     }
   }
 
+  /**
+   * @param {Node} target
+   * @param {Queryable} fragment
+   * @param {HtmxSettleInfo} settleInfo
+   */
   function swapOuterHTML(target, fragment, settleInfo) {
-    // @type {HTMLElement}
+    /** @type {Node} */
     let newElt
     const eltBeforeNewContent = target.previousSibling
     insertNodesBefore(parentElt(target), target, fragment, settleInfo)
@@ -1025,35 +1799,70 @@ var htmx = (function() {
     }
     settleInfo.elts = settleInfo.elts.filter(function(e) { return e !== target })
     while (newElt && newElt !== target) {
-      if (newElt.nodeType === Node.ELEMENT_NODE) {
+      if (newElt instanceof Element) {
         settleInfo.elts.push(newElt)
+        newElt = newElt.nextElementSibling
+      } else {
+        newElt = null
       }
-      newElt = newElt.nextElementSibling
     }
     cleanUpElement(target)
-    target.remove()
+    if (target instanceof Element) {
+      target.remove()
+    } else {
+      target.parentNode.removeChild(target)
+    }
   }
 
+  /**
+   * @param {Node} target
+   * @param {Queryable} fragment
+   * @param {HtmxSettleInfo} settleInfo
+   */
   function swapAfterBegin(target, fragment, settleInfo) {
     return insertNodesBefore(target, target.firstChild, fragment, settleInfo)
   }
 
+  /**
+   * @param {Node} target
+   * @param {Queryable} fragment
+   * @param {HtmxSettleInfo} settleInfo
+   */
   function swapBeforeBegin(target, fragment, settleInfo) {
     return insertNodesBefore(parentElt(target), target, fragment, settleInfo)
   }
 
+  /**
+   * @param {Node} target
+   * @param {Queryable} fragment
+   * @param {HtmxSettleInfo} settleInfo
+   */
   function swapBeforeEnd(target, fragment, settleInfo) {
     return insertNodesBefore(target, null, fragment, settleInfo)
   }
 
+  /**
+   * @param {Node} target
+   * @param {Queryable} fragment
+   * @param {HtmxSettleInfo} settleInfo
+   */
   function swapAfterEnd(target, fragment, settleInfo) {
     return insertNodesBefore(parentElt(target), target.nextSibling, fragment, settleInfo)
   }
-  function swapDelete(target, fragment, settleInfo) {
+
+  /**
+   * @param {Node} target
+   */
+  function swapDelete(target) {
     cleanUpElement(target)
     return parentElt(target).removeChild(target)
   }
 
+  /**
+   * @param {Node} target
+   * @param {Queryable} fragment
+   * @param {HtmxSettleInfo} settleInfo
+   */
   function swapInnerHTML(target, fragment, settleInfo) {
     const firstChild = target.firstChild
     insertNodesBefore(target, firstChild, fragment, settleInfo)
@@ -1068,11 +1877,11 @@ var htmx = (function() {
   }
 
   /**
-   * @param {string} swapStyle
-   * @param {HTMLElement} elt
-   * @param {HTMLElement} target
-   * @param {Node} fragment
-   * @param {{ tasks: (() => void)[]; }} settleInfo
+   * @param {HtmxSwapStyle} swapStyle
+   * @param {Element} elt
+   * @param {Node} target
+   * @param {Queryable} fragment
+   * @param {HtmxSettleInfo} settleInfo
    */
   function swapWithStyle(swapStyle, elt, target, fragment, settleInfo) {
     switch (swapStyle) {
@@ -1094,7 +1903,7 @@ var htmx = (function() {
         swapAfterEnd(target, fragment, settleInfo)
         return
       case 'delete':
-        swapDelete(target, fragment, settleInfo)
+        swapDelete(target)
         return
       default:
         var extensions = getExtensions(elt)
@@ -1126,8 +1935,12 @@ var htmx = (function() {
     }
   }
 
+  /**
+   * @param {DocumentFragment} fragment
+   * @param {HtmxSettleInfo} settleInfo
+   */
   function findAndSwapOobElements(fragment, settleInfo) {
-    forEach(findAll(fragment, '[hx-swap-oob], [data-hx-swap-oob]'), function(oobElement) {
+    forEach(htmx.findAll(fragment, '[hx-swap-oob], [data-hx-swap-oob]'), function(oobElement) {
       const oobValue = getAttributeValue(oobElement, 'hx-swap-oob')
       if (oobValue != null) {
         oobSwap(oobValue, oobElement, settleInfo)
@@ -1136,160 +1949,10 @@ var htmx = (function() {
   }
 
   /**
-   * @callback swapCallback
+   * @param {XMLHttpRequest} xhr
+   * @param {string} header
+   * @param {EventTarget} elt
    */
-
-  /**
-   * @typedef {Object} SwapOptions
-   * @property {?string} select
-   * @property {?string} selectOOB
-   * @property {?*} eventInfo
-   * @property {?*} anchor
-   * @property {?HTMLElement} contextElement
-   * @property {?swapCallback} afterSwapCallback
-   * @property {?swapCallback} afterSettleCallback
-   */
-
-  /**
-   * Implements complete swapping pipeline, including: focus and selection preservation,
-   * title updates, scroll, OOB swapping, normal swapping and settling
-   * @param {string|Element} target
-   * @param {string} content
-   * @param {import("./htmx").HtmxSwapSpecification} swapSpec
-   * @param {SwapOptions} swapOptions
-   */
-  function swap(target, content, swapSpec, swapOptions) {
-    if (!swapOptions) {
-      swapOptions = {}
-    }
-
-    target = resolveTarget(target)
-
-    // preserve focus and selection
-    const activeElt = document.activeElement
-    let selectionInfo = {}
-    try {
-      selectionInfo = {
-        elt: activeElt,
-        // @ts-ignore
-        start: activeElt ? activeElt.selectionStart : null,
-        // @ts-ignore
-        end: activeElt ? activeElt.selectionEnd : null
-      }
-    } catch (e) {
-      // safari issue - see https://github.com/microsoft/playwright/issues/5894
-    }
-    const settleInfo = makeSettleInfo(target)
-
-    let fragment = makeFragment(content)
-
-    settleInfo.title = fragment.title
-
-    // select-oob swaps
-    if (swapOptions.selectOOB) {
-      const oobSelectValues = swapOptions.selectOOB.split(',')
-      for (let i = 0; i < oobSelectValues.length; i++) {
-        const oobSelectValue = oobSelectValues[i].split(':', 2)
-        let id = oobSelectValue[0].trim()
-        if (id.indexOf('#') === 0) {
-          id = id.substring(1)
-        }
-        const oobValue = oobSelectValue[1] || 'true'
-        const oobElement = fragment.querySelector('#' + id)
-        if (oobElement) {
-          oobSwap(oobValue, oobElement, settleInfo)
-        }
-      }
-    }
-    // oob swaps
-    findAndSwapOobElements(fragment, settleInfo)
-    forEach(findAll(fragment, 'template'), function(template) {
-      findAndSwapOobElements(template.content, settleInfo)
-      if (template.content.childElementCount === 0) {
-        // Avoid polluting the DOM with empty templates that were only used to encapsulate oob swap
-        template.remove()
-      }
-    })
-
-    // normal swap
-    if (swapOptions.select) {
-      const newFragment = getDocument().createDocumentFragment()
-      forEach(fragment.querySelectorAll(swapOptions.select), function(node) {
-        newFragment.appendChild(node)
-      })
-      fragment = newFragment
-    }
-    handlePreservedElements(fragment)
-    swapWithStyle(swapSpec.swapStyle, swapOptions.contextElement, target, fragment, settleInfo)
-
-    // apply saved focus and selection information to swapped content
-    if (selectionInfo.elt &&
-            !bodyContains(selectionInfo.elt) &&
-            getRawAttribute(selectionInfo.elt, 'id')) {
-      const newActiveElt = document.getElementById(getRawAttribute(selectionInfo.elt, 'id'))
-      const focusOptions = { preventScroll: swapSpec.focusScroll !== undefined ? !swapSpec.focusScroll : !htmx.config.defaultFocusScroll }
-      if (newActiveElt) {
-        // @ts-ignore
-        if (selectionInfo.start && newActiveElt.setSelectionRange) {
-          try {
-            // @ts-ignore
-            newActiveElt.setSelectionRange(selectionInfo.start, selectionInfo.end)
-          } catch (e) {
-            // the setSelectionRange method is present on fields that don't support it, so just let this fail
-          }
-        }
-        newActiveElt.focus(focusOptions)
-      }
-    }
-
-    target.classList.remove(htmx.config.swappingClass)
-    forEach(settleInfo.elts, function(elt) {
-      if (elt.classList) {
-        elt.classList.add(htmx.config.settlingClass)
-      }
-      triggerEvent(elt, 'htmx:afterSwap', swapOptions.eventInfo)
-    })
-    if (swapOptions.afterSwapCallback) {
-      swapOptions.afterSwapCallback()
-    }
-
-    // merge in new title after swap but before settle
-    if (!swapSpec.ignoreTitle) {
-      handleTitle(settleInfo.title)
-    }
-
-    // settle
-    const doSettle = function() {
-      forEach(settleInfo.tasks, function(task) {
-        task.call()
-      })
-      forEach(settleInfo.elts, function(elt) {
-        if (elt.classList) {
-          elt.classList.remove(htmx.config.settlingClass)
-        }
-        triggerEvent(elt, 'htmx:afterSettle', swapOptions.eventInfo)
-      })
-
-      if (swapOptions.anchor) {
-        const anchorTarget = resolveTarget('#' + swapOptions.anchor)
-        if (anchorTarget) {
-          anchorTarget.scrollIntoView({ block: 'start', behavior: 'auto' })
-        }
-      }
-
-      updateScrollState(settleInfo.elts, swapSpec)
-      if (swapOptions.afterSettleCallback) {
-        swapOptions.afterSettleCallback()
-      }
-    }
-
-    if (swapSpec.settleDelay > 0) {
-      setTimeout(doSettle, swapSpec.settleDelay)
-    } else {
-      doSettle()
-    }
-  }
-
   function handleTriggerHeader(xhr, header, elt) {
     const triggerBody = xhr.getResponseHeader(header)
     if (triggerBody.indexOf('{') === 0) {
@@ -1300,13 +1963,13 @@ var htmx = (function() {
           if (!isRawObject(detail)) {
             detail = { value: detail }
           }
-          triggerEvent(elt, eventName, detail)
+          htmx.trigger(elt, eventName, detail)
         }
       }
     } else {
       const eventNames = triggerBody.split(',')
       for (let i = 0; i < eventNames.length; i++) {
-        triggerEvent(elt, eventNames[i].trim(), [])
+        htmx.trigger(elt, eventNames[i].trim(), [])
       }
     }
   }
@@ -1319,7 +1982,13 @@ var htmx = (function() {
   const NOT_WHITESPACE = /[^\s]/
   const COMBINED_SELECTOR_START = /[{(]/
   const COMBINED_SELECTOR_END = /[})]/
+
+  /**
+   * @param {string} str
+   * @returns {string[]}
+   */
   function tokenizeString(str) {
+    /** @type string[] */
     const tokens = []
     let position = 0
     while (position < str.length) {
@@ -1349,6 +2018,12 @@ var htmx = (function() {
     return tokens
   }
 
+  /**
+   * @param {string} token
+   * @param {string|null} last
+   * @param {string} paramName
+   * @returns {boolean}
+   */
   function isPossibleRelativeReference(token, last, paramName) {
     return SYMBOL_START.exec(token.charAt(0)) &&
       token !== 'true' &&
@@ -1358,6 +2033,12 @@ var htmx = (function() {
       last !== '.'
   }
 
+  /**
+   * @param {EventTarget|string} elt
+   * @param {string[]} tokens
+   * @param {string} paramName
+   * @returns {ConditionalFunction|null}
+   */
   function maybeGenerateConditional(elt, tokens, paramName) {
     if (tokens[0] === '[') {
       tokens.shift()
@@ -1366,6 +2047,7 @@ var htmx = (function() {
       let last = null
       while (tokens.length > 0) {
         const token = tokens[0]
+        // @ts-ignore For some reason tsc doesn't understand the shift call, and thinks we're comparing the same value here, i.e. '[' vs ']'
         if (token === ']') {
           bracketCount--
           if (bracketCount === 0) {
@@ -1399,6 +2081,11 @@ var htmx = (function() {
     }
   }
 
+  /**
+   * @param {string[]} tokens
+   * @param {RegExp} match
+   * @returns {string}
+   */
   function consumeUntil(tokens, match) {
     let result = ''
     while (tokens.length > 0 && !match.test(tokens[0])) {
@@ -1407,6 +2094,10 @@ var htmx = (function() {
     return result
   }
 
+  /**
+   * @param {string[]} tokens
+   * @returns {string}
+   */
   function consumeCSSSelector(tokens) {
     let result
     if (tokens.length > 0 && COMBINED_SELECTOR_START.test(tokens[0])) {
@@ -1422,12 +2113,13 @@ var htmx = (function() {
   const INPUT_SELECTOR = 'input, textarea, select'
 
   /**
-   * @param {HTMLElement} elt
+   * @param {Element} elt
    * @param {string} explicitTrigger
-   * @param {cache} cache for trigger specs
-   * @returns {import("./htmx").HtmxTriggerSpecification[]}
+   * @param {Object} cache for trigger specs
+   * @returns {HtmxTriggerSpecification[]}
    */
   function parseAndCacheTrigger(elt, explicitTrigger, cache) {
+    /** @type HtmxTriggerSpecification[] */
     const triggerSpecs = []
     const tokens = tokenizeString(explicitTrigger)
     do {
@@ -1436,9 +2128,10 @@ var htmx = (function() {
       const trigger = consumeUntil(tokens, /[,\[\s]/)
       if (trigger !== '') {
         if (trigger === 'every') {
+          /** @type HtmxTriggerSpecification */
           const every = { trigger: 'every' }
           consumeUntil(tokens, NOT_WHITESPACE)
-          every.pollInterval = parseInterval(consumeUntil(tokens, /[,\[\s]/))
+          every.pollInterval = htmx.parseInterval(consumeUntil(tokens, /[,\[\s]/))
           consumeUntil(tokens, NOT_WHITESPACE)
           var eventFilter = maybeGenerateConditional(elt, tokens, 'event')
           if (eventFilter) {
@@ -1446,6 +2139,7 @@ var htmx = (function() {
           }
           triggerSpecs.push(every)
         } else {
+          /** @type HtmxTriggerSpecification */
           const triggerSpec = { trigger }
           var eventFilter = maybeGenerateConditional(elt, tokens, 'event')
           if (eventFilter) {
@@ -1462,7 +2156,7 @@ var htmx = (function() {
               triggerSpec.consume = true
             } else if (token === 'delay' && tokens[0] === ':') {
               tokens.shift()
-              triggerSpec.delay = parseInterval(consumeUntil(tokens, WHITESPACE_OR_COMMA))
+              triggerSpec.delay = htmx.parseInterval(consumeUntil(tokens, WHITESPACE_OR_COMMA))
             } else if (token === 'from' && tokens[0] === ':') {
               tokens.shift()
               if (COMBINED_SELECTOR_START.test(tokens[0])) {
@@ -1484,7 +2178,7 @@ var htmx = (function() {
               triggerSpec.target = consumeCSSSelector(tokens)
             } else if (token === 'throttle' && tokens[0] === ':') {
               tokens.shift()
-              triggerSpec.throttle = parseInterval(consumeUntil(tokens, WHITESPACE_OR_COMMA))
+              triggerSpec.throttle = htmx.parseInterval(consumeUntil(tokens, WHITESPACE_OR_COMMA))
             } else if (token === 'queue' && tokens[0] === ':') {
               tokens.shift()
               triggerSpec.queue = consumeUntil(tokens, WHITESPACE_OR_COMMA)
@@ -1513,8 +2207,8 @@ var htmx = (function() {
   }
 
   /**
-   * @param {HTMLElement} elt
-   * @returns {import("./htmx").HtmxTriggerSpecification[]}
+   * @param {Element} elt
+   * @returns {HtmxTriggerSpecification[]}
    */
   function getTriggerSpecs(elt) {
     const explicitTrigger = getAttributeValue(elt, 'hx-trigger')
@@ -1537,13 +2231,21 @@ var htmx = (function() {
     }
   }
 
+  /**
+   * @param {Element} elt
+   */
   function cancelPolling(elt) {
     getInternalData(elt).cancelled = true
   }
 
+  /**
+   * @param {Element} elt
+   * @param {TriggerHandler} handler
+   * @param {HtmxTriggerSpecification} spec
+   */
   function processPolling(elt, handler, spec) {
     const nodeData = getInternalData(elt)
-    nodeData.timeout = setTimeout(function() {
+    nodeData.timeout = getWindow().setTimeout(function() {
       if (bodyContains(elt) && nodeData.cancelled !== true) {
         if (!maybeFilterEvent(spec, elt, makeEvent('hx:poll:trigger', {
           triggerSpec: spec,
@@ -1556,14 +2258,23 @@ var htmx = (function() {
     }, spec.pollInterval)
   }
 
+  /**
+   * @param {HTMLAnchorElement} elt
+   * @returns {boolean}
+   */
   function isLocalLink(elt) {
     return location.hostname === elt.hostname &&
       getRawAttribute(elt, 'href') &&
       getRawAttribute(elt, 'href').indexOf('#') !== 0
   }
 
+  /**
+   * @param {Element} elt
+   * @param {HtmxNodeInternalData} nodeData
+   * @param {HtmxTriggerSpecification[]} triggerSpecs
+   */
   function boostElement(elt, nodeData, triggerSpecs) {
-    if ((elt.tagName === 'A' && isLocalLink(elt) && (elt.target === '' || elt.target === '_self')) || elt.tagName === 'FORM') {
+    if ((elt instanceof HTMLAnchorElement && isLocalLink(elt) && (elt.target === '' || elt.target === '_self')) || elt.tagName === 'FORM') {
       nodeData.boosted = true
       let verb, path
       if (elt.tagName === 'A') {
@@ -1577,8 +2288,9 @@ var htmx = (function() {
         path = getRawAttribute(elt, 'action')
       }
       triggerSpecs.forEach(function(triggerSpec) {
-        addEventListener(elt, function(elt, evt) {
-          if (closest(elt, htmx.config.disableSelector)) {
+        addEventListener(elt, function(node, evt) {
+          const elt = asElement(node)
+          if (htmx.closest(elt, htmx.config.disableSelector)) {
             cleanUpElement(elt)
             return
           }
@@ -1589,20 +2301,23 @@ var htmx = (function() {
   }
 
   /**
-   *
    * @param {Event} evt
-   * @param {HTMLElement} elt
-   * @returns
+   * @param {Node} node
+   * @returns {boolean}
    */
-  function shouldCancel(evt, elt) {
+  function shouldCancel(evt, node) {
+    const elt = asElement(node)
+    if (!elt) {
+      return false
+    }
     if (evt.type === 'submit' || evt.type === 'click') {
       if (elt.tagName === 'FORM') {
         return true
       }
-      if (matches(elt, 'input[type="submit"], button') && closest(elt, 'form') !== null) {
+      if (matches(elt, 'input[type="submit"], button') && htmx.closest(elt, 'form') !== null) {
         return true
       }
-      if (elt.tagName === 'A' && elt.href &&
+      if (elt instanceof HTMLAnchorElement && elt.href &&
         (elt.getAttribute('href') === '#' || elt.getAttribute('href').indexOf('#') !== 0)) {
         return true
       }
@@ -1610,25 +2325,47 @@ var htmx = (function() {
     return false
   }
 
+  /**
+   * @param {Node} elt
+   * @param {Event|MouseEvent|KeyboardEvent|TouchEvent} evt
+   * @returns {boolean}
+   */
   function ignoreBoostedAnchorCtrlClick(elt, evt) {
-    return getInternalData(elt).boosted && elt.tagName === 'A' && evt.type === 'click' && (evt.ctrlKey || evt.metaKey)
+    return getInternalData(elt).boosted && elt instanceof HTMLAnchorElement && evt.type === 'click' &&
+      // @ts-ignore this will resolve to undefined for events that don't define those properties, which is fine
+      (evt.ctrlKey || evt.metaKey)
   }
 
+  /**
+   * @param {HtmxTriggerSpecification} triggerSpec
+   * @param {Node} elt
+   * @param {Event} evt
+   * @returns {boolean}
+   */
   function maybeFilterEvent(triggerSpec, elt, evt) {
     const eventFilter = triggerSpec.eventFilter
     if (eventFilter) {
       try {
         return eventFilter.call(elt, evt) !== true
       } catch (e) {
-        triggerErrorEvent(getDocument().body, 'htmx:eventFilter:error', { error: e, source: eventFilter.source })
+        const source = eventFilter.source
+        triggerErrorEvent(getDocument().body, 'htmx:eventFilter:error', { error: e, source })
         return true
       }
     }
     return false
   }
 
+  /**
+   * @param {Node} elt
+   * @param {TriggerHandler} handler
+   * @param {HtmxNodeInternalData} nodeData
+   * @param {HtmxTriggerSpecification} triggerSpec
+   * @param {boolean} [explicitCancel]
+   */
   function addEventListener(elt, handler, nodeData, triggerSpec, explicitCancel) {
     const elementData = getInternalData(elt)
+    /** @type {(Node|Window)[]} */
     let eltsToListenOn
     if (triggerSpec.from) {
       eltsToListenOn = querySelectorAllExt(elt, triggerSpec.from)
@@ -1639,10 +2376,12 @@ var htmx = (function() {
     if (triggerSpec.changed) {
       eltsToListenOn.forEach(function(eltToListenOn) {
         const eltToListenOnData = getInternalData(eltToListenOn)
+        // @ts-ignore value will be undefined for non-input elements, which is fine
         eltToListenOnData.lastValue = eltToListenOn.value
       })
     }
     forEach(eltsToListenOn, function(eltToListenOn) {
+      /** @type EventListener */
       const eventListener = function(evt) {
         if (!bodyContains(elt)) {
           eltToListenOn.removeEventListener(triggerSpec.trigger, eventListener)
@@ -1668,7 +2407,7 @@ var htmx = (function() {
             evt.stopPropagation()
           }
           if (triggerSpec.target && evt.target) {
-            if (!matches(evt.target, triggerSpec.target)) {
+            if (!matches(asElement(evt.target), triggerSpec.target)) {
               return
             }
           }
@@ -1681,10 +2420,12 @@ var htmx = (function() {
           }
           if (triggerSpec.changed) {
             const eltToListenOnData = getInternalData(eltToListenOn)
-            if (eltToListenOnData.lastValue === eltToListenOn.value) {
+            // @ts-ignore value will be undefined for non-input elements, which is fine
+            const value = eltToListenOn.value
+            if (eltToListenOnData.lastValue === value) {
               return
             }
-            eltToListenOnData.lastValue = eltToListenOn.value
+            eltToListenOnData.lastValue = value
           }
           if (elementData.delayed) {
             clearTimeout(elementData.delayed)
@@ -1696,14 +2437,14 @@ var htmx = (function() {
           if (triggerSpec.throttle > 0) {
             if (!elementData.throttle) {
               handler(elt, evt)
-              elementData.throttle = setTimeout(function() {
+              elementData.throttle = getWindow().setTimeout(function() {
                 elementData.throttle = null
               }, triggerSpec.throttle)
             }
           } else if (triggerSpec.delay > 0) {
-            elementData.delayed = setTimeout(function() { handler(elt, evt) }, triggerSpec.delay)
+            elementData.delayed = getWindow().setTimeout(function() { handler(elt, evt) }, triggerSpec.delay)
           } else {
-            triggerEvent(elt, 'htmx:trigger')
+            htmx.trigger(elt, 'htmx:trigger')
             handler(elt, evt)
           }
         }
@@ -1739,21 +2480,30 @@ var htmx = (function() {
     }
   }
 
+  /**
+   * @param {Element} elt
+   */
   function maybeReveal(elt) {
     if (!hasAttribute(elt, 'data-hx-revealed') && isScrolledIntoView(elt)) {
       elt.setAttribute('data-hx-revealed', 'true')
       const nodeData = getInternalData(elt)
       if (nodeData.initHash) {
-        triggerEvent(elt, 'revealed')
+        htmx.trigger(elt, 'revealed')
       } else {
         // if the node isn't initialized, wait for it before triggering the request
-        elt.addEventListener('htmx:afterProcessNode', function(evt) { triggerEvent(elt, 'revealed') }, { once: true })
+        elt.addEventListener('htmx:afterProcessNode', function() { htmx.trigger(elt, 'revealed') }, { once: true })
       }
     }
   }
 
   //= ===================================================================
 
+  /**
+   * @param {Element} elt
+   * @param {TriggerHandler} handler
+   * @param {HtmxNodeInternalData} nodeData
+   * @param {number} delay
+   */
   function loadImmediately(elt, handler, nodeData, delay) {
     const load = function() {
       if (!nodeData.loaded) {
@@ -1762,12 +2512,18 @@ var htmx = (function() {
       }
     }
     if (delay > 0) {
-      setTimeout(load, delay)
+      getWindow().setTimeout(load, delay)
     } else {
       load()
     }
   }
 
+  /**
+   * @param {Element} elt
+   * @param {HtmxNodeInternalData} nodeData
+   * @param {HtmxTriggerSpecification[]} triggerSpecs
+   * @returns {boolean}
+   */
   function processVerbs(elt, nodeData, triggerSpecs) {
     let explicitAction = false
     forEach(VERBS, function(verb) {
@@ -1777,8 +2533,9 @@ var htmx = (function() {
         nodeData.path = path
         nodeData.verb = verb
         triggerSpecs.forEach(function(triggerSpec) {
-          addTriggerHandler(elt, triggerSpec, nodeData, function(elt, evt) {
-            if (closest(elt, htmx.config.disableSelector)) {
+          addTriggerHandler(elt, triggerSpec, nodeData, function(node, evt) {
+            const elt = asElement(node)
+            if (htmx.closest(elt, htmx.config.disableSelector)) {
               cleanUpElement(elt)
               return
             }
@@ -1790,11 +2547,23 @@ var htmx = (function() {
     return explicitAction
   }
 
+  /**
+   * @callback TriggerHandler
+   * @param {Node} elt
+   * @param {Event} [evt]
+   */
+
+  /**
+   * @param {Node} elt
+   * @param {HtmxTriggerSpecification} triggerSpec
+   * @param {HtmxNodeInternalData} nodeData
+   * @param {TriggerHandler} handler
+   */
   function addTriggerHandler(elt, triggerSpec, nodeData, handler) {
     if (triggerSpec.trigger === 'revealed') {
       initScrollHandler()
       addEventListener(elt, handler, nodeData, triggerSpec)
-      maybeReveal(elt)
+      maybeReveal(asElement(elt))
     } else if (triggerSpec.trigger === 'intersect') {
       const observerOptions = {}
       if (triggerSpec.root) {
@@ -1807,26 +2576,34 @@ var htmx = (function() {
         for (let i = 0; i < entries.length; i++) {
           const entry = entries[i]
           if (entry.isIntersecting) {
-            triggerEvent(elt, 'intersect')
+            htmx.trigger(elt, 'intersect')
             break
           }
         }
       }, observerOptions)
-      observer.observe(elt)
-      addEventListener(elt, handler, nodeData, triggerSpec)
+      observer.observe(asElement(elt))
+      addEventListener(asElement(elt), handler, nodeData, triggerSpec)
     } else if (triggerSpec.trigger === 'load') {
       if (!maybeFilterEvent(triggerSpec, elt, makeEvent('load', { elt }))) {
-        loadImmediately(elt, handler, nodeData, triggerSpec.delay)
+        loadImmediately(asElement(elt), handler, nodeData, triggerSpec.delay)
       }
     } else if (triggerSpec.pollInterval > 0) {
       nodeData.polling = true
-      processPolling(elt, handler, triggerSpec)
+      processPolling(asElement(elt), handler, triggerSpec)
     } else {
       addEventListener(elt, handler, nodeData, triggerSpec)
     }
   }
 
-  function shouldProcessHxOn(elt) {
+  /**
+   * @param {Node} node
+   * @returns {boolean}
+   */
+  function shouldProcessHxOn(node) {
+    const elt = asElement(node)
+    if (!elt) {
+      return false
+    }
     const attributes = elt.attributes
     for (let j = 0; j < attributes.length; j++) {
       const attrName = attributes[j].name
@@ -1838,22 +2615,31 @@ var htmx = (function() {
     return false
   }
 
+  /**
+   * @param {Node} elt
+   * @returns {Element[]}
+   */
   function findHxOnWildcardElements(elt) {
     let node = null
+    /** @type {Element[]} */
     const elements = []
 
     if (!(elt instanceof ShadowRoot)) {
       if (shouldProcessHxOn(elt)) {
-        elements.push(elt)
+        elements.push(asElement(elt))
       }
 
       const iter = document.evaluate('.//*[@*[ starts-with(name(), "hx-on:") or starts-with(name(), "data-hx-on:") or' +
         ' starts-with(name(), "hx-on-") or starts-with(name(), "data-hx-on-") ]]', elt)
-      while (node = iter.iterateNext()) elements.push(node)
+      while (node = iter.iterateNext()) elements.push(asElement(node))
     }
     return elements
   }
 
+  /**
+   * @param {Element} elt
+   * @returns {NodeListOf<Element>|[]}
+   */
   function findElementsToProcess(elt) {
     if (elt.querySelectorAll) {
       const boostedSelector = ', [hx-boost] a, [data-hx-boost] a, a[hx-boost], a[data-hx-boost]'
@@ -1865,32 +2651,48 @@ var htmx = (function() {
     }
   }
 
-  // Handle submit buttons/inputs that have the form attribute set
-  // see https://developer.mozilla.org/docs/Web/HTML/Element/button
+  /**
+   * Handle submit buttons/inputs that have the form attribute set
+   * see https://developer.mozilla.org/docs/Web/HTML/Element/button
+   * @param {Event} evt
+   */
   function maybeSetLastButtonClicked(evt) {
-    const elt = closest(evt.target, "button, input[type='submit']")
+    const elt = /** @type {HTMLButtonElement|HTMLInputElement} */ (htmx.closest(asElement(evt.target), "button, input[type='submit']"))
     const internalData = getRelatedFormData(evt)
     if (internalData) {
       internalData.lastButtonClicked = elt
     }
-  };
+  }
+
+  /**
+   * @param {Event} evt
+   */
   function maybeUnsetLastButtonClicked(evt) {
     const internalData = getRelatedFormData(evt)
     if (internalData) {
       internalData.lastButtonClicked = null
     }
   }
+
+  /**
+   * @param {Event} evt
+   * @returns {HtmxNodeInternalData|undefined}
+   */
   function getRelatedFormData(evt) {
-    const elt = closest(evt.target, "button, input[type='submit']")
+    const elt = htmx.closest(asElement(evt.target), "button, input[type='submit']")
     if (!elt) {
       return
     }
-    const form = resolveTarget('#' + getRawAttribute(elt, 'form'), elt.getRootNode()) || closest(elt, 'form')
+    const form = resolveTarget('#' + getRawAttribute(elt, 'form'), elt.getRootNode()) || htmx.closest(elt, 'form')
     if (!form) {
       return
     }
     return getInternalData(form)
   }
+
+  /**
+   * @param {EventTarget} elt
+   */
   function initButtonTracking(elt) {
     // need to handle both click and focus in:
     //   focusin - in case someone tabs in to a button and hits the space bar
@@ -1900,28 +2702,20 @@ var htmx = (function() {
     elt.addEventListener('focusout', maybeUnsetLastButtonClicked)
   }
 
-  function countCurlies(line) {
-    const tokens = tokenizeString(line)
-    let netCurlies = 0
-    for (let i = 0; i < tokens.length; i++) {
-      const token = tokens[i]
-      if (token === '{') {
-        netCurlies++
-      } else if (token === '}') {
-        netCurlies--
-      }
-    }
-    return netCurlies
-  }
-
+  /**
+   * @param {EventTarget} elt
+   * @param {string} eventName
+   * @param {string} code
+   */
   function addHxOnEventHandler(elt, eventName, code) {
     const nodeData = getInternalData(elt)
     if (!Array.isArray(nodeData.onHandlers)) {
       nodeData.onHandlers = []
     }
     let func
+    /** @type EventListener */
     const listener = function(e) {
-      return maybeEval(elt, function() {
+      maybeEval(elt, function() {
         if (!func) {
           func = new Function('event', code)
         }
@@ -1932,6 +2726,9 @@ var htmx = (function() {
     nodeData.onHandlers.push({ event: eventName, listener })
   }
 
+  /**
+   * @param {Element} elt
+   */
   function processHxOnWildcard(elt) {
     // wipe any previous on handlers so that this function takes precedence
     deInitOnHandlers(elt)
@@ -1959,8 +2756,11 @@ var htmx = (function() {
     }
   }
 
+  /**
+   * @param {Element|HTMLInputElement} elt
+   */
   function initNode(elt) {
-    if (closest(elt, htmx.config.disableSelector)) {
+    if (htmx.closest(elt, htmx.config.disableSelector)) {
       cleanUpElement(elt)
       return
     }
@@ -1971,9 +2771,11 @@ var htmx = (function() {
 
       nodeData.initHash = attributeHash(elt)
 
-      triggerEvent(elt, 'htmx:beforeProcessNode')
+      htmx.trigger(elt, 'htmx:beforeProcessNode')
 
+      // @ts-ignore value will be undefined for non-input elements, which is fine
       if (elt.value) {
+        // @ts-ignore
         nodeData.lastValue = elt.value
       }
 
@@ -1998,29 +2800,27 @@ var htmx = (function() {
         initButtonTracking(elt)
       }
 
-      triggerEvent(elt, 'htmx:afterProcessNode')
+      htmx.trigger(elt, 'htmx:afterProcessNode')
     }
-  }
-
-  function processNode(elt) {
-    elt = resolveTarget(elt)
-    if (closest(elt, htmx.config.disableSelector)) {
-      cleanUpElement(elt)
-      return
-    }
-    initNode(elt)
-    forEach(findElementsToProcess(elt), function(child) { initNode(child) })
-    forEach(findHxOnWildcardElements(elt), processHxOnWildcard)
   }
 
   //= ===================================================================
   // Event/Log Support
   //= ===================================================================
 
+  /**
+   * @param {string} str
+   * @returns {string}
+   */
   function kebabEventName(str) {
     return str.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
   }
 
+  /**
+   * @param {string} eventName
+   * @param {any} detail
+   * @returns {CustomEvent}
+   */
   function makeEvent(eventName, detail) {
     let evt
     if (window.CustomEvent && typeof window.CustomEvent === 'function') {
@@ -2034,10 +2834,19 @@ var htmx = (function() {
     return evt
   }
 
+  /**
+   * @param {EventTarget|string} elt
+   * @param {string} eventName
+   * @param {any=} detail
+   */
   function triggerErrorEvent(elt, eventName, detail) {
-    triggerEvent(elt, eventName, mergeObjects({ error: eventName }, detail))
+    htmx.trigger(elt, eventName, mergeObjects({ error: eventName }, detail))
   }
 
+  /**
+   * @param {string} eventName
+   * @returns {boolean}
+   */
   function ignoreEventForLogging(eventName) {
     return eventName === 'htmx:afterProcessNode'
   }
@@ -2047,8 +2856,8 @@ var htmx = (function() {
    * executes the provided function using each of the active extensions.  It should
    * be called internally at every extendable execution point in htmx.
    *
-   * @param {HTMLElement} elt
-   * @param {(extension:import("./htmx").HtmxExtension) => void} toDo
+   * @param {Element} elt
+   * @param {(extension:HtmxExtension) => void} toDo
    * @returns void
    */
   function withExtensions(elt, toDo) {
@@ -2069,42 +2878,23 @@ var htmx = (function() {
     }
   }
 
-  function triggerEvent(elt, eventName, detail) {
-    elt = resolveTarget(elt)
-    if (detail == null) {
-      detail = {}
-    }
-    detail.elt = elt
-    const event = makeEvent(eventName, detail)
-    if (htmx.logger && !ignoreEventForLogging(eventName)) {
-      htmx.logger(elt, eventName, detail)
-    }
-    if (detail.error) {
-      logError(detail.error)
-      triggerEvent(elt, 'htmx:error', { errorInfo: detail })
-    }
-    let eventResult = elt.dispatchEvent(event)
-    const kebabName = kebabEventName(eventName)
-    if (eventResult && kebabName !== eventName) {
-      const kebabedEvent = makeEvent(kebabName, event.detail)
-      eventResult = eventResult && elt.dispatchEvent(kebabedEvent)
-    }
-    withExtensions(elt, function(extension) {
-      eventResult = eventResult && (extension.onEvent(eventName, event) !== false && !event.defaultPrevented)
-    })
-    return eventResult
-  }
-
   //= ===================================================================
   // History Support
   //= ===================================================================
   let currentPathForHistory = location.pathname + location.search
 
+  /**
+   * @returns {Element}
+   */
   function getHistoryElement() {
     const historyElt = getDocument().querySelector('[hx-history-elt],[data-hx-history-elt]')
     return historyElt || getDocument().body
   }
 
+  /**
+   * @param {string} url
+   * @param {Element} rootElt
+   */
   function saveToHistoryCache(url, rootElt) {
     if (!canAccessLocalStorage()) {
       return
@@ -2131,9 +2921,10 @@ var htmx = (function() {
       }
     }
 
+    /** @type HtmxHistoryItem */
     const newHistoryItem = { url, content: innerHTML, title, scroll }
 
-    triggerEvent(getDocument().body, 'htmx:historyItemCreated', { item: newHistoryItem, cache: historyCache })
+    htmx.trigger(getDocument().body, 'htmx:historyItemCreated', { item: newHistoryItem, cache: historyCache })
 
     historyCache.push(newHistoryItem)
     while (historyCache.length > htmx.config.historyCacheSize) {
@@ -2152,6 +2943,18 @@ var htmx = (function() {
     }
   }
 
+  /**
+   * @typedef {Object} HtmxHistoryItem
+   * @property {string} url
+   * @property {string} content
+   * @property {string} title
+   * @property {number} scroll
+   */
+
+  /**
+   * @param {string} url
+   * @returns {HtmxHistoryItem|null}
+   */
   function getCachedHistory(url) {
     if (!canAccessLocalStorage()) {
       return null
@@ -2168,11 +2971,15 @@ var htmx = (function() {
     return null
   }
 
+  /**
+   * @param {Element} elt
+   * @returns {string}
+   */
   function cleanInnerHtmlForHistory(elt) {
     const className = htmx.config.requestClass
-    const clone = elt.cloneNode(true)
-    forEach(findAll(clone, '.' + className), function(child) {
-      removeClassFromElement(child, className)
+    const clone = /** @type Element */ (elt.cloneNode(true))
+    forEach(htmx.findAll(clone, '.' + className), function(child) {
+      htmx.removeClass(child, className)
     })
     return clone.innerHTML
   }
@@ -2194,13 +3001,16 @@ var htmx = (function() {
       disableHistoryCache = getDocument().querySelector('[hx-history="false"],[data-hx-history="false"]')
     }
     if (!disableHistoryCache) {
-      triggerEvent(getDocument().body, 'htmx:beforeHistorySave', { path, historyElt: elt })
+      htmx.trigger(getDocument().body, 'htmx:beforeHistorySave', { path, historyElt: elt })
       saveToHistoryCache(path, elt)
     }
 
     if (htmx.config.historyEnabled) history.replaceState({ htmx: true }, getDocument().title, window.location.href)
   }
 
+  /**
+   * @param {string} path
+   */
   function pushUrlIntoHistory(path) {
   // remove the cache buster parameter, if any
     if (htmx.config.getCacheBusterParam) {
@@ -2215,40 +3025,48 @@ var htmx = (function() {
     currentPathForHistory = path
   }
 
+  /**
+   * @param {string} path
+   */
   function replaceUrlInHistory(path) {
     if (htmx.config.historyEnabled) history.replaceState({ htmx: true }, '', path)
     currentPathForHistory = path
   }
 
+  /**
+   * @param {HtmxSettleTask[]} tasks
+   */
   function settleImmediately(tasks) {
     forEach(tasks, function(task) {
-      task.call()
+      task.call(undefined)
     })
   }
 
+  /**
+   * @param {string} path
+   */
   function loadHistoryFromServer(path) {
     const request = new XMLHttpRequest()
     const details = { path, xhr: request }
-    triggerEvent(getDocument().body, 'htmx:historyCacheMiss', details)
+    htmx.trigger(getDocument().body, 'htmx:historyCacheMiss', details)
     request.open('GET', path, true)
     request.setRequestHeader('HX-Request', 'true')
     request.setRequestHeader('HX-History-Restore-Request', 'true')
     request.setRequestHeader('HX-Current-URL', getDocument().location.href)
     request.onload = function() {
       if (this.status >= 200 && this.status < 400) {
-        triggerEvent(getDocument().body, 'htmx:historyCacheMissLoad', details)
+        htmx.trigger(getDocument().body, 'htmx:historyCacheMissLoad', details)
         const fragment = makeFragment(this.response)
-        // @ts-ignore
+        /** @type Queryable */
         const content = fragment.querySelector('[hx-history-elt],[data-hx-history-elt]') || fragment
         const historyElement = getHistoryElement()
         const settleInfo = makeSettleInfo(historyElement)
         handleTitle(fragment.title)
 
-        // @ts-ignore
         swapInnerHTML(historyElement, content, settleInfo)
         settleImmediately(settleInfo.tasks)
         currentPathForHistory = path
-        triggerEvent(getDocument().body, 'htmx:historyRestore', { path, cacheMiss: true, serverResponse: this.response })
+        htmx.trigger(getDocument().body, 'htmx:historyRestore', { path, cacheMiss: true, serverResponse: this.response })
       } else {
         triggerErrorEvent(getDocument().body, 'htmx:historyCacheMissLoadError', details)
       }
@@ -2256,6 +3074,9 @@ var htmx = (function() {
     request.send()
   }
 
+  /**
+   * @param {string} [path]
+   */
   function restoreHistory(path) {
     saveCurrentPageToHistory()
     path = path || location.pathname + location.search
@@ -2267,14 +3088,15 @@ var htmx = (function() {
       handleTitle(fragment.title)
       swapInnerHTML(historyElement, fragment, settleInfo)
       settleImmediately(settleInfo.tasks)
-      setTimeout(function() {
+      getWindow().setTimeout(function() {
         window.scrollTo(0, cached.scroll)
       }, 0) // next 'tick', so browser has time to render layout
       currentPathForHistory = path
-      triggerEvent(getDocument().body, 'htmx:historyRestore', { path, item: cached })
+      htmx.trigger(getDocument().body, 'htmx:historyRestore', { path, item: cached })
     } else {
       if (htmx.config.refreshOnHistoryMiss) {
-      // @ts-ignore: optional parameter in reload() function throws error
+        // @ts-ignore: optional parameter in reload() function throws error
+        // noinspection JSUnresolvedReference
         window.location.reload(true)
       } else {
         loadHistoryFromServer(path)
@@ -2282,8 +3104,12 @@ var htmx = (function() {
     }
   }
 
+  /**
+   * @param {Element} elt
+   * @returns {Element[]}
+   */
   function addRequestIndicatorClasses(elt) {
-    let indicators = findAttributeTargets(elt, 'hx-indicator')
+    let indicators = /** @type Element[] */ (findAttributeTargets(elt, 'hx-indicator'))
     if (indicators == null) {
       indicators = [elt]
     }
@@ -2295,8 +3121,12 @@ var htmx = (function() {
     return indicators
   }
 
+  /**
+   * @param {Element} elt
+   * @returns {Element[]}
+   */
   function disableElements(elt) {
-    let disabledElts = findAttributeTargets(elt, 'hx-disabled-elt')
+    let disabledElts = /** @type Element[] */ (findAttributeTargets(elt, 'hx-disabled-elt'))
     if (disabledElts == null) {
       disabledElts = []
     }
@@ -2308,6 +3138,10 @@ var htmx = (function() {
     return disabledElts
   }
 
+  /**
+   * @param {Element[]} indicators
+   * @param {Element[]} disabled
+   */
   function removeRequestIndicators(indicators, disabled) {
     forEach(indicators, function(ic) {
       const internalData = getInternalData(ic)
@@ -2330,8 +3164,8 @@ var htmx = (function() {
   //= ===================================================================
 
   /**
-   * @param {HTMLElement[]} processed
-   * @param {HTMLElement} elt
+   * @param {Element[]} processed
+   * @param {Element} elt
    * @returns {boolean}
    */
   function haveSeenNode(processed, elt) {
@@ -2344,8 +3178,14 @@ var htmx = (function() {
     return false
   }
 
-  function shouldInclude(elt) {
-    if (elt.name === '' || elt.name == null || elt.disabled || closest(elt, 'fieldset[disabled]')) {
+  /**
+   * @param {Element} element
+   * @return {boolean}
+   */
+  function shouldInclude(element) {
+    // Cast to trick tsc
+    const elt = /** @type {HTMLInputElement} */ (element)
+    if (elt.name === '' || elt.name == null || elt.disabled || htmx.closest(elt, 'fieldset[disabled]')) {
       return false
     }
     // ignore "submitter" types (see jQuery src/serialize.js)
@@ -2359,7 +3199,7 @@ var htmx = (function() {
   }
 
   /** @param {string} name
-   * @param {string|Array} value
+   * @param {string|Array|FormDataEntryValue} value
    * @param {FormData} formData */
   function addValueToFormData(name, value, formData) {
     if (name != null && value != null) {
@@ -2388,10 +3228,10 @@ var htmx = (function() {
   }
 
   /**
-   * @param {HTMLElement[]} processed
+   * @param {Element[]} processed
    * @param {FormData} formData
    * @param {HtmxElementValidationError[]} errors
-   * @param {HTMLElement|HTMLInputElement|HTMLFormElement} elt
+   * @param {Element|HTMLInputElement|HTMLSelectElement|HTMLFormElement} elt
    * @param {boolean} validate
    */
   function processInputValue(processed, formData, errors, elt, validate) {
@@ -2402,12 +3242,13 @@ var htmx = (function() {
     }
     if (shouldInclude(elt)) {
       const name = getRawAttribute(elt, 'name')
+      // @ts-ignore value will be undefined for non-input elements, which is fine
       let value = elt.value
-      if (elt.multiple && elt.tagName === 'SELECT') {
-        value = toArray(elt.querySelectorAll('option:checked')).map(function(e) { return e.value })
+      if (elt instanceof HTMLSelectElement && elt.multiple) {
+        value = toArray(elt.querySelectorAll('option:checked')).map(function(e) { return (/** @type HTMLOptionElement */(e)).value })
       }
       // include file inputs
-      if (elt.files) {
+      if (elt instanceof HTMLInputElement && elt.files) {
         value = toArray(elt.files)
       }
       addValueToFormData(name, value, formData)
@@ -2415,7 +3256,7 @@ var htmx = (function() {
         validateElement(elt, errors)
       }
     }
-    if (matches(elt, 'form')) {
+    if (elt instanceof HTMLFormElement) {
       forEach(elt.elements, function(input) {
         if (processed.indexOf(input) >= 0) {
           // The input has already been processed and added to the values, but the FormData that will be
@@ -2436,20 +3277,17 @@ var htmx = (function() {
   }
 
   /**
-   * @typedef {{elt: HTMLElement, message: string, validity: ValidityState}} HtmxElementValidationError
-   */
-
-  /**
    *
-   * @param {HTMLElement|HTMLObjectElement} element
+   * @param {Element} elt
    * @param {HtmxElementValidationError[]} errors
    */
-  function validateElement(element, errors) {
+  function validateElement(elt, errors) {
+    const element = /** @type {HTMLElement & ElementInternals} */ (elt)
     if (element.willValidate) {
-      triggerEvent(element, 'htmx:validation:validate')
+      htmx.trigger(element, 'htmx:validation:validate')
       if (!element.checkValidity()) {
         errors.push({ elt: element, message: element.validationMessage, validity: element.validity })
-        triggerEvent(element, 'htmx:validation:failed', { message: element.validationMessage, validity: element.validity })
+        htmx.trigger(element, 'htmx:validation:failed', { message: element.validationMessage, validity: element.validity })
       }
     }
   }
@@ -2471,12 +3309,12 @@ var htmx = (function() {
   }
 
   /**
- * @param {HTMLElement|HTMLFormElement} elt
- * @param {string} verb
+ * @param {Element|HTMLFormElement} elt
+ * @param {HttpVerb} verb
  * @returns {{errors: HtmxElementValidationError[], formData: FormData, values: Object}}
  */
   function getInputValues(elt, verb) {
-    /** @type HTMLElement[] */
+    /** @type Element[] */
     const processed = []
     const formData = new FormData()
     const priorityFormData = new FormData()
@@ -2489,14 +3327,14 @@ var htmx = (function() {
 
     // only validate when form is directly submitted and novalidate or formnovalidate are not set
     // or if the element has an explicit hx-validate="true" on it
-    let validate = (matches(elt, 'form') && elt.noValidate !== true) || getAttributeValue(elt, 'hx-validate') === 'true'
+    let validate = (elt instanceof HTMLFormElement && elt.noValidate !== true) || getAttributeValue(elt, 'hx-validate') === 'true'
     if (internalData.lastButtonClicked) {
       validate = validate && internalData.lastButtonClicked.formNoValidate !== true
     }
 
     // for a non-GET include the closest form
     if (verb !== 'get') {
-      processInputValue(processed, priorityFormData, errors, closest(elt, 'form'), validate)
+      processInputValue(processed, priorityFormData, errors, htmx.closest(elt, 'form'), validate)
     }
 
     // include the element itself
@@ -2505,7 +3343,7 @@ var htmx = (function() {
     // if a button or submit was clicked last, include its value
     if (internalData.lastButtonClicked || elt.tagName === 'BUTTON' ||
     (elt.tagName === 'INPUT' && getRawAttribute(elt, 'type') === 'submit')) {
-      const button = internalData.lastButtonClicked || elt
+      const button = internalData.lastButtonClicked || (/** @type HTMLInputElement|HTMLButtonElement */(elt))
       const name = getRawAttribute(button, 'name')
       addValueToFormData(name, button.value, priorityFormData)
     }
@@ -2513,10 +3351,10 @@ var htmx = (function() {
     // include any explicit includes
     const includes = findAttributeTargets(elt, 'hx-include')
     forEach(includes, function(node) {
-      processInputValue(processed, formData, errors, node, validate)
+      processInputValue(processed, formData, errors, asElement(node), validate)
       // if a non-form is included, include any input values within it
       if (!matches(node, 'form')) {
-        forEach(node.querySelectorAll(INPUT_SELECTOR), function(descendant) {
+        forEach(asQueryable(node).querySelectorAll(INPUT_SELECTOR), function(descendant) {
           processInputValue(processed, formData, errors, descendant, validate)
         })
       }
@@ -2564,12 +3402,13 @@ var htmx = (function() {
   //= ===================================================================
 
   /**
- * @param {HTMLElement} elt
- * @param {HTMLElement} target
+ * @param {Element} elt
+ * @param {Element} target
  * @param {string} prompt
- * @returns {Object} // TODO: Define/Improve HtmxHeaderSpecification
+ * @returns {HtmxHeaderSpecification}
  */
   function getHeaders(elt, target, prompt) {
+    /** @type HtmxHeaderSpecification */
     const headers = {
       'HX-Request': 'true',
       'HX-Trigger': getRawAttribute(elt, 'id'),
@@ -2592,7 +3431,7 @@ var htmx = (function() {
  * and returns a new object that only contains keys that are
  * specified by the closest "hx-params" attribute
  * @param {FormData} inputValues
- * @param {HTMLElement} elt
+ * @param {Element} elt
  * @returns {FormData}
  */
   function filterValues(inputValues, elt) {
@@ -2623,19 +3462,22 @@ var htmx = (function() {
     }
   }
 
+  /**
+   * @param {Element} elt
+   * @return {boolean}
+   */
   function isAnchorLink(elt) {
-    return getRawAttribute(elt, 'href') && getRawAttribute(elt, 'href').indexOf('#') >= 0
+    return !!getRawAttribute(elt, 'href') && getRawAttribute(elt, 'href').indexOf('#') >= 0
   }
 
   /**
- *
- * @param {HTMLElement} elt
- * @param {import("./htmx").HtmxSwapStyle} swapInfoOverride
- * @returns {import("./htmx").HtmxSwapSpecification}
+ * @param {Element} elt
+ * @param {HtmxSwapStyle} [swapInfoOverride]
+ * @returns {HtmxSwapSpecification}
  */
   function getSwapSpecification(elt, swapInfoOverride) {
     const swapInfo = swapInfoOverride || getClosestAttributeValue(elt, 'hx-swap')
-    /** @type import("./htmx").HtmxSwapSpecification */
+    /** @type HtmxSwapSpecification */
     const swapSpec = {
       swapStyle: getInternalData(elt).boosted ? 'innerHTML' : htmx.config.defaultSwapStyle,
       swapDelay: htmx.config.defaultSwapDelay,
@@ -2650,9 +3492,9 @@ var htmx = (function() {
         for (let i = 0; i < split.length; i++) {
           const value = split[i]
           if (value.indexOf('swap:') === 0) {
-            swapSpec.swapDelay = parseInterval(value.substr(5))
+            swapSpec.swapDelay = htmx.parseInterval(value.substr(5))
           } else if (value.indexOf('settle:') === 0) {
-            swapSpec.settleDelay = parseInterval(value.substr(7))
+            swapSpec.settleDelay = htmx.parseInterval(value.substr(7))
           } else if (value.indexOf('transition:') === 0) {
             swapSpec.transition = value.substr(11) === 'true'
           } else if (value.indexOf('ignoreTitle:') === 0) {
@@ -2662,6 +3504,7 @@ var htmx = (function() {
             var splitSpec = scrollSpec.split(':')
             const scrollVal = splitSpec.pop()
             var selectorVal = splitSpec.length > 0 ? splitSpec.join(':') : null
+            // @ts-ignore
             swapSpec.scroll = scrollVal
             swapSpec.scrollTarget = selectorVal
           } else if (value.indexOf('show:') === 0) {
@@ -2685,6 +3528,10 @@ var htmx = (function() {
     return swapSpec
   }
 
+  /**
+   * @param {Element} elt
+   * @return {boolean}
+   */
   function usesFormData(elt) {
     return getClosestAttributeValue(elt, 'hx-encoding') === 'multipart/form-data' ||
     (matches(elt, 'form') && getRawAttribute(elt, 'enctype') === 'multipart/form-data')
@@ -2692,7 +3539,7 @@ var htmx = (function() {
 
   /**
    * @param {XMLHttpRequest} xhr
-   * @param {HTMLElement} elt
+   * @param {Element} elt
    * @param {FormData} filteredParameters
    * @returns {*|string|null}
    */
@@ -2717,19 +3564,23 @@ var htmx = (function() {
   /**
  *
  * @param {Element} target
- * @returns {import("./htmx").HtmxSettleInfo}
+ * @returns {HtmxSettleInfo}
  */
   function makeSettleInfo(target) {
     return { tasks: [], elts: [target] }
   }
 
+  /**
+   * @param {Element[]} content
+   * @param {HtmxSwapSpecification} swapSpec
+   */
   function updateScrollState(content, swapSpec) {
     const first = content[0]
     const last = content[content.length - 1]
     if (swapSpec.scroll) {
       var target = null
       if (swapSpec.scrollTarget) {
-        target = querySelectorExt(first, swapSpec.scrollTarget)
+        target = asElement(querySelectorExt(first, swapSpec.scrollTarget))
       }
       if (swapSpec.scroll === 'top' && (first || target)) {
         target = target || first
@@ -2747,21 +3598,23 @@ var htmx = (function() {
         if (swapSpec.showTarget === 'window') {
           targetStr = 'body'
         }
-        target = querySelectorExt(first, targetStr)
+        target = asElement(querySelectorExt(first, targetStr))
       }
       if (swapSpec.show === 'top' && (first || target)) {
         target = target || first
+        // @ts-ignore For some reason tsc doesn't recognize "instant" as a valid option for now
         target.scrollIntoView({ block: 'start', behavior: htmx.config.scrollBehavior })
       }
       if (swapSpec.show === 'bottom' && (last || target)) {
         target = target || last
+        // @ts-ignore For some reason tsc doesn't recognize "instant" as a valid option for now
         target.scrollIntoView({ block: 'end', behavior: htmx.config.scrollBehavior })
       }
     }
   }
 
   /**
- * @param {HTMLElement} elt
+ * @param {Element} elt
  * @param {string} attr
  * @param {boolean=} evalAsDefault
  * @param {Object=} values
@@ -2805,9 +3658,15 @@ var htmx = (function() {
         }
       }
     }
-    return getValuesForElement(parentElt(elt), attr, evalAsDefault, values)
+    return getValuesForElement(asElement(parentElt(elt)), attr, evalAsDefault, values)
   }
 
+  /**
+   * @param {EventTarget|string} elt
+   * @param {() => any} toEval
+   * @param {any=} defaultVal
+   * @returns {any}
+   */
   function maybeEval(elt, toEval, defaultVal) {
     if (htmx.config.allowEval) {
       return toEval()
@@ -2818,7 +3677,7 @@ var htmx = (function() {
   }
 
   /**
- * @param {HTMLElement} elt
+ * @param {Element} elt
  * @param {*?} expressionVars
  * @returns
  */
@@ -2827,7 +3686,7 @@ var htmx = (function() {
   }
 
   /**
- * @param {HTMLElement} elt
+ * @param {Element} elt
  * @param {*?} expressionVars
  * @returns
  */
@@ -2836,13 +3695,18 @@ var htmx = (function() {
   }
 
   /**
- * @param {HTMLElement} elt
+ * @param {Element} elt
  * @returns {FormData}
  */
   function getExpressionVars(elt) {
     return formDataFromObject(mergeObjects(getHXVarsForElement(elt), getHXValsForElement(elt)))
   }
 
+  /**
+   * @param {XMLHttpRequest} xhr
+   * @param {string} header
+   * @param {string|null} headerValue
+   */
   function safelySetHeaderValue(xhr, header, headerValue) {
     if (headerValue !== null) {
       try {
@@ -2855,6 +3719,10 @@ var htmx = (function() {
     }
   }
 
+  /**
+   * @param {XMLHttpRequest} xhr
+   * @return {string}
+   */
   function getPathFromResponse(xhr) {
   // NB: IE11 does not support this stuff
     if (xhr.responseURL && typeof (URL) !== 'undefined') {
@@ -2867,37 +3735,19 @@ var htmx = (function() {
     }
   }
 
+  /**
+   * @param {XMLHttpRequest} xhr
+   * @param {RegExp} regexp
+   * @return {boolean}
+   */
   function hasHeader(xhr, regexp) {
     return regexp.test(xhr.getAllResponseHeaders())
   }
 
-  function ajaxHelper(verb, path, context) {
-    verb = verb.toLowerCase()
-    if (context) {
-      if (context instanceof Element || isType(context, 'String')) {
-        return issueAjaxRequest(verb, path, null, null, {
-          targetOverride: resolveTarget(context),
-          returnPromise: true
-        })
-      } else {
-        return issueAjaxRequest(verb, path, resolveTarget(context.source), context.event,
-          {
-            handler: context.handler,
-            headers: context.headers,
-            values: context.values,
-            targetOverride: resolveTarget(context.target),
-            swapOverride: context.swap,
-            select: context.select,
-            returnPromise: true
-          })
-      }
-    } else {
-      return issueAjaxRequest(verb, path, null, null, {
-        returnPromise: true
-      })
-    }
-  }
-
+  /**
+   * @param {Element} elt
+   * @return {Element[]}
+   */
   function hierarchyForElt(elt) {
     const arr = []
     while (elt) {
@@ -2907,6 +3757,12 @@ var htmx = (function() {
     return arr
   }
 
+  /**
+   * @param {Element} elt
+   * @param {string} path
+   * @param {HtmxRequestConfig} requestConfig
+   * @return {boolean}
+   */
   function verifyPath(elt, path, requestConfig) {
     let sameHost
     let url
@@ -2925,9 +3781,13 @@ var htmx = (function() {
         return false
       }
     }
-    return triggerEvent(elt, 'htmx:validateUrl', mergeObjects({ url, sameHost }, requestConfig))
+    return htmx.trigger(elt, 'htmx:validateUrl', mergeObjects({ url, sameHost }, requestConfig))
   }
 
+  /**
+   * @param {Object|FormData} obj
+   * @return {FormData}
+   */
   function formDataFromObject(obj) {
     if (obj instanceof FormData) return obj
     const formData = new FormData()
@@ -2947,7 +3807,7 @@ var htmx = (function() {
 
   /**
    * @param {FormData} formData
-   * @param {string|Symbol} name
+   * @param {string} name
    * @param {Array} array
    * @returns {Array}
    */
@@ -2995,7 +3855,7 @@ var htmx = (function() {
       get: function(target, name) {
         if (typeof name === 'symbol') {
           // Forward symbol calls to the FormData itself directly
-          return Reflect.get(...arguments)
+          return Reflect.get(target, name)
         }
         if (name === 'toJSON') {
           // Support JSON.stringify call on proxy
@@ -3022,6 +3882,9 @@ var htmx = (function() {
         }
       },
       set: function(target, name, value) {
+        if (typeof name !== 'string') {
+          return false
+        }
         target.delete(name)
         if (typeof value.forEach === 'function') {
           value.forEach(function(v) { target.append(name, v) })
@@ -3031,7 +3894,9 @@ var htmx = (function() {
         return true
       },
       deleteProperty: function(target, name) {
-        target.delete(name)
+        if (typeof name === 'string') {
+          target.delete(name)
+        }
         return true
       },
       // Support Object.assign call from proxy
@@ -3044,6 +3909,15 @@ var htmx = (function() {
     })
   }
 
+  /**
+   * @param {HttpVerb} verb
+   * @param {string} path
+   * @param {Element} elt
+   * @param {Event} event
+   * @param {HtmxAjaxEtc} [etc]
+   * @param {boolean} [confirmed]
+   * @return {Promise<void>}
+   */
   function issueAjaxRequest(verb, path, elt, event, etc, confirmed) {
     let resolve = null
     let reject = null
@@ -3065,7 +3939,7 @@ var htmx = (function() {
       maybeCall(resolve)
       return promise
     }
-    const target = etc.targetOverride || getTarget(elt)
+    const target = etc.targetOverride || asElement(getTarget(elt))
     if (target == null || target == DUMMY_ELT) {
       triggerErrorEvent(elt, 'htmx:targetError', { target: getAttributeValue(elt, 'hx-target') })
       maybeCall(reject)
@@ -3085,7 +3959,7 @@ var htmx = (function() {
       if (buttonVerb != null) {
       // ignore buttons with formmethod="dialog"
         if (buttonVerb.toLowerCase() !== 'dialog') {
-          verb = buttonVerb
+          verb = (/** @type HttpVerb */(buttonVerb))
         }
       }
     }
@@ -3097,7 +3971,7 @@ var htmx = (function() {
         return issueAjaxRequest(verb, path, elt, event, etc, !!skipConfirmation)
       }
       const confirmDetails = { target, elt, path, verb, triggeringEvent: event, etc, issueRequest, question: confirmQuestion }
-      if (triggerEvent(elt, 'htmx:confirm', confirmDetails) === false) {
+      if (htmx.trigger(elt, 'htmx:confirm', confirmDetails) === false) {
         maybeCall(resolve)
         return promise
       }
@@ -3113,7 +3987,7 @@ var htmx = (function() {
       if (selector === 'this') {
         syncElt = findThisElement(elt, 'hx-sync')
       } else {
-        syncElt = querySelectorExt(elt, selector)
+        syncElt = asElement(querySelectorExt(elt, selector))
       }
       // default to the drop strategy
       syncStrategy = (syncStrings[1] || 'drop').trim()
@@ -3129,7 +4003,7 @@ var htmx = (function() {
           abortable = true
         }
       } else if (syncStrategy === 'replace') {
-        triggerEvent(syncElt, 'htmx:abort') // abort the current request and continue
+        htmx.trigger(syncElt, 'htmx:abort') // abort the current request and continue
       } else if (syncStrategy.indexOf('queue') === 0) {
         const queueStrArray = syncStrategy.split(' ')
         queueStrategy = (queueStrArray[1] || 'last').trim()
@@ -3138,7 +4012,7 @@ var htmx = (function() {
 
     if (eltData.xhr) {
       if (eltData.abortable) {
-        triggerEvent(syncElt, 'htmx:abort') // abort the current request and continue
+        htmx.trigger(syncElt, 'htmx:abort') // abort the current request and continue
       } else {
         if (queueStrategy == null) {
           if (event) {
@@ -3190,7 +4064,7 @@ var htmx = (function() {
       var promptResponse = prompt(promptQuestion)
       // prompt returns null if cancelled and empty string if accepted with no entry
       if (promptResponse === null ||
-      !triggerEvent(elt, 'htmx:prompt', { prompt: promptResponse, target })) {
+      !htmx.trigger(elt, 'htmx:prompt', { prompt: promptResponse, target })) {
         maybeCall(resolve)
         endRequestLock()
         return promise
@@ -3233,12 +4107,19 @@ var htmx = (function() {
       path = getDocument().location.href
     }
 
+    /**
+     * @type {Object}
+     * @property {boolean} [credentials]
+     * @property {number} [timeout]
+     * @property {boolean} [noHeaders]
+     */
     const requestAttrValues = getValuesForElement(elt, 'hx-request')
 
     const eltIsBoosted = getInternalData(elt).boosted
 
     let useUrlParams = htmx.config.methodsThatUseUrlParams.indexOf(verb) >= 0
 
+    /** @type HtmxRequestConfig */
     const requestConfig = {
       boosted: eltIsBoosted,
       useUrlParams,
@@ -3256,7 +4137,7 @@ var htmx = (function() {
       triggeringEvent: event
     }
 
-    if (!triggerEvent(elt, 'htmx:configRequest', requestConfig)) {
+    if (!htmx.trigger(elt, 'htmx:configRequest', requestConfig)) {
       maybeCall(resolve)
       endRequestLock()
       return promise
@@ -3271,7 +4152,7 @@ var htmx = (function() {
     useUrlParams = requestConfig.useUrlParams
 
     if (errors && errors.length > 0) {
-      triggerEvent(elt, 'htmx:validation:halted', requestConfig)
+      htmx.trigger(elt, 'htmx:validation:halted', requestConfig)
       maybeCall(resolve)
       endRequestLock()
       return promise
@@ -3302,7 +4183,7 @@ var htmx = (function() {
       triggerErrorEvent(elt, 'htmx:invalidPath', requestConfig)
       maybeCall(reject)
       return promise
-    };
+    }
 
     xhr.open(verb.toUpperCase(), finalPath, true)
     xhr.overrideMimeType('text/html')
@@ -3321,6 +4202,7 @@ var htmx = (function() {
       }
     }
 
+    /** @type {HtmxResponseInfo} */
     const responseInfo = {
       xhr,
       target,
@@ -3331,6 +4213,7 @@ var htmx = (function() {
       pathInfo: {
         requestPath: path,
         finalRequestPath: finalPath,
+        responsePath: null,
         anchor
       }
     }
@@ -3341,8 +4224,8 @@ var htmx = (function() {
         responseInfo.pathInfo.responsePath = getPathFromResponse(xhr)
         responseHandler(elt, responseInfo)
         removeRequestIndicators(indicators, disableElts)
-        triggerEvent(elt, 'htmx:afterRequest', responseInfo)
-        triggerEvent(elt, 'htmx:afterOnLoad', responseInfo)
+        htmx.trigger(elt, 'htmx:afterRequest', responseInfo)
+        htmx.trigger(elt, 'htmx:afterOnLoad', responseInfo)
         // if the body no longer contains the element, trigger the event on the closest parent
         // remaining in the DOM
         if (!bodyContains(elt)) {
@@ -3354,8 +4237,8 @@ var htmx = (function() {
             }
           }
           if (secondaryTriggerElt) {
-            triggerEvent(secondaryTriggerElt, 'htmx:afterRequest', responseInfo)
-            triggerEvent(secondaryTriggerElt, 'htmx:afterOnLoad', responseInfo)
+            htmx.trigger(secondaryTriggerElt, 'htmx:afterRequest', responseInfo)
+            htmx.trigger(secondaryTriggerElt, 'htmx:afterOnLoad', responseInfo)
           }
         }
         maybeCall(resolve)
@@ -3386,7 +4269,7 @@ var htmx = (function() {
       maybeCall(reject)
       endRequestLock()
     }
-    if (!triggerEvent(elt, 'htmx:beforeRequest', responseInfo)) {
+    if (!htmx.trigger(elt, 'htmx:beforeRequest', responseInfo)) {
       maybeCall(resolve)
       endRequestLock()
       return promise
@@ -3397,7 +4280,7 @@ var htmx = (function() {
     forEach(['loadstart', 'loadend', 'progress', 'abort'], function(eventName) {
       forEach([xhr, xhr.upload], function(target) {
         target.addEventListener(eventName, function(event) {
-          triggerEvent(elt, 'htmx:xhr:' + eventName, {
+          htmx.trigger(elt, 'htmx:xhr:' + eventName, {
             lengthComputable: event.lengthComputable,
             loaded: event.loaded,
             total: event.total
@@ -3405,12 +4288,23 @@ var htmx = (function() {
         })
       })
     })
-    triggerEvent(elt, 'htmx:beforeSend', responseInfo)
+    htmx.trigger(elt, 'htmx:beforeSend', responseInfo)
     const params = useUrlParams ? null : encodeParamsForBody(xhr, elt, filteredFormData)
     xhr.send(params)
     return promise
   }
 
+  /**
+   * @typedef {Object} HtmxHistoryUpdate
+   * @property {string|null} [type]
+   * @property {string|null} [path]
+   */
+
+  /**
+   * @param {Element} elt
+   * @param {HtmxResponseInfo} responseInfo
+   * @return {HtmxHistoryUpdate}
+   */
   function determineHistoryUpdates(elt, responseInfo) {
     const xhr = responseInfo.xhr
 
@@ -3491,13 +4385,23 @@ var htmx = (function() {
     }
   }
 
+  /**
+   * @param {HtmxResponseHandlingConfig} responseHandlingConfig
+   * @param {number} status
+   * @return {boolean}
+   */
   function codeMatches(responseHandlingConfig, status) {
     var regExp = new RegExp(responseHandlingConfig.code)
-    return regExp.test(status)
+    return regExp.test(status.toString(10))
   }
 
+  /**
+   * @param {XMLHttpRequest} xhr
+   * @return {HtmxResponseHandlingConfig}
+   */
   function resolveResponseHandling(xhr) {
     for (var i = 0; i < htmx.config.responseHandling.length; i++) {
+      /** @type HtmxResponseHandlingConfig */
       var responseHandlingElement = htmx.config.responseHandling[i]
       if (codeMatches(responseHandlingElement, xhr.status)) {
         return responseHandlingElement
@@ -3509,9 +4413,12 @@ var htmx = (function() {
     }
   }
 
+  /**
+   * @param {string} title
+   */
   function handleTitle(title) {
     if (title) {
-      const titleElt = find('title')
+      const titleElt = htmx.find('title')
       if (titleElt) {
         titleElt.innerHTML = title
       } else {
@@ -3520,13 +4427,17 @@ var htmx = (function() {
     }
   }
 
+  /**
+   * @param {Element} elt
+   * @param {HtmxResponseInfo} responseInfo
+   */
   function handleAjaxResponse(elt, responseInfo) {
     const xhr = responseInfo.xhr
     let target = responseInfo.target
     const etc = responseInfo.etc
     const responseInfoSelect = responseInfo.select
 
-    if (!triggerEvent(elt, 'htmx:beforeOnLoad', responseInfo)) return
+    if (!htmx.trigger(elt, 'htmx:beforeOnLoad', responseInfo)) return
 
     if (hasHeader(xhr, /HX-Trigger:/i)) {
       handleTriggerHeader(xhr, 'HX-Trigger', elt)
@@ -3535,14 +4446,15 @@ var htmx = (function() {
     if (hasHeader(xhr, /HX-Location:/i)) {
       saveCurrentPageToHistory()
       let redirectPath = xhr.getResponseHeader('HX-Location')
-      var swapSpec
+      /** @type {HtmxAjaxHelperContext&{path:string}} */
+      var redirectSwapSpec
       if (redirectPath.indexOf('{') === 0) {
-        swapSpec = parseJSON(redirectPath)
+        redirectSwapSpec = parseJSON(redirectPath)
         // what's the best way to throw an error if the user didn't include this
-        redirectPath = swapSpec.path
-        delete swapSpec.path
+        redirectPath = redirectSwapSpec.path
+        delete redirectSwapSpec.path
       }
-      ajaxHelper('GET', redirectPath, swapSpec).then(function() {
+      htmx.ajax('get', redirectPath, redirectSwapSpec).then(function() {
         pushUrlIntoHistory(redirectPath)
       })
       return
@@ -3565,7 +4477,7 @@ var htmx = (function() {
       if (xhr.getResponseHeader('HX-Retarget') === 'this') {
         responseInfo.target = elt
       } else {
-        responseInfo.target = querySelectorExt(elt, xhr.getResponseHeader('HX-Retarget'))
+        responseInfo.target = asElement(querySelectorExt(elt, xhr.getResponseHeader('HX-Retarget')))
       }
     }
 
@@ -3577,7 +4489,7 @@ var htmx = (function() {
     let ignoreTitle = htmx.config.ignoreTitle || responseHandling.ignoreTitle
     let selectOverride = responseHandling.select
     if (responseHandling.target) {
-      responseInfo.target = querySelectorExt(elt, responseHandling.target)
+      responseInfo.target = asElement(querySelectorExt(elt, responseHandling.target))
     }
     var swapOverride = etc.swapOverride
     if (swapOverride == null && responseHandling.swapOverride) {
@@ -3589,7 +4501,7 @@ var htmx = (function() {
       if (xhr.getResponseHeader('HX-Retarget') === 'this') {
         responseInfo.target = elt
       } else {
-        responseInfo.target = querySelectorExt(elt, xhr.getResponseHeader('HX-Retarget'))
+        responseInfo.target = asElement(querySelectorExt(elt, xhr.getResponseHeader('HX-Retarget')))
       }
     }
     if (hasHeader(xhr, /HX-Reswap:/i)) {
@@ -3597,6 +4509,7 @@ var htmx = (function() {
     }
 
     var serverResponse = xhr.response
+    /** @type HtmxBeforeSwapDetails */
     var beforeSwapDetails = mergeObjects({
       shouldSwap,
       serverResponse,
@@ -3605,9 +4518,9 @@ var htmx = (function() {
       selectOverride
     }, responseInfo)
 
-    if (responseHandling.event && !triggerEvent(target, responseHandling.event, beforeSwapDetails)) return
+    if (responseHandling.event && !htmx.trigger(target, responseHandling.event, beforeSwapDetails)) return
 
-    if (!triggerEvent(target, 'htmx:beforeSwap', beforeSwapDetails)) return
+    if (!htmx.trigger(target, 'htmx:beforeSwap', beforeSwapDetails)) return
 
     target = beforeSwapDetails.target // allow re-targeting
     serverResponse = beforeSwapDetails.serverResponse // allow updating content
@@ -3663,17 +4576,17 @@ var htmx = (function() {
         try {
           // if we need to save history, do so, before swapping so that relative resources have the correct base URL
           if (historyUpdate.type) {
-            triggerEvent(getDocument().body, 'htmx:beforeHistoryUpdate', mergeObjects({ history: historyUpdate }, responseInfo))
+            htmx.trigger(getDocument().body, 'htmx:beforeHistoryUpdate', mergeObjects({ history: historyUpdate }, responseInfo))
             if (historyUpdate.type === 'push') {
               pushUrlIntoHistory(historyUpdate.path)
-              triggerEvent(getDocument().body, 'htmx:pushedIntoHistory', { path: historyUpdate.path })
+              htmx.trigger(getDocument().body, 'htmx:pushedIntoHistory', { path: historyUpdate.path })
             } else {
               replaceUrlInHistory(historyUpdate.path)
-              triggerEvent(getDocument().body, 'htmx:replacedInHistory', { path: historyUpdate.path })
+              htmx.trigger(getDocument().body, 'htmx:replacedInHistory', { path: historyUpdate.path })
             }
           }
 
-          swap(target, serverResponse, swapSpec, {
+          htmx.swap(target, serverResponse, swapSpec, {
             select: selectOverride || select,
             selectOOB,
             eventInfo: responseInfo,
@@ -3712,8 +4625,10 @@ var htmx = (function() {
       }
 
       if (shouldTransition &&
-              triggerEvent(elt, 'htmx:beforeTransition', responseInfo) &&
-              typeof Promise !== 'undefined' && document.startViewTransition) {
+              htmx.trigger(elt, 'htmx:beforeTransition', responseInfo) &&
+              typeof Promise !== 'undefined' &&
+              // @ts-ignore experimental feature atm
+              document.startViewTransition) {
         const settlePromise = new Promise(function(_resolve, _reject) {
           settleResolve = _resolve
           settleReject = _reject
@@ -3721,6 +4636,7 @@ var htmx = (function() {
         // wrap the original doSwap() in a call to startViewTransition()
         const innerDoSwap = doSwap
         doSwap = function() {
+          // @ts-ignore experimental feature atm
           document.startViewTransition(function() {
             innerDoSwap()
             return settlePromise
@@ -3729,7 +4645,7 @@ var htmx = (function() {
       }
 
       if (swapSpec.swapDelay > 0) {
-        setTimeout(doSwap, swapSpec.swapDelay)
+        getWindow().setTimeout(doSwap, swapSpec.swapDelay)
       } else {
         doSwap()
       }
@@ -3743,13 +4659,13 @@ var htmx = (function() {
   // Extensions API
   //= ===================================================================
 
-  /** @type {Object<string, import("./htmx").HtmxExtension>} */
+  /** @type {Object<string, HtmxExtension>} */
   const extensions = {}
 
   /**
- * extensionBase defines the default functions for all extensions.
- * @returns {import("./htmx").HtmxExtension}
- */
+   * extensionBase defines the default functions for all extensions.
+   * @returns {HtmxExtension}
+   */
   function extensionBase() {
     return {
       init: function(api) { return null },
@@ -3762,34 +4678,13 @@ var htmx = (function() {
   }
 
   /**
- * defineExtension initializes the extension and adds it to the htmx registry
- *
- * @param {string} name
- * @param {import("./htmx").HtmxExtension} extension
- */
-  function defineExtension(name, extension) {
-    if (extension.init) {
-      extension.init(internalAPI)
-    }
-    extensions[name] = mergeObjects(extensionBase(), extension)
-  }
-
-  /**
- * removeExtension removes an extension from the htmx registry
- *
- * @param {string} name
- */
-  function removeExtension(name) {
-    delete extensions[name]
-  }
-
-  /**
- * getExtensions searches up the DOM tree to return all extensions that can be applied to a given element
- *
- * @param {HTMLElement} elt
- * @param {import("./htmx").HtmxExtension[]=} extensionsToReturn
- * @param {import("./htmx").HtmxExtension[]=} extensionsToIgnore
- */
+   * getExtensions searches up the DOM tree to return all extensions that can be applied to a given element
+   *
+   * @param {Element} elt
+   * @param {HtmxExtension[]=} extensionsToReturn
+   * @param {string[]=} extensionsToIgnore
+   * @returns {HtmxExtension[]}
+   */
   function getExtensions(elt, extensionsToReturn, extensionsToIgnore) {
     if (extensionsToReturn == undefined) {
       extensionsToReturn = []
@@ -3816,7 +4711,7 @@ var htmx = (function() {
         }
       })
     }
-    return getExtensions(parentElt(elt), extensionsToReturn, extensionsToIgnore)
+    return getExtensions(asElement(parentElt(elt)), extensionsToReturn, extensionsToIgnore)
   }
 
   //= ===================================================================
@@ -3828,12 +4723,12 @@ var htmx = (function() {
   })
 
   /**
-         * Execute a function now if DOMContentLoaded has fired, otherwise listen for it.
-         *
-         * This function uses isReady because there is no realiable way to ask the browswer whether
-         * the DOMContentLoaded event has already been fired; there's a gap between DOMContentLoaded
-         * firing and readystate=complete.
-         */
+   * Execute a function now if DOMContentLoaded has fired, otherwise listen for it.
+   *
+   * This function uses isReady because there is no reliable way to ask the browser whether
+   * the DOMContentLoaded event has already been fired; there's a gap between DOMContentLoaded
+   * firing and readystate=complete.
+   */
   function ready(fn) {
     // Checking readyState here is a failsafe in case the htmx script tag entered the DOM by
     // some means other than the initial page load.
@@ -3856,9 +4751,9 @@ var htmx = (function() {
   }
 
   function getMetaConfig() {
+    /** @type HTMLMetaElement */
     const element = getDocument().querySelector('meta[name="htmx-config"]')
     if (element) {
-    // @ts-ignore
       return parseJSON(element.content)
     } else {
       return null
@@ -3877,7 +4772,7 @@ var htmx = (function() {
     mergeMetaConfig()
     insertIndicatorStyles()
     let body = getDocument().body
-    processNode(body)
+    htmx.process(body)
     const restoredElts = getDocument().querySelectorAll(
       "[hx-trigger='restored'],[data-hx-trigger='restored']"
     )
@@ -3895,9 +4790,9 @@ var htmx = (function() {
       if (event.state && event.state.htmx) {
         restoreHistory()
         forEach(restoredElts, function(elt) {
-          triggerEvent(elt, 'htmx:restored', {
+          htmx.trigger(elt, 'htmx:restored', {
             document: getDocument(),
-            triggerEvent
+            triggerEvent: htmx.trigger
           })
         })
       } else {
@@ -3906,11 +4801,184 @@ var htmx = (function() {
         }
       }
     }
-    setTimeout(function() {
-      triggerEvent(body, 'htmx:load', {}) // give ready handlers a chance to load up before firing this event
+    getWindow().setTimeout(function() {
+      htmx.trigger(body, 'htmx:load', {}) // give ready handlers a chance to load up before firing this event
       body = null // kill reference for gc
     }, 0)
   })
 
   return htmx
 })()
+
+/** @typedef {'get'|'head'|'post'|'put'|'delete'|'connect'|'options'|'trace'|'patch'} HttpVerb */
+
+/**
+ * @typedef {Object} SwapOptions
+ * @property {string} [select]
+ * @property {string} [selectOOB]
+ * @property {*} [eventInfo]
+ * @property {string} [anchor]
+ * @property {Element} [contextElement]
+ * @property {swapCallback} [afterSwapCallback]
+ * @property {swapCallback} [afterSettleCallback]
+ */
+
+/**
+ * @callback swapCallback
+ */
+
+/**
+ * @typedef {'innerHTML' | 'outerHTML' | 'beforebegin' | 'afterbegin' | 'beforeend' | 'afterend' | 'delete' | 'none' | string} HtmxSwapStyle
+ */
+
+/**
+ * @typedef HtmxSwapSpecification
+ * @property {HtmxSwapStyle} swapStyle
+ * @property {number} swapDelay
+ * @property {number} settleDelay
+ * @property {boolean} [transition]
+ * @property {boolean} [ignoreTitle]
+ * @property {string} [head]
+ * @property {'top' | 'bottom'} [scroll]
+ * @property {string} [scrollTarget]
+ * @property {string} [show]
+ * @property {string} [showTarget]
+ * @property {boolean} [focusScroll]
+ */
+
+/**
+ * @typedef {((this:Node, evt:Event) => boolean) & {source: string}} ConditionalFunction
+ */
+
+/**
+ * @typedef {Object} HtmxTriggerSpecification
+ * @property {string} trigger
+ * @property {number} [pollInterval]
+ * @property {ConditionalFunction} [eventFilter]
+ * @property {boolean} [changed]
+ * @property {boolean} [once]
+ * @property {boolean} [consume]
+ * @property {number} [delay]
+ * @property {string} [from]
+ * @property {string} [target]
+ * @property {number} [throttle]
+ * @property {string} [queue]
+ * @property {string} [root]
+ * @property {string} [threshold]
+ */
+
+/**
+ * @typedef {{elt: Element, message: string, validity: ValidityState}} HtmxElementValidationError
+ */
+
+/**
+ * @typedef {Record<string, string>} HtmxHeaderSpecification
+ * @property {'true'} HX-Request
+ * @property {string|null} HX-Trigger
+ * @property {string|null} HX-Trigger-Name
+ * @property {string|null} HX-Target
+ * @property {string} HX-Current-URL
+ * @property {string} [HX-Prompt]
+ * @property {'true'} [HX-Boosted]
+ * @property {string} [Content-Type]
+ * @property {'true'} [HX-History-Restore-Request]
+ */
+
+/** @typedef HtmxAjaxHelperContext
+ * @property {Element|string} [source]
+ * @property {Event} [event]
+ * @property {HtmxAjaxHandler} [handler]
+ * @property {Element|string} target
+ * @property {HtmxSwapStyle} [swap]
+ * @property {Object|FormData} [values]
+ * @property {Record<string,string>} [headers]
+ * @property {string} [select]
+ */
+
+/**
+ * @typedef {Object} HtmxRequestConfig
+ * @property {boolean} boosted
+ * @property {boolean} useUrlParams
+ * @property {FormData} formData
+ * @property {Object} parameters formData proxy
+ * @property {FormData} unfilteredFormData
+ * @property {Object} unfilteredParameters unfilteredFormData proxy
+ * @property {HtmxHeaderSpecification} headers
+ * @property {Element} target
+ * @property {HttpVerb} verb
+ * @property {HtmxElementValidationError[]} errors
+ * @property {boolean} withCredentials
+ * @property {number} timeout
+ * @property {string} path
+ * @property {Event} triggeringEvent
+ */
+
+/**
+ * @typedef {Object} HtmxResponseInfo
+ * @property {XMLHttpRequest} xhr
+ * @property {Element} target
+ * @property {HtmxRequestConfig} requestConfig
+ * @property {HtmxAjaxEtc} etc
+ * @property {boolean} boosted
+ * @property {string} select
+ * @property {{requestPath: string, finalRequestPath: string, responsePath: string|null, anchor: string}} pathInfo
+ * @property {boolean} [failed]
+ * @property {boolean} [successful]
+ */
+
+/**
+ * @typedef {Object} HtmxAjaxEtc
+ * @property {boolean} [returnPromise]
+ * @property {HtmxAjaxHandler} [handler]
+ * @property {string} [select]
+ * @property {Element} [targetOverride]
+ * @property {HtmxSwapStyle} [swapOverride]
+ * @property {Record<string,string>} [headers]
+ * @property {Object|FormData} [values]
+ * @property {boolean} [credentials]
+ * @property {number} [timeout]
+ */
+
+/**
+ * @typedef {Object} HtmxResponseHandlingConfig
+ * @property {string} [code]
+ * @property {boolean} swap
+ * @property {boolean} [error]
+ * @property {boolean} [ignoreTitle]
+ * @property {string} [select]
+ * @property {string} [target]
+ * @property {string} [swapOverride]
+ * @property {string} [event]
+ */
+
+/**
+ * @typedef {HtmxResponseInfo & {shouldSwap: boolean, serverResponse: any, isError: boolean, ignoreTitle: boolean, selectOverride:string}} HtmxBeforeSwapDetails
+ */
+
+/**
+ * @callback HtmxAjaxHandler
+ * @param {Element} elt
+ * @param {HtmxResponseInfo} responseInfo
+ */
+
+/**
+ * @typedef {(() => void)} HtmxSettleTask
+ */
+
+/**
+ * @typedef {Object} HtmxSettleInfo
+ * @property {HtmxSettleTask[]} tasks
+ * @property {Element[]} elts
+ * @property {string} [title]
+ */
+
+/**
+ * @typedef {Object} HtmxExtension
+ * @see https://htmx.org/extensions/#defining
+ * @property {(api: any) => void} init
+ * @property {(name: string, event: Event|CustomEvent) => boolean} onEvent
+ * @property {(text: string, xhr: XMLHttpRequest, elt: Element) => string} transformResponse
+ * @property {(swapStyle: HtmxSwapStyle) => boolean} isInlineSwap
+ * @property {(swapStyle: HtmxSwapStyle, target: Element, fragment: Node, settleInfo: HtmxSettleInfo) => boolean} handleSwap
+ * @property {(xhr: XMLHttpRequest, parameters: FormData, elt: Element) => *|string|null} encodeParameters
+ */

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3,201 +3,27 @@ var htmx = (function() {
 
   // Public API
   const htmx = {
+    // Tsc madness here, assigning the functions directly results in an invalid TypeScript output, but reassigning is fine
     /* Event processing */
-    /**
-     * Adds a callback for the **htmx:load** event. This can be used to process new content, for example initializing the content with a javascript library
-     *
-     * @see https://htmx.org/api/#onLoad
-     *
-     * @param {(elt: Node) => void} callback the callback to call on newly loaded content
-     * @returns {EventListener}
-     */
-    onLoad: function(callback) {
-      const value = htmx.on('htmx:load', /** @param {CustomEvent} evt */ function(evt) {
-        callback(evt.detail.elt)
-      })
-      return value
-    },
-    /**
-     * Processes new content, enabling htmx behavior. This can be useful if you have content that is added to the DOM outside of the normal htmx request cycle but still want htmx attributes to work.
-     *
-     * @see https://htmx.org/api/#process
-     *
-     * @param {Element|string} elt element to process
-     */
-    process: function(elt) {
-      elt = resolveTarget(elt)
-      if (htmx.closest(elt, htmx.config.disableSelector)) {
-        cleanUpElement(elt)
-        return
-      }
-      initNode(elt)
-      forEach(findElementsToProcess(elt), function(child) { initNode(child) })
-      forEach(findHxOnWildcardElements(elt), processHxOnWildcard)
-    },
-    /**
-     * Adds an event listener to an element
-     *
-     * @see https://htmx.org/api/#on
-     *
-     * @param {EventTarget|string} arg1 the element to add the listener to | the event name to add the listener for
-     * @param {string|EventListener} arg2 the event name to add the listener for | the listener to add
-     * @param {EventListener} [arg3] the listener to add
-     * @returns {EventListener}
-     */
-    on: function on(arg1, arg2, arg3) {
-      ready(function() {
-        const eventArgs = processEventArgs(arg1, arg2, arg3)
-        eventArgs.target.addEventListener(eventArgs.event, eventArgs.listener)
-      })
-      const b = isFunction(arg2)
-      return b ? arg2 : arg3
-    },
-    /**
-     * Removes an event listener from an element
-     *
-     * @see https://htmx.org/api/#off
-     *
-     * @param {EventTarget|string} arg1 the element to remove the listener from | the event name to remove the listener from
-     * @param {string|EventListener} arg2 the event name to remove the listener from | the listener to remove
-     * @param {EventListener} [arg3] the listener to remove
-     * @returns {EventListener}
-     */
-    off: function(arg1, arg2, arg3) {
-      ready(function() {
-        const eventArgs = processEventArgs(arg1, arg2, arg3)
-        eventArgs.target.removeEventListener(eventArgs.event, eventArgs.listener)
-      })
-      return isFunction(arg2) ? arg2 : arg3
-    },
-    /**
-     * Triggers a given event on an element
-     *
-     * @see https://htmx.org/api/#trigger
-     *
-     * @param {EventTarget|string} elt the element to trigger the event on
-     * @param {string} eventName the name of the event to trigger
-     * @param {any=} detail details for the event
-     * @returns {boolean}
-     */
-    trigger: function(elt, eventName, detail) {
-      elt = resolveTarget(elt)
-      if (detail == null) {
-        detail = {}
-      }
-      detail.elt = elt
-      const event = makeEvent(eventName, detail)
-      if (htmx.logger && !ignoreEventForLogging(eventName)) {
-        htmx.logger(elt, eventName, detail)
-      }
-      if (detail.error) {
-        logError(detail.error)
-        htmx.trigger(elt, 'htmx:error', { errorInfo: detail })
-      }
-      let eventResult = elt.dispatchEvent(event)
-      const kebabName = kebabEventName(eventName)
-      if (eventResult && kebabName !== eventName) {
-        const kebabedEvent = makeEvent(kebabName, event.detail)
-        eventResult = eventResult && elt.dispatchEvent(kebabedEvent)
-      }
-      withExtensions(asElement(elt), function(extension) {
-        eventResult = eventResult && (extension.onEvent(eventName, event) !== false && !event.defaultPrevented)
-      })
-      return eventResult
-    },
-    /**
-     * Issues an htmx-style AJAX request
-     *
-     * @see https://htmx.org/api/#ajax
-     *
-     * @param {HttpVerb} verb
-     * @param {string} path the URL path to make the AJAX
-     * @param {Element|string|HtmxAjaxHelperContext} context the element to target (defaults to the **body**) | a selector for the target | a context object that contains any of the following
-     * @return {Promise<void>} Promise that resolves immediately if no request is sent, or when the request is complete
-     */
-    ajax: function(verb, path, context) {
-      verb = (/** @type HttpVerb */(verb.toLowerCase()))
-      if (context) {
-        if (context instanceof Element || typeof context === 'string') {
-          return issueAjaxRequest(verb, path, null, null, {
-            targetOverride: resolveTarget(context),
-            returnPromise: true
-          })
-        } else {
-          return issueAjaxRequest(verb, path, resolveTarget(context.source), context.event,
-            {
-              handler: context.handler,
-              headers: context.headers,
-              values: context.values,
-              targetOverride: resolveTarget(context.target),
-              swapOverride: context.swap,
-              select: context.select,
-              returnPromise: true
-            })
-        }
-      } else {
-        return issueAjaxRequest(verb, path, null, null, {
-          returnPromise: true
-        })
-      }
-    },
+    /** @type {typeof onLoadHelper} */
+    onLoad: null,
+    /** @type {typeof processNode} */
+    process: null,
+    /** @type {typeof addEventListenerImpl} */
+    on: null,
+    /** @type {typeof removeEventListenerImpl} */
+    off: null,
+    /** @type {typeof triggerEvent} */
+    trigger: null,
+    /** @type {typeof ajaxHelper} */
+    ajax: null,
     /* DOM querying helpers */
-    /**
-     * Finds an element matching the selector
-     *
-     * @see https://htmx.org/api/#find
-     *
-     * @param {Queryable|string} eltOrSelector  the root element to find the matching element in, inclusive | the selector to match
-     * @param {string} [selector] the selector to match
-     * @returns {Element|null}
-     */
-    find: function(eltOrSelector, selector) {
-      if (typeof eltOrSelector !== 'string') {
-        return eltOrSelector.querySelector(selector)
-      } else {
-        return htmx.find(getDocument(), eltOrSelector)
-      }
-    },
-    /**
-     * Finds all elements matching the selector
-     *
-     * @see https://htmx.org/api/#findAll
-     *
-     * @param {Queryable|string} eltOrSelector the root element to find the matching elements in, inclusive | the selector to match
-     * @param {string} [selector] the selector to match
-     * @returns {NodeListOf<Element>}
-     */
-    findAll: function(eltOrSelector, selector) {
-      if (typeof eltOrSelector !== 'string') {
-        return eltOrSelector.querySelectorAll(selector)
-      } else {
-        return htmx.findAll(getDocument(), eltOrSelector)
-      }
-    },
-    /**
-     * Finds the closest matching element in the given elements parentage, inclusive of the element
-     *
-     * @see https://htmx.org/api/#closest
-     *
-     * @param {Element|string} elt the element to find the selector from
-     * @param {string} selector the selector to find
-     * @returns {Element|null}
-     */
-    closest: function(elt, selector) {
-      elt = asElement(resolveTarget(elt))
-      if (elt && elt.closest) {
-        return elt.closest(selector)
-      } else {
-        // TODO remove when IE goes away
-        do {
-          if (elt == null || matches(elt, selector)) {
-            return elt
-          }
-        }
-        while (elt = elt && asElement(parentElt(elt)))
-        return null
-      }
-    },
+    /** @type {typeof find} */
+    find: null,
+    /** @type {typeof findAll} */
+    findAll: null,
+    /** @type {typeof closest} */
+    closest: null,
     /**
      * Returns the input values that would resolve for a given element via the htmx value resolution mechanism
      *
@@ -212,284 +38,29 @@ var htmx = (function() {
       return inputValues.values
     },
     /* DOM manipulation helpers */
-    /**
-     * Removes an element from the DOM
-     *
-     * @see https://htmx.org/api/#remove
-     *
-     * @param {Node} elt
-     * @param {number} [delay]
-     */
-    remove: function(elt, delay) {
-      elt = resolveTarget(elt)
-      if (delay) {
-        getWindow().setTimeout(function() {
-          htmx.remove(elt)
-          elt = null
-        }, delay)
-      } else {
-        parentElt(elt).removeChild(elt)
-      }
-    },
-    /**
-     * This method adds a class to the given element.
-     *
-     * @see https://htmx.org/api/#addClass
-     *
-     * @param {Element|string} elt the element to add the class to
-     * @param {string} clazz the class to add
-     * @param {number} [delay] the delay (in milliseconds) before class is added
-     */
-    addClass: function(elt, clazz, delay) {
-      elt = asElement(resolveTarget(elt))
-      if (!elt) {
-        return
-      }
-      if (delay) {
-        getWindow().setTimeout(function() {
-          htmx.addClass(elt, clazz)
-          elt = null
-        }, delay)
-      } else {
-        elt.classList && elt.classList.add(clazz)
-      }
-    },
-    /**
-     * Removes a class from the given element
-     *
-     * @see https://htmx.org/api/#removeClass
-     *
-     * @param {Node|string} node element to remove the class from
-     * @param {string} clazz the class to remove
-     * @param {number} [delay] the delay (in milliseconds before class is removed)
-     */
-    removeClass: function(node, clazz, delay) {
-      let elt = asElement(resolveTarget(node))
-      if (!elt) {
-        return
-      }
-      if (delay) {
-        getWindow().setTimeout(function() {
-          htmx.removeClass(elt, clazz)
-          elt = null
-        }, delay)
-      } else {
-        if (elt.classList) {
-          elt.classList.remove(clazz)
-          // if there are no classes left, remove the class attribute
-          if (elt.classList.length === 0) {
-            elt.removeAttribute('class')
-          }
-        }
-      }
-    },
-    /**
-     * Toggles the given class on an element
-     *
-     * @see https://htmx.org/api/#toggleClass
-     *
-     * @param {Element|string} elt the element to toggle the class on
-     * @param {string} clazz the class to toggle
-     */
-    toggleClass: function(elt, clazz) {
-      elt = resolveTarget(elt)
-      elt.classList.toggle(clazz)
-    },
-    /**
-     * Takes the given class from its siblings, so that among its siblings, only the given element will have the class.
-     *
-     * @see https://htmx.org/api/#takeClass
-     *
-     * @param {Node|string} elt the element that will take the class
-     * @param {string} clazz the class to take
-     */
-    takeClass: function(elt, clazz) {
-      elt = resolveTarget(elt)
-      forEach(elt.parentElement.children, function(child) {
-        htmx.removeClass(child, clazz)
-      })
-      htmx.addClass(asElement(elt), clazz)
-    },
-    /**
-     * Implements complete swapping pipeline, including: focus and selection preservation,
-     * title updates, scroll, OOB swapping, normal swapping and settling
-     * @param {string|Element} target
-     * @param {string} content
-     * @param {HtmxSwapSpecification} swapSpec
-     * @param {SwapOptions} [swapOptions]
-     */
-    swap: function(target, content, swapSpec, swapOptions) {
-      if (!swapOptions) {
-        swapOptions = {}
-      }
-
-      target = resolveTarget(target)
-
-      // preserve focus and selection
-      const activeElt = document.activeElement
-      let selectionInfo = {}
-      try {
-        selectionInfo = {
-          elt: activeElt,
-          // @ts-ignore
-          start: activeElt ? activeElt.selectionStart : null,
-          // @ts-ignore
-          end: activeElt ? activeElt.selectionEnd : null
-        }
-      } catch (e) {
-        // safari issue - see https://github.com/microsoft/playwright/issues/5894
-      }
-      const settleInfo = makeSettleInfo(target)
-
-      let fragment = makeFragment(content)
-
-      settleInfo.title = fragment.title
-
-      // select-oob swaps
-      if (swapOptions.selectOOB) {
-        const oobSelectValues = swapOptions.selectOOB.split(',')
-        for (let i = 0; i < oobSelectValues.length; i++) {
-          const oobSelectValue = oobSelectValues[i].split(':', 2)
-          let id = oobSelectValue[0].trim()
-          if (id.indexOf('#') === 0) {
-            id = id.substring(1)
-          }
-          const oobValue = oobSelectValue[1] || 'true'
-          const oobElement = fragment.querySelector('#' + id)
-          if (oobElement) {
-            oobSwap(oobValue, oobElement, settleInfo)
-          }
-        }
-      }
-      // oob swaps
-      findAndSwapOobElements(fragment, settleInfo)
-      forEach(htmx.findAll(fragment, 'template'), /** @param {HTMLTemplateElement} template */function(template) {
-        findAndSwapOobElements(template.content, settleInfo)
-        if (template.content.childElementCount === 0) {
-          // Avoid polluting the DOM with empty templates that were only used to encapsulate oob swap
-          template.remove()
-        }
-      })
-
-      // normal swap
-      if (swapOptions.select) {
-        const newFragment = getDocument().createDocumentFragment()
-        forEach(fragment.querySelectorAll(swapOptions.select), function(node) {
-          newFragment.appendChild(node)
-        })
-        fragment = newFragment
-      }
-      handlePreservedElements(fragment)
-      swapWithStyle(swapSpec.swapStyle, swapOptions.contextElement, target, fragment, settleInfo)
-
-      // apply saved focus and selection information to swapped content
-      if (selectionInfo.elt &&
-              !bodyContains(selectionInfo.elt) &&
-              getRawAttribute(selectionInfo.elt, 'id')) {
-        const newActiveElt = document.getElementById(getRawAttribute(selectionInfo.elt, 'id'))
-        const focusOptions = { preventScroll: swapSpec.focusScroll !== undefined ? !swapSpec.focusScroll : !htmx.config.defaultFocusScroll }
-        if (newActiveElt) {
-          // @ts-ignore
-          if (selectionInfo.start && newActiveElt.setSelectionRange) {
-            try {
-              // @ts-ignore
-              newActiveElt.setSelectionRange(selectionInfo.start, selectionInfo.end)
-            } catch (e) {
-              // the setSelectionRange method is present on fields that don't support it, so just let this fail
-            }
-          }
-          newActiveElt.focus(focusOptions)
-        }
-      }
-
-      target.classList.remove(htmx.config.swappingClass)
-      forEach(settleInfo.elts, function(elt) {
-        if (elt.classList) {
-          elt.classList.add(htmx.config.settlingClass)
-        }
-        htmx.trigger(elt, 'htmx:afterSwap', swapOptions.eventInfo)
-      })
-      if (swapOptions.afterSwapCallback) {
-        swapOptions.afterSwapCallback()
-      }
-
-      // merge in new title after swap but before settle
-      if (!swapSpec.ignoreTitle) {
-        handleTitle(settleInfo.title)
-      }
-
-      // settle
-      const doSettle = function() {
-        forEach(settleInfo.tasks, function(task) {
-          task.call()
-        })
-        forEach(settleInfo.elts, function(elt) {
-          if (elt.classList) {
-            elt.classList.remove(htmx.config.settlingClass)
-          }
-          htmx.trigger(elt, 'htmx:afterSettle', swapOptions.eventInfo)
-        })
-
-        if (swapOptions.anchor) {
-          const anchorTarget = asElement(resolveTarget('#' + swapOptions.anchor))
-          if (anchorTarget) {
-            anchorTarget.scrollIntoView({ block: 'start', behavior: 'auto' })
-          }
-        }
-
-        updateScrollState(settleInfo.elts, swapSpec)
-        if (swapOptions.afterSettleCallback) {
-          swapOptions.afterSettleCallback()
-        }
-      }
-
-      if (swapSpec.settleDelay > 0) {
-        getWindow().setTimeout(doSettle, swapSpec.settleDelay)
-      } else {
-        doSettle()
-      }
-    },
+    /** @type {typeof removeElement} */
+    remove: null,
+    /** @type {typeof addClassToElement} */
+    addClass: null,
+    /** @type {typeof removeClassFromElement} */
+    removeClass: null,
+    /** @type {typeof toggleClassOnElement} */
+    toggleClass: null,
+    /** @type {typeof takeClassForElement} */
+    takeClass: null,
+    /** @type {typeof swap} */
+    swap: null,
     /* Extension entrypoints */
-    /**
-     * defineExtension initializes the extension and adds it to the htmx registry
-     *
-     * @see https://htmx.org/api/#defineExtension
-     *
-     * @param {string} name the extension name
-     * @param {HtmxExtension} extension the extension definition
-     */
-    defineExtension: function(name, extension) {
-      if (extension.init) {
-        extension.init(internalAPI)
-      }
-      extensions[name] = mergeObjects(extensionBase(), extension)
-    },
-    /**
-     * removeExtension removes an extension from the htmx registry
-     *
-     * @see https://htmx.org/api/#removeExtension
-     *
-     * @param {string} name
-     */
-    removeExtension: function(name) {
-      delete extensions[name]
-    },
+    /** @type {typeof defineExtension} */
+    defineExtension: null,
+    /** @type {typeof removeExtension} */
+    removeExtension: null,
     /* Debugging */
-    /**
-     * Log all htmx events, useful for debugging.
-     *
-     * @see https://htmx.org/api/#logAll
-     */
-    logAll: function() {
-      htmx.logger = function(elt, event, data) {
-        if (console) {
-          console.log(event, elt, data)
-        }
-      }
-    },
-    logNone: function() {
-      htmx.logger = null
-    },
+    /** @type {typeof logAll} */
+    logAll: null,
+    /** @type {typeof logNone} */
+    logNone: null,
+    /* Debugging */
     /**
      * The logger htmx uses to log with
      *
@@ -690,44 +261,34 @@ var htmx = (function() {
         { code: '[45]..', swap: false, error: true }
       ]
     },
-    /**
-     * Parses an interval string consistent with the way htmx does. Useful for plugins that have timing-related attributes.
-     *
-     * Caution: Accepts an int followed by either **s** or **ms**. All other values use **parseFloat**
-     *
-     * @see https://htmx.org/api/#parseInterval
-     *
-     * @param {string} str timing string
-     * @returns {number|undefined}
-     */
-    parseInterval: function(str) {
-      if (str == undefined) {
-        return undefined
-      }
-
-      let interval = NaN
-      if (str.slice(-2) == 'ms') {
-        interval = parseFloat(str.slice(0, -2))
-      } else if (str.slice(-1) == 's') {
-        interval = parseFloat(str.slice(0, -1)) * 1000
-      } else if (str.slice(-1) == 'm') {
-        interval = parseFloat(str.slice(0, -1)) * 1000 * 60
-      } else {
-        interval = parseFloat(str)
-      }
-      return isNaN(interval) ? undefined : interval
-    },
-    /**
-     * @param {string} str
-     * @returns {any}
-     */
-    _: function(str) {
-      return maybeEval(getDocument().body, function() {
-        return eval(str)
-      })
-    },
+    /** @type {typeof parseInterval} */
+    parseInterval: null,
+    /** @type {typeof internalEval} */
+    _: null,
     version: '2.0a'
   }
+  // Tsc madness part 2
+  htmx.onLoad = onLoadHelper
+  htmx.process = processNode
+  htmx.on = addEventListenerImpl
+  htmx.off = removeEventListenerImpl
+  htmx.trigger = triggerEvent
+  htmx.ajax = ajaxHelper
+  htmx.find = find
+  htmx.findAll = findAll
+  htmx.closest = closest
+  htmx.remove = removeElement
+  htmx.addClass = addClassToElement
+  htmx.removeClass = removeClassFromElement
+  htmx.toggleClass = toggleClassOnElement
+  htmx.takeClass = takeClassForElement
+  htmx.swap = swap
+  htmx.defineExtension = defineExtension
+  htmx.removeExtension = removeExtension
+  htmx.logAll = logAll
+  htmx.logNone = logNone
+  htmx.parseInterval = parseInterval
+  htmx._ = internalEval
 
   const internalAPI = {
     addTriggerHandler,
@@ -735,7 +296,7 @@ var htmx = (function() {
     canAccessLocalStorage,
     findThisElement,
     filterValues,
-    swap: htmx.swap,
+    swap,
     hasAttribute,
     getAttributeValue,
     getClosestAttributeValue,
@@ -754,7 +315,7 @@ var htmx = (function() {
     querySelectorExt,
     settleImmediately,
     shouldCancel,
-    triggerEvent: htmx.trigger,
+    triggerEvent,
     triggerErrorEvent,
     withExtensions
   }
@@ -778,6 +339,34 @@ var htmx = (function() {
   function makeTagRegEx(tag, global = false) {
     return new RegExp(`<${tag}(\\s[^>]*>|>)([\\s\\S]*?)<\\/${tag}>`,
       global ? 'gim' : 'im')
+  }
+
+  /**
+   * Parses an interval string consistent with the way htmx does. Useful for plugins that have timing-related attributes.
+   *
+   * Caution: Accepts an int followed by either **s** or **ms**. All other values use **parseFloat**
+   *
+   * @see https://htmx.org/api/#parseInterval
+   *
+   * @param {string} str timing string
+   * @returns {number|undefined}
+   */
+  function parseInterval(str) {
+    if (str == undefined) {
+      return undefined
+    }
+
+    let interval = NaN
+    if (str.slice(-2) == 'ms') {
+      interval = parseFloat(str.slice(0, -2))
+    } else if (str.slice(-1) == 's') {
+      interval = parseFloat(str.slice(0, -1)) * 1000
+    } else if (str.slice(-1) == 'm') {
+      interval = parseFloat(str.slice(0, -1)) * 1000 * 60
+    } else {
+      interval = parseFloat(str)
+    }
+    return isNaN(interval) ? undefined : interval
   }
 
   /**
@@ -1259,10 +848,106 @@ var htmx = (function() {
   //= =========================================================================================
 
   /**
+   * @param {string} str
+   * @returns {any}
+   */
+  function internalEval(str) {
+    return maybeEval(getDocument().body, function() {
+      return eval(str)
+    })
+  }
+
+  /**
+   * Adds a callback for the **htmx:load** event. This can be used to process new content, for example initializing the content with a javascript library
+   *
+   * @see https://htmx.org/api/#onLoad
+   *
+   * @param {(elt: Node) => void} callback the callback to call on newly loaded content
+   * @returns {EventListener}
+   */
+  function onLoadHelper(callback) {
+    const value = htmx.on('htmx:load', /** @param {CustomEvent} evt */ function(evt) {
+      callback(evt.detail.elt)
+    })
+    return value
+  }
+
+  /**
+   * Log all htmx events, useful for debugging.
+   *
+   * @see https://htmx.org/api/#logAll
+   */
+  function logAll() {
+    htmx.logger = function(elt, event, data) {
+      if (console) {
+        console.log(event, elt, data)
+      }
+    }
+  }
+
+  function logNone() {
+    htmx.logger = null
+  }
+
+  /**
+   * Finds an element matching the selector
+   *
+   * @see https://htmx.org/api/#find
+   *
+   * @param {Queryable|string} eltOrSelector  the root element to find the matching element in, inclusive | the selector to match
+   * @param {string} [selector] the selector to match
+   * @returns {Element|null}
+   */
+  function find(eltOrSelector, selector) {
+    if (typeof eltOrSelector !== 'string') {
+      return eltOrSelector.querySelector(selector)
+    } else {
+      return find(getDocument(), eltOrSelector)
+    }
+  }
+
+  /**
+   * Finds all elements matching the selector
+   *
+   * @see https://htmx.org/api/#findAll
+   *
+   * @param {Queryable|string} eltOrSelector the root element to find the matching elements in, inclusive | the selector to match
+   * @param {string} [selector] the selector to match
+   * @returns {NodeListOf<Element>}
+   */
+  function findAll(eltOrSelector, selector) {
+    if (typeof eltOrSelector !== 'string') {
+      return eltOrSelector.querySelectorAll(selector)
+    } else {
+      return findAll(getDocument(), eltOrSelector)
+    }
+  }
+
+  /**
    * @returns Window
    */
   function getWindow() {
     return window
+  }
+
+  /**
+   * Removes an element from the DOM
+   *
+   * @see https://htmx.org/api/#remove
+   *
+   * @param {Node} elt
+   * @param {number} [delay]
+   */
+  function removeElement(elt, delay) {
+    elt = resolveTarget(elt)
+    if (delay) {
+      getWindow().setTimeout(function() {
+        removeElement(elt)
+        elt = null
+      }, delay)
+    } else {
+      parentElt(elt).removeChild(elt)
+    }
   }
 
   /**
@@ -1299,6 +984,114 @@ var htmx = (function() {
    */
   function asQueryable(elt) {
     return elt instanceof Element || elt instanceof Document || elt instanceof DocumentFragment ? elt : null
+  }
+
+  /**
+   * This method adds a class to the given element.
+   *
+   * @see https://htmx.org/api/#addClass
+   *
+   * @param {Element|string} elt the element to add the class to
+   * @param {string} clazz the class to add
+   * @param {number} [delay] the delay (in milliseconds) before class is added
+   */
+  function addClassToElement(elt, clazz, delay) {
+    elt = asElement(resolveTarget(elt))
+    if (!elt) {
+      return
+    }
+    if (delay) {
+      getWindow().setTimeout(function() {
+        addClassToElement(elt, clazz)
+        elt = null
+      }, delay)
+    } else {
+      elt.classList && elt.classList.add(clazz)
+    }
+  }
+
+  /**
+   * Removes a class from the given element
+   *
+   * @see https://htmx.org/api/#removeClass
+   *
+   * @param {Node|string} node element to remove the class from
+   * @param {string} clazz the class to remove
+   * @param {number} [delay] the delay (in milliseconds before class is removed)
+   */
+  function removeClassFromElement(node, clazz, delay) {
+    let elt = asElement(resolveTarget(node))
+    if (!elt) {
+      return
+    }
+    if (delay) {
+      getWindow().setTimeout(function() {
+        removeClassFromElement(elt, clazz)
+        elt = null
+      }, delay)
+    } else {
+      if (elt.classList) {
+        elt.classList.remove(clazz)
+        // if there are no classes left, remove the class attribute
+        if (elt.classList.length === 0) {
+          elt.removeAttribute('class')
+        }
+      }
+    }
+  }
+
+  /**
+   * Toggles the given class on an element
+   *
+   * @see https://htmx.org/api/#toggleClass
+   *
+   * @param {Element|string} elt the element to toggle the class on
+   * @param {string} clazz the class to toggle
+   */
+  function toggleClassOnElement(elt, clazz) {
+    elt = resolveTarget(elt)
+    elt.classList.toggle(clazz)
+  }
+
+  /**
+   * Takes the given class from its siblings, so that among its siblings, only the given element will have the class.
+   *
+   * @see https://htmx.org/api/#takeClass
+   *
+   * @param {Node|string} elt the element that will take the class
+   * @param {string} clazz the class to take
+   */
+  function takeClassForElement(elt, clazz) {
+    elt = resolveTarget(elt)
+    forEach(elt.parentElement.children, function(child) {
+      removeClassFromElement(child, clazz)
+    })
+    addClassToElement(asElement(elt), clazz)
+  }
+
+  /**
+   * Finds the closest matching element in the given elements parentage, inclusive of the element
+   *
+   * @see https://htmx.org/api/#closest
+   *
+   * @param {Element|string} elt the element to find the selector from
+   * @param {string} selector the selector to find
+   * @returns {Element|null}
+   */
+  function closest(elt, selector) {
+    elt = asElement(resolveTarget(elt))
+    if (elt && elt.closest) {
+      return elt.closest(selector)
+    } else {
+      // TODO remove when IE goes away
+      do {
+        if (elt == null || matches(elt, selector)) {
+          return elt
+        }
+      }
+      while (elt = elt && asElement(parentElt(elt)))
+      return null
+    }
   }
 
   /**
@@ -1341,9 +1134,9 @@ var htmx = (function() {
   function querySelectorAllExt(elt, selector, global) {
     elt = resolveTarget(elt)
     if (selector.indexOf('closest ') === 0) {
-      return [htmx.closest(asElement(elt), normalizeSelector(selector.substr(8)))]
+      return [closest(asElement(elt), normalizeSelector(selector.substr(8)))]
     } else if (selector.indexOf('find ') === 0) {
-      return [htmx.find(asQueryable(elt), normalizeSelector(selector.substr(5)))]
+      return [find(asQueryable(elt), normalizeSelector(selector.substr(5)))]
     } else if (selector === 'next') {
       return [asElement(elt).nextElementSibling]
     } else if (selector.indexOf('next ') === 0) {
@@ -1420,7 +1213,7 @@ var htmx = (function() {
    */
   function resolveTarget(eltOrSelector, context) {
     if (typeof eltOrSelector === 'string') {
-      return htmx.find(asQueryable(context) || document, eltOrSelector)
+      return find(asQueryable(context) || document, eltOrSelector)
     } else {
       return eltOrSelector
     }
@@ -1457,6 +1250,43 @@ var htmx = (function() {
         listener: arg3
       }
     }
+  }
+
+  /**
+   * Adds an event listener to an element
+   *
+   * @see https://htmx.org/api/#on
+   *
+   * @param {EventTarget|string} arg1 the element to add the listener to | the event name to add the listener for
+   * @param {string|EventListener} arg2 the event name to add the listener for | the listener to add
+   * @param {EventListener} [arg3] the listener to add
+   * @returns {EventListener}
+   */
+  function addEventListenerImpl(arg1, arg2, arg3) {
+    ready(function() {
+      const eventArgs = processEventArgs(arg1, arg2, arg3)
+      eventArgs.target.addEventListener(eventArgs.event, eventArgs.listener)
+    })
+    const b = isFunction(arg2)
+    return b ? arg2 : arg3
+  }
+
+  /**
+   * Removes an event listener from an element
+   *
+   * @see https://htmx.org/api/#off
+   *
+   * @param {EventTarget|string} arg1 the element to remove the listener from | the event name to remove the listener from
+   * @param {string|EventListener} arg2 the event name to remove the listener from | the listener to remove
+   * @param {EventListener} [arg3] the listener to remove
+   * @returns {EventListener}
+   */
+  function removeEventListenerImpl(arg1, arg2, arg3) {
+    ready(function() {
+      const eventArgs = processEventArgs(arg1, arg2, arg3)
+      eventArgs.target.removeEventListener(eventArgs.event, eventArgs.listener)
+    })
+    return isFunction(arg2) ? arg2 : arg3
   }
 
   //= ===================================================================
@@ -1603,14 +1433,14 @@ var htmx = (function() {
           }
 
           const beforeSwapDetails = { shouldSwap: true, target, fragment }
-          if (!htmx.trigger(target, 'htmx:oobBeforeSwap', beforeSwapDetails)) return
+          if (!triggerEvent(target, 'htmx:oobBeforeSwap', beforeSwapDetails)) return
 
           target = beforeSwapDetails.target // allow re-targeting
           if (beforeSwapDetails.shouldSwap) {
             swapWithStyle(swapStyle, target, target, fragment, settleInfo)
           }
           forEach(settleInfo.elts, function(elt) {
-            htmx.trigger(elt, 'htmx:oobAfterSwap', beforeSwapDetails)
+            triggerEvent(elt, 'htmx:oobAfterSwap', beforeSwapDetails)
           })
         }
       )
@@ -1626,7 +1456,7 @@ var htmx = (function() {
    * @param {DocumentFragment} fragment
    */
   function handlePreservedElements(fragment) {
-    forEach(htmx.findAll(fragment, '[hx-preserve], [data-hx-preserve]'), function(preservedElt) {
+    forEach(findAll(fragment, '[hx-preserve], [data-hx-preserve]'), function(preservedElt) {
       const id = getAttributeValue(preservedElt, 'id')
       const oldElt = getDocument().getElementById(id)
       if (oldElt != null) {
@@ -1665,10 +1495,10 @@ var htmx = (function() {
    */
   function makeAjaxLoadTask(child) {
     return function() {
-      htmx.removeClass(child, htmx.config.addedClass)
-      htmx.process(asElement(child))
+      removeClassFromElement(child, htmx.config.addedClass)
+      processNode(asElement(child))
       processFocus(asQueryable(child))
-      htmx.trigger(child, 'htmx:load')
+      triggerEvent(child, 'htmx:load')
     }
   }
 
@@ -1693,7 +1523,7 @@ var htmx = (function() {
     handleAttributes(parentNode, fragment, settleInfo)
     while (fragment.childNodes.length > 0) {
       const child = fragment.firstChild
-      htmx.addClass(asElement(child), htmx.config.addedClass)
+      addClassToElement(asElement(child), htmx.config.addedClass)
       parentNode.insertBefore(child, insertBefore)
       if (child.nodeType !== Node.TEXT_NODE && child.nodeType !== Node.COMMENT_NODE) {
         settleInfo.tasks.push(makeAjaxLoadTask(child))
@@ -1743,7 +1573,7 @@ var htmx = (function() {
     if (internalData.onHandlers) {
       for (let i = 0; i < internalData.onHandlers.length; i++) {
         const handlerInfo = internalData.onHandlers[i]
-        htmx.off(elt, handlerInfo.event, handlerInfo.listener)
+        removeEventListenerImpl(elt, handlerInfo.event, handlerInfo.listener)
       }
       delete internalData.onHandlers
     }
@@ -1760,7 +1590,7 @@ var htmx = (function() {
     if (internalData.listenerInfos) {
       forEach(internalData.listenerInfos, function(info) {
         if (info.on) {
-          htmx.off(info.on, info.trigger, info.listener)
+          removeEventListenerImpl(info.on, info.trigger, info.listener)
         }
       })
     }
@@ -1772,7 +1602,7 @@ var htmx = (function() {
    * @param {Node} element
    */
   function cleanUpElement(element) {
-    htmx.trigger(element, 'htmx:beforeCleanupElement')
+    triggerEvent(element, 'htmx:beforeCleanupElement')
     deInitNode(element)
     // @ts-ignore IE11 code
     // noinspection JSUnresolvedReference
@@ -1940,12 +1770,152 @@ var htmx = (function() {
    * @param {HtmxSettleInfo} settleInfo
    */
   function findAndSwapOobElements(fragment, settleInfo) {
-    forEach(htmx.findAll(fragment, '[hx-swap-oob], [data-hx-swap-oob]'), function(oobElement) {
+    forEach(findAll(fragment, '[hx-swap-oob], [data-hx-swap-oob]'), function(oobElement) {
       const oobValue = getAttributeValue(oobElement, 'hx-swap-oob')
       if (oobValue != null) {
         oobSwap(oobValue, oobElement, settleInfo)
       }
     })
+  }
+
+  /**
+   * Implements complete swapping pipeline, including: focus and selection preservation,
+   * title updates, scroll, OOB swapping, normal swapping and settling
+   * @param {string|Element} target
+   * @param {string} content
+   * @param {HtmxSwapSpecification} swapSpec
+   * @param {SwapOptions} [swapOptions]
+   */
+  function swap(target, content, swapSpec, swapOptions) {
+    if (!swapOptions) {
+      swapOptions = {}
+    }
+
+    target = resolveTarget(target)
+
+    // preserve focus and selection
+    const activeElt = document.activeElement
+    let selectionInfo = {}
+    try {
+      selectionInfo = {
+        elt: activeElt,
+        // @ts-ignore
+        start: activeElt ? activeElt.selectionStart : null,
+        // @ts-ignore
+        end: activeElt ? activeElt.selectionEnd : null
+      }
+    } catch (e) {
+      // safari issue - see https://github.com/microsoft/playwright/issues/5894
+    }
+    const settleInfo = makeSettleInfo(target)
+
+    let fragment = makeFragment(content)
+
+    settleInfo.title = fragment.title
+
+    // select-oob swaps
+    if (swapOptions.selectOOB) {
+      const oobSelectValues = swapOptions.selectOOB.split(',')
+      for (let i = 0; i < oobSelectValues.length; i++) {
+        const oobSelectValue = oobSelectValues[i].split(':', 2)
+        let id = oobSelectValue[0].trim()
+        if (id.indexOf('#') === 0) {
+          id = id.substring(1)
+        }
+        const oobValue = oobSelectValue[1] || 'true'
+        const oobElement = fragment.querySelector('#' + id)
+        if (oobElement) {
+          oobSwap(oobValue, oobElement, settleInfo)
+        }
+      }
+    }
+    // oob swaps
+    findAndSwapOobElements(fragment, settleInfo)
+    forEach(findAll(fragment, 'template'), /** @param {HTMLTemplateElement} template */function(template) {
+      findAndSwapOobElements(template.content, settleInfo)
+      if (template.content.childElementCount === 0) {
+        // Avoid polluting the DOM with empty templates that were only used to encapsulate oob swap
+        template.remove()
+      }
+    })
+
+    // normal swap
+    if (swapOptions.select) {
+      const newFragment = getDocument().createDocumentFragment()
+      forEach(fragment.querySelectorAll(swapOptions.select), function(node) {
+        newFragment.appendChild(node)
+      })
+      fragment = newFragment
+    }
+    handlePreservedElements(fragment)
+    swapWithStyle(swapSpec.swapStyle, swapOptions.contextElement, target, fragment, settleInfo)
+
+    // apply saved focus and selection information to swapped content
+    if (selectionInfo.elt &&
+      !bodyContains(selectionInfo.elt) &&
+      getRawAttribute(selectionInfo.elt, 'id')) {
+      const newActiveElt = document.getElementById(getRawAttribute(selectionInfo.elt, 'id'))
+      const focusOptions = { preventScroll: swapSpec.focusScroll !== undefined ? !swapSpec.focusScroll : !htmx.config.defaultFocusScroll }
+      if (newActiveElt) {
+        // @ts-ignore
+        if (selectionInfo.start && newActiveElt.setSelectionRange) {
+          try {
+            // @ts-ignore
+            newActiveElt.setSelectionRange(selectionInfo.start, selectionInfo.end)
+          } catch (e) {
+            // the setSelectionRange method is present on fields that don't support it, so just let this fail
+          }
+        }
+        newActiveElt.focus(focusOptions)
+      }
+    }
+
+    target.classList.remove(htmx.config.swappingClass)
+    forEach(settleInfo.elts, function(elt) {
+      if (elt.classList) {
+        elt.classList.add(htmx.config.settlingClass)
+      }
+      triggerEvent(elt, 'htmx:afterSwap', swapOptions.eventInfo)
+    })
+    if (swapOptions.afterSwapCallback) {
+      swapOptions.afterSwapCallback()
+    }
+
+    // merge in new title after swap but before settle
+    if (!swapSpec.ignoreTitle) {
+      handleTitle(settleInfo.title)
+    }
+
+    // settle
+    const doSettle = function() {
+      forEach(settleInfo.tasks, function(task) {
+        task.call()
+      })
+      forEach(settleInfo.elts, function(elt) {
+        if (elt.classList) {
+          elt.classList.remove(htmx.config.settlingClass)
+        }
+        triggerEvent(elt, 'htmx:afterSettle', swapOptions.eventInfo)
+      })
+
+      if (swapOptions.anchor) {
+        const anchorTarget = asElement(resolveTarget('#' + swapOptions.anchor))
+        if (anchorTarget) {
+          anchorTarget.scrollIntoView({ block: 'start', behavior: 'auto' })
+        }
+      }
+
+      updateScrollState(settleInfo.elts, swapSpec)
+      if (swapOptions.afterSettleCallback) {
+        swapOptions.afterSettleCallback()
+      }
+    }
+
+    if (swapSpec.settleDelay > 0) {
+      getWindow().setTimeout(doSettle, swapSpec.settleDelay)
+    } else {
+      doSettle()
+    }
   }
 
   /**
@@ -1963,13 +1933,13 @@ var htmx = (function() {
           if (!isRawObject(detail)) {
             detail = { value: detail }
           }
-          htmx.trigger(elt, eventName, detail)
+          triggerEvent(elt, eventName, detail)
         }
       }
     } else {
       const eventNames = triggerBody.split(',')
       for (let i = 0; i < eventNames.length; i++) {
-        htmx.trigger(elt, eventNames[i].trim(), [])
+        triggerEvent(elt, eventNames[i].trim(), [])
       }
     }
   }
@@ -2131,7 +2101,7 @@ var htmx = (function() {
           /** @type HtmxTriggerSpecification */
           const every = { trigger: 'every' }
           consumeUntil(tokens, NOT_WHITESPACE)
-          every.pollInterval = htmx.parseInterval(consumeUntil(tokens, /[,\[\s]/))
+          every.pollInterval = parseInterval(consumeUntil(tokens, /[,\[\s]/))
           consumeUntil(tokens, NOT_WHITESPACE)
           var eventFilter = maybeGenerateConditional(elt, tokens, 'event')
           if (eventFilter) {
@@ -2156,7 +2126,7 @@ var htmx = (function() {
               triggerSpec.consume = true
             } else if (token === 'delay' && tokens[0] === ':') {
               tokens.shift()
-              triggerSpec.delay = htmx.parseInterval(consumeUntil(tokens, WHITESPACE_OR_COMMA))
+              triggerSpec.delay = parseInterval(consumeUntil(tokens, WHITESPACE_OR_COMMA))
             } else if (token === 'from' && tokens[0] === ':') {
               tokens.shift()
               if (COMBINED_SELECTOR_START.test(tokens[0])) {
@@ -2178,7 +2148,7 @@ var htmx = (function() {
               triggerSpec.target = consumeCSSSelector(tokens)
             } else if (token === 'throttle' && tokens[0] === ':') {
               tokens.shift()
-              triggerSpec.throttle = htmx.parseInterval(consumeUntil(tokens, WHITESPACE_OR_COMMA))
+              triggerSpec.throttle = parseInterval(consumeUntil(tokens, WHITESPACE_OR_COMMA))
             } else if (token === 'queue' && tokens[0] === ':') {
               tokens.shift()
               triggerSpec.queue = consumeUntil(tokens, WHITESPACE_OR_COMMA)
@@ -2290,7 +2260,7 @@ var htmx = (function() {
       triggerSpecs.forEach(function(triggerSpec) {
         addEventListener(elt, function(node, evt) {
           const elt = asElement(node)
-          if (htmx.closest(elt, htmx.config.disableSelector)) {
+          if (closest(elt, htmx.config.disableSelector)) {
             cleanUpElement(elt)
             return
           }
@@ -2314,7 +2284,7 @@ var htmx = (function() {
       if (elt.tagName === 'FORM') {
         return true
       }
-      if (matches(elt, 'input[type="submit"], button') && htmx.closest(elt, 'form') !== null) {
+      if (matches(elt, 'input[type="submit"], button') && closest(elt, 'form') !== null) {
         return true
       }
       if (elt instanceof HTMLAnchorElement && elt.href &&
@@ -2444,7 +2414,7 @@ var htmx = (function() {
           } else if (triggerSpec.delay > 0) {
             elementData.delayed = getWindow().setTimeout(function() { handler(elt, evt) }, triggerSpec.delay)
           } else {
-            htmx.trigger(elt, 'htmx:trigger')
+            triggerEvent(elt, 'htmx:trigger')
             handler(elt, evt)
           }
         }
@@ -2488,10 +2458,10 @@ var htmx = (function() {
       elt.setAttribute('data-hx-revealed', 'true')
       const nodeData = getInternalData(elt)
       if (nodeData.initHash) {
-        htmx.trigger(elt, 'revealed')
+        triggerEvent(elt, 'revealed')
       } else {
         // if the node isn't initialized, wait for it before triggering the request
-        elt.addEventListener('htmx:afterProcessNode', function() { htmx.trigger(elt, 'revealed') }, { once: true })
+        elt.addEventListener('htmx:afterProcessNode', function() { triggerEvent(elt, 'revealed') }, { once: true })
       }
     }
   }
@@ -2535,7 +2505,7 @@ var htmx = (function() {
         triggerSpecs.forEach(function(triggerSpec) {
           addTriggerHandler(elt, triggerSpec, nodeData, function(node, evt) {
             const elt = asElement(node)
-            if (htmx.closest(elt, htmx.config.disableSelector)) {
+            if (closest(elt, htmx.config.disableSelector)) {
               cleanUpElement(elt)
               return
             }
@@ -2576,7 +2546,7 @@ var htmx = (function() {
         for (let i = 0; i < entries.length; i++) {
           const entry = entries[i]
           if (entry.isIntersecting) {
-            htmx.trigger(elt, 'intersect')
+            triggerEvent(elt, 'intersect')
             break
           }
         }
@@ -2657,7 +2627,7 @@ var htmx = (function() {
    * @param {Event} evt
    */
   function maybeSetLastButtonClicked(evt) {
-    const elt = /** @type {HTMLButtonElement|HTMLInputElement} */ (htmx.closest(asElement(evt.target), "button, input[type='submit']"))
+    const elt = /** @type {HTMLButtonElement|HTMLInputElement} */ (closest(asElement(evt.target), "button, input[type='submit']"))
     const internalData = getRelatedFormData(evt)
     if (internalData) {
       internalData.lastButtonClicked = elt
@@ -2679,11 +2649,11 @@ var htmx = (function() {
    * @returns {HtmxNodeInternalData|undefined}
    */
   function getRelatedFormData(evt) {
-    const elt = htmx.closest(asElement(evt.target), "button, input[type='submit']")
+    const elt = closest(asElement(evt.target), "button, input[type='submit']")
     if (!elt) {
       return
     }
-    const form = resolveTarget('#' + getRawAttribute(elt, 'form'), elt.getRootNode()) || htmx.closest(elt, 'form')
+    const form = resolveTarget('#' + getRawAttribute(elt, 'form'), elt.getRootNode()) || closest(elt, 'form')
     if (!form) {
       return
     }
@@ -2760,7 +2730,7 @@ var htmx = (function() {
    * @param {Element|HTMLInputElement} elt
    */
   function initNode(elt) {
-    if (htmx.closest(elt, htmx.config.disableSelector)) {
+    if (closest(elt, htmx.config.disableSelector)) {
       cleanUpElement(elt)
       return
     }
@@ -2771,7 +2741,7 @@ var htmx = (function() {
 
       nodeData.initHash = attributeHash(elt)
 
-      htmx.trigger(elt, 'htmx:beforeProcessNode')
+      triggerEvent(elt, 'htmx:beforeProcessNode')
 
       // @ts-ignore value will be undefined for non-input elements, which is fine
       if (elt.value) {
@@ -2800,8 +2770,26 @@ var htmx = (function() {
         initButtonTracking(elt)
       }
 
-      htmx.trigger(elt, 'htmx:afterProcessNode')
+      triggerEvent(elt, 'htmx:afterProcessNode')
     }
+  }
+
+  /**
+   * Processes new content, enabling htmx behavior. This can be useful if you have content that is added to the DOM outside of the normal htmx request cycle but still want htmx attributes to work.
+   *
+   * @see https://htmx.org/api/#process
+   *
+   * @param {Element|string} elt element to process
+   */
+  function processNode(elt) {
+    elt = resolveTarget(elt)
+    if (closest(elt, htmx.config.disableSelector)) {
+      cleanUpElement(elt)
+      return
+    }
+    initNode(elt)
+    forEach(findElementsToProcess(elt), function(child) { initNode(child) })
+    forEach(findHxOnWildcardElements(elt), processHxOnWildcard)
   }
 
   //= ===================================================================
@@ -2840,7 +2828,7 @@ var htmx = (function() {
    * @param {any=} detail
    */
   function triggerErrorEvent(elt, eventName, detail) {
-    htmx.trigger(elt, eventName, mergeObjects({ error: eventName }, detail))
+    triggerEvent(elt, eventName, mergeObjects({ error: eventName }, detail))
   }
 
   /**
@@ -2876,6 +2864,42 @@ var htmx = (function() {
     } else if (console.log) {
       console.log('ERROR: ', msg)
     }
+  }
+
+  /**
+   * Triggers a given event on an element
+   *
+   * @see https://htmx.org/api/#trigger
+   *
+   * @param {EventTarget|string} elt the element to trigger the event on
+   * @param {string} eventName the name of the event to trigger
+   * @param {any=} detail details for the event
+   * @returns {boolean}
+   */
+  function triggerEvent(elt, eventName, detail) {
+    elt = resolveTarget(elt)
+    if (detail == null) {
+      detail = {}
+    }
+    detail.elt = elt
+    const event = makeEvent(eventName, detail)
+    if (htmx.logger && !ignoreEventForLogging(eventName)) {
+      htmx.logger(elt, eventName, detail)
+    }
+    if (detail.error) {
+      logError(detail.error)
+      triggerEvent(elt, 'htmx:error', { errorInfo: detail })
+    }
+    let eventResult = elt.dispatchEvent(event)
+    const kebabName = kebabEventName(eventName)
+    if (eventResult && kebabName !== eventName) {
+      const kebabedEvent = makeEvent(kebabName, event.detail)
+      eventResult = eventResult && elt.dispatchEvent(kebabedEvent)
+    }
+    withExtensions(asElement(elt), function(extension) {
+      eventResult = eventResult && (extension.onEvent(eventName, event) !== false && !event.defaultPrevented)
+    })
+    return eventResult
   }
 
   //= ===================================================================
@@ -2924,7 +2948,7 @@ var htmx = (function() {
     /** @type HtmxHistoryItem */
     const newHistoryItem = { url, content: innerHTML, title, scroll }
 
-    htmx.trigger(getDocument().body, 'htmx:historyItemCreated', { item: newHistoryItem, cache: historyCache })
+    triggerEvent(getDocument().body, 'htmx:historyItemCreated', { item: newHistoryItem, cache: historyCache })
 
     historyCache.push(newHistoryItem)
     while (historyCache.length > htmx.config.historyCacheSize) {
@@ -2978,8 +3002,8 @@ var htmx = (function() {
   function cleanInnerHtmlForHistory(elt) {
     const className = htmx.config.requestClass
     const clone = /** @type Element */ (elt.cloneNode(true))
-    forEach(htmx.findAll(clone, '.' + className), function(child) {
-      htmx.removeClass(child, className)
+    forEach(findAll(clone, '.' + className), function(child) {
+      removeClassFromElement(child, className)
     })
     return clone.innerHTML
   }
@@ -3001,7 +3025,7 @@ var htmx = (function() {
       disableHistoryCache = getDocument().querySelector('[hx-history="false"],[data-hx-history="false"]')
     }
     if (!disableHistoryCache) {
-      htmx.trigger(getDocument().body, 'htmx:beforeHistorySave', { path, historyElt: elt })
+      triggerEvent(getDocument().body, 'htmx:beforeHistorySave', { path, historyElt: elt })
       saveToHistoryCache(path, elt)
     }
 
@@ -3048,14 +3072,14 @@ var htmx = (function() {
   function loadHistoryFromServer(path) {
     const request = new XMLHttpRequest()
     const details = { path, xhr: request }
-    htmx.trigger(getDocument().body, 'htmx:historyCacheMiss', details)
+    triggerEvent(getDocument().body, 'htmx:historyCacheMiss', details)
     request.open('GET', path, true)
     request.setRequestHeader('HX-Request', 'true')
     request.setRequestHeader('HX-History-Restore-Request', 'true')
     request.setRequestHeader('HX-Current-URL', getDocument().location.href)
     request.onload = function() {
       if (this.status >= 200 && this.status < 400) {
-        htmx.trigger(getDocument().body, 'htmx:historyCacheMissLoad', details)
+        triggerEvent(getDocument().body, 'htmx:historyCacheMissLoad', details)
         const fragment = makeFragment(this.response)
         /** @type Queryable */
         const content = fragment.querySelector('[hx-history-elt],[data-hx-history-elt]') || fragment
@@ -3066,7 +3090,7 @@ var htmx = (function() {
         swapInnerHTML(historyElement, content, settleInfo)
         settleImmediately(settleInfo.tasks)
         currentPathForHistory = path
-        htmx.trigger(getDocument().body, 'htmx:historyRestore', { path, cacheMiss: true, serverResponse: this.response })
+        triggerEvent(getDocument().body, 'htmx:historyRestore', { path, cacheMiss: true, serverResponse: this.response })
       } else {
         triggerErrorEvent(getDocument().body, 'htmx:historyCacheMissLoadError', details)
       }
@@ -3092,7 +3116,7 @@ var htmx = (function() {
         window.scrollTo(0, cached.scroll)
       }, 0) // next 'tick', so browser has time to render layout
       currentPathForHistory = path
-      htmx.trigger(getDocument().body, 'htmx:historyRestore', { path, item: cached })
+      triggerEvent(getDocument().body, 'htmx:historyRestore', { path, item: cached })
     } else {
       if (htmx.config.refreshOnHistoryMiss) {
         // @ts-ignore: optional parameter in reload() function throws error
@@ -3183,9 +3207,9 @@ var htmx = (function() {
    * @return {boolean}
    */
   function shouldInclude(element) {
-    // Cast to trick tsc
+    // Cast to trick tsc, undefined values will work fine here
     const elt = /** @type {HTMLInputElement} */ (element)
-    if (elt.name === '' || elt.name == null || elt.disabled || htmx.closest(elt, 'fieldset[disabled]')) {
+    if (elt.name === '' || elt.name == null || elt.disabled || closest(elt, 'fieldset[disabled]')) {
       return false
     }
     // ignore "submitter" types (see jQuery src/serialize.js)
@@ -3284,10 +3308,10 @@ var htmx = (function() {
   function validateElement(elt, errors) {
     const element = /** @type {HTMLElement & ElementInternals} */ (elt)
     if (element.willValidate) {
-      htmx.trigger(element, 'htmx:validation:validate')
+      triggerEvent(element, 'htmx:validation:validate')
       if (!element.checkValidity()) {
         errors.push({ elt: element, message: element.validationMessage, validity: element.validity })
-        htmx.trigger(element, 'htmx:validation:failed', { message: element.validationMessage, validity: element.validity })
+        triggerEvent(element, 'htmx:validation:failed', { message: element.validationMessage, validity: element.validity })
       }
     }
   }
@@ -3334,7 +3358,7 @@ var htmx = (function() {
 
     // for a non-GET include the closest form
     if (verb !== 'get') {
-      processInputValue(processed, priorityFormData, errors, htmx.closest(elt, 'form'), validate)
+      processInputValue(processed, priorityFormData, errors, closest(elt, 'form'), validate)
     }
 
     // include the element itself
@@ -3492,9 +3516,9 @@ var htmx = (function() {
         for (let i = 0; i < split.length; i++) {
           const value = split[i]
           if (value.indexOf('swap:') === 0) {
-            swapSpec.swapDelay = htmx.parseInterval(value.substr(5))
+            swapSpec.swapDelay = parseInterval(value.substr(5))
           } else if (value.indexOf('settle:') === 0) {
-            swapSpec.settleDelay = htmx.parseInterval(value.substr(7))
+            swapSpec.settleDelay = parseInterval(value.substr(7))
           } else if (value.indexOf('transition:') === 0) {
             swapSpec.transition = value.substr(11) === 'true'
           } else if (value.indexOf('ignoreTitle:') === 0) {
@@ -3745,6 +3769,43 @@ var htmx = (function() {
   }
 
   /**
+   * Issues an htmx-style AJAX request
+   *
+   * @see https://htmx.org/api/#ajax
+   *
+   * @param {HttpVerb} verb
+   * @param {string} path the URL path to make the AJAX
+   * @param {Element|string|HtmxAjaxHelperContext} context the element to target (defaults to the **body**) | a selector for the target | a context object that contains any of the following
+   * @return {Promise<void>} Promise that resolves immediately if no request is sent, or when the request is complete
+   */
+  function ajaxHelper(verb, path, context) {
+    verb = (/** @type HttpVerb */(verb.toLowerCase()))
+    if (context) {
+      if (context instanceof Element || typeof context === 'string') {
+        return issueAjaxRequest(verb, path, null, null, {
+          targetOverride: resolveTarget(context),
+          returnPromise: true
+        })
+      } else {
+        return issueAjaxRequest(verb, path, resolveTarget(context.source), context.event,
+          {
+            handler: context.handler,
+            headers: context.headers,
+            values: context.values,
+            targetOverride: resolveTarget(context.target),
+            swapOverride: context.swap,
+            select: context.select,
+            returnPromise: true
+          })
+      }
+    } else {
+      return issueAjaxRequest(verb, path, null, null, {
+        returnPromise: true
+      })
+    }
+  }
+
+  /**
    * @param {Element} elt
    * @return {Element[]}
    */
@@ -3781,7 +3842,7 @@ var htmx = (function() {
         return false
       }
     }
-    return htmx.trigger(elt, 'htmx:validateUrl', mergeObjects({ url, sameHost }, requestConfig))
+    return triggerEvent(elt, 'htmx:validateUrl', mergeObjects({ url, sameHost }, requestConfig))
   }
 
   /**
@@ -3971,7 +4032,7 @@ var htmx = (function() {
         return issueAjaxRequest(verb, path, elt, event, etc, !!skipConfirmation)
       }
       const confirmDetails = { target, elt, path, verb, triggeringEvent: event, etc, issueRequest, question: confirmQuestion }
-      if (htmx.trigger(elt, 'htmx:confirm', confirmDetails) === false) {
+      if (triggerEvent(elt, 'htmx:confirm', confirmDetails) === false) {
         maybeCall(resolve)
         return promise
       }
@@ -4003,7 +4064,7 @@ var htmx = (function() {
           abortable = true
         }
       } else if (syncStrategy === 'replace') {
-        htmx.trigger(syncElt, 'htmx:abort') // abort the current request and continue
+        triggerEvent(syncElt, 'htmx:abort') // abort the current request and continue
       } else if (syncStrategy.indexOf('queue') === 0) {
         const queueStrArray = syncStrategy.split(' ')
         queueStrategy = (queueStrArray[1] || 'last').trim()
@@ -4012,7 +4073,7 @@ var htmx = (function() {
 
     if (eltData.xhr) {
       if (eltData.abortable) {
-        htmx.trigger(syncElt, 'htmx:abort') // abort the current request and continue
+        triggerEvent(syncElt, 'htmx:abort') // abort the current request and continue
       } else {
         if (queueStrategy == null) {
           if (event) {
@@ -4064,7 +4125,7 @@ var htmx = (function() {
       var promptResponse = prompt(promptQuestion)
       // prompt returns null if cancelled and empty string if accepted with no entry
       if (promptResponse === null ||
-      !htmx.trigger(elt, 'htmx:prompt', { prompt: promptResponse, target })) {
+      !triggerEvent(elt, 'htmx:prompt', { prompt: promptResponse, target })) {
         maybeCall(resolve)
         endRequestLock()
         return promise
@@ -4137,7 +4198,7 @@ var htmx = (function() {
       triggeringEvent: event
     }
 
-    if (!htmx.trigger(elt, 'htmx:configRequest', requestConfig)) {
+    if (!triggerEvent(elt, 'htmx:configRequest', requestConfig)) {
       maybeCall(resolve)
       endRequestLock()
       return promise
@@ -4152,7 +4213,7 @@ var htmx = (function() {
     useUrlParams = requestConfig.useUrlParams
 
     if (errors && errors.length > 0) {
-      htmx.trigger(elt, 'htmx:validation:halted', requestConfig)
+      triggerEvent(elt, 'htmx:validation:halted', requestConfig)
       maybeCall(resolve)
       endRequestLock()
       return promise
@@ -4224,8 +4285,8 @@ var htmx = (function() {
         responseInfo.pathInfo.responsePath = getPathFromResponse(xhr)
         responseHandler(elt, responseInfo)
         removeRequestIndicators(indicators, disableElts)
-        htmx.trigger(elt, 'htmx:afterRequest', responseInfo)
-        htmx.trigger(elt, 'htmx:afterOnLoad', responseInfo)
+        triggerEvent(elt, 'htmx:afterRequest', responseInfo)
+        triggerEvent(elt, 'htmx:afterOnLoad', responseInfo)
         // if the body no longer contains the element, trigger the event on the closest parent
         // remaining in the DOM
         if (!bodyContains(elt)) {
@@ -4237,8 +4298,8 @@ var htmx = (function() {
             }
           }
           if (secondaryTriggerElt) {
-            htmx.trigger(secondaryTriggerElt, 'htmx:afterRequest', responseInfo)
-            htmx.trigger(secondaryTriggerElt, 'htmx:afterOnLoad', responseInfo)
+            triggerEvent(secondaryTriggerElt, 'htmx:afterRequest', responseInfo)
+            triggerEvent(secondaryTriggerElt, 'htmx:afterOnLoad', responseInfo)
           }
         }
         maybeCall(resolve)
@@ -4269,7 +4330,7 @@ var htmx = (function() {
       maybeCall(reject)
       endRequestLock()
     }
-    if (!htmx.trigger(elt, 'htmx:beforeRequest', responseInfo)) {
+    if (!triggerEvent(elt, 'htmx:beforeRequest', responseInfo)) {
       maybeCall(resolve)
       endRequestLock()
       return promise
@@ -4280,7 +4341,7 @@ var htmx = (function() {
     forEach(['loadstart', 'loadend', 'progress', 'abort'], function(eventName) {
       forEach([xhr, xhr.upload], function(target) {
         target.addEventListener(eventName, function(event) {
-          htmx.trigger(elt, 'htmx:xhr:' + eventName, {
+          triggerEvent(elt, 'htmx:xhr:' + eventName, {
             lengthComputable: event.lengthComputable,
             loaded: event.loaded,
             total: event.total
@@ -4288,7 +4349,7 @@ var htmx = (function() {
         })
       })
     })
-    htmx.trigger(elt, 'htmx:beforeSend', responseInfo)
+    triggerEvent(elt, 'htmx:beforeSend', responseInfo)
     const params = useUrlParams ? null : encodeParamsForBody(xhr, elt, filteredFormData)
     xhr.send(params)
     return promise
@@ -4418,7 +4479,7 @@ var htmx = (function() {
    */
   function handleTitle(title) {
     if (title) {
-      const titleElt = htmx.find('title')
+      const titleElt = find('title')
       if (titleElt) {
         titleElt.innerHTML = title
       } else {
@@ -4437,7 +4498,7 @@ var htmx = (function() {
     const etc = responseInfo.etc
     const responseInfoSelect = responseInfo.select
 
-    if (!htmx.trigger(elt, 'htmx:beforeOnLoad', responseInfo)) return
+    if (!triggerEvent(elt, 'htmx:beforeOnLoad', responseInfo)) return
 
     if (hasHeader(xhr, /HX-Trigger:/i)) {
       handleTriggerHeader(xhr, 'HX-Trigger', elt)
@@ -4454,7 +4515,7 @@ var htmx = (function() {
         redirectPath = redirectSwapSpec.path
         delete redirectSwapSpec.path
       }
-      htmx.ajax('get', redirectPath, redirectSwapSpec).then(function() {
+      ajaxHelper('get', redirectPath, redirectSwapSpec).then(function() {
         pushUrlIntoHistory(redirectPath)
       })
       return
@@ -4518,9 +4579,9 @@ var htmx = (function() {
       selectOverride
     }, responseInfo)
 
-    if (responseHandling.event && !htmx.trigger(target, responseHandling.event, beforeSwapDetails)) return
+    if (responseHandling.event && !triggerEvent(target, responseHandling.event, beforeSwapDetails)) return
 
-    if (!htmx.trigger(target, 'htmx:beforeSwap', beforeSwapDetails)) return
+    if (!triggerEvent(target, 'htmx:beforeSwap', beforeSwapDetails)) return
 
     target = beforeSwapDetails.target // allow re-targeting
     serverResponse = beforeSwapDetails.serverResponse // allow updating content
@@ -4576,17 +4637,17 @@ var htmx = (function() {
         try {
           // if we need to save history, do so, before swapping so that relative resources have the correct base URL
           if (historyUpdate.type) {
-            htmx.trigger(getDocument().body, 'htmx:beforeHistoryUpdate', mergeObjects({ history: historyUpdate }, responseInfo))
+            triggerEvent(getDocument().body, 'htmx:beforeHistoryUpdate', mergeObjects({ history: historyUpdate }, responseInfo))
             if (historyUpdate.type === 'push') {
               pushUrlIntoHistory(historyUpdate.path)
-              htmx.trigger(getDocument().body, 'htmx:pushedIntoHistory', { path: historyUpdate.path })
+              triggerEvent(getDocument().body, 'htmx:pushedIntoHistory', { path: historyUpdate.path })
             } else {
               replaceUrlInHistory(historyUpdate.path)
-              htmx.trigger(getDocument().body, 'htmx:replacedInHistory', { path: historyUpdate.path })
+              triggerEvent(getDocument().body, 'htmx:replacedInHistory', { path: historyUpdate.path })
             }
           }
 
-          htmx.swap(target, serverResponse, swapSpec, {
+          swap(target, serverResponse, swapSpec, {
             select: selectOverride || select,
             selectOOB,
             eventInfo: responseInfo,
@@ -4625,7 +4686,7 @@ var htmx = (function() {
       }
 
       if (shouldTransition &&
-              htmx.trigger(elt, 'htmx:beforeTransition', responseInfo) &&
+              triggerEvent(elt, 'htmx:beforeTransition', responseInfo) &&
               typeof Promise !== 'undefined' &&
               // @ts-ignore experimental feature atm
               document.startViewTransition) {
@@ -4675,6 +4736,32 @@ var htmx = (function() {
       handleSwap: function(swapStyle, target, fragment, settleInfo) { return false },
       encodeParameters: function(xhr, parameters, elt) { return null }
     }
+  }
+
+  /**
+   * defineExtension initializes the extension and adds it to the htmx registry
+   *
+   * @see https://htmx.org/api/#defineExtension
+   *
+   * @param {string} name the extension name
+   * @param {HtmxExtension} extension the extension definition
+   */
+  function defineExtension(name, extension) {
+    if (extension.init) {
+      extension.init(internalAPI)
+    }
+    extensions[name] = mergeObjects(extensionBase(), extension)
+  }
+
+  /**
+   * removeExtension removes an extension from the htmx registry
+   *
+   * @see https://htmx.org/api/#removeExtension
+   *
+   * @param {string} name
+   */
+  function removeExtension(name) {
+    delete extensions[name]
   }
 
   /**
@@ -4772,7 +4859,7 @@ var htmx = (function() {
     mergeMetaConfig()
     insertIndicatorStyles()
     let body = getDocument().body
-    htmx.process(body)
+    processNode(body)
     const restoredElts = getDocument().querySelectorAll(
       "[hx-trigger='restored'],[data-hx-trigger='restored']"
     )
@@ -4790,9 +4877,9 @@ var htmx = (function() {
       if (event.state && event.state.htmx) {
         restoreHistory()
         forEach(restoredElts, function(elt) {
-          htmx.trigger(elt, 'htmx:restored', {
+          triggerEvent(elt, 'htmx:restored', {
             document: getDocument(),
-            triggerEvent: htmx.trigger
+            triggerEvent
           })
         })
       } else {
@@ -4802,7 +4889,7 @@ var htmx = (function() {
       }
     }
     getWindow().setTimeout(function() {
-      htmx.trigger(body, 'htmx:load', {}) // give ready handlers a chance to load up before firing this event
+      triggerEvent(body, 'htmx:load', {}) // give ready handlers a chance to load up before firing this event
       body = null // kill reference for gc
     }, 0)
   })

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -894,7 +894,7 @@ var htmx = (function() {
    *
    * @see https://htmx.org/api/#find
    *
-   * @param {Queryable|string} eltOrSelector  the root element to find the matching element in, inclusive | the selector to match
+   * @param {ParentNode|string} eltOrSelector  the root element to find the matching element in, inclusive | the selector to match
    * @param {string} [selector] the selector to match
    * @returns {Element|null}
    */
@@ -911,7 +911,7 @@ var htmx = (function() {
    *
    * @see https://htmx.org/api/#findAll
    *
-   * @param {Queryable|string} eltOrSelector the root element to find the matching elements in, inclusive | the selector to match
+   * @param {ParentNode|string} eltOrSelector the root element to find the matching elements in, inclusive | the selector to match
    * @param {string} [selector] the selector to match
    * @returns {NodeListOf<Element>}
    */
@@ -975,14 +975,10 @@ var htmx = (function() {
   }
 
   /**
-   * @typedef {Element|Document|DocumentFragment} Queryable
-   */
-
-  /**
    * @param {EventTarget} elt
-   * @return {Queryable|null}
+   * @return {ParentNode|null}
    */
-  function asQueryable(elt) {
+  function asParentNode(elt) {
     return elt instanceof Element || elt instanceof Document || elt instanceof DocumentFragment ? elt : null
   }
 
@@ -1136,7 +1132,7 @@ var htmx = (function() {
     if (selector.indexOf('closest ') === 0) {
       return [closest(asElement(elt), normalizeSelector(selector.substr(8)))]
     } else if (selector.indexOf('find ') === 0) {
-      return [find(asQueryable(elt), normalizeSelector(selector.substr(5)))]
+      return [find(asParentNode(elt), normalizeSelector(selector.substr(5)))]
     } else if (selector === 'next') {
       return [asElement(elt).nextElementSibling]
     } else if (selector.indexOf('next ') === 0) {
@@ -1156,7 +1152,7 @@ var htmx = (function() {
     } else if (selector.indexOf('global ') === 0) {
       return querySelectorAllExt(elt, selector.slice(7), true)
     } else {
-      return toArray(asQueryable(getRootNode(elt, !!global)).querySelectorAll(normalizeSelector(selector)))
+      return toArray(asParentNode(getRootNode(elt, !!global)).querySelectorAll(normalizeSelector(selector)))
     }
   }
 
@@ -1167,7 +1163,7 @@ var htmx = (function() {
    * @returns {Element}
    */
   var scanForwardQuery = function(start, match, global) {
-    const results = asQueryable(getRootNode(start, global)).querySelectorAll(match)
+    const results = asParentNode(getRootNode(start, global)).querySelectorAll(match)
     for (let i = 0; i < results.length; i++) {
       const elt = results[i]
       if (elt.compareDocumentPosition(start) === Node.DOCUMENT_POSITION_PRECEDING) {
@@ -1183,7 +1179,7 @@ var htmx = (function() {
    * @returns {Element}
    */
   var scanBackwardsQuery = function(start, match, global) {
-    const results = asQueryable(getRootNode(start, global)).querySelectorAll(match)
+    const results = asParentNode(getRootNode(start, global)).querySelectorAll(match)
     for (let i = results.length - 1; i >= 0; i--) {
       const elt = results[i]
       if (elt.compareDocumentPosition(start) === Node.DOCUMENT_POSITION_FOLLOWING) {
@@ -1213,7 +1209,7 @@ var htmx = (function() {
    */
   function resolveTarget(eltOrSelector, context) {
     if (typeof eltOrSelector === 'string') {
-      return find(asQueryable(context) || document, eltOrSelector)
+      return find(asParentNode(context) || document, eltOrSelector)
     } else {
       return eltOrSelector
     }
@@ -1429,7 +1425,7 @@ var htmx = (function() {
           fragment = getDocument().createDocumentFragment()
           fragment.appendChild(oobElementClone)
           if (!isInlineSwap(swapStyle, target)) {
-            fragment = asQueryable(oobElementClone) // if this is not an inline swap, we use the content of the node, not the node itself
+            fragment = asParentNode(oobElementClone) // if this is not an inline swap, we use the content of the node, not the node itself
           }
 
           const beforeSwapDetails = { shouldSwap: true, target, fragment }
@@ -1467,7 +1463,7 @@ var htmx = (function() {
 
   /**
    * @param {Node} parentNode
-   * @param {Queryable} fragment
+   * @param {ParentNode} fragment
    * @param {HtmxSettleInfo} settleInfo
    */
   function handleAttributes(parentNode, fragment, settleInfo) {
@@ -1476,7 +1472,7 @@ var htmx = (function() {
       if (id && id.length > 0) {
         const normalizedId = id.replace("'", "\\'")
         const normalizedTag = newNode.tagName.replace(':', '\\:')
-        const parentElt = asQueryable(parentNode)
+        const parentElt = asParentNode(parentNode)
         const oldNode = parentElt && parentElt.querySelector(normalizedTag + "[id='" + normalizedId + "']")
         if (oldNode && oldNode !== parentElt) {
           const newAttributes = newNode.cloneNode()
@@ -1497,13 +1493,13 @@ var htmx = (function() {
     return function() {
       removeClassFromElement(child, htmx.config.addedClass)
       processNode(asElement(child))
-      processFocus(asQueryable(child))
+      processFocus(asParentNode(child))
       triggerEvent(child, 'htmx:load')
     }
   }
 
   /**
-   * @param {Queryable} child
+   * @param {ParentNode} child
    */
   function processFocus(child) {
     const autofocus = '[autofocus]'
@@ -1516,7 +1512,7 @@ var htmx = (function() {
   /**
    * @param {Node} parentNode
    * @param {Node} insertBefore
-   * @param {Queryable} fragment
+   * @param {ParentNode} fragment
    * @param {HtmxSettleInfo} settleInfo
    */
   function insertNodesBefore(parentNode, insertBefore, fragment, settleInfo) {
@@ -1614,7 +1610,7 @@ var htmx = (function() {
 
   /**
    * @param {Node} target
-   * @param {Queryable} fragment
+   * @param {ParentNode} fragment
    * @param {HtmxSettleInfo} settleInfo
    */
   function swapOuterHTML(target, fragment, settleInfo) {
@@ -1646,7 +1642,7 @@ var htmx = (function() {
 
   /**
    * @param {Node} target
-   * @param {Queryable} fragment
+   * @param {ParentNode} fragment
    * @param {HtmxSettleInfo} settleInfo
    */
   function swapAfterBegin(target, fragment, settleInfo) {
@@ -1655,7 +1651,7 @@ var htmx = (function() {
 
   /**
    * @param {Node} target
-   * @param {Queryable} fragment
+   * @param {ParentNode} fragment
    * @param {HtmxSettleInfo} settleInfo
    */
   function swapBeforeBegin(target, fragment, settleInfo) {
@@ -1664,7 +1660,7 @@ var htmx = (function() {
 
   /**
    * @param {Node} target
-   * @param {Queryable} fragment
+   * @param {ParentNode} fragment
    * @param {HtmxSettleInfo} settleInfo
    */
   function swapBeforeEnd(target, fragment, settleInfo) {
@@ -1673,7 +1669,7 @@ var htmx = (function() {
 
   /**
    * @param {Node} target
-   * @param {Queryable} fragment
+   * @param {ParentNode} fragment
    * @param {HtmxSettleInfo} settleInfo
    */
   function swapAfterEnd(target, fragment, settleInfo) {
@@ -1690,7 +1686,7 @@ var htmx = (function() {
 
   /**
    * @param {Node} target
-   * @param {Queryable} fragment
+   * @param {ParentNode} fragment
    * @param {HtmxSettleInfo} settleInfo
    */
   function swapInnerHTML(target, fragment, settleInfo) {
@@ -1710,7 +1706,7 @@ var htmx = (function() {
    * @param {HtmxSwapStyle} swapStyle
    * @param {Element} elt
    * @param {Node} target
-   * @param {Queryable} fragment
+   * @param {ParentNode} fragment
    * @param {HtmxSettleInfo} settleInfo
    */
   function swapWithStyle(swapStyle, elt, target, fragment, settleInfo) {
@@ -3081,7 +3077,7 @@ var htmx = (function() {
       if (this.status >= 200 && this.status < 400) {
         triggerEvent(getDocument().body, 'htmx:historyCacheMissLoad', details)
         const fragment = makeFragment(this.response)
-        /** @type Queryable */
+        /** @type ParentNode */
         const content = fragment.querySelector('[hx-history-elt],[data-hx-history-elt]') || fragment
         const historyElement = getHistoryElement()
         const settleInfo = makeSettleInfo(historyElement)
@@ -3378,7 +3374,7 @@ var htmx = (function() {
       processInputValue(processed, formData, errors, asElement(node), validate)
       // if a non-form is included, include any input values within it
       if (!matches(node, 'form')) {
-        forEach(asQueryable(node).querySelectorAll(INPUT_SELECTOR), function(descendant) {
+        forEach(asParentNode(node).querySelectorAll(INPUT_SELECTOR), function(descendant) {
           processInputValue(processed, formData, errors, descendant, validate)
         })
       }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -375,7 +375,7 @@ var htmx = (function() {
    * @returns {(string | null)}
    */
   function getRawAttribute(elt, name) {
-    return elt instanceof Element && elt.getAttribute && elt.getAttribute(name)
+    return elt instanceof Element && elt.getAttribute(name)
   }
 
   /**


### PR DESCRIPTION
# Highlights
- Added JSDoc basically everywhere
- Used parent types whenever possible _(i.e. Node instead of Element, Element instead of HTMLElement and so on)_
- Typescript types definition is now generated, using `npm run type-declarations`
- Inlined public API's functions within the `htmx` object itself as `tsc` would otherwise generate invalid TypeScript code
- I put all custom `typedef`s in the global scope so that `tsc` properly exports them, and at the bottom of the file as I thought it would be pretty annoying to have to scroll past 150~ lines of JSDoc to start reading the code
- To avoid making _too many_ changes to the code, I added a few `// @ts-ignore` in places where code _is_ valid but tsc is too strict

Tests pass, also ran the tests in the extensions repo, all clear


# Going further
If this is accepted, I would recommend going further with the following:
- Call `tsc` in the `npm t` script to have the pipeline check the code is correctly typed before merging PRs
- Make a custom JS script _(called with node in the npm command along tsc)_ to copy the JSDoc descriptions and default values hints _(as all JSDoc is lost along tsc's generation)_
