### PR TITLE
bodyContains: Walk up the nested shadow root chain to check if the body contains the element

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -764,13 +764,16 @@ var htmx = (function() {
    * @returns {boolean}
    */
   function bodyContains(elt) {
-    // IE Fix
-    const rootNode = elt.getRootNode && elt.getRootNode()
-    if (rootNode && rootNode instanceof window.ShadowRoot) {
-      return getDocument().body.contains(rootNode.host)
-    } else {
-      return getDocument().body.contains(elt)
+    // Shortcut for older browsers missing getRootNode() to avoid checking
+    // the condition on every iteration.
+    if (!elt.getRootNode) {
+      return getDocument().body.contains(elt);
     }
+    // Escape from shadow root.
+    while (elt.getRootNode() instanceof window.ShadowRoot) {
+      elt = elt.getRootNode().host;
+    }
+    return getDocument().body.contains(elt);
   }
 
   /**


### PR DESCRIPTION
## Description

`bodyContains()` currently assumes that shadow root host element is always contained in the root body. That may not be the case and I experienced problem when nesting web components that rely on HTMX (e.g. `hx-get`. This change walks up the chain of shadow roots to find the topmost host element and verify for that one if it exists in the root body.

I did not find a corresponding issue, but I did find an older related issue: #718. I didn't file a new issue as it looks like a fairly straight-forward fix for what I think is just a bug.

## Testing
I ran this with my test site which uses nested web components ('open' shadow DOM) combined with HTMX. This change enabled `hx-get="..."` with `hx-target="click"` to work for me.

## Checklist
* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [X] I ran the test suite locally (`npm run test`) and verified that it succeeded
