### PR TITLE
Drop IE11

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ directly in HTML, using [attributes](https://htmx.org/reference#attributes), so 
 htmx is small ([~14k min.gz'd](https://unpkg.com/htmx.org/dist/)),
 [dependency-free](https://github.com/bigskysoftware/htmx/blob/master/package.json),
 [extendable](https://htmx.org/extensions) &
-IE11 compatible
+IE11 compatible _(version 1 only)_
 
 ## motivation
 


### PR DESCRIPTION
## Description

IE11 Compatibility dropped since Version 2

Some documentation and code aren't updated for that

## Related

- Contributes to #2637 

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly approved via an issue