### PR TITLE
Trivial grammar fixes

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -55,7 +55,7 @@ custom_classes = "wide-content"
 htmx is a library that allows you to access modern browser features directly from HTML, rather than using
 javascript.
 
-To understand htmx, first lets take a look at an anchor tag:
+To understand htmx, first let's take a look at an anchor tag:
 
 ```html
 <a href="/blog">Blog</a>
@@ -690,7 +690,7 @@ shows how to use [sweetalert2](https://sweetalert2.github.io/) library for confi
 
 #### Confirming Requests Using Events
 
-Another option to do confirmation with is via the [`htmx:confirm` event](@/events.md#htmx:confirm) event.  This event
+Another option to do confirmation with is via the [`htmx:confirm` event](@/events.md#htmx:confirm).  This event
 is fired on *every* trigger for a request (not just on elements that have a `hx-confirm` attribute) and can be used
 to implement asynchronous confirmation of the request.
 


### PR DESCRIPTION
Two trivial fixes found while reading the docs:

* Add a missing `'`, courtesy of the [Apostrophe Protection Society](https://www.apostrophe.org.uk/) :-). It's an abbreviation of "let us" here, not the word "lets".
* Remove a duplicated word "event".

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
