### PR TITLE
#41540 Update Quarkus with recent examples

### DIFF
--- a/www/content/server-examples.md
+++ b/www/content/server-examples.md
@@ -64,7 +64,8 @@ These examples may make it a bit easier to get started using htmx with your plat
 
 ### Quarkus
 
-- <https://github.com/derkoe/quarkus-htmx-todos>
+- <https://github.com/ia3andy/renotes>
+- <https://github.com/ia3andy/htmx-todo>
 
 ## ColdFusion (CFML - a JVM Language)
 


### PR DESCRIPTION
## Description
Make sure Quarkus is referenced with recent examples in the htmx ecosystem

Corresponding issue: https://github.com/quarkusio/quarkus/issues/41540

## Testing
no test needed because it's just update the examples on www

## Checklist

* [x ] I have read the contribution guidelines
* [x ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
