### PR TITLE
Documentation typo, remove malformed closing "/tr>"

### DIFF
--- a/www/content/_index.md
+++ b/www/content/_index.md
@@ -308,7 +308,6 @@ Thank you to all our generous <a href="https://github.com/sponsors/bigskysoftwar
         </a>
 </td>
 </tr>
-/tr>
 <tr>
 <td></td>
 <td>


### PR DESCRIPTION
## Description
Fixes a typo in the documentation where a stray malformed `/tr>` tag is rendered on screen.

Corresponding issue:

## Testing
Manually tested in browser.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
