### PR TITLE
Minor change in the documentation

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -806,7 +806,7 @@ However, you could wrap the htmx-enhanced input in a form element:
     <input class="form-control" type="search"
         name="search" placeholder="Begin typing to search users..."
         hx-post="/search"
-        hx-trigger="keyup changed delay:500ms, search"
+        hx-trigger="keyup changed throttle:500ms, search"
         hx-target="#search-results"
         hx-indicator=".htmx-indicator">
 </form>


### PR DESCRIPTION
As a new user, I initially thought `"delay"` acted like a debouncer, waiting for the user to stop typing before sending a request. However, `throttle` is the correct approach for this scenario. Although the example doesn't focus on efficient event handling, changing it to `throttle` would prevent confusion and align with best practices, as `delay` simply postpones requests without debouncing. This update ensures clarity for new users.

Thanks!