### PR TITLE
[FIX] Properly remove request indicators

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3269,16 +3269,18 @@ var htmx = (function() {
    * @param {Element[]} disabled
    */
   function removeRequestIndicators(indicators, disabled) {
+    forEach(indicators.concat(disabled), function(ele) {
+      const internalData = getInternalData(ele)
+      internalData.requestCount = (internalData.requestCount || 0) - 1
+    })
     forEach(indicators, function(ic) {
       const internalData = getInternalData(ic)
-      internalData.requestCount = (internalData.requestCount || 0) - 1
       if (internalData.requestCount === 0) {
         ic.classList.remove.call(ic.classList, htmx.config.requestClass)
       }
     })
     forEach(disabled, function(disabledElement) {
       const internalData = getInternalData(disabledElement)
-      internalData.requestCount = (internalData.requestCount || 0) - 1
       if (internalData.requestCount === 0) {
         disabledElement.removeAttribute('disabled')
         disabledElement.removeAttribute('data-disabled-by-htmx')


### PR DESCRIPTION
## Description
Bug: 
When `htmx-request` is placed on the same element that is disabled by `hx-disabled-elt` request count is increased twice on the same element. However, when removing request indicators, the request counts for indicators and disabled elements are deducted separately. This meant that when checking the indicators, request count would not be 0, and `htmx-reqest` is not properly removed.

Solution:
Deduct request counts first for both indicators and disabled elements, before removing request indicators.

Corresponding issue: https://github.com/bigskysoftware/htmx/issues/2295 https://github.com/bigskysoftware/htmx/issues/2234
Also in extensions repo: https://github.com/bigskysoftware/htmx-extensions/issues/79

## Testing
Tested with a personal project as well as using the sample code provided in the issues.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
