### PR TITLE
Doc: Update oobBeforeSwap

### DIFF
--- a/www/content/events.md
+++ b/www/content/events.md
@@ -310,7 +310,7 @@ This event is triggered as part of an [out of band swap](@/docs.md#oob_swaps) an
 
 * `detail.elt` - the element that dispatched the request
 * `detail.fragment` - the response fragment
-* `detail.shouldSwap` - if the content will be swapped (defaults to `false` for non-200 response codes)
+* `detail.shouldSwap` - if the content will be swapped (defaults to `true`)
 * `detail.target` - the target of the swap
 
 ### Event - `htmx:oobErrorNoTarget` {#htmx:oobErrorNoTarget}

--- a/www/content/events.md
+++ b/www/content/events.md
@@ -297,10 +297,9 @@ This event is triggered as part of an [out of band swap](@/docs.md#oob_swaps) an
 
 ##### Details
 
-* `detail.elt` - the element that dispatched the request
-* `detail.xhr` - the `XMLHttpRequest`
-* `detail.target` - the target of the request
-* `detail.requestConfig` - the configuration of the AJAX request
+* `detail.shouldSwap` - if the content will be swapped (defaults to `true`)
+* `detail.target` - the target of the swap
+* `detail.fragment` - the response fragment
 
 ### Event - `htmx:oobBeforeSwap` {#htmx:oobBeforeSwap}
 
@@ -308,10 +307,9 @@ This event is triggered as part of an [out of band swap](@/docs.md#oob_swaps) an
 
 ##### Details
 
-* `detail.elt` - the element that dispatched the request
-* `detail.fragment` - the response fragment
 * `detail.shouldSwap` - if the content will be swapped (defaults to `true`)
 * `detail.target` - the target of the swap
+* `detail.fragment` - the response fragment
 
 ### Event - `htmx:oobErrorNoTarget` {#htmx:oobErrorNoTarget}
 

--- a/www/content/events.md
+++ b/www/content/events.md
@@ -309,8 +309,7 @@ This event is triggered as part of an [out of band swap](@/docs.md#oob_swaps) an
 ##### Details
 
 * `detail.elt` - the element that dispatched the request
-* `detail.xhr` - the `XMLHttpRequest`
-* `detail.requestConfig` - the configuration of the AJAX request
+* `detail.fragment` - the response fragment
 * `detail.shouldSwap` - if the content will be swapped (defaults to `false` for non-200 response codes)
 * `detail.target` - the target of the swap
 


### PR DESCRIPTION
## Description
Updated oobBeforeSwap since it's out of date for two reasons:
- `shouldSwap` always defaults to true
- `xhr` and `requestConfig` are not properties of `detail`
- `fragment` is not documented

Regarding the `shouldSwap`, I've run tests returning 300 status codes and they did not set the `shouldSwap` property to false, as was previously specified. I've also reviewed the [source code](https://github.com/bigskysoftware/htmx/blob/f9b3f883576c979b533ed657b8a7556c3b1982e4/src/htmx.js#L2933) with a debugger to ensure that the `shouldSwap` in fact never changes and is always true unless modified by the event listener.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded :cry: 
