### PR TITLE
Make readonly bash variables explicitly readonly

### DIFF
--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -2,7 +2,7 @@
 # This script is intended to be run from npm, via `npm run dist`
 set -euo pipefail
 
-HTMX_SRC="src/htmx.js"
+readonly HTMX_SRC="src/htmx.js"
 
 # Clean the dist directory
 rm -rf dist/*

--- a/scripts/www.sh
+++ b/scripts/www.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-STATIC_ROOT="www/static"
+readonly STATIC_ROOT="www/static"
 PACKAGE_VERSION=$(cat package.json | grep version | cut -d '"' -f 4)
 
 


### PR DESCRIPTION
## Description

In bash scripts, I noticed a few variables that are read-only, but they're not declared as `readonly` in bash. Declaring them as `readonly` protects against potential bugs in the future where code may unintentionally overwrite these variables.

I didn't apply `readonly` to the variable `PACKAGE_VERSION` because it is unused and I'm proposing its deletion in https://github.com/bigskysoftware/htmx/pull/2666

Corresponding issue: N/A

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

I ran the scripts manually.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
