### PR TITLE
Allow non-id selectors in `hx-select-oob` to fix #2561

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -864,13 +864,12 @@ return (function () {
             if (oobSelects) {
                 var oobSelectValues = oobSelects.split(",");
                 for (var i = 0; i < oobSelectValues.length; i++) {
-                    var oobSelectValue = oobSelectValues[i].split(":", 2);
-                    var id = oobSelectValue[0].trim();
-                    if (id.indexOf("#") === 0) {
-                        id = id.substring(1);
-                    }
-                    var oobValue = oobSelectValue[1] || "true";
-                    var oobElement = fragment.querySelector("#" + id);
+                    const oobSelectValue = oobSelectValues[i]
+                    // Support colon in css selectors
+                    const colon = oobSelectValue.lastIndexOf(':')
+                    const split_at = colon == -1 ? oobSelectValue.length : colon
+                    const oobValue = oobSelectValue.substring(split_at + 1) || 'true'
+                    const oobElement = fragment.querySelector(oobSelectValue.substring(0, split_at))
                     if (oobElement) {
                         oobSwap(oobValue, oobElement, settleInfo);
                     }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -864,12 +864,12 @@ return (function () {
             if (oobSelects) {
                 var oobSelectValues = oobSelects.split(",");
                 for (var i = 0; i < oobSelectValues.length; i++) {
-                    const oobSelectValue = oobSelectValues[i]
+                    var oobSelectValue = oobSelectValues[i]
                     // Support colon in css selectors
-                    const colon = oobSelectValue.lastIndexOf(':')
-                    const split_at = colon == -1 ? oobSelectValue.length : colon
-                    const oobValue = oobSelectValue.substring(split_at + 1) || 'true'
-                    const oobElement = fragment.querySelector(oobSelectValue.substring(0, split_at))
+                    var colon = oobSelectValue.lastIndexOf(':')
+                    var split_at = colon == -1 ? oobSelectValue.length : colon
+                    var oobValue = oobSelectValue.substring(split_at + 1) || 'true'
+                    var oobElement = fragment.querySelector(oobSelectValue.substring(0, split_at))
                     if (oobElement) {
                         oobSwap(oobValue, oobElement, settleInfo);
                     }

--- a/test/attributes/hx-select-oob.js
+++ b/test/attributes/hx-select-oob.js
@@ -49,6 +49,38 @@ describe("hx-select-oob attribute", function () {
         div2.innerHTML.should.equal("");
     });
 
-
+  it('supports different swap styles', function()
+  {
+      this.server.respondWith('GET', '/test', "<div id='d1'>foo</div><ul id='d2'><li>baz</li></ul>")
+      var div = make('<div hx-get="/test" hx-select="#d1" hx-select-oob="#d2:beforeend"></div>')
+      make('<ul id="d2"><li>bar</li></ul>')
+      div.click()
+      this.server.respond()
+      div.innerHTML.should.equal('<div id="d1">foo</div>')
+      var list = byId('d2')
+      list.innerHTML.should.equal('<li>bar</li><li>baz</li>')
+  })
+  it('supports non-id selectors', function()
+  {
+      this.server.respondWith('GET', '/test', "<div id='d1'>foo</div><div id='d2' identifier='something-else'>bar</div>")
+      var div = make('<div hx-get="/test" hx-select="#d1" hx-select-oob="div[identifier=\'something-else\']"></div>')
+      make('<div id="d2"></div>')
+      div.click()
+      this.server.respond()
+      div.innerHTML.should.equal('<div id="d1">foo</div>')
+      var div2 = byId('d2')
+      div2.innerHTML.should.equal('bar')
+  })
+  it('supports non-id selectors with colons', function()
+  {
+      this.server.respondWith('GET', '/test', "<div id='d1'>foo</div><div id='d2'>bar</div><div id='d3'>baz</div>")
+      var div = make('<div hx-get="/test" hx-select="#d1" hx-select-oob="#d2:has(~ #d3)"></div>')
+      make('<div id="d2"></div>')
+      div.click()
+      this.server.respond()
+      div.innerHTML.should.equal('<div id="d1">foo</div>')
+      var div2 = byId('d2')
+      div2.innerHTML.should.equal('bar')
+  })
 });
 

--- a/test/attributes/hx-select-oob.js
+++ b/test/attributes/hx-select-oob.js
@@ -74,13 +74,13 @@ describe("hx-select-oob attribute", function () {
   it('supports non-id selectors with colons', function()
   {
       this.server.respondWith('GET', '/test', "<div id='d1'>foo</div><div id='d2'>bar</div><div id='d3'>baz</div>")
-      var div = make('<div hx-get="/test" hx-select="#d1" hx-select-oob="#d2:has(~ #d3)"></div>')
+      var div = make('<div id="d4" hx-get="/test" hx-select="#d1" hx-select-oob="#d2:has(~ #d3):innerHTML"></div>')
       make('<div id="d2"></div>')
       div.click()
       this.server.respond()
-      div.innerHTML.should.equal('<div id="d1">foo</div>')
       var div2 = byId('d2')
       div2.innerHTML.should.equal('bar')
+      div.innerHTML.should.equal('<div id="d1">foo</div>')
   })
 });
 


### PR DESCRIPTION
## Description
This pull request fixes #2561. I retargeted it against `v1` as suggested on discord. I found this issue with the `hx-select-oob` attribute while trying to help a beginner on discord. This technically breaks an obscure behavior of adding back `#` to a selector if it does not begin with a `#`. This behavior is neither documented nor tested. In fact, the documentation suggests you can use this with any CSS selector, not just id selectors(though it does not give an example). 

> Each value in the comma separated list of values can specify any valid [hx-swap](https://htmx.org/attributes/hx-swap/) strategy by separating the selector and the swap strategy with a :.

As I have explained in the issue, this can cause really strange behavior when combined with non-id selectors by reinterpreting them as id selectors(and that too not even properly).

## Testing
I added tests for non-id selectors and tests for non-id selectors with colons. I also added missing tests for `hx-select-oob` with different swap styles

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
