### PR TITLE
Add Recipya to the webring

### DIFF
--- a/www/content/webring.md
+++ b/www/content/webring.md
@@ -108,6 +108,7 @@ title = "htmx webring"
   <tr><td><a rel="nofollow" target="_blank" href="https://openunited.com/">OpenUnited</a></td><td>A Digital Talent match-making platform</td></tr>
   <tr><td><a rel="nofollow" target="_blank" href="https://gophemeral.com">Gophemeral</a></td><td>Share secrets securely!</td></tr>
   <tr><td><a rel="nofollow" target="_blank" href="https://signup.casa">Signup Casa</a></td><td>Simple, convenient sign-up forms.</td></tr>
+  <tr><td><a rel="nofollow" target="_blank" href="https://recipes.musicavis.ca">Recipya</a></td><td>A clean, simple and powerful recipe manager your whole family can enjoy.</td></tr>
 </tbody>
 </table>
 </div>


### PR DESCRIPTION
## Description
Adds [Recipya](https://recipes.musicavis.ca) to the webring.

Source code: https://github.com/reaper47/recipya
Where htmx is used: https://github.com/reaper47/recipya/tree/main/web/components

Corresponding issue:
N/A

## Testing
N/A: change to just the website

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
