### PR TITLE
Update webpack and Vite istallation instructions for htmx 2.0

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -162,7 +162,7 @@ import 'htmx.org';
 ```
 
 However, you will probably need the global `htmx` variable, which gives your code access to methods like
-`htmx.onLoad` and allow you to use npm-installed htmx plugins. You can use one of the solutions following solutions
+`htmx.onLoad` and allow you to use npm-installed htmx plugins. You can use one of the following solutions
 to achieve this.
 
 

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -154,6 +154,12 @@ For npm-style build systems, you can install htmx via [npm](https://www.npmjs.co
 npm install htmx.org@2.0.4
 ```
 
+and for extensions:
+```sh
+npm install htmx-ext-debug@2.0.1
+```
+
+
 After installing, you’ll need to use appropriate tooling to use `node_modules/htmx.org/dist/htmx[.esm, .cjs, .amd].js` (or `.min.js`).
 
 In the simplest case all you need to do is to add this import to your entry point (like `index.js`)
@@ -161,69 +167,27 @@ In the simplest case all you need to do is to add this import to your entry poin
 import 'htmx.org';
 ```
 
-However, you will probably need the global `htmx` variable, which gives your code access to methods like
-`htmx.onLoad` and allow you to use npm-installed htmx plugins. You can use one of the following solutions
-to achieve this.
-
-
-#### Global variable 
-
-Create a local `htmx.js` with the following content:
+If you need access to methods like `htmx.onLoad` use the following import statement instead:
 
 ```js
 import htmx from "htmx.org";
-window.htmx = htmx;
 ```
 
-Import this file in your entry point (like `index.js`):
+#### Example
 
 ```js
-import './htmx.js';
+// Option 1
+// After htmx.org is imported you can import extensions.
+import 'htmx.org';
+import 'htmx-ext-debug';
 
-// now you can import extensions
-import 'htmx-ext-debug/debug.js';
-// and use htmx methods
+// Option 2
+// After htmx is imported from htmx.org you can import extensions and use the `htmx` object.
+import htmx from "htmx.org";
+import 'htmx-ext-debug';
 htmx.onLoad((content) => {
     console.log('Hello')
 });
-```
- 
-#### Webpack
-
-If you are using [webpack](https://webpack.js.org) to manage your javascript, the better option is 
-to add the following to your `webpack.config.js`
-
-```js
-import webpack from 'webpack';
-
-/** @type {import("webpack").Configuration} */
-export default {
-  entry: './src/index.js',
-  //[...]
-  plugins: [
-    new webpack.ProvidePlugin({
-      htmx: 'htmx.org',
-    }),
-  ],
-};
-```
-
-#### Vite
-
-If you are using [Vite](https://vitejs.dev) to manage your javascript, the better option is 
-to add the following to your [vite.config.js](https://vitejs.dev/guide/backend-integration.html):
-
-```js
-import inject from '@rollup/plugin-inject';
-
-export default defineConfig({
-  build: {...},
-  plugins: [
-    inject({
-      htmx: 'htmx.org',
-    }),
-  ],
-})
 ```
 
 Finally, rebuild your bundle.

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -190,47 +190,36 @@ window.htmx = htmx;
 
 If you are using [Vite](https://vitejs.dev) to manage your javascript:
 
-* Install `htmx.org` via your favourite package manager (like npm or yarn)
-* Add the import to your entrypoint(s). For example if you
-[serve the HTML using a backend](https://vitejs.dev/guide/backend-integration.html)
-and your vite.config.js looks like this:
+1. Install `htmx.org` via your favourite package manager (like npm or yarn)
 
-```js
-export default defineConfig({
-  build: {
-    manifest: true,
-    rollupOptions: {
-      input: '/path/to/main.js',
-    },
-  },
-})
-```
+2. Load htmx
 
-* then add the following import to the `/path/to/main.js`
-
-```js
-import 'htmx.org';
-```
-
-You will probably also want to use the global htmx variable so that you can access methods like
+   You will probably want to use the global htmx variable so that you can access methods like
 `htmx.onLoad` or use npm-installed plugins that expect `htmx` global to be present.
-To do this you need to inject it to the window scope:
+    
+   To achieve this you need to inject `htmx` into the window scope.
 
-* Add the following to your `vite.config.js`:
+   * Add the following to your `vite.config.js`:
 
-```js
-export default defineConfig({
-  build: {
-    plugins: [
-      inject({
-        htmx: 'htmx.org/dist/htmx.esm',
-      }),
-    ],
-  },
-})
-```
+   ```js
+   export default defineConfig({
+     build: {
+       plugins: [
+         inject({
+           htmx: 'htmx.org/dist/htmx.esm',
+         }),
+       ],
+     },
+   })
+   ```
 
-* Finally, rebuild your bundle
+   Alternatively, if you don't need the `htmx` global variable then add the following to
+   your entry point [main.js file](https://vitejs.dev/guide/backend-integration.html):
+   ```js
+   import 'htmx.org';
+   ```
+
+3. Finally, rebuild your bundle
 
 ## AJAX
 

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -146,34 +146,38 @@ and include it where necessary with a `<script>` tag:
 <script src="/path/to/htmx.min.js"></script>
 ```
 
-### npm
+### Via npm
 
+#### Package Installation
 For npm-style build systems, you can install htmx via [npm](https://www.npmjs.com/):
 
 ```sh
 npm install htmx.org@2.0.4
 ```
 
-and for extensions:
+and, for extensions:
 ```sh
 npm install htmx-ext-debug@2.0.1
 ```
 
+#### Importing
 
-After installing, you’ll need to use appropriate tooling to use `node_modules/htmx.org/dist/htmx[.esm, .cjs, .amd].js` (or `.min.js`).
+After htmx and any extensions are installed, all you need to do is import `htmx` in your entry point file
+(like `index.js`).
 
-In the simplest case all you need to do is to add this import to your entry point (like `index.js`)
+
+The simplest option is:
 ```js
 import 'htmx.org';
 ```
 
-If you need access to methods like `htmx.onLoad` use the following import statement instead:
+If you need access to methods like `htmx.onLoad`, use the following import statement instead:
 
 ```js
 import htmx from "htmx.org";
 ```
 
-#### Example
+#### Examples
 
 ```js
 // Option 1

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -154,14 +154,14 @@ For npm-style build systems, you can install htmx via [npm](https://www.npmjs.co
 npm install htmx.org@2.0.4
 ```
 
-After installing, you’ll need to use appropriate tooling to use `node_modules/htmx.org/dist/htmx.js` (or `.min.js`).
+After installing, you’ll need to use appropriate tooling to use `node_modules/htmx.org/dist/htmx[esm, cjs, amd].js` (or `.min.js`).
 For example, you might bundle htmx with some extensions and project-specific code.
 
 ### Webpack
 
-If you are using webpack to manage your javascript:
+If you are using [webpack](https://webpack.js.org) to manage your javascript:
 
-* Install `htmx` via your favourite package manager (like npm or yarn)
+* Install `htmx.org` via your favourite package manager (like npm or yarn)
 * Add the import to your `index.js`
 
 ```js
@@ -180,7 +180,54 @@ import 'path/to/my_custom.js';
 * Then add this code to the file:
 
 ```js
-window.htmx = require('htmx.org');
+import htmx from "htmx.org/dist/htmx.esm";
+window.htmx = htmx;
+```
+
+* Finally, rebuild your bundle
+
+### Vite
+
+If you are using [Vite](https://vitejs.dev) to manage your javascript:
+
+* Install `htmx.org` via your favourite package manager (like npm or yarn)
+* Add the import to your entrypoint(s). For example if you
+[serve the HTML using a backend](https://vitejs.dev/guide/backend-integration.html)
+and your vite.config.js looks like this:
+
+```js
+export default defineConfig({
+  build: {
+    manifest: true,
+    rollupOptions: {
+      input: '/path/to/main.js',
+    },
+  },
+})
+```
+
+* then add the following import to the `/path/to/main.js`
+
+```js
+import 'htmx.org';
+```
+
+You will probably also want to use the global htmx variable so that you can access methods like
+`htmx.onLoad` or use npm-installed plugins that expect `htmx` global to be present.
+To do this you need to inject it to the window scope:
+
+* Add the following to your `vite.config.js`:
+
+```js
+export default defineConfig({
+  build: {
+    plugins: [
+      inject({
+        htmx: 'htmx.org/dist/htmx.esm',
+      }),
+    ],
+  },
+})
 ```
 
 * Finally, rebuild your bundle

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -171,7 +171,7 @@ to achieve this.
 Create a local `htmx.js` with the following content:
 
 ```js
-import htmx from "htmx.org/dist/htmx.esm";
+import htmx from "htmx.org";
 window.htmx = htmx;
 ```
 
@@ -202,7 +202,7 @@ export default {
   //[...]
   plugins: [
     new webpack.ProvidePlugin({
-      htmx: 'htmx.org/dist/htmx.esm',
+      htmx: 'htmx.org',
     }),
   ],
 };
@@ -221,7 +221,7 @@ export default defineConfig({
    //[...]
    plugins: [
      inject({
-       htmx: 'htmx.org/dist/htmx.esm',
+       htmx: 'htmx.org',
      }),
    ],
  },

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -154,72 +154,81 @@ For npm-style build systems, you can install htmx via [npm](https://www.npmjs.co
 npm install htmx.org@2.0.4
 ```
 
-After installing, you’ll need to use appropriate tooling to use `node_modules/htmx.org/dist/htmx[esm, cjs, amd].js` (or `.min.js`).
-For example, you might bundle htmx with some extensions and project-specific code.
+After installing, you’ll need to use appropriate tooling to use `node_modules/htmx.org/dist/htmx[.esm, .cjs, .amd].js` (or `.min.js`).
 
-### Webpack
-
-If you are using [webpack](https://webpack.js.org) to manage your javascript:
-
-* Install `htmx.org` via your favourite package manager (like npm or yarn)
-* Add the import to your `index.js`
-
+In the simplest case all you need to do is to add this import to your entry point (like `index.js`)
 ```js
 import 'htmx.org';
 ```
 
-If you want to use the global `htmx` variable (recommended), you need to inject it to the window scope:
+However, you will probably need the global `htmx` variable, which gives your code access to methods like
+`htmx.onLoad` and allow you to use npm-installed htmx plugins. You can use one of the solutions following solutions
+to achieve this.
 
-* Create a custom JS file
-* Import this file to your `index.js` (below the import from step 2)
 
-```js
-import 'path/to/my_custom.js';
-```
+#### Global variable 
 
-* Then add this code to the file:
+Create a local `htmx.js` with the following content:
 
 ```js
 import htmx from "htmx.org/dist/htmx.esm";
 window.htmx = htmx;
 ```
 
-* Finally, rebuild your bundle
+Import this file in your entry point (like `index.js`):
 
-### Vite
+```js
+import './htmx.js';
 
-If you are using [Vite](https://vitejs.dev) to manage your javascript:
+// now you can import extensions
+import 'htmx-ext-debug/debug.js';
+// and use htmx methods
+htmx.onLoad((content) => {
+    console.log('Hello')
+});
+```
+ 
+#### Webpack
 
-1. Install `htmx.org` via your favourite package manager (like npm or yarn)
+If you are using [webpack](https://webpack.js.org) to manage your javascript, the better option is 
+to add the following to your `webpack.config.js`
 
-2. Load htmx
+```js
+import webpack from 'webpack';
 
-   You will probably want to use the global htmx variable so that you can access methods like
-`htmx.onLoad` or use npm-installed plugins that expect `htmx` global to be present.
-    
-   To achieve this you need to inject `htmx` into the window scope.
+/** @type {import("webpack").Configuration} */
+export default {
+  entry: './src/index.js',
+  //[...]
+  plugins: [
+    new webpack.ProvidePlugin({
+      htmx: 'htmx.org/dist/htmx.esm',
+    }),
+  ],
+};
+```
 
-   * Add the following to your `vite.config.js`:
+#### Vite
 
-   ```js
-   export default defineConfig({
-     build: {
-       plugins: [
-         inject({
-           htmx: 'htmx.org/dist/htmx.esm',
-         }),
-       ],
-     },
-   })
-   ```
+If you are using [Vite](https://vitejs.dev) to manage your javascript, the better option is 
+to add the following to your [vite.config.js](https://vitejs.dev/guide/backend-integration.html):
 
-   Alternatively, if you don't need the `htmx` global variable then add the following to
-   your entry point [main.js file](https://vitejs.dev/guide/backend-integration.html):
-   ```js
-   import 'htmx.org';
-   ```
+```js
+import inject from '@rollup/plugin-inject';
 
-3. Finally, rebuild your bundle
+export default defineConfig({
+ build: {
+   //[...]
+   plugins: [
+     inject({
+       htmx: 'htmx.org/dist/htmx.esm',
+     }),
+   ],
+ },
+})
+```
+
+Finally, rebuild your bundle.
 
 ## AJAX
 

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -217,14 +217,12 @@ to add the following to your [vite.config.js](https://vitejs.dev/guide/backend-i
 import inject from '@rollup/plugin-inject';
 
 export default defineConfig({
- build: {
-   //[...]
-   plugins: [
-     inject({
-       htmx: 'htmx.org',
-     }),
-   ],
- },
+  build: {...},
+  plugins: [
+    inject({
+      htmx: 'htmx.org',
+    }),
+  ],
 })
 ```
 


### PR DESCRIPTION
## Description

The webpack installation instructions are no longer valid for htmx 2.0. There are also no installation instructions for Vite. 
This is affecting multiple people, judging from the issue tracker.

Corresponding issue:
- https://github.com/bigskysoftware/htmx/issues/2628
- https://github.com/bigskysoftware/htmx/issues/2657
- https://github.com/bigskysoftware/htmx/issues/2659

## Testing
It's a documentation update and the only way to test it is to follow the new guidelines. These new guidelines are what works for me and other people (see issues listed above).

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
