### PR TITLE
Change hx-trigger's changed modifier to work for independent trigger specifications

### DIFF
--- a/test/attributes/hx-trigger.js
+++ b/test/attributes/hx-trigger.js
@@ -64,6 +64,7 @@ describe('hx-trigger attribute', function() {
     div.innerHTML.should.equal('Requests: 1')
   })
 
+  // This test and the next one should be kept in sync.
   it('changed modifier works along from clause with two inputs', function() {
     var requests = 0
     this.server.respondWith('GET', '/test', function(xhr) {
@@ -104,6 +105,50 @@ describe('hx-trigger attribute', function() {
     input2.click()
     this.server.respond()
     div.innerHTML.should.equal('Requests: 2')
+  })
+
+  // This test and the previous one should be kept in sync.
+  it('changed modifier counts each triggerspec separately', function() {
+    var requests = 0
+    this.server.respondWith('GET', '/test', function(xhr) {
+      requests++
+      xhr.respond(200, {}, 'Requests: ' + requests)
+    })
+    var input1 = make('<input type="text"/>')
+    var input2 = make('<input type="text"/>')
+    make('<div hx-trigger="click changed from:input" hx-target="#d1" hx-get="/test"></div>')
+    make('<div hx-trigger="click changed from:input" hx-target="#d1" hx-get="/test"></div>')
+    var div = make('<div id="d1"></div>')
+
+    input1.click()
+    this.server.respond()
+    div.innerHTML.should.equal('')
+    input2.click()
+    this.server.respond()
+    div.innerHTML.should.equal('')
+
+    input1.value = 'bar'
+    input2.click()
+    this.server.respond()
+    div.innerHTML.should.equal('')
+    input1.click()
+    this.server.respond()
+    div.innerHTML.should.equal('Requests: 2')
+
+    input1.click()
+    this.server.respond()
+    div.innerHTML.should.equal('Requests: 2')
+    input2.click()
+    this.server.respond()
+    div.innerHTML.should.equal('Requests: 2')
+
+    input2.value = 'foo'
+    input1.click()
+    this.server.respond()
+    div.innerHTML.should.equal('Requests: 2')
+    input2.click()
+    this.server.respond()
+    div.innerHTML.should.equal('Requests: 4')
   })
 
   it('once modifier works', function() {

--- a/test/attributes/hx-trigger.js
+++ b/test/attributes/hx-trigger.js
@@ -151,6 +151,48 @@ describe('hx-trigger attribute', function() {
     div.innerHTML.should.equal('Requests: 4')
   })
 
+  it('separate changed modifier works along from clause with two inputs', function() {
+    var requests = 0
+    this.server.respondWith('GET', '/test', function(xhr) {
+      requests++
+      xhr.respond(200, {}, 'Requests: ' + requests)
+    })
+    var input1 = make('<input type="text"/>')
+    var input2 = make('<input type="text"/>')
+    make('<div hx-trigger="click changed from:input:nth-child(1), click changed from:input:nth-child(2)" hx-target="#d1" hx-get="/test"></div>')
+    var div = make('<div id="d1"></div>')
+
+    input1.click()
+    this.server.respond()
+    div.innerHTML.should.equal('')
+    input2.click()
+    this.server.respond()
+    div.innerHTML.should.equal('')
+
+    input1.value = 'bar'
+    input2.click()
+    this.server.respond()
+    div.innerHTML.should.equal('')
+    input1.click()
+    this.server.respond()
+    div.innerHTML.should.equal('Requests: 1')
+
+    input1.click()
+    this.server.respond()
+    div.innerHTML.should.equal('Requests: 1')
+    input2.click()
+    this.server.respond()
+    div.innerHTML.should.equal('Requests: 1')
+
+    input2.value = 'foo'
+    input1.click()
+    this.server.respond()
+    div.innerHTML.should.equal('Requests: 1')
+    input2.click()
+    this.server.respond()
+    div.innerHTML.should.equal('Requests: 2')
+  })
+
   it('once modifier works', function() {
     var requests = 0
     this.server.respondWith('GET', '/test', function(xhr) {


### PR DESCRIPTION
## Description
Trigger specifications can reference multiple HTML nodes via from and a single element can have multiple trigger specifications for different HTML nodes. One example is given in #2056. Active search with multiple search fields is another one. The latter doesn't currently work because the trigger needs to be on the form element, but the logic doesn't check the event target, but only the element itself.

Corresponding issue: #2056 

## Testing
Test case covers the original problem from #2056 as well as the related case of referencing different elements. Both tests fail without the implementation change.

## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [X] I ran the test suite locally (`npm run test`) and verified that it succeeded
