### PR TITLE
Issue #2676 - Tests for v2 to prevent regression of issue from v1

### DIFF
--- a/test/core/ajax.js
+++ b/test/core/ajax.js
@@ -559,6 +559,34 @@ describe('Core htmx AJAX Tests', function() {
     values.should.deep.equal({ c1: ['cb1', 'cb3'], c2: 'cb5', c3: 'cb6' })
   })
 
+  it('properly handles radio inputs', function() {
+    var values
+    this.server.respondWith('Post', '/test', function(xhr) {
+      values = getParameters(xhr)
+      xhr.respond(204, {}, '')
+    })
+
+    var form = make('<form hx-post="/test" hx-trigger="click">' +
+        '<div role="radiogroup">' +
+        '<input id="rb1" name="r1" value="rb1" type="radio">' +
+        '<input id="rb2" name="r1" value="rb2" type="radio">' +
+        '<input id="rb3" name="r1" value="rb3" type="radio">' +
+        '<input id="rb4" name="r2" value="rb4"  type="radio">' +
+        '<input id="rb5" name="r2" value="rb5"  type="radio">' +
+        '<input id="rb6" name="r3" value="rb6"  type="radio">' +
+        '</div>' +
+        '</form>')
+
+    form.click()
+    this.server.respond()
+    values.should.deep.equal({})
+
+    byId('rb1').checked = true
+    form.click()
+    this.server.respond()
+    values.should.deep.equal({ r1: 'rb1' })
+  })
+
   it('text nodes dont screw up settling via variable capture', function() {
     this.server.respondWith('GET', '/test', "<div id='d1' hx-trigger='click consume' hx-get='/test2'></div>fooo")
     this.server.respondWith('GET', '/test2', 'clicked')

--- a/test/core/validation.js
+++ b/test/core/validation.js
@@ -102,7 +102,45 @@ describe('Core htmx client side validation tests', function() {
     form.textContent.should.equal('Clicked!')
   })
 
-  it('hyperscript validation error prevents request', function() {
+  it('Custom validation error prevents request for unticked checkboxes', function()
+    {
+        this.server.respondWith("POST", "/test", "Clicked!");
+
+        var form = make('<form hx-post="/test" hx-trigger="click">' +
+            'No Request' +
+            '<input id="i1" name="i1" type="checkbox">' +
+            '</form>');
+        byId("i1").setCustomValidity("Nope");
+        form.textContent.should.equal("No Request");
+        form.click();
+        this.server.respond();
+        form.textContent.should.equal("No Request");
+        byId("i1").setCustomValidity("");
+        form.click();
+        this.server.respond();
+        form.textContent.should.equal("Clicked!");
+    });
+
+    it('Custom validation error prevents request for unselected radiogroups', function()
+    {
+        this.server.respondWith("POST", "/test", "Clicked!");
+
+        var form = make('<form hx-post="/test" hx-trigger="click">' +
+            'No Request' +
+            '<input id="i1" name="i1" type="radio">' +
+            '</form>');
+        byId("i1").setCustomValidity("Nope");
+        form.textContent.should.equal("No Request");
+        form.click();
+        this.server.respond();
+        form.textContent.should.equal("No Request");
+        byId("i1").setCustomValidity("");
+        form.click();
+        this.server.respond();
+        form.textContent.should.equal("Clicked!");
+    });
+
+    it('hyperscript validation error prevents request', function(){
     this.server.respondWith('POST', '/test', 'Clicked!')
 
     var form = make('<form hx-post="/test" hx-trigger="click">' +

--- a/test/core/validation.js
+++ b/test/core/validation.js
@@ -102,45 +102,43 @@ describe('Core htmx client side validation tests', function() {
     form.textContent.should.equal('Clicked!')
   })
 
-  it('Custom validation error prevents request for unticked checkboxes', function()
-    {
-        this.server.respondWith("POST", "/test", "Clicked!");
+  it('Custom validation error prevents request for unticked checkboxes', function() {
+    this.server.respondWith('POST', '/test', 'Clicked!')
 
-        var form = make('<form hx-post="/test" hx-trigger="click">' +
-            'No Request' +
-            '<input id="i1" name="i1" type="checkbox">' +
-            '</form>');
-        byId("i1").setCustomValidity("Nope");
-        form.textContent.should.equal("No Request");
-        form.click();
-        this.server.respond();
-        form.textContent.should.equal("No Request");
-        byId("i1").setCustomValidity("");
-        form.click();
-        this.server.respond();
-        form.textContent.should.equal("Clicked!");
-    });
+    var form = make('<form hx-post="/test" hx-trigger="click">' +
+        'No Request' +
+        '<input id="i1" name="i1" type="checkbox">' +
+        '</form>')
+    byId('i1').setCustomValidity('Nope')
+    form.textContent.should.equal('No Request')
+    form.click()
+    this.server.respond()
+    form.textContent.should.equal('No Request')
+    byId('i1').setCustomValidity('')
+    form.click()
+    this.server.respond()
+    form.textContent.should.equal('Clicked!')
+  })
 
-    it('Custom validation error prevents request for unselected radiogroups', function()
-    {
-        this.server.respondWith("POST", "/test", "Clicked!");
+  it('Custom validation error prevents request for unselected radiogroups', function() {
+    this.server.respondWith('POST', '/test', 'Clicked!')
 
-        var form = make('<form hx-post="/test" hx-trigger="click">' +
-            'No Request' +
-            '<input id="i1" name="i1" type="radio">' +
-            '</form>');
-        byId("i1").setCustomValidity("Nope");
-        form.textContent.should.equal("No Request");
-        form.click();
-        this.server.respond();
-        form.textContent.should.equal("No Request");
-        byId("i1").setCustomValidity("");
-        form.click();
-        this.server.respond();
-        form.textContent.should.equal("Clicked!");
-    });
+    var form = make('<form hx-post="/test" hx-trigger="click">' +
+        'No Request' +
+        '<input id="i1" name="i1" type="radio">' +
+        '</form>')
+    byId('i1').setCustomValidity('Nope')
+    form.textContent.should.equal('No Request')
+    form.click()
+    this.server.respond()
+    form.textContent.should.equal('No Request')
+    byId('i1').setCustomValidity('')
+    form.click()
+    this.server.respond()
+    form.textContent.should.equal('Clicked!')
+  })
 
-    it('hyperscript validation error prevents request', function(){
+  it('hyperscript validation error prevents request', function() {
     this.server.respondWith('POST', '/test', 'Clicked!')
 
     var form = make('<form hx-post="/test" hx-trigger="click">' +


### PR DESCRIPTION
## Description
Added a basic test for radio input form submission, following the example for checkbox inputs.
Added tests for custom validation on radio and checkbox inputs when the inputs are empty, to support things like 'you must choose an option from at least one of these groups' etc.
These tests pass for v2 due to the refactoring of `processInputValue` in commit `b9322450ff42a5bdf25b194fcdb6ecc744353819` : https://github.com/bigskysoftware/htmx/commit/b9322450ff42a5bdf25b194fcdb6ecc744353819#diff-f14ff7f8c91a6f76e7688c45ca01d600e8928769b268caa71cf09b8f12661f3dR2528-R2530
 - however, it's not totally obvious reading that code why there are now two separate calls to `validateElement` under different conditions, so while I'll submit the main bugfix for https://github.com/bigskysoftware/htmx/issues/2676 under v1, I would like to make sure there's test coverage of the problem for any future refactoring applied to this function in v2.

Corresponding issue: https://github.com/bigskysoftware/htmx/issues/2676

## Testing
As above - manually tested the fix in v1 using the replication sample attached to the ticket, wrote the tests and saw they failed when without the fix. Carried the fixes over to v2, saw that the tests passed now, checked why, and thought it best to submit the tests anyway.

## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [X] I ran the test suite locally (`npm run test`) and verified that it succeeded
