### PR TITLE
Do not boost forms with method="dialog"

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2273,7 +2273,7 @@ var htmx = (function() {
    * @param {HtmxTriggerSpecification[]} triggerSpecs
    */
   function boostElement(elt, nodeData, triggerSpecs) {
-    if ((elt instanceof HTMLAnchorElement && isLocalLink(elt) && (elt.target === '' || elt.target === '_self')) || elt.tagName === 'FORM') {
+    if ((elt instanceof HTMLAnchorElement && isLocalLink(elt) && (elt.target === '' || elt.target === '_self')) || (elt.tagName === 'FORM' && String(getRawAttribute(elt, 'method')).toLowerCase() !== 'dialog')) {
       nodeData.boosted = true
       let verb, path
       if (elt.tagName === 'A') {

--- a/test/attributes/hx-boost.js
+++ b/test/attributes/hx-boost.js
@@ -72,7 +72,7 @@ describe('hx-boost attribute', function() {
   })
 
   it('does not boost forms with method="dialog"', function() {
-    make('<div hx-target="this" hx-boost="true"><form id="f1" action="/test" method="dialog"><button id="b1">close</button></form></div>')
+    make('<div hx-boost="true"><form id="f1" action="/test" method="dialog"><button id="b1">close</button></form></div>')
     var form = byId('f1')
 
     var internalData = htmx._('getInternalData')(form)

--- a/test/attributes/hx-boost.js
+++ b/test/attributes/hx-boost.js
@@ -71,6 +71,14 @@ describe('hx-boost attribute', function() {
     div.innerHTML.should.equal('Boosted')
   })
 
+  it('does not boost forms with method="dialog"', function() {
+    make('<div hx-target="this" hx-boost="true"><form id="f1" action="/test" method="dialog"><button id="b1">close</button></form></div>')
+    var form = byId('f1')
+
+    var internalData = htmx._('getInternalData')(form)
+    should.equal(undefined, internalData.boosted)
+  })
+
   it('handles basic anchor properly w/ data-* prefix', function() {
     this.server.respondWith('GET', '/test', 'Boosted')
     var div = make('<div data-hx-target="this" data-hx-boost="true"><a id="a1" href="/test">Foo</a></div>')


### PR DESCRIPTION
## Description

Boosting forms with method="dialog" should not trigger AJAX requests because these are only meant to close parent `<dialog>`  elements and not submit anything.


> When a `<form>` within a `<dialog>` is submitted via the dialog method, the dialog box closes, the states of the form controls are saved but not submitted


source: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog#usage_notes

## Testing

Can be tested with the following snippet:


```html

<body hx-boost="true">
  <dialog id="modal">
    <form method="dialog">
      <button>Close modal</button>
    </form>
  </dialog>
</body>

<script type="text/javascript">
   document.getElementById("modal").showModal()
</script>
```

Clicking the "Close modal" button should not trigger any AJAX requests

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
