### PR TITLE
Fix: htmx-request class removal for parallel requests

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3182,14 +3182,14 @@ var htmx = (function() {
   function removeRequestIndicators(indicators, disabled) {
     forEach(indicators, function(ic) {
       const internalData = getInternalData(ic)
-      internalData.requestCount = (internalData.requestCount || 0) - 1
+      internalData.requestCount = Math.max((internalData.requestCount || 0) - 1, 0)
       if (internalData.requestCount === 0) {
         ic.classList.remove.call(ic.classList, htmx.config.requestClass)
       }
     })
     forEach(disabled, function(disabledElement) {
       const internalData = getInternalData(disabledElement)
-      internalData.requestCount = (internalData.requestCount || 0) - 1
+      internalData.requestCount = Math.max((internalData.requestCount || 0) - 1, 0)
       if (internalData.requestCount === 0) {
         disabledElement.removeAttribute('disabled')
       }


### PR DESCRIPTION
## Description
This patch addresses a concurrency issue where the same indicator, when used for multiple parallel requests, could result in a negative request count. This issue prevented the proper removal of the `htmx-request` class upon completion of all requests.

The fix ensures accurate tracking of active requests.

## Testing
Test case for multiple requests with same indicator is already covered, but reproducing this race condition in test is hard.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
