### PR TITLE
fix(swap): apply swap delay in swap function instead of handleAjaxResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [2.0.2] - 2024-08-09
+## [2.0.2] - 2024-08-12
 * no longer boost forms of type `dialog`
 * properly trigger the `htmx:trigger` event when an event is delayed or throttled
 * file upload is now fixed

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1797,6 +1797,30 @@ var htmx = (function() {
   }
 
   /**
+   * Apply swapping class and then execute the swap with optional delay
+   * @param {string|Element} target
+   * @param {string} content
+   * @param {HtmxSwapSpecification} swapSpec
+   * @param {SwapOptions} [swapOptions]
+   */
+  function swap(target, content, swapSpec, swapOptions) {
+    if (!swapOptions) {
+      swapOptions = {}
+    }
+
+    target = resolveTarget(target)
+    target.classList.add(htmx.config.swappingClass)
+    const localSwap = function() {
+      runSwap(target, content, swapSpec, swapOptions)
+    }
+    if (swapSpec?.swapDelay && swapSpec.swapDelay > 0) {
+      getWindow().setTimeout(localSwap, swapSpec.swapDelay)
+    } else {
+      localSwap()
+    }
+  }
+
+  /**
    * Implements complete swapping pipeline, including: focus and selection preservation,
    * title updates, scroll, OOB swapping, normal swapping and settling
    * @param {string|Element} target
@@ -1804,7 +1828,7 @@ var htmx = (function() {
    * @param {HtmxSwapSpecification} swapSpec
    * @param {SwapOptions} [swapOptions]
    */
-  function swap(target, content, swapSpec, swapOptions) {
+  function runSwap(target, content, swapSpec, swapOptions) {
     if (!swapOptions) {
       swapOptions = {}
     }
@@ -4695,8 +4719,6 @@ var htmx = (function() {
         swapSpec.ignoreTitle = ignoreTitle
       }
 
-      target.classList.add(htmx.config.swappingClass)
-
       // optional transition API promise callbacks
       let settleResolve = null
       let settleReject = null
@@ -4783,12 +4805,7 @@ var htmx = (function() {
           })
         }
       }
-
-      if (swapSpec.swapDelay > 0) {
-        getWindow().setTimeout(doSwap, swapSpec.swapDelay)
-      } else {
-        doSwap()
-      }
+      doSwap()
     }
     if (isError) {
       triggerErrorEvent(elt, 'htmx:responseError', mergeObjects({ error: 'Response Status Error Code ' + xhr.status + ' from ' + responseInfo.pathInfo.requestPath }, responseInfo))

--- a/www/content/attributes/hx-indicator.md
+++ b/www/content/attributes/hx-indicator.md
@@ -31,10 +31,10 @@ that will show the spinner:
         transition: opacity 500ms ease-in;
     }
     .htmx-request .htmx-indicator{
-        opacity:1
+        opacity:1;
     }
     .htmx-request.htmx-indicator{
-        opacity:1
+        opacity:1;
     }
 ```
 

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -996,7 +996,7 @@ config:
 If you wanted to swap everything, regardless of HTTP response code, you could use this configuration:
 
 ```html
-<meta name="htmx-config" content='{code:".*", swap: true}, // all responses are swapped'>
+<meta name="htmx-config" content='{"responseHandling": [{"code":".*", "swap": true}]}' /> <!--all responses are swapped-->
 ```
 
 Finally, it is worth considering using the [Response Targets](https://github.com/bigskysoftware/htmx-extensions/blob/main/src/response-targets/README.md)

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -933,7 +933,7 @@ the response.
 In the event of an error response from the server (e.g. a 404 or a 501), htmx will trigger the [`htmx:responseError`](@/events.md#htmx:responseError)
 event, which you can handle.
 
-In the event of a connection error, the `htmx:sendError` event will be triggered.
+In the event of a connection error, the [`htmx:sendError`](@/events.md#htmx:sendError) `htmx:sendError` event will be triggered.
 
 ### Configuring Response Handling {#response-handling}
 

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -137,7 +137,7 @@ While the CDN approach is extremely simple, you may want to consider
 
 The next easiest way to install htmx is to simply copy it into your project.
 
-Download `htmx.min.js` [from unpkg.com](https://unpkg.com/htmx.org@2.0.1/dist/htmx.min.js) and add it to the appropriate directory in your project
+Download `htmx.min.js` [from unpkg.com](https://unpkg.com/htmx.org@2.0.2/dist/htmx.min.js) and add it to the appropriate directory in your project
 and include it where necessary with a `<script>` tag:
 
 ```html
@@ -149,7 +149,7 @@ and include it where necessary with a `<script>` tag:
 For npm-style build systems, you can install htmx via [npm](https://www.npmjs.com/):
 
 ```sh
-npm install htmx.org@2.0.1
+npm install htmx.org@2.0.2
 ```
 
 After installing, you’ll need to use appropriate tooling to use `node_modules/htmx.org/dist/htmx.js` (or `.min.js`).

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -117,7 +117,7 @@ tag to your document head.  There is no need for a build system to use it.
 
 ### Via A CDN (e.g. unpkg.com)
 
-The fastest way to get going with htmx is to load it via a CDN. You can simply add this to 
+The fastest way to get going with htmx is to load it via a CDN. You can simply add this to
 your head tag and get going:
 
 ```html
@@ -130,7 +130,7 @@ An unminified version is also available for debugging as well:
 <script src="https://unpkg.com/htmx.org@2.0.2/dist/htmx.js" integrity="sha384-yZq+5izaUBKcRgFbxgkRYwpHhHHCpp5nseXp0MEQ1A4MTWVMnqkmcuFez8x5qfxr" crossorigin="anonymous"></script>
 ```
 
-While the CDN approach is extremely simple, you may want to consider 
+While the CDN approach is extremely simple, you may want to consider
 [not using CDNs in production](https://blog.wesleyac.com/posts/why-not-javascript-cdn).
 
 ### Download a copy
@@ -710,7 +710,7 @@ document.body.addEventListener('htmx:confirm', function(evt) {
       if (confirmed) {
         evt.detail.issueRequest();
       }
-    });     
+    });
   }
 });
 ```
@@ -933,7 +933,7 @@ the response.
 In the event of an error response from the server (e.g. a 404 or a 501), htmx will trigger the [`htmx:responseError`](@/events.md#htmx:responseError)
 event, which you can handle.
 
-In the event of a connection error, the [`htmx:sendError`](@/events.md#htmx:sendError) `htmx:sendError` event will be triggered.
+In the event of a connection error, the [`htmx:sendError`](@/events.md#htmx:sendError) event will be triggered.
 
 ### Configuring Response Handling {#response-handling}
 
@@ -966,8 +966,8 @@ The fields available for response handling configuration on entries in this arra
 #### Configuring Response Handling Examples {#response-handling}
 
 As an example of how to use this configuration, consider a situation when a server-side framework responds with a
-[`422 - Unprocessable Entity`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422) response when validation errors occur.  By default, htmx will ignore the response, 
-since it matches the Regular Expression `[45]..`. 
+[`422 - Unprocessable Entity`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422) response when validation errors occur.  By default, htmx will ignore the response,
+since it matches the Regular Expression `[45]..`.
 
 Using the [meta config](#configuration-options) mechanism for configuring responseHandling, we could add the following
 config:

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -121,13 +121,13 @@ The fastest way to get going with htmx is to load it via a CDN. You can simply a
 your head tag and get going:
 
 ```html
-<script src="https://unpkg.com/htmx.org@2.0.2" integrity="sha384-QWGpdj554B4ETpJJC9z+ZHJcA/i59TyjxEPXiiUgN2WmTyV5OEZWCD6gQhgkdpB/" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/htmx.org@2.0.2" integrity="sha384-Y7hw+L/jvKeWIRRkqWYfPcvVxHzVzn5REgzbawhxAuQGwX1XWe70vji+VSeHOThJ" crossorigin="anonymous"></script>
 ```
 
 An unminified version is also available for debugging as well:
 
 ```html
-<script src="https://unpkg.com/htmx.org@2.02/dist/htmx.js" integrity="sha384-gpIh5aLQ0qmX8kZdyhsd6jA24uKLkqIr1WAGtantR4KsS97l/NRBvh8/8OYGThAf" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/htmx.org@2.02/dist/htmx.js" integrity="sha384-yZq+5izaUBKcRgFbxgkRYwpHhHHCpp5nseXp0MEQ1A4MTWVMnqkmcuFez8x5qfxr" crossorigin="anonymous"></script>
 ```
 
 While the CDN approach is extremely simple, you may want to consider 

--- a/www/content/examples/lazy-load.md
+++ b/www/content/examples/lazy-load.md
@@ -8,7 +8,7 @@ state that looks like this:
 
 ```html
 <div hx-get="/graph" hx-trigger="load">
-  <img  alt="Result loading..." class="htmx-indicator" width="150" src="/img/bars.svg"/>
+  <img alt="Result loading..." class="htmx-indicator" width="150" src="/img/bars.svg"/>
 </div>
 ```
 
@@ -54,7 +54,7 @@ img {
     // templates
     function lazyTemplate(page) {
       return `<div hx-get="/graph" hx-trigger="load">
-  <img  alt="Result loading..." class="htmx-indicator" width="150" src="/img/bars.svg"/>
+  <img alt="Result loading..." class="htmx-indicator" width="150" src="/img/bars.svg"/>
 </div>`;
     }
 </script>

--- a/www/content/extensions/_index.md
+++ b/www/content/extensions/_index.md
@@ -1,0 +1,3 @@
++++
+redirect_to = "https://extensions.htmx.org"
++++

--- a/www/content/server-examples.md
+++ b/www/content/server-examples.md
@@ -126,6 +126,9 @@ These examples may make it a bit easier to get started using htmx with your plat
 ### http4s
 - <https://github.com/martinprobson/http4s-htmx-demo>
 
+### zio-http
+- <https://github.com/rockthejvm/scalatags-htmx-demo>
+
 ## Kotlin
 
 ### Ktor


### PR DESCRIPTION
## Description

moved application of swap delay to swap function so that the JS api can also use the swap delay

Corresponding issue:

## Testing
manually tested in my local environment, both with the JS api and with normal hx requests

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
