### PR TITLE
Add htmx4s to scala server-examples

### DIFF
--- a/www/content/server-examples.md
+++ b/www/content/server-examples.md
@@ -125,6 +125,7 @@ These examples may make it a bit easier to get started using htmx with your plat
   
 ### http4s
 - <https://github.com/martinprobson/http4s-htmx-demo>
+- <https://github.com/eikek/htmx4s>
 
 ## Kotlin
 


### PR DESCRIPTION
## Description

Hi, I included my scala library to the examples section of the website (servers).

I did not run `npm run test`, because it is only a documentation change.
I did run `zola check` that reported a list of broken links, but it didn't include this new one :-).

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
