### PR TITLE
fix: Fix loading-state container reference in loading-states extension

### DIFF
--- a/src/ext/loading-states.js
+++ b/src/ext/loading-states.js
@@ -61,8 +61,10 @@
 
 	htmx.defineExtension('loading-states', {
 		onEvent: function (name, evt) {
+            var parent = evt.target || evt.detail.elt;
+
 			if (name === 'htmx:beforeRequest') {
-				const container = loadingStateContainer(evt.target)
+				const container = loadingStateContainer(parent)
 
 				const loadingStateTypes = [
 					'data-loading',


### PR DESCRIPTION
## Description

Applied fix as in https://github.com/bigskysoftware/htmx/commit/695fd8aa14404afc695ae96949ce61965fc2b3ae for loading-states extension.

Corresponding issue: https://github.com/bigskysoftware/htmx/issues/2450

## Testing

I tested it locally on MacOS M1 Sonoma with Safari 17.4.1

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
