### PR TITLE
Checking readyState is interactive before listening for DOMContentLoaded

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -4899,7 +4899,7 @@ var htmx = (function() {
   function ready(fn) {
     // Checking readyState here is a failsafe in case the htmx script tag entered the DOM by
     // some means other than the initial page load.
-    if (isReady || getDocument().readyState === 'complete') {
+    if (isReady || getDocument().readyState === 'interactive' || getDocument().readyState === 'complete') {
       fn()
     } else {
       getDocument().addEventListener('DOMContentLoaded', fn)


### PR DESCRIPTION
## Description
This is to fix issue #2264. Sometimes DOMContentLoaded can fire before readyState === 'complete'.

Corresponding issue:

## Testing
The unit test suite passed.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
