### PR TITLE
(website) Fix url to github stars

### DIFF
--- a/www/content/talk/index.md
+++ b/www/content/talk/index.md
@@ -28,7 +28,7 @@ Email: [htmx@bigsky.software](mailto:htmx@bigsky.software)
 
 ## GitHub Stars
 
-View a graph of github stars [here](https://star-history.com/embed?#bigskysoftware/htmx&bigskysoftware/_hyperscript&Date)
+View a graph of github stars [here](https://star-history.com/#bigskysoftware/htmx&Date)
 
 ## Webring
 


### PR DESCRIPTION
The old url doesn't work, this replaces it with one that does work.


Alternatively, if you would like to embed the graph in the page, you can use the following markdown.
```
[![Star History Chart](https://api.star-history.com/svg?repos=bigskysoftware/htmx&type=Date)](https://star-history.com/#bigskysoftware/htmx&Date)
```
[![Star History Chart](https://api.star-history.com/svg?repos=bigskysoftware/htmx&type=Date)](https://star-history.com/#bigskysoftware/htmx&Date)

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
