### PR TITLE
HtmxAjaxHelperContext typedef should have all optional fields

### DIFF
--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -113,7 +113,7 @@ type HtmxAjaxHelperContext = {
     source?: Element | string;
     event?: Event;
     handler?: HtmxAjaxHandler;
-    target: Element | string;
+    target?: Element | string;
     swap?: HtmxSwapStyle;
     values?: any | FormData;
     headers?: Record<string, string>;

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -5036,7 +5036,7 @@ var htmx = (function() {
  * @property {Element|string} [source]
  * @property {Event} [event]
  * @property {HtmxAjaxHandler} [handler]
- * @property {Element|string} target
+ * @property {Element|string} [target]
  * @property {HtmxSwapStyle} [swap]
  * @property {Object|FormData} [values]
  * @property {Record<string,string>} [headers]

--- a/www/content/api.md
+++ b/www/content/api.md
@@ -53,7 +53,7 @@ or
 * `verb` - 'GET', 'POST', etc.
 * `path` - the URL path to make the AJAX
 * `context` - a context object that contains any of the following
-    * `source` - the source element of the request
+    * `source` - the source element of the request, `hx-*` attrs which affect the request will be resolved against that element and its ancestors
     * `event` - an event that "triggered" the request
     * `handler` - a callback that will handle the response HTML
     * `target` - the target to swap the response into


### PR DESCRIPTION
## Description
The typedef is currently more strict than the code, and prevents IMHO the most useful way to configure ajax requests.

I also added a clarification to the `htmx.ajax` docs about what specifying `source` in the context object actually does.

See discussion here:
https://github.com/bigskysoftware/htmx/discussions/2698

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [x] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
   ...oh, do the docs and code changes need to be in separate PRs?
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
