### PR TITLE
Link to htmx:sendError from error description

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -933,7 +933,7 @@ the response.
 In the event of an error response from the server (e.g. a 404 or a 501), htmx will trigger the [`htmx:responseError`](@/events.md#htmx:responseError)
 event, which you can handle.
 
-In the event of a connection error, the `htmx:sendError` event will be triggered.
+In the event of a connection error, the [`htmx:sendError`](@/events.md#htmx:sendError) `htmx:sendError` event will be triggered.
 
 ### Configuring Response Handling {#response-handling}
 


### PR DESCRIPTION
## Description

Add a link, as exists for `htmx:responseError` above.

Corresponding issue: n/a

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
