### PR TITLE
Additional note for `hx-select` in documentation

### DIFF
--- a/www/content/attributes/hx-select.md
+++ b/www/content/attributes/hx-select.md
@@ -21,3 +21,4 @@ which will replace the entire button in the DOM.
 ## Notes
 
 * `hx-select` is inherited and can be placed on a parent element
+* `hx-select="*"` will select the entire response content, which is the default behavior


### PR DESCRIPTION
Explain how to set hx-select behavior to the default, useful when behavior is inherited by a parent.

## Description
Spent a good hour trying to reset an `hx-select` attribute that was being inherited from a parent element. I knew the inheritance was causing the issue as that is mentioned here, but was unsure how to properly deal with it's implications, I hope this note will help others deal with this moving forward.

If you feel inclined, feel free to adjust my wording. 

Cheers.

## Testing
N/A

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
