### PR TITLE
docs: fix `this` binding in `onClick .then` handler with arrow function

### DIFF
--- a/www/content/examples/confirm.md
+++ b/www/content/examples/confirm.md
@@ -17,7 +17,7 @@ the and the [`htmx:confirm`](@/events.md#htmx:confirm) event.
 <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 <button hx-get="/confirmed" 
         hx-trigger='confirmed'
-        onClick="Swal.fire({title: 'Confirm', text:'Do you want to continue?'}).then(function(result){
+        onClick="Swal.fire({title: 'Confirm', text:'Do you want to continue?'}).then((result)=>{
             if(result.isConfirmed){
               htmx.trigger(this, 'confirmed');  
             } 


### PR DESCRIPTION
## Description
*Please describe what changes you made, and why you feel they are necessary. Make sure to include
code examples, where applicable.*

### What

Update the `.then()` handler in the `onClick` attribute to use an arrow function instead of a traditional `function(arg)` expression. 

### Why

The `window` scope was being accessed instead of the intended `button`.
This fixes the `this` binding within the lexical scope, ensuring that `this` is bound to the `button` instead of the `window` and resolving the issue.

Corresponding issue: #2257 

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

### Preview

The GIF demonstrates that clicking the button logs `this` to the console. The change ensures correct `this` binding, logging the specific button instead of the window.

```javascript
if (result.isConfirmed) {
    console.log(this);
    htmx.trigger(this, 'confirmed');
}
```

![Animation_htmx_arrow_fn](https://github.com/bigskysoftware/htmx/assets/76430758/e6a9afdd-eb22-4017-8418-631349f80934)

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
