### PR TITLE
Add view transitions when navigating the history

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3205,19 +3205,30 @@ var htmx = (function() {
     path = path || location.pathname + location.search
     const cached = getCachedHistory(path)
     if (cached) {
-      const fragment = makeFragment(cached.content)
-      const historyElement = getHistoryElement()
-      const settleInfo = makeSettleInfo(historyElement)
-      handleTitle(cached.title)
-      handlePreservedElements(fragment)
-      swapInnerHTML(historyElement, fragment, settleInfo)
-      restorePreservedElements()
-      settleImmediately(settleInfo.tasks)
-      getWindow().setTimeout(function() {
-        window.scrollTo(0, cached.scroll)
-      }, 0) // next 'tick', so browser has time to render layout
-      currentPathForHistory = path
-      triggerEvent(getDocument().body, 'htmx:historyRestore', { path, item: cached })
+      let restoreHistoryFromCache = function() {
+        const fragment = makeFragment(cached.content)
+        const historyElement = getHistoryElement()
+        const settleInfo = makeSettleInfo(historyElement)
+        handleTitle(cached.title)
+        handlePreservedElements(fragment)
+        swapInnerHTML(historyElement, fragment, settleInfo)
+        restorePreservedElements()
+        settleImmediately(settleInfo.tasks)
+        getWindow().setTimeout(function() {
+          window.scrollTo(0, cached.scroll)
+        }, 0) // next 'tick', so browser has time to render layout
+        currentPathForHistory = path
+        triggerEvent(getDocument().body, 'htmx:historyRestore', { path, item: cached })
+      }
+      const shouldTransition = htmx.config.globalViewTransitions;
+      if (shouldTransition && document.startViewTransition) {
+        const innerRestoreHistoryFromCache = restoreHistoryFromCache
+        // wrap the original doRestoreHistory() in a call to startViewTransition()
+        restoreHistoryFromCache = document.startViewTransition(
+          () => innerRestoreHistoryFromCache()
+        );
+      }
+      restoreHistoryFromCache()
     } else {
       if (htmx.config.refreshOnHistoryMiss) {
         // @ts-ignore: optional parameter in reload() function throws error

--- a/www/content/_index.md
+++ b/www/content/_index.md
@@ -161,6 +161,7 @@ Thank you to all our generous <a href="https://github.com/sponsors/bigskysoftwar
   padding: 16px;
   min-height: 100px;
   border-bottom: none;
+  width:33%;
 }
 
 @media only screen and (max-width: 760px)  {
@@ -174,34 +175,48 @@ Thank you to all our generous <a href="https://github.com/sponsors/bigskysoftwar
 
 </style>
 <div style="overflow-x: auto">
+
+<h1 style="margin-top:32px;text-align:center">Platinum Sponsor</h1>
 <table id="sponsor-table">
 <tr>
 <td colspan="3">
-        <a data-github-account="NotASithLord" href="https://hydrahost.com">
-          <img class="dark-hidden" src="/img/hydra-hosting.svg" alt="The GPU Marketplace" style="width:100%;">
-          <img class="dark-visible" src="/img/hydra-hosting-dark.svg" alt="The GPU Marketplace" style="width:100%;">
-        </a>
-</td>
-</tr>
-<tr>
-<td colspan="3">
-        <a data-github-account="deco-cx" href="https://deco.cx/?utm_source=htmx"><img src="/img/deco.cx-logo-outline.png" alt="Your first and last web editor" style="width:100%;"></a>
-</td>
-</tr>
-<tr>
-<td>
-        <a data-github-account="JetBrainsOfficial" href="https://www.jetbrains.com"><img src="/img/jetbrains.svg" alt="Jetbrains" style="max-width:30%;min-width:100px;"></a>
-</td>
-<td>
         <a data-github-account="commspace" href="https://www.commspace.co.za">
         <img class="dark-hidden" src="/img/commspace.svg" alt="commspace" style="min-width:200px"/>
         <img class="dark-visible" src="/img/commspace-dark.svg" alt="commspace" style="min-width:200px"/>
         </a>
 </td>
+</tr>
+</table>
+
+## Gold Sponsors
+
+<table id="sponsor-table">
+<tr>
 <td>
-        <a href="https://github.blog/2023-04-12-github-accelerator-our-first-cohort-and-whats-next"><img class="dark-invert" src="/img/Github_Logo.png" alt="GitHub" style="max-width:30%;min-width:100px;"></a>
+        <a data-github-account="NotASithLord" href="https://hydrahost.com">
+          <img class="dark-hidden" src="/img/hydra-hosting.svg" alt="The GPU Marketplace" style="width:100%;">
+          <img class="dark-visible" src="/img/hydra-hosting-dark.svg" alt="The GPU Marketplace" style="width:100%;">
+        </a>
+</td>
+<td>
+        <a data-github-account="deco-cx" href="https://deco.cx/?utm_source=htmx"><img src="/img/deco.cx-logo-outline.png" alt="Your first and last web editor" style="width:100%;"></a>
 </td>
 </tr>
+</table>
+
+## Silver Sponsors
+
+<table id="sponsor-table">
+<tr>
+<td>
+        <a data-github-account="JetBrainsOfficial" href="https://www.jetbrains.com"><img src="/img/jetbrains.svg" alt="Jetbrains" style="max-width:80%;min-width:100px;"></a>
+</td>
+<td>
+        <a href="https://github.blog/2023-04-12-github-accelerator-our-first-cohort-and-whats-next"><img class="dark-invert" src="/img/Github_Logo.png" alt="GitHub" style="max-width:80%;min-width:100px;"></a>
+</td>
+</tr>
+</table>
+<table id="sponsor-table">
 <tr>
 <td>
         <a data-github-account="craftcms" href="https://craftcms.com">

--- a/www/content/_index.md
+++ b/www/content/_index.md
@@ -170,7 +170,12 @@ Thank you to all our generous <a href="https://github.com/sponsors/bigskysoftwar
 	table, thead, tbody, th, td, tr {
 		display: block;
 	}
-
+    #sponsor-table td {
+      width:90%;
+    }
+    #sponsor-table td * {
+      margin: auto;
+    }
 }
 
 </style>

--- a/www/content/attributes/hx-indicator.md
+++ b/www/content/attributes/hx-indicator.md
@@ -31,10 +31,10 @@ that will show the spinner:
         transition: opacity 500ms ease-in;
     }
     .htmx-request .htmx-indicator{
-        opacity:1
+        opacity:1;
     }
     .htmx-request.htmx-indicator{
-        opacity:1
+        opacity:1;
     }
 ```
 

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -996,7 +996,7 @@ config:
 If you wanted to swap everything, regardless of HTTP response code, you could use this configuration:
 
 ```html
-<meta name="htmx-config" content='{code:".*", swap: true}, // all responses are swapped'>
+<meta name="htmx-config" content='{"responseHandling": [{"code":".*", "swap": true}]}' /> <!--all responses are swapped-->
 ```
 
 Finally, it is worth considering using the [Response Targets](https://github.com/bigskysoftware/htmx-extensions/blob/main/src/response-targets/README.md)

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -55,7 +55,7 @@ custom_classes = "wide-content"
 htmx is a library that allows you to access modern browser features directly from HTML, rather than using
 javascript.
 
-To understand htmx, first lets take a look at an anchor tag:
+To understand htmx, first let's take a look at an anchor tag:
 
 ```html
 <a href="/blog">Blog</a>
@@ -690,7 +690,7 @@ shows how to use [sweetalert2](https://sweetalert2.github.io/) library for confi
 
 #### Confirming Requests Using Events
 
-Another option to do confirmation with is via the [`htmx:confirm` event](@/events.md#htmx:confirm) event.  This event
+Another option to do confirmation with is via the [`htmx:confirm` event](@/events.md#htmx:confirm).  This event
 is fired on *every* trigger for a request (not just on elements that have a `hx-confirm` attribute) and can be used
 to implement asynchronous confirmation of the request.
 

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -933,7 +933,7 @@ the response.
 In the event of an error response from the server (e.g. a 404 or a 501), htmx will trigger the [`htmx:responseError`](@/events.md#htmx:responseError)
 event, which you can handle.
 
-In the event of a connection error, the `htmx:sendError` event will be triggered.
+In the event of a connection error, the [`htmx:sendError`](@/events.md#htmx:sendError) `htmx:sendError` event will be triggered.
 
 ### Configuring Response Handling {#response-handling}
 

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -127,7 +127,7 @@ your head tag and get going:
 An unminified version is also available for debugging as well:
 
 ```html
-<script src="https://unpkg.com/htmx.org@2.02/dist/htmx.js" integrity="sha384-yZq+5izaUBKcRgFbxgkRYwpHhHHCpp5nseXp0MEQ1A4MTWVMnqkmcuFez8x5qfxr" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/htmx.org@2.0.2/dist/htmx.js" integrity="sha384-yZq+5izaUBKcRgFbxgkRYwpHhHHCpp5nseXp0MEQ1A4MTWVMnqkmcuFez8x5qfxr" crossorigin="anonymous"></script>
 ```
 
 While the CDN approach is extremely simple, you may want to consider 

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -137,7 +137,7 @@ While the CDN approach is extremely simple, you may want to consider
 
 The next easiest way to install htmx is to simply copy it into your project.
 
-Download `htmx.min.js` [from unpkg.com](https://unpkg.com/htmx.org@2.0.1/dist/htmx.min.js) and add it to the appropriate directory in your project
+Download `htmx.min.js` [from unpkg.com](https://unpkg.com/htmx.org@2.0.2/dist/htmx.min.js) and add it to the appropriate directory in your project
 and include it where necessary with a `<script>` tag:
 
 ```html
@@ -149,7 +149,7 @@ and include it where necessary with a `<script>` tag:
 For npm-style build systems, you can install htmx via [npm](https://www.npmjs.com/):
 
 ```sh
-npm install htmx.org@2.0.1
+npm install htmx.org@2.0.2
 ```
 
 After installing, you’ll need to use appropriate tooling to use `node_modules/htmx.org/dist/htmx.js` (or `.min.js`).

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -117,7 +117,7 @@ tag to your document head.  There is no need for a build system to use it.
 
 ### Via A CDN (e.g. unpkg.com)
 
-The fastest way to get going with htmx is to load it via a CDN. You can simply add this to 
+The fastest way to get going with htmx is to load it via a CDN. You can simply add this to
 your head tag and get going:
 
 ```html
@@ -130,7 +130,7 @@ An unminified version is also available for debugging as well:
 <script src="https://unpkg.com/htmx.org@2.0.2/dist/htmx.js" integrity="sha384-yZq+5izaUBKcRgFbxgkRYwpHhHHCpp5nseXp0MEQ1A4MTWVMnqkmcuFez8x5qfxr" crossorigin="anonymous"></script>
 ```
 
-While the CDN approach is extremely simple, you may want to consider 
+While the CDN approach is extremely simple, you may want to consider
 [not using CDNs in production](https://blog.wesleyac.com/posts/why-not-javascript-cdn).
 
 ### Download a copy
@@ -710,7 +710,7 @@ document.body.addEventListener('htmx:confirm', function(evt) {
       if (confirmed) {
         evt.detail.issueRequest();
       }
-    });     
+    });
   }
 });
 ```
@@ -933,7 +933,7 @@ the response.
 In the event of an error response from the server (e.g. a 404 or a 501), htmx will trigger the [`htmx:responseError`](@/events.md#htmx:responseError)
 event, which you can handle.
 
-In the event of a connection error, the [`htmx:sendError`](@/events.md#htmx:sendError) `htmx:sendError` event will be triggered.
+In the event of a connection error, the [`htmx:sendError`](@/events.md#htmx:sendError) event will be triggered.
 
 ### Configuring Response Handling {#response-handling}
 
@@ -966,8 +966,8 @@ The fields available for response handling configuration on entries in this arra
 #### Configuring Response Handling Examples {#response-handling}
 
 As an example of how to use this configuration, consider a situation when a server-side framework responds with a
-[`422 - Unprocessable Entity`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422) response when validation errors occur.  By default, htmx will ignore the response, 
-since it matches the Regular Expression `[45]..`. 
+[`422 - Unprocessable Entity`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422) response when validation errors occur.  By default, htmx will ignore the response,
+since it matches the Regular Expression `[45]..`.
 
 Using the [meta config](#configuration-options) mechanism for configuring responseHandling, we could add the following
 config:

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -121,13 +121,13 @@ The fastest way to get going with htmx is to load it via a CDN. You can simply a
 your head tag and get going:
 
 ```html
-<script src="https://unpkg.com/htmx.org@2.0.2" integrity="sha384-QWGpdj554B4ETpJJC9z+ZHJcA/i59TyjxEPXiiUgN2WmTyV5OEZWCD6gQhgkdpB/" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/htmx.org@2.0.2" integrity="sha384-Y7hw+L/jvKeWIRRkqWYfPcvVxHzVzn5REgzbawhxAuQGwX1XWe70vji+VSeHOThJ" crossorigin="anonymous"></script>
 ```
 
 An unminified version is also available for debugging as well:
 
 ```html
-<script src="https://unpkg.com/htmx.org@2.02/dist/htmx.js" integrity="sha384-gpIh5aLQ0qmX8kZdyhsd6jA24uKLkqIr1WAGtantR4KsS97l/NRBvh8/8OYGThAf" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/htmx.org@2.02/dist/htmx.js" integrity="sha384-yZq+5izaUBKcRgFbxgkRYwpHhHHCpp5nseXp0MEQ1A4MTWVMnqkmcuFez8x5qfxr" crossorigin="anonymous"></script>
 ```
 
 While the CDN approach is extremely simple, you may want to consider 

--- a/www/content/examples/lazy-load.md
+++ b/www/content/examples/lazy-load.md
@@ -8,7 +8,7 @@ state that looks like this:
 
 ```html
 <div hx-get="/graph" hx-trigger="load">
-  <img  alt="Result loading..." class="htmx-indicator" width="150" src="/img/bars.svg"/>
+  <img alt="Result loading..." class="htmx-indicator" width="150" src="/img/bars.svg"/>
 </div>
 ```
 
@@ -54,7 +54,7 @@ img {
     // templates
     function lazyTemplate(page) {
       return `<div hx-get="/graph" hx-trigger="load">
-  <img  alt="Result loading..." class="htmx-indicator" width="150" src="/img/bars.svg"/>
+  <img alt="Result loading..." class="htmx-indicator" width="150" src="/img/bars.svg"/>
 </div>`;
     }
 </script>

--- a/www/content/extensions/_index.md
+++ b/www/content/extensions/_index.md
@@ -1,0 +1,3 @@
++++
+redirect_to = "https://extensions.htmx.org"
++++

--- a/www/content/server-examples.md
+++ b/www/content/server-examples.md
@@ -126,6 +126,9 @@ These examples may make it a bit easier to get started using htmx with your plat
 ### http4s
 - <https://github.com/martinprobson/http4s-htmx-demo>
 
+### zio-http
+- <https://github.com/rockthejvm/scalatags-htmx-demo>
+
 ## Kotlin
 
 ### Ktor


### PR DESCRIPTION
## Description
I added ViewTransitions to the restoreHistory function. In this pull request I only made this change when the user has enabled htmx.config.globalViewTransitions. This is as a PR for opening a discussion on this as anything else as I have some questions to the best approach for this work. 

I understand that because this not a either a bugfix, a documentation update, or a new feature that has been explicitly approved via an issue. I apologise as I only saw those particular guideline

### Questions

1. Should this have its own config flag to enable this behavior? Potentially this is breaking expectations by adding this to navigating history. Is adding this under globalViewTransitions sensible here? Maybe a config flag like `htmx.config.historyViewTransitions`? 
2. Should a htmx:beforeTransition event be thrown?

### Idea

During development of this I had an idea but I thought it would be too big a PR and I wanted to start this initial discussion first, but I considered that it could be possible to add a transition flag into the history. This would be caught from the hx-swap of each request and mean that 

Corresponding issue:

https://github.com/bigskysoftware/htmx/issues/1703


## Testing
I tested this manually, switching on and off the `htmx.config.globalViewTransitions` flag. I ran the test suite locally and the linting rules

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
