### PR TITLE
Add ability to trigger an event on another element using `HX-Trigger` response header

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1952,11 +1952,11 @@ var htmx = (function() {
       for (const eventName in triggers) {
         if (triggers.hasOwnProperty(eventName)) {
           let detail = triggers[eventName]
-          if (!isRawObject(detail)) {
-            detail = { value: detail }
-          } else {
+          if (isRawObject(detail)) {
             // @ts-ignore
             elt = detail.target !== undefined ? detail.target : elt
+          } else {
+            detail = { value: detail }
           }
           triggerEvent(elt, eventName, detail)
         }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1953,9 +1953,10 @@ var htmx = (function() {
         if (triggers.hasOwnProperty(eventName)) {
           let detail = triggers[eventName]
           if (!isRawObject(detail)) {
+            detail = { value: detail }
+          } else {
             // @ts-ignore
             elt = detail.target !== undefined ? detail.target : elt
-            detail = { value: detail }
           }
           triggerEvent(elt, eventName, detail)
         }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1953,9 +1953,8 @@ var htmx = (function() {
         if (triggers.hasOwnProperty(eventName)) {
           let detail = triggers[eventName]
           if (!isRawObject(detail)) {
-            if (detail.target !== undefined) {
-              elt = detail.target
-            }
+            // @ts-ignore
+            elt = detail.target !== undefined ? detail.target : elt
             detail = { value: detail }
           }
           triggerEvent(elt, eventName, detail)

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1953,8 +1953,8 @@ var htmx = (function() {
         if (triggers.hasOwnProperty(eventName)) {
           let detail = triggers[eventName]
           if (!isRawObject(detail)) {
-            if (detail.elt !== undefined) {
-              elt = detail.elt
+            if (detail.target !== undefined) {
+              elt = detail.target
             }
             detail = { value: detail }
           }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1953,6 +1953,9 @@ var htmx = (function() {
         if (triggers.hasOwnProperty(eventName)) {
           let detail = triggers[eventName]
           if (!isRawObject(detail)) {
+            if (detail.elt !== undefined) {
+              elt = detail.elt
+            }
             detail = { value: detail }
           }
           triggerEvent(elt, eventName, detail)

--- a/test/core/headers.js
+++ b/test/core/headers.js
@@ -147,6 +147,21 @@ describe('Core htmx AJAX headers', function() {
     invokedEvent.should.equal(true)
   })
 
+  it('should handle JSON with target array arg HX-Trigger response header properly', function() {
+    this.server.respondWith('GET', '/test', [200, { 'HX-Trigger': '{"foo":{"target":"#testdiv"}}' }, ''])
+
+    var div = make('<div hx-get="/test"></div>')
+    var testdiv = make('<div id="testdiv"></div>')
+    var invokedEvent = false
+    testdiv.addEventListener('foo', function(evt) {
+      invokedEvent = true
+      evt.detail.elt.should.equal(testdiv)
+    })
+    div.click()
+    this.server.respond()
+    invokedEvent.should.equal(true)
+  })
+
   it('should survive malformed JSON in HX-Trigger response header', function() {
     this.server.respondWith('GET', '/test', [200, { 'HX-Trigger': '{not: valid}' }, ''])
 

--- a/www/content/headers/hx-trigger.md
+++ b/www/content/headers/hx-trigger.md
@@ -60,6 +60,12 @@ document.body.addEventListener("showMessage", function(evt){
 
 Each property of the JSON object on the right hand side will be copied onto the details object for the event.
 
+### Targetting Other Elements
+
+You can trigger events on other target elements by adding a `target` argument to the JSON object.
+
+`HX-Trigger: {"showMessage":{"target" : "#otherElement"}}`
+
 ### Multiple Triggers
 
 If you wish to invoke multiple events, you can simply add additional properties to the top level JSON


### PR DESCRIPTION
## Description

This PR adds the ability to trigger an event on another element using the [`HX-Trigger`](https://htmx.org/headers/hx-trigger/) response header (also `HX-Trigger-After-Swap` and `HX-Trigger-After-Settle`) by allowing a `target` argument.

```
HX-Trigger: {"myEvent": {"target": "#myElement"}}
```

## Testing

Added a test to ensure the event is triggered on the `target` element.

## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [X] I ran the test suite locally (`npm run test`) and verified that it succeeded
