### PR TITLE
Listen to resize events and check revealed

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2471,6 +2471,7 @@ var htmx = (function() {
         windowIsScrolling = true
       }
       window.addEventListener('scroll', scrollHandler)
+      window.addEventListener('resize', scrollHandler)
       setInterval(function() {
         if (windowIsScrolling) {
           windowIsScrolling = false


### PR DESCRIPTION
## Description
It is possible that element can be revealed not only because of scroll but because window size is changed or other elements in a page dynamically changed.

Corresponding issue:

## Testing
1. Load test page in small window with test element (activated by hx-trigger="revealed") below visible area.
2. Resize the window.
3. When test element is visible revealed event is missing.


## Checklist

* [yep] I have read the contribution guidelines
* [dev] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [fix] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
