### PR TITLE
Add reference to hx-preserve to the example at "Preserving File Inputs after Form Errors"

### DIFF
--- a/www/content/examples/file-upload-input.md
+++ b/www/content/examples/file-upload-input.md
@@ -5,7 +5,16 @@ template = "demo.html"
 
 When using server-side error handling and validation with forms that include both primitive values and file inputs, the file input's value is lost when the form returns with error messages. Consequently, users are required to re-upload the file, resulting in a less user-friendly experience.
 
-To overcome the problem of losing file input value in simple cases, you can adopt the following approach:
+To overcome the problem of losing the file input value, you can use the `hx-preserve` attribute on the input element:
+
+```html
+<form method="POST" id="binaryForm" enctype="multipart/form-data" hx-swap="outerHTML" hx-target="#binaryForm">
+    <input hx-preserve id="someId" type="file" name="binaryFile">
+    <button type="submit">Submit</button>
+</form>
+```
+
+Alternatively, you can restructure the form so that the file input is located outside the area that will be swapped.
 
 Before:
 

--- a/www/content/examples/file-upload-input.md
+++ b/www/content/examples/file-upload-input.md
@@ -5,16 +5,19 @@ template = "demo.html"
 
 When using server-side error handling and validation with forms that include both primitive values and file inputs, the file input's value is lost when the form returns with error messages. Consequently, users are required to re-upload the file, resulting in a less user-friendly experience.
 
-To overcome the problem of losing the file input value, you can use the `hx-preserve` attribute on the input element:
+To overcome the problem of losing the file input value, you can use the `hx-preserve` attribute on the `input` element:
 
 ```html
 <form method="POST" id="binaryForm" enctype="multipart/form-data" hx-swap="outerHTML" hx-target="#binaryForm">
     <input hx-preserve id="someId" type="file" name="binaryFile">
+    <!-- Other code here, such as input error handling. -->
     <button type="submit">Submit</button>
 </form>
 ```
 
-Alternatively, you can restructure the form so that the file input is located outside the area that will be swapped.
+If the file field is returned with errors on it, they will be displayed provided that `hx-preserve` was placed in the `input` only and not the element that would show the errors (e.g. `ol.errorlist`). If in a given circumstance you want the file upload input to return *without* preserving the user's chosen file (for example, because the file was an invalid type), you can manage that on the server side by omitting the `hx-preserve` attribute when the field has the relevant errors.
+
+Alternatively, you can preserve file inputs after form errors by restructuring the form so that the file input is located outside the area that will be swapped.
 
 Before:
 


### PR DESCRIPTION
## Description

I have added a second approach to preserving file inputs after form errors (in the example at *file-upload-input.md*), using `hx-preserve`. 

The approach currently suggested requires a restructuring of the form that will not always be feasible or convenient. I have found that adding `hx-preserve` to the file input 
causes the expected behavior: the user does not have to choose a file again before 
re-submitting the form.

The approach is:
```html
<form method="POST" id="binaryForm" enctype="multipart/form-data" hx-swap="outerHTML" hx-target="#binaryForm">
    <input hx-preserve id="someId" type="file" name="binaryFile">
    <button type="submit">Submit</button>
</form>
```

I feel this change is necessary because the current version of *file-upload-input.md* 
leaves the impression that there is no htmx attribute that can preserve the file input's 
value if the input is within the area that htmx will swap. I'm a little 
embarrassed to say that this is the conclusion I drew when I saw the current version of 
*file-upload-input.md* and I charged ahead and made an extension that moved my input out 
of the swap zone and put it back after the swap. My bad. But it might help others to 
point out that `hx-preserve` is available for this use case.

## Testing

My own testing on the `hx-preserve` approach shows it can acheive the following behaviour:

- if the form has errors and is returned, the original file input choice is preserved
  and the form can be successfully re-submitted. 

- if the file field has errors on it, they will be displayed provided that `hx-preserve` was
  placed in the `input` only and not the errors element (e.g. `ol.errorlist`)

- if you want the file upload input to return *without* the user's chosen file
  because the field was invalid, you can manage that on the server side by omitting 
  the `hx-preserve` attribute when the field has errors. (For example, if the user 
  chooses an invalid file type, you may want the file field to come back with no 
  value so the user is forced to make another choice.)

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
  - I have tried to target the `master` branch. Sorry if that didn't work!
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
  - Nope. This PR address documentation only, under `www`.