### PR TITLE
_index.md: remove malformed html fragment in sponsors table

### DIFF
--- a/www/content/_index.md
+++ b/www/content/_index.md
@@ -308,7 +308,6 @@ Thank you to all our generous <a href="https://github.com/sponsors/bigskysoftwar
         </a>
 </td>
 </tr>
-/tr>
 <tr>
 <td></td>
 <td>


### PR DESCRIPTION
## Description

before

<img width="676" alt="image" src="https://github.com/bigskysoftware/htmx/assets/5464072/82182771-2e47-45d1-a176-75eddef29251">

## Testing

n/a

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
