### PR TITLE
Fixed escaping on normalizeSelector [2601]

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1129,7 +1129,7 @@ var htmx = (function() {
     if (startsWith(trimmedSelector, '<') && endsWith(trimmedSelector, '/>')) {
       return trimmedSelector.substring(1, trimmedSelector.length - 2)
     } else {
-      return trimmedSelector.replaceAll(':', '\\:').replaceAll('.', '\\.'); // Issue 2601: colons and dots are valid id characters but need to be escaped
+      return trimmedSelector.replace(/\:/g, '\\:').replace(/\./g, '\\.')
     }
   }
 

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1128,8 +1128,10 @@ var htmx = (function() {
     const trimmedSelector = selector.trim()
     if (startsWith(trimmedSelector, '<') && endsWith(trimmedSelector, '/>')) {
       return trimmedSelector.substring(1, trimmedSelector.length - 2)
-    } else {
+    } else if (startsWith(trimmedSelector, '#')) {
       return trimmedSelector.replace(/\:/g, '\\:').replace(/\./g, '\\.')
+    } else {
+      return trimmedSelector
     }
   }
 

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1129,7 +1129,7 @@ var htmx = (function() {
     if (startsWith(trimmedSelector, '<') && endsWith(trimmedSelector, '/>')) {
       return trimmedSelector.substring(1, trimmedSelector.length - 2)
     } else {
-      return trimmedSelector
+      return trimmedSelector.replaceAll(':', '\\:').replaceAll('.', '\\.'); // Issue 2601: colons and dots are valid id characters but need to be escaped
     }
   }
 


### PR DESCRIPTION
## Description
Colons and dots are valid id characters but need to be escaped. This PR adds escaping to the normalizeSelector-function.

Corresponding issue: https://github.com/bigskysoftware/htmx/issues/2601

## Testing
I've tested that adding this escaping locally to htmx.js fixes the issue. I've not tested others scenarios that use normalizeSelector, but all code paths are feeding to the querySelectorAll so seems solid.

## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [X] I ran the test suite locally (`npm run test`) and verified that it succeeded
All tests were green but there was one mention of an issue elsewhere in code that seemed unrelated
`  1) hx-indicator attribute
       multiple requests with same indicator are handled properly:`
