### PR TITLE
clear up oob swap expected behaviour

### DIFF
--- a/www/content/attributes/hx-swap-oob.md
+++ b/www/content/attributes/hx-swap-oob.md
@@ -34,7 +34,7 @@ If another swap value is given, that swap strategy will be used instead but note
  ...
 </div>
 <div id="alerts" hx-swap-oob="beforeend">
-    <p>Saved again!</p> <!--swap inner contents to end of alters but not wraping oob div-->
+    <p>Saved again!</p> <!--swap inner contents to end of alerts but not wraping oob div-->
 </div>
 ```
 

--- a/www/content/attributes/hx-swap-oob.md
+++ b/www/content/attributes/hx-swap-oob.md
@@ -25,9 +25,9 @@ The value of the `hx-swap-oob` can be:
 * any valid [`hx-swap`](@/attributes/hx-swap.md) value
 * any valid [`hx-swap`](@/attributes/hx-swap.md) value, followed by a colon, followed by a CSS selector
 
-If the value is `true` or `outerHTML` (which are equivalent) the element will be swapped inline.
+If the value is `true` or `outerHTML` (which are equivalent) the element will be swapped inline with the contents of the whole tag.
 
-If a swap value is given, that swap strategy will be used.
+If another swap value is given, that swap strategy will be used instead but note that only the inner contents of tag will be used for most non inline swap strategies
 
 If a selector is given, all elements matched by that selector will be swapped.  If not, the element with an ID matching the new content will be swapped.
 

--- a/www/content/attributes/hx-swap-oob.md
+++ b/www/content/attributes/hx-swap-oob.md
@@ -27,9 +27,27 @@ The value of the `hx-swap-oob` can be:
 
 If the value is `true` or `outerHTML` (which are equivalent) the element will be swapped inline with the contents of the whole tag.
 
-If another swap value is given, that swap strategy will be used instead but note that only the inner contents of tag will be used for most non inline swap strategies
+If another swap value is given, that swap strategy will be used instead but note that only the inner contents of tag will be used for most non inline swap strategies.
+
+```html
+<div>
+ ...
+</div>
+<div id="alerts" hx-swap-oob="beforeend">
+    <p>Saved again!</p> <!--swap inner contents to end of alters but not wraping oob div-->
+</div>
+```
 
 If a selector is given, all elements matched by that selector will be swapped.  If not, the element with an ID matching the new content will be swapped.
+
+```html
+<div>
+ ...
+</div>
+<div hx-swap-oob="outerHTML:.alerts" class="alerts">
+    Replace all the alerts!
+</div>
+```
 
 ### Troublesome Tables
 


### PR DESCRIPTION
## Description
Try to clarify the expected behavior of oob swap strategies which work a little different to normal swaps.  all the non inline swap strategies like beforeend etc seem to work differently than they do with full swaps in that it is the inner contents of the tag supplied with the hx-swap-oob attribute that is swapped in and not the tag itself.  This gives you the flexibility to swap in non tag wrapped data if needed and to not add additional hx-swap-oob tags into the DOM that have no client DOM function but it does mean you have to add an additional layer by wrapping the oob content in a dummy div tag sometimes.

Corresponding issue:
#2790 

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
