### PR TITLE
Optimize Head regex

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -583,7 +583,7 @@ var htmx = (function() {
    */
   function makeFragment(response) {
     // strip head tag to determine shape of response we are dealing with
-    const responseWithNoHead = response.replace(/<head(\s[^>]*>|>)(.*?)<\/head>/ism, '')
+    const responseWithNoHead = response.replace(/<head(\s[^>]*)?>.*?<\/head>/is, '')
     const startTag = getStartTag(responseWithNoHead)
     /** @type DocumentFragmentWithTitle */
     let fragment

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -337,21 +337,9 @@ var htmx = (function() {
     return '[hx-' + verb + '], [data-hx-' + verb + ']'
   }).join(', ')
 
-  const HEAD_TAG_REGEX = makeTagRegEx('head')
-
   //= ===================================================================
   // Utilities
   //= ===================================================================
-
-  /**
-   * @param {string} tag
-   * @param {boolean} global
-   * @returns {RegExp}
-   */
-  function makeTagRegEx(tag, global = false) {
-    return new RegExp(`<${tag}(\\s[^>]*>|>)([\\s\\S]*?)<\\/${tag}>`,
-      global ? 'gim' : 'im')
-  }
 
   /**
    * Parses an interval string consistent with the way htmx does. Useful for plugins that have timing-related attributes.
@@ -595,7 +583,7 @@ var htmx = (function() {
    */
   function makeFragment(response) {
     // strip head tag to determine shape of response we are dealing with
-    const responseWithNoHead = response.replace(HEAD_TAG_REGEX, '')
+    const responseWithNoHead = response.replace(/<head(\s[^>]*>|>)(.*?)<\/head>/ism, '')
     const startTag = getStartTag(responseWithNoHead)
     /** @type DocumentFragmentWithTitle */
     let fragment

--- a/test/manual/hxboost_partial_template_parsing/index.html
+++ b/test/manual/hxboost_partial_template_parsing/index.html
@@ -19,7 +19,7 @@
     </style>
 
     <script src="../../../src/htmx.js" hx-preserve="true"></script>
-    <script src="../../../src/ext/head-support.js" hx-preserve="true"></script>
+    <script src="https://unpkg.com/htmx-ext-head-support@2.0.0/head-support.js" hx-preserve="true"></script>
 </head>
 <body hx-ext="head-support" hx-boost="true">
     <header hx-push-url="false" hx-target="main" hx-swap="innerHTML">


### PR DESCRIPTION
## Description
Their was a change to add a regex tag utility function in #2024 and this combined three regex creations into a single function.  Since then it seems the svg and title regex were simplified out with the htmx 2.0 re-write and we are now left with a redundant function that is only used to generate a single HEAD_TAG_REGEX which is only used once in makeFragment.  So my proposed change here is to just simply remove this utility function and move the single use regex inline which should simplify readability and code minification.

Previous regex format was:

``` javascript
new RegExp(`<${tag}(\\s[^>]*>|>)([\\s\\S]*?)<\\/${tag}>`, global ? 'gim' : 'im')
```
And I'm simplified this to:
``` javascript
/<head(\s[^>]*)?>.*?<\/head>/is
```
Note [\s\S] is now .* because of the s option and m option is not needed here.  

Corresponding issue:

## Testing
Found the manual tests added with the #2024 change and was able to manually test this change worked fine with these manual tests after updating the test to link to the now external head-support extension.
Also tested with `npm run test` but found that this remove head feature in makeFragment has no coverage in these tests as breaking it caused no test failures.  Because it is only used by head-support extension and not core htmx.
Manually ran the manual-tests folder in the head-support extension with the updated htmx changes as well and found no issues.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
