### PR TITLE
Fix example for responseHandling config via <meta> tag

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -972,10 +972,17 @@ Using the [meta config](#configuration-options) mechanism for configuring respon
 config:
 
 ```html
-<meta name="htmx-config" content='{code:"204", swap: false},   // 204 - No Content by default does nothing, but is not an error
-                                  {code:"[23]..", swap: true}, // 200 & 300 responses are non-errors and are swapped
-                                  {code:"422", swap: true}, // 422 responses are swapped
-                                  {code:"[45]..", swap: false, error:true}, // 400 & 500 responses are not swapped and are errors'>
+<meta
+	name="htmx-config"
+	content='{
+        "responseHandling":[
+            {"code":"204", "swap": false},
+            {"code":"[23]..", "swap": true},
+            {"code":"422", "swap": true},
+            {"code":"[45]..", "swap": false, "error":true}
+        ]
+    }'
+/>
 ```
 
 If you wanted to swap everything, regardless of HTTP response code, you could use this configuration:


### PR DESCRIPTION
## Description

In the docs, the following example is given to configure response handling via the `<meta>` tag:

```html
<meta name="htmx-config" content='{code:"204", swap: false},   // 204 - No Content by default does nothing, but is not an error
                                  {code:"[23]..", swap: true}, // 200 & 300 responses are non-errors and are swapped
                                  {code:"422", swap: true}, // 422 responses are swapped
                                  {code:"[45]..", swap: false, error:true}, // 400 & 500 responses are not swapped and are errors'>
```

However, if this is used in a site which loads [htmx v0.2.0](https://unpkg.com/htmx.org@2.0.0/dist/htmx.js), the following error is thrown:

```
htmx.js:2914 SyntaxError: Expected property name or '}' in JSON at position 1 (line 1 column 2)
    at JSON.parse (<anonymous>)
    at parseJSON (htmx.js:816:19)
    at getMetaConfig (htmx.js:4902:14)
    at mergeMetaConfig (htmx.js:4909:24)
    at HTMLDocument.<anonymous> (htmx.js:4917:5)
```

Fixing all errors like unquoted keys, comments and missing `responseHandling` key lead me to this config:

```html
<meta
	name="htmx-config"
	content='{
		"responseHandling":[
			{"code":"204", "swap": false},
			{"code":"[23]..", "swap": true},
			{"code":"422", "swap": true},
			{"code":"[45]..", "swap": false, "error":true}
		]
	}'
/>
```

It's unfortunate that JSON does not support comments but I think having a working example in the documentation is more important.

Corresponding issue: n/a

## Testing

I tested this change by copy-pasting the configuration into `<head>` of my site

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
