### PR TITLE
fix: type definitions for HtmxExtension

### DIFF
--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -15,7 +15,7 @@ declare namespace htmx {
     const toggleClass: (elt: string | Element, clazz: string) => void;
     const takeClass: (elt: string | Node, clazz: string) => void;
     const swap: (target: string | Element, content: string, swapSpec: HtmxSwapSpecification, swapOptions?: SwapOptions) => void;
-    const defineExtension: (name: string, extension: any) => void;
+    const defineExtension: (name: string, extension: HtmxExtension) => void;
     const removeExtension: (name: string) => void;
     const logAll: () => void;
     const logNone: () => void;
@@ -192,4 +192,12 @@ type HtmxSettleInfo = {
     elts: Element[];
     title?: string;
 };
-type HtmxExtension = any;
+type HtmxExtension = {
+    init: (api: any) => void;
+    onEvent: (name: string, event: Event | CustomEvent) => boolean;
+    transformResponse: (text: string, xhr: XMLHttpRequest, elt: Element) => string;
+    isInlineSwap: (swapStyle: HtmxSwapStyle) => boolean;
+    handleSwap: (swapStyle: HtmxSwapStyle, target: Node, fragment: Node, settleInfo: HtmxSettleInfo) => boolean | Node[];
+    encodeParameters: (xhr: XMLHttpRequest, parameters: FormData, elt: Node) => any | string | null;
+    getSelectors: () => string[] | null;
+};

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1753,7 +1753,7 @@ var htmx = (function() {
           try {
             const newElements = ext.handleSwap(swapStyle, target, fragment, settleInfo)
             if (newElements) {
-              if (typeof newElements.length !== 'undefined') {
+              if (Array.isArray(newElements)) {
                 // if handleSwap returns an array (like) of elements, we handle them
                 for (let j = 0; j < newElements.length; j++) {
                   const child = newElements[j]
@@ -5121,12 +5121,13 @@ var htmx = (function() {
  */
 
 /**
+ * @see https://github.com/bigskysoftware/htmx-extensions/blob/main/README.md
  * @typedef {Object} HtmxExtension
- * @see https://htmx.org/extensions/#defining
  * @property {(api: any) => void} init
  * @property {(name: string, event: Event|CustomEvent) => boolean} onEvent
  * @property {(text: string, xhr: XMLHttpRequest, elt: Element) => string} transformResponse
  * @property {(swapStyle: HtmxSwapStyle) => boolean} isInlineSwap
- * @property {(swapStyle: HtmxSwapStyle, target: Element, fragment: Node, settleInfo: HtmxSettleInfo) => boolean} handleSwap
- * @property {(xhr: XMLHttpRequest, parameters: FormData, elt: Element) => *|string|null} encodeParameters
+ * @property {(swapStyle: HtmxSwapStyle, target: Node, fragment: Node, settleInfo: HtmxSettleInfo) => boolean|Node[]} handleSwap
+ * @property {(xhr: XMLHttpRequest, parameters: FormData, elt: Node) => *|string|null} encodeParameters
+ * @property {() => string[]|null} getSelectors
  */


### PR DESCRIPTION
The @see tag prevented `tsc` to properly generate types for `HtmxExtension`. Moving the `@see` above `@typedef` fixes this and adds types for `HtmxExtension` back to the package ;-)

## Description

https://github.com/bigskysoftware/htmx/pull/2336 updated type generation but as a side effect the type definition of `HtmxExtension` got dropped / changed to `any`. 

This is fixed now ;) 

Note: I did not create an issue to prevent spam, if it's important, I'm more than happy to create one after the fact 😉

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
