### PR TITLE
Allow htmx:beforeSwap to change swapOverride

### DIFF
--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -184,6 +184,7 @@ type HtmxBeforeSwapDetails = HtmxResponseInfo & {
     isError: boolean;
     ignoreTitle: boolean;
     selectOverride: string;
+    swapOverride: HtmxSwapStyle;
 };
 type HtmxAjaxHandler = (elt: Element, responseInfo: HtmxResponseInfo) => any;
 type HtmxSettleTask = (() => void);

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -4667,7 +4667,7 @@ var htmx = (function() {
       if (historyUpdate.type) {
         saveCurrentPageToHistory()
       }
-      
+
       var swapSpec = getSwapSpecification(elt, swapOverride)
 
       if (!swapSpec.hasOwnProperty('ignoreTitle')) {
@@ -5099,7 +5099,7 @@ var htmx = (function() {
  */
 
 /**
- * @typedef {HtmxResponseInfo & {shouldSwap: boolean, serverResponse: any, isError: boolean, ignoreTitle: boolean, selectOverride:string}} HtmxBeforeSwapDetails
+ * @typedef {HtmxResponseInfo & {shouldSwap: boolean, serverResponse: any, isError: boolean, ignoreTitle: boolean, selectOverride:string, swapOverride:string}} HtmxBeforeSwapDetails
  */
 
 /**

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -4635,7 +4635,8 @@ var htmx = (function() {
       serverResponse,
       isError,
       ignoreTitle,
-      selectOverride
+      selectOverride,
+      swapOverride
     }, responseInfo)
 
     if (responseHandling.event && !triggerEvent(target, responseHandling.event, beforeSwapDetails)) return
@@ -4647,6 +4648,7 @@ var htmx = (function() {
     isError = beforeSwapDetails.isError // allow updating error
     ignoreTitle = beforeSwapDetails.ignoreTitle // allow updating ignoring title
     selectOverride = beforeSwapDetails.selectOverride // allow updating select override
+    swapOverride = beforeSwapDetails.swapOverride // allow updating swap override
 
     responseInfo.target = target // Make updated target available to response events
     responseInfo.failed = isError // Make failed property available to response events
@@ -4665,10 +4667,7 @@ var htmx = (function() {
       if (historyUpdate.type) {
         saveCurrentPageToHistory()
       }
-
-      if (hasHeader(xhr, /HX-Reswap:/i)) {
-        swapOverride = xhr.getResponseHeader('HX-Reswap')
-      }
+      
       var swapSpec = getSwapSpecification(elt, swapOverride)
 
       if (!swapSpec.hasOwnProperty('ignoreTitle')) {

--- a/test/core/events.js
+++ b/test/core/events.js
@@ -681,4 +681,28 @@ describe('Core htmx Events', function() {
       htmx.off('htmx:afterSwap', afterSwapHandler)
     }
   })
+
+  it('htmx:beforeSwap can override swap style using evt.detail.swapOverride and has final say on it', function() {
+    var swapWasOverriden = false
+    var responseBody = 'look at me. i’m the innerHTML now.'
+
+    var beforeSwapHandler = htmx.on('htmx:beforeSwap', function(evt) {
+      evt.detail.swapOverride = 'innerHTML'
+    })
+    var afterSwapHandler = htmx.on('htmx:afterSwap', function(evt) {
+      console.log('afterSwap', byId('b').innerHTML)
+      swapWasOverriden = byId('b') !== null && byId('b').innerHTML === responseBody
+    })
+
+    try {
+      this.server.respondWith('GET', '/test', [200, { 'HX-Reswap': 'afterbegin' }, responseBody])
+      make("<div id='a' hx-get='/test' hx-target='#b' hx-swap='beforeend'></div><div id='b'> – IF YOU CAN READ THIS, IT FAILED – </div>")
+      byId('a').click()
+      this.server.respond()
+      swapWasOverriden.should.equal(true)
+    } finally {
+      htmx.off('htmx:beforeSwap', beforeSwapHandler)
+      htmx.off('htmx:afterSwap', afterSwapHandler)
+    }
+  })
 })


### PR DESCRIPTION
This half-fixes a regression, because this used to work once by updating `event.detail.etc.swapOverride`. This PR however expects the swap style in `event.detail.swapOverride` to match the other overrides.

I removed the bit about the `HX-Reswap` header because the same thing already happens further up, and the header value should be overridable by the event.

## Testing
I've added a test that will check if the swap style set in `htmx:beforeSwap` was **actually** used regardless of the `hx-swap` attribute or the `HX-Reswap` header. The header override still works if `htmx:beforeSwap` leaves it alone.

## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [X] I ran the test suite locally (`npm run test`) and verified that it succeeded

Cheers and sorry about opening this twice, I thought I could rename the branch without destroying the old PR...