### PR TITLE
Ability to add `options` argument to event listener

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1247,9 +1247,6 @@ var htmx = (function() {
    * @returns {EventArgs}
    */
   function processEventArgs(arg1, arg2, arg3, arg4) {
-    if (arg4 == null) {
-      arg4 = {}
-    }
     if (isFunction(arg2)) {
       return {
         target: getDocument().body,

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1242,8 +1242,8 @@ var htmx = (function() {
   /**
    * @param {EventTarget|AnyEventName} arg1
    * @param {AnyEventName|EventListener} arg2
-   * @param {EventListener|Object} [arg3]
-   * @param {Object} [arg4]
+   * @param {EventListener|Object|boolean} [arg3]
+   * @param {Object|boolean} [arg4]
    * @returns {EventArgs}
    */
   function processEventArgs(arg1, arg2, arg3, arg4) {
@@ -1274,8 +1274,8 @@ var htmx = (function() {
    *
    * @param {EventTarget|string} arg1 the element to add the listener to | the event name to add the listener for
    * @param {string|EventListener} arg2 the event name to add the listener for | the listener to add
-   * @param {EventListener|Object} [arg3] the listener to add | options to add
-   * @param {Object} [arg4] options to add
+   * @param {EventListener|Object|boolean} [arg3] the listener to add | options to add
+   * @param {Object|boolean} [arg4] options to add
    * @returns {EventListener}
    */
   function addEventListenerImpl(arg1, arg2, arg3, arg4) {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1243,10 +1243,13 @@ var htmx = (function() {
    * @param {EventTarget|AnyEventName} arg1
    * @param {AnyEventName|EventListener} arg2
    * @param {EventListener|Object|boolean} [arg3]
-   * @param {Object|boolean} [arg4]
+   * @param {Object|boolean=} [arg4]
    * @returns {EventArgs}
    */
   function processEventArgs(arg1, arg2, arg3, arg4) {
+    if (arg4 == null) {
+      arg4 = {}
+    }
     if (isFunction(arg2)) {
       return {
         target: getDocument().body,

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1243,7 +1243,7 @@ var htmx = (function() {
    * @param {EventTarget|AnyEventName} arg1
    * @param {AnyEventName|EventListener} arg2
    * @param {EventListener|Object|boolean} [arg3]
-   * @param {Object|boolean=} [arg4]
+   * @param {Object|boolean} [arg4]
    * @returns {EventArgs}
    */
   function processEventArgs(arg1, arg2, arg3, arg4) {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1242,8 +1242,8 @@ var htmx = (function() {
   /**
    * @param {EventTarget|AnyEventName} arg1
    * @param {AnyEventName|EventListener} arg2
-   * @param {EventListener|Object|boolean} [arg3]
-   * @param {Object|boolean} [arg4]
+   * @param {EventListener|Object} [arg3]
+   * @param {Object} [arg4]
    * @returns {EventArgs}
    */
   function processEventArgs(arg1, arg2, arg3, arg4) {
@@ -1274,8 +1274,8 @@ var htmx = (function() {
    *
    * @param {EventTarget|string} arg1 the element to add the listener to | the event name to add the listener for
    * @param {string|EventListener} arg2 the event name to add the listener for | the listener to add
-   * @param {EventListener|Object|boolean} [arg3] the listener to add | options to add
-   * @param {Object|boolean} [arg4] options to add
+   * @param {EventListener|Object} [arg3] the listener to add | options to add
+   * @param {Object} [arg4] options to add
    * @returns {EventListener}
    */
   function addEventListenerImpl(arg1, arg2, arg3, arg4) {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1236,26 +1236,30 @@ var htmx = (function() {
    * @property {EventTarget} target
    * @property {AnyEventName} event
    * @property {EventListener} listener
+   * @property {Object|boolean} options
    */
 
   /**
    * @param {EventTarget|AnyEventName} arg1
    * @param {AnyEventName|EventListener} arg2
-   * @param {EventListener} [arg3]
+   * @param {EventListener|Object|boolean} [arg3]
+   * @param {Object|boolean} [arg4]
    * @returns {EventArgs}
    */
-  function processEventArgs(arg1, arg2, arg3) {
+  function processEventArgs(arg1, arg2, arg3, arg4) {
     if (isFunction(arg2)) {
       return {
         target: getDocument().body,
         event: asString(arg1),
-        listener: arg2
+        listener: arg2,
+        options: arg3
       }
     } else {
       return {
         target: resolveTarget(arg1),
         event: asString(arg2),
-        listener: arg3
+        listener: arg3,
+        options: arg4
       }
     }
   }
@@ -1267,13 +1271,14 @@ var htmx = (function() {
    *
    * @param {EventTarget|string} arg1 the element to add the listener to | the event name to add the listener for
    * @param {string|EventListener} arg2 the event name to add the listener for | the listener to add
-   * @param {EventListener} [arg3] the listener to add
+   * @param {EventListener|Object|boolean} [arg3] the listener to add | options to add
+   * @param {Object|boolean} [arg4] options to add
    * @returns {EventListener}
    */
-  function addEventListenerImpl(arg1, arg2, arg3) {
+  function addEventListenerImpl(arg1, arg2, arg3, arg4) {
     ready(function() {
-      const eventArgs = processEventArgs(arg1, arg2, arg3)
-      eventArgs.target.addEventListener(eventArgs.event, eventArgs.listener)
+      const eventArgs = processEventArgs(arg1, arg2, arg3, arg4)
+      eventArgs.target.addEventListener(eventArgs.event, eventArgs.listener, eventArgs.options)
     })
     const b = isFunction(arg2)
     return b ? arg2 : arg3

--- a/test/core/events.js
+++ b/test/core/events.js
@@ -77,7 +77,7 @@ describe('Core htmx Events', function() {
     }
   })
 
-  it('events accept an options argument', function() {
+  it('events accept an options argument and the result works as expected', function() {
     var invoked = 0
     var handler = htmx.on('custom', function() {
       invoked = invoked + 1
@@ -89,25 +89,6 @@ describe('Core htmx Events', function() {
       invoked.should.equal(1)
     } finally {
       htmx.off('custom', handler)
-    }
-  })
-
-  it('events accept a useCapture argument', function() {
-    var invoked = []
-    var callable = function(evt) {
-      invoked.push(evt.target.tagName)
-    }
-    try {
-      var parent = make("<div hx-post='/test'></div>")
-      var child = make("<span hx-post='/test'></span>")
-      parent.appendChild(child)
-      var parentHandler = htmx.on(parent, 'custom', callable, true)
-      var childHandler = htmx.on(child, 'custom', callable)
-      htmx.trigger(child, 'custom')
-      invoked.should.equal(['div', 'span'])
-    } finally {
-      htmx.off('custom', parentHandler)
-      htmx.off('custom', childHandler)
     }
   })
 

--- a/test/core/events.js
+++ b/test/core/events.js
@@ -77,6 +77,21 @@ describe('Core htmx Events', function() {
     }
   })
 
+  it('events accept an options argument', function() {
+    var invoked = 0
+    var handler = htmx.on('custom', function() {
+      invoked = invoked + 1
+    }, { once: true })
+    try {
+      var div = make("<div hx-post='/test'></div>")
+      htmx.trigger(div, 'custom')
+      htmx.trigger(div, 'custom')
+      invoked.should.equal(1)
+    } finally {
+      htmx.off('custom', handler)
+    }
+  })
+
   it('htmx:configRequest allows attribute removal', function() {
     var param = 'foo'
     var handler = htmx.on('htmx:configRequest', function(evt) {

--- a/test/core/events.js
+++ b/test/core/events.js
@@ -93,14 +93,14 @@ describe('Core htmx Events', function() {
   })
 
   it('events accept a useCapture argument', function() {
-    var invoked = [];
+    var invoked = []
     var callable = function(evt) {
-      invoked.push(evt.target.tagName);
+      invoked.push(evt.target.tagName)
     }
     try {
-      var parent = make("<div></div>")
-      var child = make("<span></span>")
-      parent.appendChild(child);
+      var parent = make("<div hx-post='/test'></div>")
+      var child = make("<span hx-post='/test'></span>")
+      parent.appendChild(child)
       var parentHandler = htmx.on(parent, 'custom', callable, true)
       var childHandler = htmx.on(child, 'custom', callable)
       htmx.trigger(child, 'custom')

--- a/test/core/events.js
+++ b/test/core/events.js
@@ -92,6 +92,25 @@ describe('Core htmx Events', function() {
     }
   })
 
+  it('events accept a useCapture argument', function() {
+    var invoked = [];
+    var callable = function(evt) {
+      invoked.push(evt.target.tagName);
+    }
+    try {
+      var parent = make("<div></div>")
+      var child = make("<span></span>")
+      parent.appendChild(child);
+      var parentHandler = htmx.on(parent, 'custom', callable, true)
+      var childHandler = htmx.on(child, 'custom', callable)
+      htmx.trigger(child, 'custom')
+      invoked.should.equal(['div', 'span'])
+    } finally {
+      htmx.off('custom', parentHandler)
+      htmx.off('custom', childHandler)
+    }
+  })
+
   it('htmx:configRequest allows attribute removal', function() {
     var param = 'foo'
     var handler = htmx.on('htmx:configRequest', function(evt) {

--- a/www/content/api.md
+++ b/www/content/api.md
@@ -316,14 +316,14 @@ Adds an event listener to an element
 
 * `eventName` - the event name to add the listener for
 * `listener` - the listener to add
-* `options` - [options](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#options) to add to the event listener (optional)
+* `options` - an [options](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#options) object (or a [useCapture](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#usecapture) boolean) to add to the event listener (optional)
 
 or
 
 * `target` - the element to add the listener to
 * `eventName` - the event name to add the listener for
 * `listener` - the listener to add
-* `options` - [options](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#options) to add to the event listener (optional)
+* `options` - an [options](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#options) object (or a [useCapture](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#usecapture) boolean) to add to the event listener (optional)
 
 ##### Example
 

--- a/www/content/api.md
+++ b/www/content/api.md
@@ -316,12 +316,14 @@ Adds an event listener to an element
 
 * `eventName` - the event name to add the listener for
 * `listener` - the listener to add
+* `options` - [options](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#options) to add to the event listener (optional)
 
 or
 
 * `target` - the element to add the listener to
 * `eventName` - the event name to add the listener for
 * `listener` - the listener to add
+* `options` - [options](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#options) to add to the event listener (optional)
 
 ##### Example
 
@@ -331,6 +333,9 @@ or
 
     // add a click listener to the given div
     var myEventListener = htmx.on("#my-div", "click", function(evt){ console.log(evt); });
+
+    // add a click listener to the given div that should only be invoked once
+    var myEventListener = htmx.on("#my-div", "click", function(evt){ console.log(evt); }, { once: true });
 ```
 
 ### Method - `htmx.onLoad()` {#onLoad}


### PR DESCRIPTION
This PR adds the ability to add an `options` (or `useCapture`) argument to the event listener when using `htmx.on()`.

As per the [`addEventListener()`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) method spec, the third argument accepts an [`options`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#options) object or a [`useCapture`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#usecapture) boolean.

Usage:

```js
// Using an object
htmx.on('htmx:afterSwap', () => console.log('Swapped'), { once: true }); 
htmx.on('#my-div', 'htmx:afterSwap', () => console.log('Swapped'), { once: true });

// Using a boolean
htmx.on('htmx:afterSwap', () => console.log('Swapped'), true); 
htmx.on('#my-div', 'htmx:afterSwap', () => console.log('Swapped'), true);
```

**Note to the reviewer:** please double check my JSDoc annotations, I think they’re accurate but I’m not 100% sure.

## Testing

I added a test that verifies that the `options` argument is respected.

https://github.com/bigskysoftware/htmx/blob/b266104d3ecaaf850450b0475c2c1f6d95c5f4ea/test/core/events.js#L80-L93

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] ~~This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue~~ This is a minor addition to an existing feature, not pre-approved 😬 
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded