### PR TITLE
2.0 Swap API Normalization + OOB swap modifier support

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1449,12 +1449,12 @@ var htmx = (function() {
               maybeDelay(doSettle, swapSpec.settleDelay)
             }
 
-            doSwap = wrapWithTransition(doSwap, swapSpec)
+            doSwap = wrapWithTransition(doSwap, swapSpec, swapOptions)
 
             try {
               maybeDelay(doSwap, swapSpec.swapDelay)
             } catch (e) {
-              triggerErrorEvent(elt, 'htmx:oobSwapError', swapOptions.eventInfo)
+              triggerErrorEvent(swapOptions.contextElement, 'htmx:oobSwapError', swapOptions.eventInfo)
             }
           }
         }
@@ -1846,6 +1846,10 @@ var htmx = (function() {
     if (!swapOptions) {
       swapOptions = {}
     }
+    // default contextElement for logging
+    if (!swapOptions.contextElement) {
+      swapOptions.contextElement = document.body
+    }
 
     target = resolveTarget(target)
 
@@ -1923,7 +1927,7 @@ var htmx = (function() {
       maybeDelay(doSettle, swapSpec.settleDelay)
     }
 
-    doSwap = wrapWithTransition(doSwap, swapSpec)
+    doSwap = wrapWithTransition(doSwap, swapSpec, swapOptions)
 
     try {
       maybeDelay(doSwap, swapSpec.swapDelay)
@@ -1948,8 +1952,9 @@ var htmx = (function() {
   /**
    * @param {Function} callback
    * @param {HtmxSwapSpecification} swapSpec
+   * @param {SwapOptions} swapOptions
    */
-  function wrapWithTransition(callback, swapSpec) {
+  function wrapWithTransition(callback, swapSpec, swapOptions) {
     let shouldTransition = htmx.config.globalViewTransitions
     if (swapSpec.hasOwnProperty('transition')) {
       shouldTransition = swapSpec.transition
@@ -1958,7 +1963,7 @@ var htmx = (function() {
     if (shouldTransition &&
           // @ts-ignore experimental feature atm
           document.startViewTransition) {
-      triggerEvent(elt, 'htmx:beforeTransition', swapSpec.eventInfo)
+      triggerEvent(swapOptions.contextElement, 'htmx:beforeTransition', swapSpec.eventInfo)
 
       // const innerCallback = callback
 
@@ -1999,7 +2004,6 @@ var htmx = (function() {
     updateScrollState(settleInfo.elts, swapSpec)
     if (swapOptions.afterSettleCallback) {
       swapOptions.afterSettleCallback()
-      // maybeCall(settleResolve)
     }
   }
 

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1846,7 +1846,7 @@ var htmx = (function() {
     if (!swapOptions) {
       swapOptions = {}
     }
-    // default contextElement for logging
+    // default contextElement for events
     if (!swapOptions.contextElement) {
       swapOptions.contextElement = document.body
     }
@@ -4966,7 +4966,6 @@ var htmx = (function() {
 /**
  * @typedef HtmxSwapSpecification
  * @property {HtmxSwapStyle} swapStyle
- * @property {string} swapStyleSelector
  * @property {number} swapDelay
  * @property {number} settleDelay
  * @property {boolean} [transition]

--- a/test/attributes/hx-swap-oob.js
+++ b/test/attributes/hx-swap-oob.js
@@ -162,4 +162,30 @@ describe('hx-swap-oob attribute', function() {
     byId('d1').innerHTML.should.equal('Test')
     byId('td1').innerHTML.should.equal('hey')
   })
+
+  it('oob swap works with a swap delay', function(done) {
+    this.server.respondWith('GET', '/test', "<div id='d2' hx-swap-oob='innerHTML swap:10ms'>Clicked!</div>")
+    var div = make("<div id='d1' hx-get='/test'></div>")
+    var div2 = make("<div id='d2'></div>")
+    div.click()
+    this.server.respond()
+    div2.innerText.should.equal('')
+    setTimeout(function() {
+      div2.innerText.should.equal('Clicked!')
+      done()
+    }, 30)
+  })
+
+  it('oob swap works with a settle delay', function(done) {
+    this.server.respondWith('GET', '/test', "<div id='d2' class='foo' hx-swap-oob='true settle:10ms'>Clicked!</div>")
+    var div = make("<div id='d1' hx-get='/test'></div>")
+    var div2 = make("<div id='d2'></div>")
+    div.click()
+    this.server.respond()
+    div2.classList.contains('foo').should.equal(false)
+    setTimeout(function() {
+      byId('d2').classList.contains('foo').should.equal(true)
+      done()
+    }, 30)
+  })
 })


### PR DESCRIPTION
## Description

This is a bugfix refactor for v2.0 that does the following:

- Normalizes the new `swap()` api to handle all modifiers internally such as view transitions, swap delay, and settle delay. Previously these features were limited to the XHR handler and would not work via other contexts, such as SSE/WS.
- Brings OOB swaps closer to being "first class swaps" as support for swap modifiers has been added to them.

```
# OOB Swap Example
<div hx-swap-oob="true:.selector transition:true swap:3s settle:2s"></div>
```

IMO These are both pretty important to ensure that all swaps work the same, no matter the type or context from which they are called. There are a couple issues about this specifically and maybe many tangential ones.

I didn't open an issue myself or start a discussion beforehand, but hoping to use this PR as the forum to determine the best way forward on this. Thanks!


## Testing

Added new tests for hx-swap-oob modifiers, swap: and settle:

```
npm run test
```

## Checklist

* [ X ] I have read the contribution guidelines
* [ X ] FOR 2.0...  I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ X ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ X ] I ran the test suite locally (`npm run test`) and verified that it succeeded
