### PR TITLE
Add capabilities to cancel an hx-trigger polling

### DIFF
--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -55,6 +55,7 @@ declare namespace htmx {
         const disableInheritance: boolean;
         const responseHandling: HtmxResponseHandlingConfig[];
         const allowNestedOobSwaps: boolean;
+        const cancelPollingOnError: boolean;
     }
     const parseInterval: (str: string) => number;
     const _: (str: string) => any;

--- a/test/attributes/hx-trigger.js
+++ b/test/attributes/hx-trigger.js
@@ -172,6 +172,77 @@ describe('hx-trigger attribute', function() {
     make('<div hx-trigger="every 10ms" hx-get="/test"/>')
   })
 
+  it('polling should be cancelled on error', function(complete) {
+    this.timeout(2000)
+    var completeTimeout = setTimeout(complete, 1000)
+
+    htmx.config.cancelPollingOnError = true
+    var requests = 0
+    this.server.autoRespond = true
+    this.server.respondWith('GET', '/test', function(xhr) {
+      requests++
+      var status = requests > 1 ? 500 : 200
+      xhr.respond(status, {}, 'Requests: ' + requests)
+    })
+
+    document.addEventListener('htmx:afterRequest', function(evt) {
+      if (requests > 2) {
+        clearTimeout(completeTimeout)
+        chai.assert.fail('Polling should have been cancelled')
+      }
+    })
+
+    make('<div hx-trigger="every 250ms" hx-get="/test"></div>')
+  })
+
+  it('polling should be cancelled by response header', function(complete) {
+    this.timeout(2000)
+    var completeTimeout = setTimeout(complete, 1000)
+
+    var requests = 0
+    this.server.autoRespond = true
+    this.server.respondWith('GET', '/test', function(xhr) {
+      requests++
+      xhr.respond(200, { 'HX-Cancel-Polling': 'true' }, 'Requests: ' + requests)
+    })
+
+    document.addEventListener('htmx:afterRequest', function(evt) {
+      if (requests > 2) {
+        clearTimeout(completeTimeout)
+        chai.assert.fail('Polling should have been cancelled')
+      }
+    })
+
+    make('<div hx-trigger="every 250ms" hx-get="/test"></div>')
+  })
+
+  it('polling should be cancelled by event', function(complete) {
+    this.timeout(2000)
+    var completeTimeout = setTimeout(complete, 1000)
+
+    var requests = 0
+    this.server.autoRespond = true
+    this.server.respondWith('GET', '/test', function(xhr) {
+      requests++
+      xhr.respond(200, {}, 'Requests: ' + requests)
+    })
+
+    document.addEventListener('htmx:cancelPolling', function(evt) {
+      if (requests > 1) {
+        evt.preventDefault()
+      }
+    })
+
+    document.addEventListener('htmx:afterRequest', function(evt) {
+      if (requests > 2) {
+        clearTimeout(completeTimeout)
+        chai.assert.fail('Polling should have been cancelled')
+      }
+    })
+
+    make('<div hx-trigger="every 250ms" hx-get="/test"></div>')
+  })
+
   it('non-default value works w/ data-* prefix', function() {
     this.server.respondWith('GET', '/test', 'Clicked!')
     var form = make('<form data-hx-get="/test" data-hx-trigger="click">Click Me!</form>')

--- a/www/content/api.md
+++ b/www/content/api.md
@@ -134,7 +134,8 @@ Note that using a [meta tag](@/docs.md#config) is the preferred mechanism for se
 * `selfRequestsOnly:true` - boolean: whether to only allow AJAX requests to the same domain as the current document
 * `ignoreTitle:false` - boolean: if set to `true` htmx will not update the title of the document when a `title` tag is found in new content
 * `scrollIntoViewOnBoost:true` - boolean: whether or not the target of a boosted element is scrolled into the viewport. If `hx-target` is omitted on a boosted element, the target defaults to `body`, causing the page to scroll to the top.
-* `triggerSpecsCache:null` - object: the cache to store evaluated trigger specifications into, improving parsing performance at the cost of more memory usage. You may define a simple object to use a never-clearing cache, or implement your own system using a [proxy object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy) |
+* `triggerSpecsCache:null` - object: the cache to store evaluated trigger specifications into, improving parsing performance at the cost of more memory usage. You may define a simple object to use a never-clearing cache, or implement your own system using a [proxy object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy)
+* `allowNestedOobSwaps:true` - boolean: process OOB swaps on elements that are nested within the main response element. See [Nested OOB Swaps](@/attributes/hx-swap-oob.md#nested-oob-swaps).
 
 ##### Example
 

--- a/www/content/api.md
+++ b/www/content/api.md
@@ -136,6 +136,7 @@ Note that using a [meta tag](@/docs.md#config) is the preferred mechanism for se
 * `scrollIntoViewOnBoost:true` - boolean: whether or not the target of a boosted element is scrolled into the viewport. If `hx-target` is omitted on a boosted element, the target defaults to `body`, causing the page to scroll to the top.
 * `triggerSpecsCache:null` - object: the cache to store evaluated trigger specifications into, improving parsing performance at the cost of more memory usage. You may define a simple object to use a never-clearing cache, or implement your own system using a [proxy object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy)
 * `allowNestedOobSwaps:true` - boolean: process OOB swaps on elements that are nested within the main response element. See [Nested OOB Swaps](@/attributes/hx-swap-oob.md#nested-oob-swaps).
+* `cancelPollingOnError:false` - boolean: if set to `true` an hx-trigger polling would be cancelled if a response error (status not 200) occurs.
 
 ##### Example
 

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -306,8 +306,19 @@ This tells htmx
 
 > Every 2 seconds, issue a GET to /news and load the response into the div
 
-If you want to stop polling from a server response you can respond with the HTTP response code [`286`](https://en.wikipedia.org/wiki/86_(term))
-and the element will cancel the polling.
+By default htmx will not interrupt the polling in case of an error. This can be achieved with the
+configuration option [htmx.config.cancelPollingOnError](@/reference.md#config).
+
+If you want to cancel the polling manually you can use the event [htmx:cancelPolling](@/events.md#htmx:cancelPolling)
+or the HTTP response header `HX-Cancel-Polling` with `true` and the element will cancel the polling.
+
+```javascript
+document.addEventListener('htmx:cancelPolling', function(evt) {
+    if (evt.detail.xhr.status !== 200) {
+      evt.preventDefault();
+    }
+});
+```
 
 #### Load Polling {#load_polling}
 
@@ -1032,6 +1043,7 @@ htmx includes a number of useful headers in requests:
 
 htmx supports some htmx-specific response headers:
 
+* `HX-Cancel-Polling` - if set to "true" the client-side will cancel the related polling
 * [`HX-Location`](@/headers/hx-location.md) - allows you to do a client-side redirect that does not do a full page reload
 * [`HX-Push-Url`](@/headers/hx-push-url.md) - pushes a new url into the history stack
 * `HX-Redirect` - can be used to do a client-side redirect to a new location

--- a/www/content/events.md
+++ b/www/content/events.md
@@ -153,6 +153,27 @@ happen instead.
 * `detail.requestConfig` - the configuration of the AJAX request
 * `detail.shouldSwap` - if the content will be swapped (defaults to `false` for non-200 response codes)
 * `detail.target` - the target of the swap
+* 
+### Event - `htmx:cancelPolling` {#htmx:cancelPolling}
+
+This event can be used to programmatically cancel an [hx-trigger polling](@/attributes/hx-trigger.md#polling).
+If you want to cancel an [hx-trigger polling](@/attributes/hx-trigger.md#polling) in the case of errors only,
+consider using [htmx.config.cancelPollingOnError](@/reference.md#config) instead.
+
+```javascript
+document.addEventListener('htmx:cancelPolling', function(evt) {
+    if (evt.detail.xhr.status !== 200) {
+      evt.preventDefault();
+    }
+});
+```
+
+##### Details
+
+* `detail.elt` - the element that dispatched the request
+* `detail.xhr` - the `XMLHttpRequest`
+* `detail.requestConfig` - the configuration of the AJAX request
+* `detail.target` - the target of the swap
 
 ### Event - `htmx:configRequest` {#htmx:configRequest}
 

--- a/www/content/reference.md
+++ b/www/content/reference.md
@@ -110,6 +110,7 @@ All other attributes available in htmx.
 
 | Header                                               | Description |
 |------------------------------------------------------|-------------|
+| `HX-Cancel-Polling`                                  | if set to "true" the client-side will cancel the related polling |
 | [`HX-Location`](@/headers/hx-location.md)            | allows you to do a client-side redirect that does not do a full page reload
 | [`HX-Push-Url`](@/headers/hx-push-url.md)            | pushes a new url into the history stack
 | `HX-Redirect`                                        | can be used to do a client-side redirect to a new location
@@ -250,6 +251,7 @@ listed below:
 | `htmx.config.scrollIntoViewOnBoost`   | defaults to `true`, whether or not the target of a boosted element is scrolled into the viewport. If `hx-target` is omitted on a boosted element, the target defaults to `body`, causing the page to scroll to the top. |
 | `htmx.config.triggerSpecsCache`       | defaults to `null`, the cache to store evaluated trigger specifications into, improving parsing performance at the cost of more memory usage. You may define a simple object to use a never-clearing cache, or implement your own system using a [proxy object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy) |
 | `htmx.config.allowNestedOobSwaps`     | defaults to `true`, whether to process OOB swaps on elements that are nested within the main response element. See [Nested OOB Swaps](@/attributes/hx-swap-oob.md#nested-oob-swaps). |
+| `htmx.config.cancelPollingOnError`     | defaults to `false`, whether an hx-trigger polling should be cancelled if a response error (status not 200) occurs. |
 
 </div>
 


### PR DESCRIPTION
## Description
This adds three ways to cancel an [hx-trigger polling](https://htmx.org/attributes/hx-trigger/#polling). The first is a new configuration option `htmx.config.cancelPollingOnError`, which can be activated to cancel an hx-trigger polling in case of an error (status not 200). The second is a new event `htmx:cancelPolling` and the third is a new response header `HX-Cancel-Polling`.

```js
document.addEventListener('htmx:cancelPolling', function(evt) {
    if (evt.detail.xhr.status !== 200) {
      evt.preventDefault();
    }
});
```

Corresponding issue: #2489

## Testing
Unit tests added.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
