### PR TITLE
Fix file upload through htmx.ajax

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3918,7 +3918,7 @@ var htmx = (function() {
       if (obj.hasOwnProperty(key)) {
         if (typeof obj[key].forEach === 'function') {
           obj[key].forEach(function(v) { formData.append(key, v) })
-        } else if (typeof obj[key] === 'object') {
+        } else if (typeof obj[key] === 'object' && !(obj[key] instanceof Blob)) {
           formData.append(key, JSON.stringify(obj[key]))
         } else {
           formData.append(key, obj[key])

--- a/test/core/parameters.js
+++ b/test/core/parameters.js
@@ -312,4 +312,56 @@ describe('Core htmx Parameter Handling', function() {
     this.server.respond()
     form.innerHTML.should.equal('Clicked!')
   })
+
+  it('file is correctly uploaded with file input', function() {
+    this.server.respondWith('POST', '/test', function(xhr) {
+      should.equal(xhr.requestHeaders['Content-Type'], undefined)
+
+      const file = xhr.requestBody.get('file')
+      file.should.instanceOf(File)
+      file.name.should.equal('test.txt')
+
+      xhr.respond(200, {}, 'OK')
+    })
+
+    const form = make('<form hx-post="/test" hx-target="#result" hx-encoding="multipart/form-data">' +
+      '<input type="file" name="file">' +
+      '<button type="submit"></button>' +
+      '</form>')
+    const input = form.querySelector('input')
+    const file = new File(['Test'], 'test.txt', { type: 'text/plain' })
+    const dataTransfer = new DataTransfer()
+    dataTransfer.items.add(file)
+    input.files = dataTransfer.files
+
+    const result = make('<div id="result"></div>')
+
+    form.querySelector('button').click()
+    this.server.respond()
+    result.innerHTML.should.equal('OK')
+  })
+
+  it('file is correctly uploaded with htmx.ajax', function() {
+    this.server.respondWith('POST', '/test', function(xhr) {
+      should.equal(xhr.requestHeaders['Content-Type'], undefined)
+
+      const file = xhr.requestBody.get('file')
+      file.should.instanceOf(File)
+      file.name.should.equal('test.txt')
+
+      xhr.respond(200, {}, 'OK')
+    })
+
+    const div = make('<div hx-encoding="multipart/form-data"></div>')
+
+    htmx.ajax('POST', '/test', {
+      source: div,
+      values: {
+        file: new File(['Test'], 'test.txt', { type: 'text/plain' })
+      }
+    })
+
+    this.server.respond()
+    div.innerHTML.should.equal('OK')
+  })
 })


### PR DESCRIPTION
Fixes #2630

## Description
When converting an object to FormData, we had a simple check that if a value was an object, we'd JSON-stringify it before appending it to the FormData.

#2748 addressed a _similar_ issue, thoughI had totally missed that a similar check was done elsewhere in the code.

One case was not handled here, causing the referenced issue ; the `Blob` type, that `FormData` can perfectly handle _(a type that includes `File`s)_, would be JSON-stringified instead of directly passed to `FormData.append` as it's an `object` itself, resulting in the loss of the file data, and that conversion to an empty object.

Corresponding issue: #2630

## Testing
Added a test cases, to ensure that `htmx.ajax` with a file passed in parameters, is correctly uploaded and not empty.
Also added another test case with a file input as I found out we didn't have any yet.

Additionnaly, you can:
- Observe the current behavior on [this JSFiddle](https://jsfiddle.net/6tf8wc2z/), notice how the file is an empty object instead of a binary
- Observe the behavior with this PR's fix on [this JSFiddle](https://jsfiddle.net/6tf8wc2z/1/), notice how the file is now correctly a binary

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
