### PR TITLE
Fix example for mustache in client-side-templates extension.

### DIFF
--- a/www/content/extensions/client-side-templates.md
+++ b/www/content/extensions/client-side-templates.md
@@ -81,7 +81,7 @@ a [`<template>` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/t
     <p id="content">Start</p>
 
     <template id="foo">
-      <p> {% raw %}{{userId}}{% endraw %} and {% raw %}{{id}}{% endraw %} and {% raw %}{{title}}{% endraw %} and {% raw %}{{completed}}{% endraw %}</p>
+      <p> {{userId}} and {{id}} and {{title}} and {{completed}}</p>
     </template>
   </div>
 </body>

--- a/www/content/extensions/client-side-templates.md
+++ b/www/content/extensions/client-side-templates.md
@@ -81,7 +81,7 @@ a [`<template>` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/t
     <p id="content">Start</p>
 
     <template id="foo">
-      <p> {% raw %}{{userID}}{% endraw %} and {% raw %}{{id}}{% endraw %} and {% raw %}{{title}}{% endraw %} and {% raw %}{{completed}}{% endraw %}</p>
+      <p> {% raw %}{{userId}}{% endraw %} and {% raw %}{{id}}{% endraw %} and {% raw %}{{title}}{% endraw %} and {% raw %}{{completed}}{% endraw %}</p>
     </template>
   </div>
 </body>


### PR DESCRIPTION
## Description
The unnecessary escape sequences were removed from the [mustache full example](https://htmx.org/extensions/client-side-templates/#full-mustache-html-example) as they broke the output.
The template key "UserID" was renamed to "UserId" as the [test API](https://jsonplaceholder.typicode.com/todos/1) uses "UserId". The old key name would result in a blank string as the keys wouldnt match.

Corresponding issue:
https://github.com/bigskysoftware/htmx/issues/2407

## Testing
I have tested the changed example in the docs. It is working correctly.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
