### PR TITLE
Add passing test for hx-vals being sent to server on ws ext calls

### DIFF
--- a/test/ext/ws.js
+++ b/test/ext/ws.js
@@ -205,6 +205,21 @@ describe("web-sockets extension", function () {
         headers['HX-Target'].should.be.equal('target');
     })
 
+    it('sends hx-vals server', function () {
+        var div = make('<div hx-ext="ws" ws-connect="ws://localhost:8080" hx-vals="js:{theAnswer:42}"><button hx-trigger="click" hx-target="#target" ws-send id="d1" name="d1-name">div1</button><output id="target"></output></div>');
+        this.tickMock();
+
+        byId("d1").click();
+
+        this.tickMock();
+
+        this.messages.length.should.equal(1);
+        var message = JSON.parse(this.messages[0]);
+        var theAnswer = message.theAnswer;
+
+        theAnswer.should.be.equal(42);
+    })
+
     it('handles message from the server', function () {
         var div = make('<div hx-ext="ws" ws-connect="ws://localhost:8080"><div id="d1">div1</div><div id="d2">div2</div></div>');
         this.tickMock();

--- a/test/ext/ws.js
+++ b/test/ext/ws.js
@@ -205,7 +205,7 @@ describe("web-sockets extension", function () {
         headers['HX-Target'].should.be.equal('target');
     })
 
-    it('sends hx-vals server', function () {
+    it('sends hx-vals to the server', function () {
         var div = make('<div hx-ext="ws" ws-connect="ws://localhost:8080" hx-vals="js:{theAnswer:42}"><button hx-trigger="click" hx-target="#target" ws-send id="d1" name="d1-name">div1</button><output id="target"></output></div>');
         this.tickMock();
 


### PR DESCRIPTION
## Description

Added test to confirm hx-vals are being successfully sent on WebSocket extension calls. 

Corresponding issue: #2415

## Testing

This PR adds a test.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
