### PR TITLE
always do innerHTML swap if target is body

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1626,6 +1626,9 @@ var htmx = (function() {
    * @param {HtmxSettleInfo} settleInfo
    */
   function swapOuterHTML(target, fragment, settleInfo) {
+    if (target instanceof Element && target.tagName === 'BODY') {
+      return swapInnerHTML(target, fragment, settleInfo)
+    }
     /** @type {Node} */
     let newElt
     const eltBeforeNewContent = target.previousSibling


### PR DESCRIPTION
## Description
*Please describe what changes you made, and why you feel they are necessary. Make sure to include
code examples, where applicable.*

Corresponding issue:
Fix #2639

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

I tested manually with v1.9.12 and v2.0.0, the fix works. It's essentially same behaviour copied from v1.9.12.

I also tried to add a unit test in `/test/core/ajax.js` the following:

```js
  it('can swap body with outerHTML', function() {
    this.server.respondWith('GET', '/test', '<html><body>Clicked!</body></html>')
    var a1 = make('<a hx-get="/test" hx-target="body" hx-swap="outerHTML">Click Me</a>')
    a1.click()
    this.server.respond()
    document.body.innerHTML.should.equal('Clicked!')
  })
```

But because how the test is setup, I can't seem to replace `body`, it replaces the whole mocha test page.

I also tried to use an iframe, but failed to make it work. I think it's best to leave this to a capable person to add this piece of test in.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
