### PR TITLE
[Documentartion]Add more information about other swap strategies

### DIFF
--- a/www/content/attributes/hx-swap-oob.md
+++ b/www/content/attributes/hx-swap-oob.md
@@ -35,7 +35,7 @@ If a selector is given, all elements matched by that selector will be swapped.  
 
 As mentioned previously when using swap strategies other than `true` or `outerHTML` the encapsulating tags are stripped, as such you need to excapsulate the returned data with the correct tags for the context.
 
-For a table that uses `<tbody>`:
+When trying to insert a `<tr>` in a table that uses `<tbody>`:
 ```html
 <tbody hx-swap-oob="beforeend:#table tbody">
 	<tr>

--- a/www/content/attributes/hx-swap-oob.md
+++ b/www/content/attributes/hx-swap-oob.md
@@ -31,26 +31,6 @@ If a swap value is given, that swap strategy will be used and the encapsulating 
 
 If a selector is given, all elements matched by that selector will be swapped.  If not, the element with an ID matching the new content will be swapped.
 
-### Troublesome Tables and lists
-
-Note that you can use a `template` tag to encapsulate types of elements that, by the HTML spec, can't stand on their own in the
-DOM (`<tr>`, `<td>`, `<th>`, `<thead>`, `<tbody>`, `<tfoot>`, `<colgroup>`, `<caption>`, `<col>` & `<li>`).
-
-Here is an example with an out of band swap of a table row being encapsulated in this way:
-
-```html
-<div>
-    ...
-</div>
-<template>
-    <tr id="row" hx-swap-oob="true">
-        ...
-    </tr>
-</template>
-```
-
-Note that these template tags will be removed from the final content of the page.
-
 ### Using alternate swap strategies
 
 As mentioned previously when using swap strategies other than `true` or `outerHTML` the encapsulating tags are stripped, as such you need to excapsulate the returned data with the correct tags for the context.
@@ -86,6 +66,26 @@ A `<p>` can be encapsulated in `<div>` or `<span>`:
 	<p>...</p>
 </span>
 ```
+
+### Troublesome Tables and lists
+
+Note that you can use a `template` tag to encapsulate types of elements that, by the HTML spec, can't stand on their own in the
+DOM (`<tr>`, `<td>`, `<th>`, `<thead>`, `<tbody>`, `<tfoot>`, `<colgroup>`, `<caption>`, `<col>` & `<li>`).
+
+Here is an example with an out of band swap of a table row being encapsulated in this way:
+
+```html
+<div>
+    ...
+</div>
+<template>
+    <tr id="row" hx-swap-oob="true">
+        ...
+    </tr>
+</template>
+```
+
+Note that these template tags will be removed from the final content of the page.
 
 ### Slippery SVGs
 

--- a/www/content/attributes/hx-swap-oob.md
+++ b/www/content/attributes/hx-swap-oob.md
@@ -27,14 +27,14 @@ The value of the `hx-swap-oob` can be:
 
 If the value is `true` or `outerHTML` (which are equivalent) the element will be swapped inline.
 
-If a swap value is given, that swap strategy will be used.
+If a swap value is given, that swap strategy will be used and the encapsulating tag pair will be stripped for all strategies other than `outerHTML`.
 
 If a selector is given, all elements matched by that selector will be swapped.  If not, the element with an ID matching the new content will be swapped.
 
-### Troublesome Tables
+### Troublesome Tables and lists
 
 Note that you can use a `template` tag to encapsulate types of elements that, by the HTML spec, can't stand on their own in the
-DOM (`<tr>`, `<td>`, `<th>`, `<thead>`, `<tbody>`, `<tfoot>`, `<colgroup>`, `<caption>` & `<col>`).
+DOM (`<tr>`, `<td>`, `<th>`, `<thead>`, `<tbody>`, `<tfoot>`, `<colgroup>`, `<caption>`, `<col>` & `<li>`).
 
 Here is an example with an out of band swap of a table row being encapsulated in this way:
 
@@ -50,6 +50,42 @@ Here is an example with an out of band swap of a table row being encapsulated in
 ```
 
 Note that these template tags will be removed from the final content of the page.
+
+### Using alternate swap strategies
+
+As mentioned previously when using swap strategies other than `true` or `outerHTML` the encapsulating tags are stripped, as such you need to excapsulate the returned data with the correct tags for the context.
+
+For a table that uses `<tbody>`:
+```html
+<tbody hx-swap-oob="beforeend:#table tbody">
+	<tr>
+		...
+	</tr>
+</tbody>
+```
+
+A "plain" table:
+```html
+<table hx-swap-oob="beforeend:#table2">
+	<tr>
+		...
+	</tr>
+</table>
+```
+
+An `<li>` may be encapsulated in `<ul>`, `<ol>`, `<div>` or `<span>`, for example:
+```html
+<ul hx-swap-oob="beforeend:#list1">
+	<li>...</li>
+</ul>
+```
+
+A `<p>` can be encapsulated in `<div>` or `<span>`:
+```html
+<span hx-swap-oob="beforeend:#text">
+	<p>...</p>
+</span>
+```
 
 ### Slippery SVGs
 

--- a/www/content/attributes/hx-swap-oob.md
+++ b/www/content/attributes/hx-swap-oob.md
@@ -53,7 +53,7 @@ A "plain" table:
 </table>
 ```
 
-An `<li>` may be encapsulated in `<ul>`, `<ol>`, `<div>` or `<span>`, for example:
+A `<li>` may be encapsulated in `<ul>`, `<ol>`, `<div>` or `<span>`, for example:
 ```html
 <ul hx-swap-oob="beforeend:#list1">
 	<li>...</li>


### PR DESCRIPTION
## Description
This extends the `hx-swap-oob` documentation with more information on using it with alternate swap strategies which can be finicky, all my conclusions are based on trial and error using htmx 2.0.2 on Firefox 129.

More background on all the testing I did can be found in #2560 

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* ~~[ ] I ran the test suite locally (`npm run test`) and verified that it succeeded~~
