### PR TITLE
fix responseHandling meta example

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -996,7 +996,7 @@ config:
 If you wanted to swap everything, regardless of HTTP response code, you could use this configuration:
 
 ```html
-<meta name="htmx-config" content='{code:".*", swap: true}, // all responses are swapped'>
+<meta name="htmx-config" content='{"responseHandling": [{"code":".*", "swap": true}]}' /> <!--all responses are swapped-->
 ```
 
 Finally, it is worth considering using the [Response Targets](https://github.com/bigskysoftware/htmx-extensions/blob/main/src/response-targets/README.md)


### PR DESCRIPTION
## Description
one of the responseHandling examples has invalid js code which needs to be a JSON string format and its missing the root responseHandling node. and comments can't be in json.

Corresponding issue:

## Testing
Tested new meta tag to make sure it works as expected when used in a header.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
