### PR TITLE
Fix: values order with non-GET requests

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3382,10 +3382,10 @@ var htmx = (function() {
   function overrideFormData(receiver, donor) {
     for (const key of donor.keys()) {
       receiver.delete(key)
-      donor.getAll(key).forEach(function(value) {
-        receiver.append(key, value)
-      })
     }
+    donor.forEach(function(value, key) {
+      receiver.append(key, value)
+    })
     return receiver
   }
 

--- a/test/core/parameters.js
+++ b/test/core/parameters.js
@@ -293,4 +293,23 @@ describe('Core htmx Parameter Handling', function() {
     this.server.respond()
     form.innerHTML.should.equal('Clicked!')
   })
+
+  it('order of parameters follows order of input elements with POST', function() {
+    this.server.respondWith('POST', '/test', function(xhr) {
+      xhr.requestBody.should.equal('foo=bar&bar=foo&foo=bar&foo2=bar2')
+      xhr.respond(200, {}, 'Clicked!')
+    })
+
+    var form = make('<form hx-post="/test">' +
+      '<input name="foo" value="bar">' +
+      '<input name="bar" value="foo">' +
+      '<input name="foo" value="bar">' +
+      '<input name="foo2" value="bar2">' +
+      '<button id="b1">Click Me!</button>' +
+      '</form>')
+
+    byId('b1').click()
+    this.server.respond()
+    form.innerHTML.should.equal('Clicked!')
+  })
 })


### PR DESCRIPTION
## Description
Former implementation of `overrideFormData` was overriding all values for a given key, one key after the other, thus breaking the initial order of values.
This situation wasn't caught by existing tests (see 01b292ada48f31276642b587eb67128367349701), as the tested case was a `GET` request, for which we don't run the values override with the closest form's values.

This PR fixes #2703 by overriding values in order using `forEach` on the `FormData`, ensuring to preserve the initial order

Corresponding issue: #2703

## Testing
Added a test case for a `POST` request as well

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
