### PR TITLE
Stop center aligning docs nav on small screen

### DIFF
--- a/www/themes/htmx-theme/static/css/site.css
+++ b/www/themes/htmx-theme/static/css/site.css
@@ -270,7 +270,6 @@ ol li {
       float: right;
   }
   .nav {
-      text-align: center;
       font-size: 1.2em;
       line-height: 1.3em;
   }


### PR DESCRIPTION
## Description
*Please describe what changes you made, and why you feel they are necessary. Make sure to include
code examples, where applicable.*

Docs page's nav items contain hierarchical indentation for headings that doesn't work well when text is aligned center on small screen. This PR removes the responsible text-align style to keep the nav items left-aligned on small screen. The changed style also matches the current style on larger screen.

See the following images for comparison:

| Before | After |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/0c4492d1-6d80-45ce-8160-3dc066c5df19) | ![image](https://github.com/user-attachments/assets/ecace927-dd01-4c4d-9e9a-02ac0d4c5dda) |

The change in this PR should not affect the style for any other part of the website since CSS `.nav` class is only used for the container element of docs nav items located in the `www/content/docs.md` file: https://github.com/bigskysoftware/htmx/blob/4a2289d1cae39af0935d85954c15d28ed96b5821/www/content/docs.md?plain=1#L7

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
