### PR TITLE
fix cdn typo

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -127,7 +127,7 @@ your head tag and get going:
 An unminified version is also available for debugging as well:
 
 ```html
-<script src="https://unpkg.com/htmx.org@2.02/dist/htmx.js" integrity="sha384-yZq+5izaUBKcRgFbxgkRYwpHhHHCpp5nseXp0MEQ1A4MTWVMnqkmcuFez8x5qfxr" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/htmx.org@2.0.2/dist/htmx.js" integrity="sha384-yZq+5izaUBKcRgFbxgkRYwpHhHHCpp5nseXp0MEQ1A4MTWVMnqkmcuFez8x5qfxr" crossorigin="anonymous"></script>
 ```
 
 While the CDN approach is extremely simple, you may want to consider 


### PR DESCRIPTION
## Description
unminified cdn link has missing . and should be 2.0.2 not 2.02

Corresponding issue:
#2812

## Testing
Tested cdn link was broken but worked in a project fine with updated link

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
