### PR TITLE
expose overrideFormData in internal API, use it in ws.js for hx-vals processing

### DIFF
--- a/src/ext/ws.js
+++ b/src/ext/ws.js
@@ -345,7 +345,7 @@ This extension adds support for WebSockets to htmx.  See /www/extensions/ws.md f
 				var errors = results.errors;
 				var rawParameters = results.values;
 				var expressionVars = api.getExpressionVars(sendElt);
-				var allParameters = api.mergeObjects(rawParameters, expressionVars);
+				var allParameters = api.overrideFormData(rawParameters, expressionVars);
 				var filteredParameters = api.filterValues(allParameters, sendElt);
 
 				var sendConfig = {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -318,6 +318,7 @@ var htmx = (function() {
     mergeObjects,
     makeSettleInfo,
     oobSwap,
+    overrideFormData,
     querySelectorExt,
     settleImmediately,
     shouldCancel,


### PR DESCRIPTION
## Description
After switching to FormData type for hx-vals, old implementation of ws.js that used mergeObjects was no longer working. This changes exposes method for merging FormData objects in the internal API and makes used of it in ws.js

Corresponding issue: bigskysoftware/htmx-extensions#10

## Testing
I tested it using the ws-sse test server

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a **bugfix**, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
