### PR TITLE
fix: Fire htmx:trigger event on delayed triggers

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2441,7 +2441,10 @@ var htmx = (function() {
               }, triggerSpec.throttle)
             }
           } else if (triggerSpec.delay > 0) {
-            elementData.delayed = getWindow().setTimeout(function() { handler(elt, evt) }, triggerSpec.delay)
+            elementData.delayed = getWindow().setTimeout(function() {
+              triggerEvent(elt, 'htmx:trigger')
+              handler(elt, evt)
+            }, triggerSpec.delay)
           } else {
             triggerEvent(elt, 'htmx:trigger')
             handler(elt, evt)

--- a/test/attributes/hx-trigger.js
+++ b/test/attributes/hx-trigger.js
@@ -939,6 +939,23 @@ describe('hx-trigger attribute', function() {
     }
   })
 
+  it('fires the htmx:trigger event for delayed triggers', function(done) {
+    var param = 'foo'
+    var handler = htmx.on('htmx:trigger', function(evt) {
+      param = 'bar'
+    })
+    var div = make('<button hx-trigger="click delay:10ms">Submit</button>')
+    div.click()
+    setTimeout(function() {
+      try {
+        should.equal(param, 'bar')
+        done()
+      } finally {
+        htmx.off('htmx:trigger', handler)
+      }
+    }, 50)
+  })
+
   it('filters support "this" reference to the current element', function() {
     this.server.respondWith('GET', '/test', 'Called!')
     var form = make('<form hx-get="/test" hx-trigger="click[this.classList.contains(\'bar\')]">Not Called</form>')


### PR DESCRIPTION
## Description
`hx-trigger` with delay modifier did not fire `htmx:trigger` event. This behavior was inconsistent with plain(non-delay) events.
Demo: https://jsfiddle.net/yu59noed/

## Testing
Added test case for delayed htmx:trigger. This test case failed on current dev branch.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
