### PR TITLE
Bump Zola version to 0.19.1

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ publish = "public"
 command = "zola build"
 
 [build.environment]
-ZOLA_VERSION = "0.17.1"
+ZOLA_VERSION = "0.19.1"
 
 [context.deploy-preview]
 command = "zola build --base-url $DEPLOY_PRIME_URL"


### PR DESCRIPTION
## Description

The current website build uses Zola 0.17.1, and is not generating `atom.xml`. Building the site with version 0.19.1 does generate this file (at least locally). This PR bumps the version in the Netlify config file.

Corresponding issue: N/A _(Discord ping)_

## Testing

[Zola's Netlify deployment docs](https://www.getzola.org/documentation/deployment/netlify/) say that any valid version will work in this config.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] ~~I ran the test suite locally (`npm run test`) and verified that it succeeded~~ _(N/A; website change)_
