### PR TITLE
Remove Node 15 requirement mention from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,6 @@ No time? Then [become a sponsor](https://github.com/sponsors/bigskysoftware#spon
 
 To develop htmx locally, you will need to install the development dependencies.
 
-__Requires Node 15.__
-
 Run:
 
 ```


### PR DESCRIPTION
## Description
_Disclaimer: targeting dev as htmx 2 isn't on master yet and htmx 1 still requires Node 15._
As per #2122, one may now use Node 20 or even 18, we finally don't require Node 15 specifically anymore,

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
