### PR TITLE
Bug 2676 pre submit custom validation v1

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2502,18 +2502,29 @@ return (function () {
             return false;
         }
 
-        function shouldInclude(elt) {
-            if(elt.name === "" || elt.name == null || elt.disabled || closest(elt, "fieldset[disabled]")) {
+        function couldInclude(elt) {
+            if (elt.name === '' || elt.name == null || elt.disabled || closest(elt, 'fieldset[disabled]')) {
                 return false;
             }
             // ignore "submitter" types (see jQuery src/serialize.js)
-            if (elt.type === "button" || elt.type === "submit" || elt.tagName === "image" || elt.tagName === "reset" || elt.tagName === "file" ) {
+            if (elt.type === 'button' || elt.type === 'submit' || elt.tagName === 'image' || elt.tagName === 'reset' || elt.tagName === 'file') {
+                return false;
+            }
+            return true;
+        }
+
+        function shouldInclude(elt) {
+            if (!couldInclude(elt)) {
                 return false;
             }
             if (elt.type === "checkbox" || elt.type === "radio" ) {
                 return elt.checked;
             }
             return true;
+        }
+
+        function shouldValidate(elt) {
+            return couldInclude(elt);
         }
 
         function addValueToValues(name, value, values) {
@@ -2556,9 +2567,9 @@ return (function () {
                     value = toArray(elt.files);
                 }
                 addValueToValues(name, value, values);
-                if (validate) {
-                    validateElement(elt, errors);
-                }
+            }
+            if (validate && shouldValidate(elt)) {
+                validateElement(elt, errors);
             }
             if (matches(elt, 'form')) {
                 var inputs = elt.elements;

--- a/test/core/ajax.js
+++ b/test/core/ajax.js
@@ -586,6 +586,35 @@ describe("Core htmx AJAX Tests", function(){
 
     });
 
+    it('properly handles radio inputs', function()
+    {
+        var values;
+        this.server.respondWith('Post', '/test', function(xhr) {
+            values = getParameters(xhr)
+            xhr.respond(204, {}, '')
+        });
+
+        var form = make('<form hx-post="/test" hx-trigger="click">' +
+            '<div role="radiogroup">' +
+            '<input id="rb1" name="r1" value="rb1" type="radio">' +
+            '<input id="rb2" name="r1" value="rb2" type="radio">' +
+            '<input id="rb3" name="r1" value="rb3" type="radio">' +
+            '<input id="rb4" name="r2" value="rb4"  type="radio">' +
+            '<input id="rb5" name="r2" value="rb5"  type="radio">' +
+            '<input id="rb6" name="r3" value="rb6"  type="radio">' +
+            '</div>' +
+            '</form>');
+
+        form.click();
+        this.server.respond();
+        values.should.deep.equal({});
+
+        byId('rb1').checked = true;
+        form.click();
+        this.server.respond();
+        values.should.deep.equal({ r1: 'rb1' });
+    });
+
     it('text nodes dont screw up settling via variable capture', function()
     {
         this.server.respondWith("GET", "/test", "<div id='d1' hx-trigger='click consume' hx-get='/test2'></div>fooo");

--- a/test/core/validation.js
+++ b/test/core/validation.js
@@ -108,6 +108,42 @@ describe("Core htmx client side validation tests", function(){
         form.textContent.should.equal("Clicked!");
     });
 
+    it('Custom validation error prevents request for unticked checkboxes', function() {
+        this.server.respondWith('POST', '/test', 'Clicked!');
+
+        var form = make('<form hx-post="/test" hx-trigger="click">' +
+            'No Request' +
+            '<input id="i1" name="i1" type="checkbox">' +
+            '</form>');
+        byId('i1').setCustomValidity('Nope');
+        form.textContent.should.equal('No Request');
+        form.click();
+        this.server.respond();
+        form.textContent.should.equal('No Request');
+        byId('i1').setCustomValidity('');
+        form.click();
+        this.server.respond();
+        form.textContent.should.equal('Clicked!');
+    });
+
+    it('Custom validation error prevents request for unselected radiogroups', function() {
+        this.server.respondWith('POST', '/test', 'Clicked!');
+
+        var form = make('<form hx-post="/test" hx-trigger="click">' +
+            'No Request' +
+            '<input id="i1" name="i1" type="radio">' +
+            '</form>');
+        byId('i1').setCustomValidity('Nope');
+        form.textContent.should.equal('No Request');
+        form.click();
+        this.server.respond();
+        form.textContent.should.equal('No Request');
+        byId('i1').setCustomValidity('');
+        form.click();
+        this.server.respond();
+        form.textContent.should.equal('Clicked!');
+    });
+
     it('hyperscript validation error prevents request', function()
     {
         if (IsIE11()) {


### PR DESCRIPTION
## Description
Separated 'should include in form submission' from 'should validate as part of form submission' to ensure custom validation hooks are still evaluated on unchecked checkboxes and radiogroups without a selection.

Corresponding issue: https://github.com/bigskysoftware/htmx/issues/2676

## Testing
Tested manually using the replication sample attached to the ticket. Added automated tests without the fix to demonstrate the problem, and then restored the fix and checked that the failing tests now passed.

## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [X] I ran the test suite locally (`npm run test`) and verified that it succeeded
