### PR TITLE
Add shadowRoot host selector

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1161,6 +1161,8 @@ var htmx = (function() {
       return [document.body]
     } else if (selector === 'root') {
       return [getRootNode(elt, !!global)]
+    } else if (selector === 'host') {
+      return [(/** @type ShadowRoot */(elt.getRootNode())).host]
     } else if (selector.indexOf('global ') === 0) {
       return querySelectorAllExt(elt, selector.slice(7), true)
     } else {

--- a/test/core/shadowdom.js
+++ b/test/core/shadowdom.js
@@ -19,7 +19,9 @@ describe('Core htmx Shadow DOM Tests', function() {
   afterEach(function() {
     this.server.restore()
     clearWorkArea()
-    getWorkArea().shadowRoot.innerHTML = ''
+    var workArea = getWorkArea()
+    if (!workArea.shadowRoot) workArea.attachShadow({ mode: 'open' })
+    workArea.shadowRoot.innerHTML = ''
   })
 
   // Locally redefine the `byId` and `make` functions to use shadow DOM
@@ -61,6 +63,14 @@ describe('Core htmx Shadow DOM Tests', function() {
   })
   it('properly escapes shadow root for extended selector', function() {
     var div = make('<div hx-target="global #work-area"></div>')
+    htmx.defineExtension('test/shadowdom.js', {
+      init: function(api) {
+        api.getTarget(div).should.equal(getWorkArea())
+      }
+    })
+  })
+  it('properly retrives shadow root host for extended selector', function() {
+    var div = make('<div hx-target="host"></div>')
     htmx.defineExtension('test/shadowdom.js', {
       init: function(api) {
         api.getTarget(div).should.equal(getWorkArea())
@@ -1312,5 +1322,35 @@ describe('Core htmx Shadow DOM Tests', function() {
     btn.click()
     window.foo.should.equal(true)
     delete window.foo
+  })
+
+  it('can target shadow DOM Host and place content below web component', function() {
+    this.server.respondWith('GET', '/test', '<div id="r1">Clicked!</div>')
+    var btn = make('<button hx-get="/test" hx-target="host" hx-swap="afterend">Click Me!</button>')
+    btn.click()
+    this.server.respond()
+    var r1 = document.getElementById('r1')
+    r1.innerHTML.should.equal('Clicked!')
+    r1.remove()
+  })
+
+  it('can target global id outside shadow DOM and place content', function() {
+    this.server.respondWith('GET', '/test', '<div id="r2">Clicked!</div>')
+    var btn = make('<button hx-get="/test" hx-target="global #work-area" hx-swap="beforebegin">Click Me!</button>')
+    btn.click()
+    this.server.respond()
+    var r2 = document.getElementById('r2')
+    r2.innerHTML.should.equal('Clicked!')
+    r2.remove()
+  })
+
+  it('can target shadow DOM Host with outerHTML swap and replace it', function() {
+    this.server.respondWith('GET', '/test', '<div id="work-area" hx-history-elt>Clicked!</div>')
+    var btn = make('<button hx-get="/test" hx-target="host" hx-swap="outerHTML">Click Me!</button>')
+    btn.click()
+    chai.expect(getWorkArea().shadowRoot).to.not.be.a('null')
+    this.server.respond()
+    getWorkArea().innerHTML.should.equal('Clicked!')
+    chai.expect(getWorkArea().shadowRoot).to.be.a('null')
   })
 })


### PR DESCRIPTION
## Description
In the web component documentation there is a reference to using 'host' to target the web components shadow DOM host element but this was never implemented as a valid target in htmx.  So I've implemented this as a valid selector and added tests to confirm swapping it and elements outside the shadow DOM can be targeted for replacement.

There was a similar 'root' one implemented however from my testing this seems to not be usable for two reasons.  First is that because the shadow root has a very different type called ShadowRoot which does not support most of the options a Node or Element would support which means swaps to this target fail when trying to add classes to the root. Also target has now been wrapped in asElement() which strips root target.  So we should probably remove this non functional root selector as it is not documented anywhere either.  The 'root' target could have been used by non web component use but this would make it return Document which is also not a Element so it gets stripped as well making it unusable here as well.  So there should be no downside I can see if we remove 'root'.

Corresponding issue:
#2846

## Testing
Wrote new tests to confirm it is working as expected plus did some manual testing in a test app to confirm Host replacment was working as expected.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
