### PR TITLE
Redirect /extensions to extensions website

### DIFF
--- a/www/content/extensions/_index.md
+++ b/www/content/extensions/_index.md
@@ -1,0 +1,3 @@
++++
+redirect_to = "https://extensions.htmx.org"
++++


### PR DESCRIPTION
## Description
As we moved extensions to a separate repository and removed docs from the main website, the https://htmx.org/extensions page that used to display the extensions documentation, now results in a 404,
As @alexpetros suggested, this isn't ideal and should at least redirect to the new extensions website.

Related issue: #2813

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
