### PR TITLE
Fix: specify all arguments to document.evaluate

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1968,7 +1968,7 @@ return (function () {
 
             if (document.evaluate) {
                 var iter = document.evaluate('.//*[@*[ starts-with(name(), "hx-on:") or starts-with(name(), "data-hx-on:") or' +
-                                                                           ' starts-with(name(), "hx-on-") or starts-with(name(), "data-hx-on-") ]]', elt)
+                                                                           ' starts-with(name(), "hx-on-") or starts-with(name(), "data-hx-on-") ]]', elt, null, 0, null)
                 while (node = iter.iterateNext()) elements.push(node)
             } else if (typeof elt.getElementsByTagName === "function") {
                 var allElements = elt.getElementsByTagName("*")


### PR DESCRIPTION
## Description
Fixes https://github.com/bigskysoftware/htmx/issues/2581. Adds the following arguments to [document.evaluate](https://developer.mozilla.org/en-US/docs/Web/API/Document/evaluate):

- namespaceResolver: null (for HTML documents)
- resultType: 0 (ANY_TYPE)
- result: null (unused, return value in use)

Issue was also resolved in the PaleMoon browser in https://repo.palemoon.org/MoonchildProductions/UXP/commit/43862ee764f6a409ace73ef034b8f854690269b3 with the same arguments.

## Testing
`npm run test` did not work locally because of ECONNREFUSED error with `mocha-chrome`. No manual testing performed. Feel free to close issue and PR if that's not enough.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
