### PR TITLE
:bug: Prevents erroring on null vals

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3927,7 +3927,7 @@ var htmx = (function() {
     const formData = new FormData()
     for (const key in obj) {
       if (obj.hasOwnProperty(key)) {
-        if (typeof obj[key].forEach === 'function') {
+        if (obj[key] && typeof obj[key].forEach === 'function') {
           obj[key].forEach(function(v) { formData.append(key, v) })
         } else if (typeof obj[key] === 'object' && !(obj[key] instanceof Blob)) {
           formData.append(key, JSON.stringify(obj[key]))

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -4020,7 +4020,7 @@ var htmx = (function() {
           return false
         }
         target.delete(name)
-        if (typeof value.forEach === 'function') {
+        if (value && typeof value.forEach === 'function') {
           value.forEach(function(v) { target.append(name, v) })
         } else if (typeof value === 'object' && !(value instanceof Blob)) {
           target.append(name, JSON.stringify(value))

--- a/test/attributes/hx-vals.js
+++ b/test/attributes/hx-vals.js
@@ -297,4 +297,15 @@ describe('hx-vals attribute', function() {
     }
     calledEvent.should.equal(true)
   })
+  it('hx-vals works with null values', function() {
+    this.server.respondWith('POST', '/vars', function(xhr) {
+      var params = getParameters(xhr)
+      params.i1.should.equal('null')
+      xhr.respond(200, {}, 'Clicked!')
+    })
+    var div = make("<div hx-post='/vars' hx-vals='{\"i1\": null }'></div>")
+    div.click()
+    this.server.respond()
+    div.innerHTML.should.equal('Clicked!')
+  })
 })

--- a/test/core/parameters.js
+++ b/test/core/parameters.js
@@ -276,6 +276,14 @@ describe('Core htmx Parameter Handling', function() {
     vals.foo.should.equal('bar')
   })
 
+  it('formdata works with null values', function() {
+    var form = make('<form hx-post="/test"><input name="foo" value="bar"/></form>')
+    var vals = htmx._('getInputValues')(form, 'get').values
+    function updateToNull() { vals.foo = null }
+    updateToNull.should.not.throw()
+    vals.foo.should.equal('null')
+  })
+
   it('order of parameters follows order of input elements', function() {
     this.server.respondWith('GET', '/test?foo=bar&bar=foo&foo=bar&foo2=bar2', function(xhr) {
       xhr.respond(200, {}, 'Clicked!')


### PR DESCRIPTION
## Description

This prevents accessing the `forEach` key on `null` or `undefined` values. `null` is valid in JSON, so it should be supported by the `hx-vals` attribute. This is a regression from 1.x

Could use optional chaining, but I'd imagine that isn't an accepted feature. I also assume the fact it doesn't use `Array.isArray` is because it wants to support other containers that implement `forEach`. So just doing a truthy test is satisfactory, since there is 0% chance that someone is going to be passing `document.all` as a value.

Corresponding issue:

## Testing

Added test. Change is common sense, but the test ensures it's condition into the future.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
