### PR TITLE
Update confirm.md

### DIFF
--- a/www/content/examples/confirm.md
+++ b/www/content/examples/confirm.md
@@ -9,7 +9,7 @@ applications UX.
 
 In this example we will see how to use [sweetalert2](https://sweetalert2.github.io)  to implement a custom confirmation dialog. Below are two 
 examples, one using a click+custom event method, and one using the built-in `hx-confirm` attribute and
-the and the [`htmx:confirm`](@/events.md#htmx:confirm) event.
+the [`htmx:confirm`](@/events.md#htmx:confirm) event.
 
 ## Using on click+custom event
 


### PR DESCRIPTION
Fix typo - repeated "and the"

## Description
"and the and the" -> "and the" in the doc.

Corresponding issue: none

## Testing
Just the website change.

## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [-] [Only doc update, so not needed] I ran the test suite locally (`npm run test`) and verified that it succeeded
