### PR TITLE
doc fix: innerHTML is the default swapping strategy

### DIFF
--- a/www/content/attributes/hx-swap-oob.md
+++ b/www/content/attributes/hx-swap-oob.md
@@ -25,7 +25,7 @@ The value of the `hx-swap-oob` can be:
 * any valid [`hx-swap`](@/attributes/hx-swap.md) value
 * any valid [`hx-swap`](@/attributes/hx-swap.md) value, followed by a colon, followed by a CSS selector
 
-If the value is `true` or `outerHTML` (which are equivalent) the element will be swapped inline.
+If the value is `true` or `innerHTML` (which are equivalent) the content of the element will be swapped inline.
 
 If a swap value is given, that swap strategy will be used.
 


### PR DESCRIPTION
## Description
*Please describe what changes you made, and why you feel they are necessary. Make sure to include
code examples, where applicable.*
Issue: because of a bug in the hx-swap-oob documentation I spent significant amount of time getting around the issue that attributes are not swapped with the ,,true'' swapping strategy by default.

https://github.com/bigskysoftware/htmx/issues/2876

Corresponding issue: #2876

## Testing
Tested by hand

## Checklist

* [ ] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
