### PR TITLE
Documentation of svg oob swaps

### DIFF
--- a/www/content/attributes/hx-swap-oob.md
+++ b/www/content/attributes/hx-swap-oob.md
@@ -53,7 +53,7 @@ Note that these template tags will be removed from the final content of the page
 
 ### Slipery SVGs
 
-Some element types like SVG use an alternative XML namespace for all their children and this prevents internal elements from working if you swap them in unless they are encapsulated in a SVG tag. So to allow you to modify the internal contents of an existing SVG you can use both a `template` and `svg` tags to encapsulate these elements which allows them to get the correct namespace applied.
+Some element types like SVG use an alternative XML namespace for all their children and this prevents internal elements from working if you swap them in unless they are encapsulated in a SVG tag. So to allow you to modify the internal contents of an existing SVG you can use both `template` and `svg` tags to encapsulate these elements which allows them to get the correct namespace applied.
 
 Here is an example with an out of band swap of svg elements being encapsulated in this way:
 

--- a/www/content/attributes/hx-swap-oob.md
+++ b/www/content/attributes/hx-swap-oob.md
@@ -70,7 +70,7 @@ Here is an example with an out of band swap of svg elements being encapsulated i
 ```
 This will replace circle1 inline and then insert circle2 before circle1. 
 
-Note that these template and svg wrapping tags will be removed from the final content of the page.
+Note that these `template` and `svg` wrapping tags will be removed from the final content of the page.
 
 ## Nested OOB Swaps
 

--- a/www/content/attributes/hx-swap-oob.md
+++ b/www/content/attributes/hx-swap-oob.md
@@ -51,6 +51,27 @@ Here is an example with an out of band swap of a table row being encapsulated in
 
 Note that these template tags will be removed from the final content of the page.
 
+### Slipery SVGs
+
+Some element types like SVG use an alternative XML namespace for all their children and this prevents internal elements from working if you swap them in unless they are encapsulated in a SVG tag. So to allow you to modify the internal contents of an existing SVG you can use both a `template` and `svg` tags to encapsulate these elements which allows them to get the correct namespace applied.
+
+Here is an example with an out of band swap of svg elements being encapsulated in this way:
+
+```html
+<div>
+    ...
+</div>
+<template><svg>
+    <circle hx-swap-oob="true" id="circle1" r="35" cx="50" cy="50" fill="red" /> 
+</svg></template>
+<template><svg hx-swap-oob="beforebegin:#circle1">
+    <circle id="circle2" r="45" cx="50" cy="50" fill="blue" /> 
+</svg></template>
+```
+This will replace circle1 inline and then insert circle2 before circle1. 
+
+Note that these template and svg wrapping tags will be removed from the final content of the page.
+
 ## Nested OOB Swaps
 
 By default, any element with `hx-swap-oob=` attribute anywhere in the response is processed for oob swap behavior, including when an element is nested within the main response element.

--- a/www/content/attributes/hx-swap-oob.md
+++ b/www/content/attributes/hx-swap-oob.md
@@ -51,9 +51,9 @@ Here is an example with an out of band swap of a table row being encapsulated in
 
 Note that these template tags will be removed from the final content of the page.
 
-### Slipery SVGs
+### Slippery SVGs
 
-Some element types like SVG use an alternative XML namespace for all their children and this prevents internal elements from working if you swap them in unless they are encapsulated in a SVG tag. So to allow you to modify the internal contents of an existing SVG you can use both `template` and `svg` tags to encapsulate these elements which allows them to get the correct namespace applied.
+Some element types, like SVG, use a specific XML namespace for their child elements. This prevents internal elements from working correctly when swapped in, unless they are encapsulated within a `svg` tag. To modify the internal contents of an existing SVG, you can use both `template` and `svg` tags to encapsulate the elements, allowing them to get the correct namespace applied.
 
 Here is an example with an out of band swap of svg elements being encapsulated in this way:
 


### PR DESCRIPTION
## Description
SVGs have issues when you try and modify their contents because they have a different namespace that is only setup when you wrap them in a svg tag.  So to allow internal SVG replacment I've found you can use wrapping in both template and svg tags which then works well with OOB swaps.  It is also possible to do similar full swaps but you have to use hx-select and its not as easy.

Corresponding issue:

## Testing
Performed manual testing of different oob internal svg swaps to check it works as expected

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
