### PR TITLE
WS.js fix for Safari on iOS 17.4

### DIFF
--- a/src/ext/sse.js
+++ b/src/ext/sse.js
@@ -37,10 +37,11 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 		 */
 		onEvent: function(name, evt) {
 
+			var parent = evt.target || evt.detail.elt;
 			switch (name) {
 
 				case "htmx:beforeCleanupElement":
-					var internalData = api.getInternalData(evt.target)
+					var internalData = api.getInternalData(parent)
 					// Try to remove remove an EventSource when elements are removed
 					if (internalData.sseEventSource) {
 						internalData.sseEventSource.close();
@@ -50,7 +51,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 
 				// Try to create EventSources when elements are processed
 				case "htmx:afterProcessNode":
-					ensureEventSourceOnElement(evt.target);
+					ensureEventSourceOnElement(parent);
 			}
 		}
 	});

--- a/src/ext/ws.js
+++ b/src/ext/ws.js
@@ -38,13 +38,14 @@ This extension adds support for WebSockets to htmx.  See /www/extensions/ws.md f
 		 * @param {Event} evt
 		 */
 		onEvent: function (name, evt) {
+			var parent = evt.target || evt.detail.elt;
 
 			switch (name) {
 
 				// Try to close the socket when elements are removed
 				case "htmx:beforeCleanupElement":
 
-					var internalData = api.getInternalData(evt.target)
+					var internalData = api.getInternalData(parent)
 
 					if (internalData.webSocket) {
 						internalData.webSocket.close();
@@ -53,8 +54,6 @@ This extension adds support for WebSockets to htmx.  See /www/extensions/ws.md f
 
 				// Try to create websockets when elements are processed
 				case "htmx:beforeProcessNode":
-					var parent = evt.target;
-
 					forEach(queryAttributeOnThisOrChildren(parent, "ws-connect"), function (child) {
 						ensureWebSocket(child)
 					});


### PR DESCRIPTION
## Description

Seems like Safari on iOS 17.4 doesn't correctly set `event.target` from custom events dispatched from JS. Earlier same issue occurred in my htmx-signalr extension: https://github.com/Renerick/htmx-signalr/pull/11

Corresponding issue: https://discord.com/channels/725789699527933952/1216185723229704222

## Testing

I've ran the test suite and verified that test server still works. However, I don't have iOS 17.4 device at hand, so will have to ask the user to verify if it works.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a **bugfix**, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
