### PR TITLE
Fix #2317 force conversion to FormData for xhr.send

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3591,7 +3591,9 @@ var htmx = (function() {
       return encodedParameters
     } else {
       if (usesFormData(elt)) {
-        return formDataFromObject(filteredParameters)
+        // Force conversion to an actual FormData object in case filteredParameters is a formDataProxy
+        // See https://github.com/bigskysoftware/htmx/issues/2317
+        return overrideFormData(new FormData(), formDataFromObject(filteredParameters))
       } else {
         return urlEncode(filteredParameters)
       }


### PR DESCRIPTION
## Description
In a `multipart/form-data` form, current implementation with the proxied FormData results in requests being malformed (wrong content type set to `text/plain`, FormData sent as `[object FormData]` in the payload)
Couldn't get the proxy object to work properly with XMLHTTPRequest's `send` method; even though calls are being forwarded to the underlying FormData through the proxy, the request won't set its type to `multipart/form-data` when appropriate and instead send a `text/plain` request.
One simple fix/workaround here is to copy the values into a new, actual FormData (not a proxied one)

Corresponding issue:
#2317 
Also see [this JSFiddle](https://jsfiddle.net/ftksy2wu/) to reproduce the issue

## Testing
Didn't know how to add a reliable test for this tbh, given that we mock the requests in our test suite

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
