### PR TITLE
docs: aria-selected true in Tabs HATEOS example

### DIFF
--- a/www/content/examples/tabs-hateoas.md
+++ b/www/content/examples/tabs-hateoas.md
@@ -16,7 +16,7 @@ Subsequent tab pages display all tabs and highlight the selected one accordingly
 
 ```html
 <div class="tab-list" role="tablist">
-	<button hx-get="/tab1" class="selected" role="tab" aria-selected="false" aria-controls="tab-content">Tab 1</button>
+	<button hx-get="/tab1" class="selected" role="tab" aria-selected="true" aria-controls="tab-content">Tab 1</button>
 	<button hx-get="/tab2" role="tab" aria-selected="false" aria-controls="tab-content">Tab 2</button>
 	<button hx-get="/tab3" role="tab" aria-selected="false" aria-controls="tab-content">Tab 3</button>
 </div>


### PR DESCRIPTION
## Description
The `aria-selected` attribute should be set to true in the first tab for consistency with the class `selected` being set.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
