### PR TITLE
fix 3rd party lib name in example doc

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -888,7 +888,7 @@ First we need to initialize elements that have the class in new content:
 ```javascript
 htmx.onLoad(function (target) {
     // find all elements in the new content that should be
-    // an editor and init w/ quill
+    // an editor and init w/ TomSelect
     var editors = target.querySelectorAll(".tomselect")
             .forEach(elt => new TomSelect(elt))
 });


### PR DESCRIPTION
## Description

Fix 3rd party library name in documentation (https://htmx.org/docs/#undoing-dom-mutations-by-3rd-party-libraries)

Corresponding issue:

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, **a documentation update**, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
