### PR TITLE
Make docs' content responsively wider

### DIFF
--- a/www/themes/htmx-theme/static/css/site.css
+++ b/www/themes/htmx-theme/static/css/site.css
@@ -336,7 +336,37 @@ a[href]:hover, .btn:hover {
 }
 
 .c.wide-content {
-  max-width: 50em;
+  width: 100%
+}
+
+@media (min-width: 640px){
+  .c.wide-content {
+    max-width: 640px
+  }
+}
+
+@media (min-width: 768px){
+  .c.wide-content {
+    max-width: 768px
+  }
+}
+
+@media (min-width: 1024px){
+  .c.wide-content {
+    max-width: 1024px
+  }
+}
+
+@media (min-width: 1280px){
+  .c.wide-content {
+    max-width: 1280px
+  }
+}
+
+@media (min-width: 1536px){
+  .c.wide-content {
+    max-width: 1536px
+  }
 }
 
 .btn.primary {

--- a/www/themes/htmx-theme/templates/base.html
+++ b/www/themes/htmx-theme/templates/base.html
@@ -22,7 +22,11 @@
 <body hx-ext="class-tools, preload">
 
 <div class="top-nav">
-    <div class="c">
+    {% if page and page.path is starting_with("/docs") %}
+    <div class="c wide-content">
+    {% else %}
+    <div class="c content">
+    {% endif %}
         <div class="menu">
             <div class="logo-wrapper">
                 <a href="/" class="logo light">&lt;<b>/</b>&gt; htm<b>x</b></a>

--- a/www/themes/htmx-theme/templates/base.html
+++ b/www/themes/htmx-theme/templates/base.html
@@ -22,11 +22,7 @@
 <body hx-ext="class-tools, preload">
 
 <div class="top-nav">
-    {% if page and page.path is starting_with("/docs") %}
-    <div class="c wide-content">
-    {% else %}
     <div class="c content">
-    {% endif %}
         <div class="menu">
             <div class="logo-wrapper">
                 <a href="/" class="logo light">&lt;<b>/</b>&gt; htm<b>x</b></a>

--- a/www/themes/htmx-theme/templates/base.html
+++ b/www/themes/htmx-theme/templates/base.html
@@ -22,7 +22,7 @@
 <body hx-ext="class-tools, preload">
 
 <div class="top-nav">
-    <div class="c content">
+    <div class="c">
         <div class="menu">
             <div class="logo-wrapper">
                 <a href="/" class="logo light">&lt;<b>/</b>&gt; htm<b>x</b></a>


### PR DESCRIPTION
## Description
For wider screens the documentation and its content is too narrow. This will add more breakpoints (inspired by Tailwind's breakpoints) to /docs, but leave narrow column for other pages.

Corresponding issue: #2633 

## Testing
Visually with Zola

### New
![Screen Shot 2024-06-18 at 19 48 47](https://github.com/bigskysoftware/htmx/assets/135402/4d2bb345-ebcc-4948-a05f-69bc78b689bf)

### Current
![Screen Shot 2024-06-18 at 19 51 38](https://github.com/bigskysoftware/htmx/assets/135402/2318a0e9-4570-4737-a475-c897dfd3286c)




## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
