### PR TITLE
have bodyContains() recursively check elt's host

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -764,13 +764,16 @@ var htmx = (function() {
    * @returns {boolean}
    */
   function bodyContains(elt) {
-    // IE Fix
-    const rootNode = elt.getRootNode && elt.getRootNode()
-    if (rootNode && rootNode instanceof window.ShadowRoot) {
-      return getDocument().body.contains(rootNode.host)
-    } else {
-      return getDocument().body.contains(elt)
+    // if elt is inside a possibly-nested shadow root, we need to check the host
+    while (true) {
+      const rootNode = elt.getRootNode && elt.getRootNode()
+      if (rootNode && rootNode instanceof window.ShadowRoot) {
+        elt = rootNode.host
+      } else {
+        break
+      }
     }
+    return getDocument().body.contains(elt)
   }
 
   /**


### PR DESCRIPTION
## Description
Make bodyContains recursively check elt's host in case elt is in nested web components.

Corresponding issue:

## Testing
Tested by running htmx.process() on elements that are within nested web components.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
