### PR TITLE
Document how to use event delegation within hx-trigger for dynamically added elements

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -246,7 +246,9 @@ issuing the request.  If the event triggers again, the countdown is reset.
 *  `throttle:<time interval>` - wait the given amount of time (e.g. `1s`) before
 issuing the request.  Unlike `delay` if a new event occurs before the time limit is hit the event will be discarded,
 so the request will trigger at the end of the time period.
-*  `from:<CSS Selector>` - listen for the event on a different element.  This can be used for things like keyboard shortcuts. Note that this CSS selector is not re-evaluated if the page changes.
+*  `from:<CSS Selector>` - listen for the event on a different element.  This can be used for things like keyboard shortcuts.
+Note that this CSS selector is not re-evaluated if the page changes. For dynamically added elements, use event delegation
+by enclosing the selector in curly braces, e.g. `hx-trigger="click from:{#main .dynamic-element}"`.
 
 You can use these attributes to implement many common UX patterns, such as [Active Search](@/examples/active-search.md):
 


### PR DESCRIPTION
## Description
This PR updates the main docs page with `hx-trigger CSS Selector bullet point to explain how to use event delegation for dynamically added elements.

The new information helps users understand how to:
1. Use event delegation for dynamically added elements
2. Avoid syntax errors when using **selectors with spaces**

Previously, the documentation didn't cover how to handle event delegation for elements added to the DOM after the initial page load. I struggled with htmx errors due to white space issues when referencing the dynamic element. So I thought it's worth documenting.

So before I **wrongly** was trying:
```html
hx-trigger="click from:#main .dynamic-element"
```
Now I know to **correctly** do:
```html
hx-trigger="click from:{#main .dynamic-element}"
```

The update adds information on using curly braces `{}` to the `from:` modifier of `hx-trigger`. 

This documentation update corresponds to the implementation in PR #1913, which introduced this functionality to HTMX.

## Testing
This change is purely to document an existing feature. I've tested the curly-brace notation in a working project.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
