### PR TITLE
fix htmx.ajax defaulting to swap body when target not found

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3891,7 +3891,7 @@ var htmx = (function() {
     if (context) {
       if (context instanceof Element || typeof context === 'string') {
         return issueAjaxRequest(verb, path, null, null, {
-          targetOverride: resolveTarget(context),
+          targetOverride: resolveTarget(context) || DUMMY_ELT,
           returnPromise: true
         })
       } else {
@@ -3900,7 +3900,7 @@ var htmx = (function() {
             handler: context.handler,
             headers: context.headers,
             values: context.values,
-            targetOverride: resolveTarget(context.target),
+            targetOverride: resolveTarget(context.target) || DUMMY_ELT,
             swapOverride: context.swap,
             select: context.select,
             returnPromise: true

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3900,7 +3900,7 @@ var htmx = (function() {
             handler: context.handler,
             headers: context.headers,
             values: context.values,
-            targetOverride: resolveTarget(context.target) || DUMMY_ELT,
+            targetOverride: resolveTarget(context.target) || asElement(getTarget(resolveTarget(context.source))) || DUMMY_ELT,
             swapOverride: context.swap,
             select: context.select,
             returnPromise: true

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3900,7 +3900,7 @@ var htmx = (function() {
             handler: context.handler,
             headers: context.headers,
             values: context.values,
-            targetOverride: resolveTarget(context.target) || asElement(getTarget(resolveTarget(context.source))) || DUMMY_ELT,
+            targetOverride: resolveTarget(context.target) || (context.target ? DUMMY_ELT : asElement(getTarget(resolveTarget(context.source)))) || DUMMY_ELT,
             swapOverride: context.swap,
             select: context.select,
             returnPromise: true

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3900,7 +3900,7 @@ var htmx = (function() {
             handler: context.handler,
             headers: context.headers,
             values: context.values,
-            targetOverride: resolveTarget(context.target) || (context.target ? DUMMY_ELT : asElement(getTarget(resolveTarget(context.source)))) || DUMMY_ELT,
+            targetOverride: resolveTarget(context.target) || ((!context.target && resolveTarget(context.source)) ? null : DUMMY_ELT),
             swapOverride: context.swap,
             select: context.select,
             returnPromise: true

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3895,12 +3895,18 @@ var htmx = (function() {
           returnPromise: true
         })
       } else {
+        let resolvedTarget = resolveTarget(context.target)
+        // If target is supplied but can't resolve OR both target and source can't be resolved
+        // then use DUMMY_ELT to abort the request with htmx:targetError to avoid it replacing body by mistake
+        if ((context.target && !resolvedTarget) || (!resolvedTarget && !resolveTarget(context.source))) {
+          resolvedTarget = DUMMY_ELT
+        }
         return issueAjaxRequest(verb, path, resolveTarget(context.source), context.event,
           {
             handler: context.handler,
             headers: context.headers,
             values: context.values,
-            targetOverride: resolveTarget(context.target) || ((!context.target && resolveTarget(context.source)) ? null : DUMMY_ELT),
+            targetOverride: resolvedTarget,
             swapOverride: context.swap,
             select: context.select,
             returnPromise: true

--- a/test/core/api.js
+++ b/test/core/api.js
@@ -256,7 +256,7 @@ describe('Core htmx API test', function() {
     this.server.respondWith('GET', '/test', 'foo!')
     var div = make("<div id='d1'></div>")
     htmx.ajax('GET', '/test', {
-      source: 'd2'
+      source: '#d2'
     }).then(
       (value) => {
       },

--- a/test/core/api.js
+++ b/test/core/api.js
@@ -213,7 +213,7 @@ describe('Core htmx API test', function() {
     div.innerHTML.should.equal('foo!')
   })
 
-  it('ajax api does not fall back to body when target missing', function() {
+  it('ajax api does not fall back to body when target invalid', function() {
     this.server.respondWith('GET', '/test', 'foo!')
     var div = make("<div id='d1'></div>")
     htmx.ajax('GET', '/test', '#d2')
@@ -221,7 +221,7 @@ describe('Core htmx API test', function() {
     document.body.innerHTML.should.not.equal('foo!')
   })
 
-  it('ajax api fails when target missing', function(done) {
+  it('ajax api fails when target invalid', function(done) {
     this.server.respondWith('GET', '/test', 'foo!')
     var div = make("<div id='d1'></div>")
     htmx.ajax('GET', '/test', '#d2').then(
@@ -233,6 +233,33 @@ describe('Core htmx API test', function() {
     )
     this.server.respond()
     div.innerHTML.should.equal('')
+  })
+
+  it('ajax api fails when target invalid even if source set', function(done) {
+    this.server.respondWith('GET', '/test', 'foo!')
+    var div = make("<div id='d1'></div>")
+    htmx.ajax('GET', '/test', {
+      source: div,
+      target: '#d2'
+    }).then(
+      (value) => {
+      },
+      (reason) => {
+        done()
+      }
+    )
+    this.server.respond()
+    div.innerHTML.should.equal('')
+  })
+
+  it('ajax api falls back to targeting source if target not set', function() {
+    this.server.respondWith('GET', '/test', 'foo!')
+    var div = make("<div id='d1'></div>")
+    htmx.ajax('GET', '/test', {
+      source: div
+    })
+    this.server.respond()
+    div.innerHTML.should.equal('foo!')
   })
 
   it('ajax api works with swapSpec', function() {

--- a/test/core/api.js
+++ b/test/core/api.js
@@ -252,6 +252,22 @@ describe('Core htmx API test', function() {
     div.innerHTML.should.equal('')
   })
 
+  it('ajax api fails when source invalid and no target set', function(done) {
+    this.server.respondWith('GET', '/test', 'foo!')
+    var div = make("<div id='d1'></div>")
+    htmx.ajax('GET', '/test', {
+      source: 'd2'
+    }).then(
+      (value) => {
+      },
+      (reason) => {
+        done()
+      }
+    )
+    this.server.respond()
+    div.innerHTML.should.equal('')
+  })
+
   it('ajax api falls back to targeting source if target not set', function() {
     this.server.respondWith('GET', '/test', 'foo!')
     var div = make("<div id='d1'></div>")

--- a/test/core/api.js
+++ b/test/core/api.js
@@ -213,6 +213,28 @@ describe('Core htmx API test', function() {
     div.innerHTML.should.equal('foo!')
   })
 
+  it('ajax api does not fall back to body when target missing', function() {
+    this.server.respondWith('GET', '/test', 'foo!')
+    var div = make("<div id='d1'></div>")
+    htmx.ajax('GET', '/test', '#d2')
+    this.server.respond()
+    document.body.innerHTML.should.not.equal('foo!')
+  })
+
+  it('ajax api fails when target missing', function(done) {
+    this.server.respondWith('GET', '/test', 'foo!')
+    var div = make("<div id='d1'></div>")
+    htmx.ajax('GET', '/test', '#d2').then(
+      (value) => {
+      },
+      (reason) => {
+        done()
+      }
+    )
+    this.server.respond()
+    div.innerHTML.should.equal('')
+  })
+
   it('ajax api works with swapSpec', function() {
     this.server.respondWith('GET', '/test', "<p class='test'>foo!</p>")
     var div = make("<div><div id='target'></div></div>")


### PR DESCRIPTION
## Description
The htmx.ajax helper function can cause issues when the target is not set correctly or the target selector happens to be missing in the DOM as it passes in null target override to the ajax request which defaults to targeting the body.  Changing it to detect invalid targets and pass in a DUMMY_ELT which triggers the htmx:targetError solves this.  Also had to handle situations where a valid source is supplied as its valid to fall back to source targeting an explicit target is not defined but if we still want it to fail if target was defined.

Corresponding issue:
#2869 

## Testing
Wrote some new tests to cover most invalid targeting situations and also tested calling htmx.ajax manually to confirm it rejects invalid targets but passes though valid ones fine.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
