### PR TITLE
[2.0] Improve extension registration logic

### DIFF
--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -53,6 +53,7 @@ declare namespace htmx {
         const triggerSpecsCache: any | null;
         const disableInheritance: boolean;
         const responseHandling: HtmxResponseHandlingConfig[];
+        const allowNestedOobSwaps: boolean;
     }
     const parseInterval: (str: string) => number;
     const _: (str: string) => any;

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -323,8 +323,7 @@ var htmx = (function() {
     shouldCancel,
     triggerEvent,
     triggerErrorEvent,
-    withExtensions,
-    extensionEnabled
+    withExtensions
   }
 
   const VERBS = ['get', 'post', 'put', 'delete', 'patch']
@@ -2892,42 +2891,6 @@ var htmx = (function() {
         logError(e)
       }
     })
-  }
-
-  /**
-   * `extensionEnabled` checks if an extension with given name is active on an element.
-   * This method is intended to be used in the extension API
-   *
-   * @param {Element} elt
-   * @param {string} extensionName
-   * @returns {boolean}
-   */
-  function extensionEnabled(elt, extensionName, extensionsToReturn, extensionsToIgnore) {
-    if (extensionsToReturn == undefined) {
-      extensionsToReturn = []
-    }
-    if (elt == undefined) {
-      return extensionsToReturn.indexOf(extensionName) >= 0
-    }
-    if (extensionsToIgnore == undefined) {
-      extensionsToIgnore = []
-    }
-    const extensionsForElement = getAttributeValue(elt, 'hx-ext')
-    if (extensionsForElement) {
-      forEach(extensionsForElement.split(','), function(extensionName) {
-        extensionName = extensionName.replace(/ /g, '')
-        if (extensionName.slice(0, 7) == 'ignore:') {
-          extensionsToIgnore.push(extensionName.slice(7))
-          return
-        }
-        if (extensionsToIgnore.indexOf(extensionName) < 0) {
-          if (extensionName && extensionsToReturn.indexOf(extensionName) < 0) {
-            extensionsToReturn.push(extensionName)
-          }
-        }
-      })
-    }
-    return extensionEnabled(asElement(parentElt(elt)), extensionName, extensionsToReturn, extensionsToIgnore)
   }
 
   function logError(msg) {


### PR DESCRIPTION
## Description
This PR improves htmx extension registration by allowing extensions to contribute to the selector used in `findElementsToProcess`. This change makes extension initialization much simpler since it can just inform htmx about what elements it want to process without the need to look for them in processed fragments. This change nicely avoids double processing issue since deduplication logic is implemeted by `querySelectorAll` 

Corresponding issue: bigskysoftware/htmx-extensions#16

## Testing
Since 2.0 repo has no extension, tests for this behavior are added to corresponding extension directory over at bigskysoftware/htmx-extensions

see https://github.com/bigskysoftware/htmx-extensions/pull/18

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
