### PR TITLE
Ws fix hx vals number handling

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3736,7 +3736,7 @@ var htmx = (function() {
  * @returns {FormData}
  */
   function getExpressionVars(elt) {
-    return formDataFromObject(mergeObjects(getHXVarsForElement(elt), getHXValsForElement(elt)))
+    return mergeObjects(getHXVarsForElement(elt), getHXValsForElement(elt))
   }
 
   /**
@@ -4168,7 +4168,7 @@ var htmx = (function() {
     if (etc.values) {
       overrideFormData(rawFormData, formDataFromObject(etc.values))
     }
-    const expressionVars = getExpressionVars(elt)
+    const expressionVars = formDataFromObject(getExpressionVars(elt))
     const allFormData = overrideFormData(rawFormData, expressionVars)
     let filteredFormData = filterValues(allFormData, elt)
 


### PR DESCRIPTION
## Description
This is a continuation of #2417. It changes getExpressionVar to return JS object instead of FormData, converting it to FormData only when it's needed (in XHR request serialization) and utilizing it in ws js by using mergeObjects again
Corresponding issue:

## Testing
ws-sse test server, the tests are green. Draft as this solution has not been discussed yet

