### PR TITLE
Handle null values in hx-vals and improve formData handling

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3962,7 +3962,7 @@ var htmx = (function() {
     const formData = new FormData()
     for (const key in obj) {
       if (obj.hasOwnProperty(key)) {
-        if (typeof obj[key].forEach === 'function') {
+        if (obj[key] && typeof obj[key].forEach === 'function') {
           obj[key].forEach(function(v) { formData.append(key, v) })
         } else if (typeof obj[key] === 'object' && !(obj[key] instanceof Blob)) {
           formData.append(key, JSON.stringify(obj[key]))

--- a/test/attributes/hx-vals.js
+++ b/test/attributes/hx-vals.js
@@ -120,6 +120,18 @@ describe('hx-vals attribute', function() {
     div.innerHTML.should.equal('Clicked!')
   })
 
+  it('hx-vals works with braces and null value', function() {
+    this.server.respondWith('POST', '/vars', function(xhr) {
+      var params = getParameters(xhr)
+      params.i1.should.equal('null')
+      xhr.respond(200, {}, 'Clicked!')
+    })
+    var div = make('<div hx-post="/vars" hx-vals="javascript:{i1:null}"></div>')
+    div.click()
+    this.server.respond()
+    div.innerHTML.should.equal('Clicked!')
+  })
+
   it('multiple hx-vals works', function() {
     this.server.respondWith('POST', '/vars', function(xhr) {
       var params = getParameters(xhr)


### PR DESCRIPTION
## Description
- Updated the condition to handle cases where `obj[key]` is null before checking for `forEach` function. This ensures that formData does not throw an error when null values are encountered.

Corresponding issue:

## Testing
- Added a test case to validate the correct behavior of `hx-vals` when null values are passed (e.g., `hx-vals="javascript:{i1:null}"`).


## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
