### PR TITLE
Add HTML comment and catch-all to responseHandling config via <meta> tag

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -977,6 +977,7 @@ config:
   * 204 No Content by default does nothing, but is not an error
   * 2xx, 3xx and 422 responses are non-errors and are swapped
   * 4xx & 5xx responses are not swapped and are errors
+  * all other responses are swapped using "..." as a catch-all
 -->
 <meta
 	name="htmx-config"
@@ -985,7 +986,8 @@ config:
             {"code":"204", "swap": false},
             {"code":"[23]..", "swap": true},
             {"code":"422", "swap": true},
-            {"code":"[45]..", "swap": false, "error":true}
+            {"code":"[45]..", "swap": false, "error":true},
+            {"code":"...", "swap": true}
         ]
     }'
 />

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -973,6 +973,11 @@ Using the [meta config](#configuration-options) mechanism for configuring respon
 config:
 
 ```html
+<!--
+  * 204 No Content by default does nothing, but is not an error
+  * 2xx, 3xx and 422 responses are non-errors and are swapped
+  * 4xx & 5xx responses are not swapped and are errors
+-->
 <meta
 	name="htmx-config"
 	content='{


### PR DESCRIPTION
## Description

These are the changes that I forgot to include in https://github.com/bigskysoftware/htmx/pull/2715 based on feedback in the comments.

Corresponding ~issue~ PR: https://github.com/bigskysoftware/htmx/pull/2715

/cc  @alexpetros (as requested in https://github.com/bigskysoftware/htmx/pull/2715#issuecomment-2269835949)

## Testing

Made sure config is valid JSON. Rest was already tested in https://github.com/bigskysoftware/htmx/pull/2715.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
