### PR TITLE
Let templates have plaintext as contents (fixes 2702)

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1854,7 +1854,7 @@ var htmx = (function() {
       findAndSwapOobElements(fragment, settleInfo)
       forEach(findAll(fragment, 'template'), /** @param {HTMLTemplateElement} template */function(template) {
         findAndSwapOobElements(template.content, settleInfo)
-        if (template.content.childElementCount === 0) {
+        if (template.content.childElementCount === 0 && template.content.textContent.trim() === '') {
         // Avoid polluting the DOM with empty templates that were only used to encapsulate oob swap
           template.remove()
         }


### PR DESCRIPTION
## Description
*Please describe what changes you made, and why you feel they are necessary. Make sure to include
code examples, where applicable.*

I introduced an additional check `template.content.textContent.trim() === ''` to make sure templates are not removed if they have plaintext inside.

Corresponding issue:
#2702 

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

I ran the sample server.py code provided by the person opening the PR. I then changed the source to htmx to my localhost htmx src. I added the additional check in the if statement and refreshed a few times.

**Without my change:**

with plaintext:
<img width="439" alt="image" src="https://github.com/bigskysoftware/htmx/assets/40846846/7d1a118b-a105-4c05-925f-ed428035bec0">

without plaintext:
<img width="448" alt="image" src="https://github.com/bigskysoftware/htmx/assets/40846846/f5e7554b-dd10-45cc-b0c8-7eca3daf17b6">

**With my change:**

with plaintext:
<img width="442" alt="image" src="https://github.com/bigskysoftware/htmx/assets/40846846/2d214e75-09ab-4ae1-a87f-a7f2ed98c154">

without plaintext:
<img width="436" alt="image" src="https://github.com/bigskysoftware/htmx/assets/40846846/00b8aaaf-0396-4290-af54-11aa584d456a">



## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
