### PR TITLE
Fix: stringify objects when appending them to FormData

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -4008,6 +4008,8 @@ var htmx = (function() {
         target.delete(name)
         if (typeof value.forEach === 'function') {
           value.forEach(function(v) { target.append(name, v) })
+        } else if (typeof value === 'object' && !(value instanceof Blob)) {
+          target.append(name, JSON.stringify(value))
         } else {
           target.append(name, value)
         }


### PR DESCRIPTION
## Description
Current implementation of FormData proxy fails to encode objects, which are appended as a poorly-stringified version, aka `'[object Object]'` (the `toString` equivalent).
This PR fixes this by calling `JSON.stringify` on such objects

Corresponding issue: #2616

## Testing
- Current situation can be tested on [this JSFiddle](https://jsfiddle.net/g9yq8f7h/1/), notice how the `foo` param is incorrectly formatted
- Fix with this PR can be tested on [this JSFiddle](https://jsfiddle.net/g9yq8f7h/2/), notice how the `foo` param is now correctly formatted

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
