### PR TITLE
Update hx-indicator.md

### DIFF
--- a/www/content/attributes/hx-indicator.md
+++ b/www/content/attributes/hx-indicator.md
@@ -81,7 +81,7 @@ This simulates what a spinner might look like in that situation:
 * `hx-indicator` is inherited and can be placed on a parent element
 * In the absence of an explicit indicator, the `htmx-request` class will be added to the element triggering the
   request
-* If you want to use your own CSS but still use `htmx-indicator` as class name, then you need to disable `includeIndicatorStyles`. See [Configuring htmx](@/docs.md#config). The easiest way is to add this the `<head>` of your HTML:
+* If you want to use your own CSS but still use `htmx-indicator` as class name, then you need to disable `includeIndicatorStyles`. See [Configuring htmx](@/docs.md#config). The easiest way is to add this to the `<head>` of your HTML:
 ```html
 <meta name="htmx-config" content='{"includeIndicatorStyles": false}'>
 ```


### PR DESCRIPTION
Fix typo: "add this the" -> "add this to the"

Fix typo - missing "to"

## Description
"and this the" -> "and this to the" in the doc.

Corresponding issue: none

## Testing
Just the website change.

## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [-] [Only doc update, so not needed] I ran the test suite locally (`npm run test`) and verified that it succeeded
