### PR TITLE
docs: fix incorrect payload in update-other-content oob page

### DIFF
--- a/www/content/examples/update-other-content.md
+++ b/www/content/examples/update-other-content.md
@@ -120,20 +120,21 @@ Using this approach, the HTML doesn't need to change from the original setup at 
 Instead of modifying something on the front end, in your response to the `POST` to `/contacts` you would include some additional content:
 
 ```html
-<tr hx-swap-oob="beforeend:#contacts-table">
+<tbody hx-swap-oob="beforeend:#contacts-table">
+  <tr>
     <td>Joe Smith</td>
     <td>joe@smith.com</td>
-</tr>
-<form hx-post="/contacts">
-  <label>
-    Name
-        <input name="name" type="text">  
-  </label>
-  <label>
-    Email
-        <input name="email" type="email">  
-  </label>
-</form>
+  </tr>
+</tbody>
+
+<label>
+  Name
+      <input name="name" type="text">
+</label>
+<label>
+  Email
+      <input name="email" type="email">
+</label>
 ```
 
 This content uses the [hx-swap-oob](@/attributes/hx-swap-oob.md) attribute to append itself to the `#contacts-table`, updating


### PR DESCRIPTION
## Description
Fix a document in response payload in [update-other-content](https://htmx.org/examples/update-other-content/#oob) page regarding oob

## Testing
Website change. No test. build is successful

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
