### PR TITLE
Delete unused bash variable

### DIFF
--- a/scripts/www.sh
+++ b/scripts/www.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 STATIC_ROOT="www/static"
-PACKAGE_VERSION=$(cat package.json | grep version | cut -d '"' -f 4)
 
 
 cp node_modules/mocha/mocha.js "$STATIC_ROOT/node_modules/mocha/mocha.js"


### PR DESCRIPTION
## Description

The `PACKAGE_VERSION` variable is unused, so it should just be deleted.

Corresponding issue:

## Testing

I ran the script manually.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
