### PR TITLE
Fix IE11 incompatibilities

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -138,12 +138,12 @@ return (function () {
 
         /**
          * @param {string} tag
-         * @param {boolean} global
+         * @param {boolean} [global]
          * @returns {RegExp}
          */
-        function makeTagRegEx(tag, global = false) {
-            return new RegExp(`<${tag}(\\s[^>]*>|>)([\\s\\S]*?)<\\/${tag}>`,
-                global ? 'gim' : 'im');
+        function makeTagRegEx(tag, global) {
+          return new RegExp('<' + tag + '(\\s[^>]*>|>)([\\s\\S]*?)<\\/' + tag + '>',
+            !!global ? 'gim' : 'im')
         }
 
         function parseInterval(str) {
@@ -1945,6 +1945,9 @@ return (function () {
 
         function shouldProcessHxOn(elt) {
             var attributes = elt.attributes
+            if (!attributes) {
+                return false
+            }
             for (var j = 0; j < attributes.length; j++) {
                 var attrName = attributes[j].name
                 if (startsWith(attrName, "hx-on:") || startsWith(attrName, "data-hx-on:") ||
@@ -1967,11 +1970,11 @@ return (function () {
                 var iter = document.evaluate('.//*[@*[ starts-with(name(), "hx-on:") or starts-with(name(), "data-hx-on:") or' +
                                                                            ' starts-with(name(), "hx-on-") or starts-with(name(), "data-hx-on-") ]]', elt)
                 while (node = iter.iterateNext()) elements.push(node)
-            } else {
+            } else if (typeof elt.getElementsByTagName === "function") {
                 var allElements = elt.getElementsByTagName("*")
                 for (var i = 0; i < allElements.length; i++) {
-                    if (shouldProcessHxOn(allElements[i])) {
-                        elements.push(allElements[i])
+                  if (shouldProcessHxOn(allElements[i])) {
+                      elements.push(allElements[i])
                     }
                 }
             }

--- a/test/core/ajax.js
+++ b/test/core/ajax.js
@@ -1237,6 +1237,11 @@ describe("Core htmx AJAX Tests", function(){
     })
 
     it('properly handles inputs external to form', function () {
+        if (!supportsFormAttribute()) {
+            this._runnable.title += " - Skipped as IE11 doesn't support form attribute"
+            this.skip()
+            return
+        }
         var values;
         this.server.respondWith("Post", "/test", function (xhr) {
             values = getParameters(xhr);
@@ -1287,6 +1292,11 @@ describe("Core htmx AJAX Tests", function(){
     })
 
     it("can associate submit buttons from outside a form with the current version of the form after swap", function(){
+        if (!supportsFormAttribute()) {
+            this._runnable.title += " - Skipped as IE11 doesn't support form attribute"
+            this.skip()
+            return
+        }
         const template = '<form ' +
               'id="hello" ' +
               'hx-target="#hello" ' +

--- a/test/core/regressions.js
+++ b/test/core/regressions.js
@@ -246,6 +246,11 @@ describe("Core htmx Regression Tests", function(){
     })
 
     it("script tags only execute once using templates", function(done) {
+        if (!supportsTemplates()) {
+            this._runnable.title += " - Skipped as IE11 doesn't support templates"
+            this.skip()
+            return
+        }
         var oldUseTemplateFragmentsValue = htmx.config.useTemplateFragments
         htmx.config.useTemplateFragments = true
 
@@ -267,6 +272,11 @@ describe("Core htmx Regression Tests", function(){
     })
 
     it("script tags only execute once when nested using templates", function(done) {
+        if (!supportsTemplates()) {
+            this._runnable.title += " - Skipped as IE11 doesn't support templates"
+            this.skip()
+            return
+        }
         var oldUseTemplateFragmentsValue = htmx.config.useTemplateFragments
         htmx.config.useTemplateFragments = true
 


### PR DESCRIPTION
## Description
Fixes some IE11 incompatibilities
- default parameter value in `function makeTagRegEx(tag, global = false)`, [not supported by IE11](https://caniuse.com/mdn-javascript_functions_default_parameters)
- string literals in that same function, [not supported by IE11](https://caniuse.com/template-literals) either
- the test utility functions call `htmx.processNode` on text nodes (i.e. not actual `Element`s). This fails gracefully on modern browsers but not so gracefully on IE11. Added 2 checks in hx-on processing functions, to avoid calling undefined references (a text node doesn't have `.attributes` neither `getElementsByTagName`)
- some tests cannot work on IE11 (unsupported features) but were simply not skipped, fixed that

Corresponding issue:

## Testing
See #1687 with the procedure to run tests on IE11

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
