### PR TITLE
Fix focusin-based tests

### DIFF
--- a/test/core/parameters.js
+++ b/test/core/parameters.js
@@ -134,8 +134,10 @@ describe('Core htmx Parameter Handling', function() {
       vals.do.should.equal('rey')
       vals.btn.should.equal('bar')
       done()
-    })
+    }, { once: true })
     button.focus()
+    // Headless / Hardly-throttled CPU might result in 'focusin' not being fired, double it just in case
+    htmx.trigger(button, 'focusin')
   })
 
   it('form includes last focused submit', function(done) {
@@ -149,8 +151,10 @@ describe('Core htmx Parameter Handling', function() {
       vals.do.should.equal('rey')
       vals.s1.should.equal('bar')
       done()
-    })
+    }, { once: true })
     button.focus()
+    // Headless / Hardly-throttled CPU might result in 'focusin' not being fired, double it just in case
+    htmx.trigger(button, 'focusin')
   })
 
   it('form does not include button when focus is lost', function() {


### PR DESCRIPTION
## Description
Even though we call `.focus` on elements in these 2 tests, the `focusin` event _might_ not be fired.

### How to reproduce it?
Disclaimer: the CI suddenly constantly fails on this, and I have no idea why, specifically why it worked until now and suddenly doesn't anymore.
To reproduce that issue, run the tests locally through `npx serve` (thus browser context) with a `20x CPU slowdown` throttling. Refresh the tests page, and click outside it **before** these tests run.
Adding logs reveal that, even though the `document.activeElement` gets properly updated to the focused element, the `focusin` event won't fire, until the window gets focused back (clicking inside it).
I guess that's an expected browser-UX feature, where the browser waits for the user to actually focus the element (thus focus the browser window first) before notifying it.
The issue here is that we don't really know how things work when running headless through `mocha-chrome`, but I'm thinking this _could_ explain why the pipeline fails.

### Suggested solution
The suggested solution here simply doubles the `focusin` event by manually triggering it with `htmx.trigger`.
This doesn't change the test as, **what we're testing is not the `focusin` event itself being fired** (that's the browser's job), just ensuring that **htmx behaves correctly _once_ that event has been fired**.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
