### PR TITLE
Extension perf improvments

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2884,8 +2884,8 @@ var htmx = (function() {
   /**
    * `withExtensions` locates all active extensions for a provided element, then
    * executes the provided function using each of the active extensions.  It should
-   * be called internally at every extendable execution point in htmx. Optionally 
-   * pass the extension action name you are using to improve lookup performance. 
+   * be called internally at every extendable execution point in htmx. Optionally
+   * pass the extension action name you are using to improve lookup performance.
    *
    * @param {Element} elt
    * @param {(extension:HtmxExtension) => void} toDo
@@ -4649,7 +4649,7 @@ var htmx = (function() {
 
       withExtensions(elt, function(extension) {
         serverResponse = extension.transformResponse(serverResponse, xhr, elt)
-      },'transformResponse')
+      }, 'transformResponse')
 
       // Save current page if there will be a history update
       if (historyUpdate.type) {
@@ -4840,7 +4840,7 @@ var htmx = (function() {
     if (extensionsToReturn == undefined) {
       extensionsToReturn = []
     }
-    if (elt == undefined || action && !extensionActions.includes(action)) {
+    if (elt == undefined || (action && !extensionActions.includes(action))) {
       return extensionsToReturn
     }
     if (extensionsToIgnore == undefined) {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -4840,7 +4840,7 @@ var htmx = (function() {
     if (extensionsToReturn == undefined) {
       extensionsToReturn = []
     }
-    if (elt == undefined || action && !extensionActions.includes(func)) {
+    if (elt == undefined || action && !extensionActions.includes(action)) {
       return extensionsToReturn
     }
     if (extensionsToIgnore == undefined) {


### PR DESCRIPTION
## Description
I noticed while debugging and investigating how the extension code works that when not using a large range of extensions it still has to traverse up the DOM to search for active extensions on the active element for all the plugin extension points that use  withExtensions(). Even with no extensions installed it performs this additional effort.  Also I found that during the findElementsToProcess() function it was calling all extensions to build a recent extensionSelectors feature on every process when this is static work that could be performed instead once at extension install time to speed things up a little.

So I've made the following performance improvements:

1. During Extension Activation It now generates an extensionActions array of all function names the installed extensions are using which is deduped 
2. Changed getExtensions() to have an action optional argument where you can provide it with the action you need to run on all extensions and it checks if none of the installed extensions implement this action it returns so it doesn't have to recurse up the DOM inspecting element attributes for hx-ext
3. Updated all calls to getExtensions to pass in the required action.
4. Created extensionSelectors string that is filled in once during extension activation and then used as a static string on each node process.

Note that this change does change the definition of the withExtensions() function published to extensions via internalAPI by adding a new action optional parameter.  But all existing extensions will keep working with existing behavior as they will not be passing this new parameter in which means they will not take advantage of the minor performance gain.  Extensions could adopt the use of the action parameter but then they would no longer be compatible with older versions of htmx 2.0 so probably best left as is till this change is well established.

Corresponding issue: #2712

## Testing
Was not able to get new working tests for these internal only changes so to test this I test loading real and manual dummy extensions to confirm the two new objects were getting populated as expected and added some console.logs to check it has reduced the number of calls made to lookup extensions.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
