### PR TITLE
Add apply-parent-classes feature to `class-tools`

### DIFF
--- a/src/ext/class-tools.js
+++ b/src/ext/class-tools.js
@@ -80,7 +80,14 @@
             if (name === "htmx:afterProcessNode") {
                 var elt = evt.detail.elt;
                 maybeProcessClasses(elt);
-                if (elt.querySelectorAll) {
+
+                var classList = elt.getAttribute("apply-parent-classes") || elt.getAttribute("data-apply-parent-classes");
+                if (classList) {
+                    var parent = elt.parentElement;
+                    parent.removeChild(elt);
+                    parent.setAttribute("classes", classList);
+                    maybeProcessClasses(parent);
+                } else if (elt.querySelectorAll) {
                     var children = elt.querySelectorAll("[classes], [data-classes]");
                     for (var i = 0; i < children.length; i++) {
                         maybeProcessClasses(children[i]);


### PR DESCRIPTION
This PR adds a very useful feature.

It reads any `apply-parent-classes` or `data-apply-parent-classes` nodes, and then applies the class changes to its _parent_.  The nodes are _removed_ afterwards and not left in the target; therefore they are transitional and only act as containers to the class modification commands.

This can be used to surgically add/remove classes in any DOM element via OOB updates..

For example, the following will add the `foo` class to `#my-element` after 1 second, then remove the `foo` class one second later, vanishing without a trace afterwards.  The net effect is direct OOB control by the server of client-side CSS classes.

```html
<div hx-swap-oob="beforeend: #my-element">
    <div apply-parent-classes="add foo:1s, remove bar:1s></div>
</div>
```

This is a way to non-intrusively affect the CSS classes of an element without knowing its content.
