### PR TITLE
feat(hx-trigger): add support for rootMargin on intersect

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2179,7 +2179,7 @@ var htmx = (function() {
               triggerSpec[token] = consumeUntil(tokens, WHITESPACE_OR_COMMA)
             } else if (token === 'rootMargin' && tokens[0] === ':') {
               tokens.shift()
-              triggerSpec[token] = consumeUntil(tokens, WHITESPACE).replace(/_/g, ' ')
+              triggerSpec[token] = consumeUntil(tokens, /,|(root)|(threshold)/).replace(/_/g, ' ')
             } else {
               triggerErrorEvent(elt, 'htmx:syntax:error', { token: tokens.shift() })
             }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2177,6 +2177,9 @@ var htmx = (function() {
             } else if (token === 'threshold' && tokens[0] === ':') {
               tokens.shift()
               triggerSpec[token] = consumeUntil(tokens, WHITESPACE_OR_COMMA)
+            } else if (token === 'rootMargin' && tokens[0] === ':') {
+              tokens.shift()
+              triggerSpec[token] = consumeUntil(tokens, WHITESPACE).replace(/_/g, ' ')
             } else {
               triggerErrorEvent(elt, 'htmx:syntax:error', { token: tokens.shift() })
             }
@@ -2567,6 +2570,9 @@ var htmx = (function() {
       }
       if (triggerSpec.threshold) {
         observerOptions.threshold = parseFloat(triggerSpec.threshold)
+      }
+      if (triggerSpec.rootMargin) {
+        observerOptions.rootMargin = triggerSpec.rootMargin
       }
       const observer = new IntersectionObserver(function(entries) {
         for (let i = 0; i < entries.length; i++) {
@@ -5010,6 +5016,7 @@ var htmx = (function() {
  * @property {string} [queue]
  * @property {string} [root]
  * @property {string} [threshold]
+ * @property {string} [rootMargin]
  */
 
 /**

--- a/www/content/attributes/hx-trigger.md
+++ b/www/content/attributes/hx-trigger.md
@@ -98,7 +98,7 @@ There are some additional non-standard events that htmx supports:
 * `intersect` - fires once when an element first intersects the viewport.  This supports two additional options:
     * `root:<selector>` - a CSS selector of the root element for intersection
     * `threshold:<float>` - a floating point number between 0.0 and 1.0, indicating what amount of intersection to fire the event on
-    * `rootMargin:<margin>` - a string, formatted similarly to a CSS margin, but only with support for pixels and percentages. To specify multiple directions, separate the values with `_`, e.g., `10px_20px_30px_40px`
+    * `rootMargin:<margin>` - a string, formatted similarly to a CSS margin, but only with support for pixels and percentages. For example, `20%` or `10px 20px 30px 40px`.
 
 ### Triggering via the `HX-Trigger` header
 

--- a/www/content/attributes/hx-trigger.md
+++ b/www/content/attributes/hx-trigger.md
@@ -98,6 +98,7 @@ There are some additional non-standard events that htmx supports:
 * `intersect` - fires once when an element first intersects the viewport.  This supports two additional options:
     * `root:<selector>` - a CSS selector of the root element for intersection
     * `threshold:<float>` - a floating point number between 0.0 and 1.0, indicating what amount of intersection to fire the event on
+    * `rootMargin:<margin>` - a string, formatted similarly to a CSS margin, but only with support for pixels and percentages. To specify multiple directions, separate the values with `_`, e.g., `10px_20px_30px_40px`
 
 ### Triggering via the `HX-Trigger` header
 


### PR DESCRIPTION
## Description

Add support for [`rootMargin`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/rootMargin) in `intersect` triggers. This allows us to extend the size of the intersect area. I've selected to separate multiple values using underscores, similar to how [Tailwind](https://tailwindcss.com/docs/content#using-spaces-and-underscores) solves it.

Corresponding issue: #1349 

## Testing

I've tested it locally using one of my own projects. I didn't find any tests for the `intersect` modifiers, so I couldn't find anything to base new tests on.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
