### PR TITLE
fix: head-support race condition #2599

### DIFF
--- a/dist/ext/head-support.js
+++ b/dist/ext/head-support.js
@@ -3,144 +3,170 @@
 //
 // An extension to htmx 1.0 to add head tag merging.
 //==========================================================
-(function(){
+(function () {
+	if (htmx.version && !htmx.version.startsWith('1.')) {
+		console.warn(
+			'WARNING: You are using an htmx 1 extension with htmx ' +
+				htmx.version +
+				'.  It is recommended that you move to the version of this extension found on https://extensions.htmx.org'
+		);
+	}
 
-    if (htmx.version && !htmx.version.startsWith("1.")) {
-        console.warn("WARNING: You are using an htmx 1 extension with htmx " + htmx.version +
-            ".  It is recommended that you move to the version of this extension found on https://extensions.htmx.org")
-    }
+	var api = null;
 
-    var api = null;
+	function log() {
+		//console.log(arguments);
+	}
 
-    function log() {
-        //console.log(arguments);
-    }
+	function mergeHead(newContent, defaultMergeStrategy) {
+		if (newContent && newContent.indexOf('<head') > -1) {
+			const htmlDoc = document.createElement('html');
+			// remove svgs to avoid conflicts
+			var contentWithSvgsRemoved = newContent.replace(
+				/<svg(\s[^>]*>|>)([\s\S]*?)<\/svg>/gim,
+				''
+			);
+			// extract head tag
+			var headTag = contentWithSvgsRemoved.match(
+				/(<head(\s[^>]*>|>)([\s\S]*?)<\/head>)/im
+			);
 
-    function mergeHead(newContent, defaultMergeStrategy) {
+			// if the  head tag exists...
+			if (headTag) {
+				var added = [];
+				var removed = [];
+				var preserved = [];
+				var nodesToAppend = [];
 
-        if (newContent && newContent.indexOf('<head') > -1) {
-            const htmlDoc = document.createElement("html");
-            // remove svgs to avoid conflicts
-            var contentWithSvgsRemoved = newContent.replace(/<svg(\s[^>]*>|>)([\s\S]*?)<\/svg>/gim, '');
-            // extract head tag
-            var headTag = contentWithSvgsRemoved.match(/(<head(\s[^>]*>|>)([\s\S]*?)<\/head>)/im);
+				htmlDoc.innerHTML = headTag;
+				var newHeadTag = htmlDoc.querySelector('head');
+				var currentHead = document.head;
 
-            // if the  head tag exists...
-            if (headTag) {
+				if (newHeadTag == null) {
+					return;
+				} else {
+					// put all new head elements into a Map, by their outerHTML
+					var srcToNewHeadNodes = new Map();
+					for (const newHeadChild of newHeadTag.children) {
+						srcToNewHeadNodes.set(newHeadChild.outerHTML, newHeadChild);
+					}
+				}
 
-                var added = []
-                var removed = []
-                var preserved = []
-                var nodesToAppend = []
+				// determine merge strategy
+				var mergeStrategy =
+					api.getAttributeValue(newHeadTag, 'hx-head') || defaultMergeStrategy;
 
-                htmlDoc.innerHTML = headTag;
-                var newHeadTag = htmlDoc.querySelector("head");
-                var currentHead = document.head;
+				// get the current head
+				for (const currentHeadElt of currentHead.children) {
+					// If the current head element is in the map
+					var inNewContent = srcToNewHeadNodes.has(currentHeadElt.outerHTML);
+					var isReAppended =
+						currentHeadElt.getAttribute('hx-head') === 're-eval';
+					var isPreserved =
+						api.getAttributeValue(currentHeadElt, 'hx-preserve') === 'true';
+					if (inNewContent || isPreserved) {
+						if (isReAppended) {
+							// remove the current version and let the new version replace it and re-execute
+							removed.push(currentHeadElt);
+						} else {
+							// this element already exists and should not be re-appended, so remove it from
+							// the new content map, preserving it in the DOM
+							srcToNewHeadNodes.delete(currentHeadElt.outerHTML);
+							preserved.push(currentHeadElt);
+						}
+					} else {
+						if (mergeStrategy === 'append') {
+							// we are appending and this existing element is not new content
+							// so if and only if it is marked for re-append do we do anything
+							if (isReAppended) {
+								removed.push(currentHeadElt);
+								nodesToAppend.push(currentHeadElt);
+							}
+						} else {
+							// if this is a merge, we remove this content since it is not in the new head
+							if (
+								api.triggerEvent(document.body, 'htmx:removingHeadElement', {
+									headElement: currentHeadElt,
+								}) !== false
+							) {
+								removed.push(currentHeadElt);
+							}
+						}
+					}
+				}
 
-                if (newHeadTag == null) {
-                    return;
-                } else {
-                    // put all new head elements into a Map, by their outerHTML
-                    var srcToNewHeadNodes = new Map();
-                    for (const newHeadChild of newHeadTag.children) {
-                        srcToNewHeadNodes.set(newHeadChild.outerHTML, newHeadChild);
-                    }
-                }
+				// Push the tremaining new head elements in the Map into the
+				// nodes to append to the head tag
+				nodesToAppend.push(...srcToNewHeadNodes.values());
+				log('to append: ', nodesToAppend);
 
+				for (const newNode of nodesToAppend) {
+					log('adding: ', newNode);
+					var newElt = document
+						.createRange()
+						.createContextualFragment(newNode.outerHTML);
+					log(newElt);
+					if (
+						api.triggerEvent(document.body, 'htmx:addingHeadElement', {
+							headElement: newElt,
+						}) !== false
+					) {
+						currentHead.appendChild(newElt);
+						added.push(newElt);
+					}
+				}
 
+				// remove all removed elements, after we have appended the new elements to avoid
+				// additional network requests for things like style sheets
+				for (const removedElement of removed) {
+					if (
+						api.triggerEvent(document.body, 'htmx:removingHeadElement', {
+							headElement: removedElement,
+						}) !== false
+					) {
+						currentHead.removeChild(removedElement);
+					}
+				}
 
-                // determine merge strategy
-                var mergeStrategy = api.getAttributeValue(newHeadTag, "hx-head") || defaultMergeStrategy;
+				api.triggerEvent(document.body, 'htmx:afterHeadMerge', {
+					added: added,
+					kept: preserved,
+					removed: removed,
+				});
+			}
+		}
+	}
 
-                // get the current head
-                for (const currentHeadElt of currentHead.children) {
+	htmx.defineExtension('head-support', {
+		init: function (apiRef) {
+			// store a reference to the internal API.
+			api = apiRef;
 
-                    // If the current head element is in the map
-                    var inNewContent = srcToNewHeadNodes.has(currentHeadElt.outerHTML);
-                    var isReAppended = currentHeadElt.getAttribute("hx-head") === "re-eval";
-                    var isPreserved = api.getAttributeValue(currentHeadElt, "hx-preserve") === "true";
-                    if (inNewContent || isPreserved) {
-                        if (isReAppended) {
-                            // remove the current version and let the new version replace it and re-execute
-                            removed.push(currentHeadElt);
-                        } else {
-                            // this element already exists and should not be re-appended, so remove it from
-                            // the new content map, preserving it in the DOM
-                            srcToNewHeadNodes.delete(currentHeadElt.outerHTML);
-                            preserved.push(currentHeadElt);
-                        }
-                    } else {
-                        if (mergeStrategy === "append") {
-                            // we are appending and this existing element is not new content
-                            // so if and only if it is marked for re-append do we do anything
-                            if (isReAppended) {
-                                removed.push(currentHeadElt);
-                                nodesToAppend.push(currentHeadElt);
-                            }
-                        } else {
-                            // if this is a merge, we remove this content since it is not in the new head
-                            if (api.triggerEvent(document.body, "htmx:removingHeadElement", {headElement: currentHeadElt}) !== false) {
-                                removed.push(currentHeadElt);
-                            }
-                        }
-                    }
-                }
+			htmx.on('htmx:afterSettle', function (evt) {
+				var serverResponse = evt.detail.xhr.response;
+				if (
+					api.triggerEvent(document.body, 'htmx:beforeHeadMerge', evt.detail)
+				) {
+					mergeHead(serverResponse, evt.detail.boosted ? 'merge' : 'append');
+				}
+			});
 
-                // Push the tremaining new head elements in the Map into the
-                // nodes to append to the head tag
-                nodesToAppend.push(...srcToNewHeadNodes.values());
-                log("to append: ", nodesToAppend);
+			htmx.on('htmx:historyRestore', function (evt) {
+				if (
+					api.triggerEvent(document.body, 'htmx:beforeHeadMerge', evt.detail)
+				) {
+					if (evt.detail.cacheMiss) {
+						mergeHead(evt.detail.serverResponse, 'merge');
+					} else {
+						mergeHead(evt.detail.item.head, 'merge');
+					}
+				}
+			});
 
-                for (const newNode of nodesToAppend) {
-                    log("adding: ", newNode);
-                    var newElt = document.createRange().createContextualFragment(newNode.outerHTML);
-                    log(newElt);
-                    if (api.triggerEvent(document.body, "htmx:addingHeadElement", {headElement: newElt}) !== false) {
-                        currentHead.appendChild(newElt);
-                        added.push(newElt);
-                    }
-                }
-
-                // remove all removed elements, after we have appended the new elements to avoid
-                // additional network requests for things like style sheets
-                for (const removedElement of removed) {
-                    if (api.triggerEvent(document.body, "htmx:removingHeadElement", {headElement: removedElement}) !== false) {
-                        currentHead.removeChild(removedElement);
-                    }
-                }
-
-                api.triggerEvent(document.body, "htmx:afterHeadMerge", {added: added, kept: preserved, removed: removed});
-            }
-        }
-    }
-
-    htmx.defineExtension("head-support", {
-        init: function(apiRef) {
-            // store a reference to the internal API.
-            api = apiRef;
-
-            htmx.on('htmx:afterSwap', function(evt){
-                var serverResponse = evt.detail.xhr.response;
-                if (api.triggerEvent(document.body, "htmx:beforeHeadMerge", evt.detail)) {
-                    mergeHead(serverResponse, evt.detail.boosted ? "merge" : "append");
-                }
-            })
-
-            htmx.on('htmx:historyRestore', function(evt){
-                if (api.triggerEvent(document.body, "htmx:beforeHeadMerge", evt.detail)) {
-                    if (evt.detail.cacheMiss) {
-                        mergeHead(evt.detail.serverResponse, "merge");
-                    } else {
-                        mergeHead(evt.detail.item.head, "merge");
-                    }
-                }
-            })
-
-            htmx.on('htmx:historyItemCreated', function(evt){
-                var historyItem = evt.detail.item;
-                historyItem.head = document.head.outerHTML;
-            })
-        }
-    });
-
-})()
+			htmx.on('htmx:historyItemCreated', function (evt) {
+				var historyItem = evt.detail.item;
+				historyItem.head = document.head.outerHTML;
+			});
+		},
+	});
+})();


### PR DESCRIPTION
## Description
currently the head-support feature starts doing its merging based off an `htmx:afterSwap` event. This means that any script being loaded into the DOM from the htmxSwap that wants to run some initialisation code may run after the `htmx:afterHeadMerge` event has triggered, and never see it.

An example for this would be if you want to return a ChartJS from an endpoint along with the script to display the chart.

```html
    <head>
      <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
    </head>
    <canvas id="myChart"></canvas>
    <script>
      htmx.on('htmx:afterHeadMerge', function () {
        (async () => {
          while (!Chart) {
            await new Promise((resolve) => setTimeout(resolve, 100));
          }
          var ctx = document.getElementById('myChart').getContext('2d');
          var myChart = new Chart(ctx, { <CONFIG> });
        })();
      });
    </script>
```
The polling is necessary to check that the `Chart` class has been declared (i.e. the new head script has loaded)
(and yes this could do with a timeout so it doesn't try for ever, but this is the basic solution)
However, this code won't work every time if we have `htmx:afterSwap` in `head-support.js` as the trigger.

Changing `htmx:afterSwap` to `htmx:afterSettle` ensures the DOM has settled (i.e. our event listener has been registered) before the head swap functionality is performed and our code works as expected.

## Testing
This was tested with the above code by calling this code on a lazy-loaded hx-post.
The race condition seems to be gone.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
