### PR TITLE
Properly handle buttons with formmethod=dialog

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -4077,9 +4077,11 @@ var htmx = (function() {
 
       const buttonVerb = getRawAttribute(submitter, 'formmethod')
       if (buttonVerb != null) {
-      // ignore buttons with formmethod="dialog"
-        if (buttonVerb.toLowerCase() !== 'dialog') {
+        if (VERBS.includes(buttonVerb.toLowerCase())) {
           verb = (/** @type HttpVerb */(buttonVerb))
+        } else {
+          maybeCall(resolve)
+          return promise
         }
       }
     }

--- a/test/core/ajax.js
+++ b/test/core/ajax.js
@@ -1178,32 +1178,16 @@ describe('Core htmx AJAX Tests', function() {
     values.should.deep.equal({ t1: 'textValue', b1: ['inputValue', 'buttonValue'], s1: 'selectValue' })
   })
 
-  it('handles form post with button formmethod dialog properly', function() {
-    var values
+  it('properly handles clicked buttons with a dialog formmethod', function() {
+    var request = false
     this.server.respondWith('POST', '/test', function(xhr) {
-      values = getParameters(xhr)
-      xhr.respond(200, {}, '')
+      request = true
+      xhr.respond(200, {}, '<button>Bar</button>')
     })
-
     make('<dialog><form hx-post="/test"><button id="submit" formmethod="dialog" name="foo" value="bar">submit</button></form></dialog>')
-
     byId('submit').click()
     this.server.respond()
-    values.should.deep.equal({ foo: 'bar' })
-  })
-
-  it('handles form get with button formmethod dialog properly', function() {
-    var responded = false
-    this.server.respondWith('GET', '/test', function(xhr) {
-      responded = true
-      xhr.respond(200, {}, '')
-    })
-
-    make('<dialog><form hx-get="/test"><button id="submit" formmethod="dialog">submit</button></form></dialog>')
-
-    byId('submit').click()
-    this.server.respond()
-    responded.should.equal(true)
+    should.equal(request, false)
   })
 
   it('can associate submit buttons from outside a form with the current version of the form after swap', function() {

--- a/test/core/shadowdom.js
+++ b/test/core/shadowdom.js
@@ -1242,32 +1242,16 @@ describe('Core htmx Shadow DOM Tests', function() {
     values.should.deep.equal({ t1: 'textValue', b1: ['inputValue', 'buttonValue'], s1: 'selectValue' })
   })
 
-  it('handles form post with button formmethod dialog properly', function() {
-    var values
+  it('properly handles clicked buttons with a dialog formmethod', function() {
+    var request = false
     this.server.respondWith('POST', '/test', function(xhr) {
-      values = getParameters(xhr)
-      xhr.respond(200, {}, '')
+      request = true
+      xhr.respond(200, {}, '<button>Bar</button>')
     })
-
     make('<dialog><form hx-post="/test"><button id="submit" formmethod="dialog" name="foo" value="bar">submit</button></form></dialog>')
-
     byId('submit').click()
     this.server.respond()
-    values.should.deep.equal({ foo: 'bar' })
-  })
-
-  it('handles form get with button formmethod dialog properly', function() {
-    var responded = false
-    this.server.respondWith('GET', '/test', function(xhr) {
-      responded = true
-      xhr.respond(200, {}, '')
-    })
-
-    make('<dialog><form hx-get="/test"><button id="submit" formmethod="dialog">submit</button></form></dialog>')
-
-    byId('submit').click()
-    this.server.respond()
-    responded.should.equal(true)
+    should.equal(request, false)
   })
 
   it('can associate submit buttons from outside a form with the current version of the form after swap', function() {


### PR DESCRIPTION
## Description
Buttons with `formmethod` specified should only be handled by HTMX if the value is an HTTP verb. This partially addresses Issue #2554 (along with PR #2752) and (imho) fixes the behavior introduced in PR #1867. If a button with `formmethod="dialog"` is a clicked, HTMX should ignore the request and let the browser handle closing the dialog (see [this comment](https://github.com/bigskysoftware/htmx/pull/1867#issuecomment-2242733913)).

## Testing
I removed two ajax tests added by PR #2752 (that were also duplicated in the shadowdom tests) and replaced them with a test that should be checking that the server had no response. The tests passed but I'm not 100% the test were correctly written.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
