### PR TITLE
Link to section on CSS Transitions instead of Mozilla page

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -1037,7 +1037,7 @@ Note that all client side validations must be re-done on the server side, as the
 
 ## Animations
 
-Htmx allows you to use [CSS transitions](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions)
+Htmx allows you to use [CSS transitions](#css_transitions)
 in many situations using only HTML and CSS.
 
 Please see the [Animation Guide](@/examples/animations.md) for more details on the options available.


### PR DESCRIPTION
## Description
In the Animations section of the documentation, I had expected that the link labeled "CSS Transitions" would jump me to the CSS Transitions section. Instead it redirected me to a Mozilla webpage which was unexpected.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
