### PR TITLE
Handle Space before comma in Trigger Spec

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2171,8 +2171,8 @@ var htmx = (function() {
           if (eventFilter) {
             triggerSpec.eventFilter = eventFilter
           }
+          consumeUntil(tokens, NOT_WHITESPACE)
           while (tokens.length > 0 && tokens[0] !== ',') {
-            consumeUntil(tokens, NOT_WHITESPACE)
             const token = tokens.shift()
             if (token === 'changed') {
               triggerSpec.changed = true

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2217,6 +2217,7 @@ var htmx = (function() {
             } else {
               triggerErrorEvent(elt, 'htmx:syntax:error', { token: tokens.shift() })
             }
+            consumeUntil(tokens, NOT_WHITESPACE)
           }
           triggerSpecs.push(triggerSpec)
         }

--- a/test/attributes/hx-trigger.js
+++ b/test/attributes/hx-trigger.js
@@ -1079,4 +1079,19 @@ describe('hx-trigger attribute', function() {
 
     htmx.config.triggerSpecsCache = initialCacheConfig
   })
+
+  it('handles spaces at the end of trigger specs', function() {
+    var requests = 0
+    this.server.respondWith('GET', '/test', function(xhr) {
+      requests++
+      xhr.respond(200, {}, 'Requests: ' + requests)
+    })
+    var div = make('<div hx-trigger="load , click" hx-get="/test">Requests: 0</div>')
+    div.innerHTML.should.equal('Requests: 0')
+    this.server.respond()
+    div.innerHTML.should.equal('Requests: 1')
+    div.click()
+    this.server.respond()
+    div.innerHTML.should.equal('Requests: 2')
+  })
 })

--- a/test/attributes/hx-trigger.js
+++ b/test/attributes/hx-trigger.js
@@ -1086,7 +1086,7 @@ describe('hx-trigger attribute', function() {
       requests++
       xhr.respond(200, {}, 'Requests: ' + requests)
     })
-    var div = make('<div hx-trigger="load , click" hx-get="/test">Requests: 0</div>')
+    var div = make('<div hx-trigger="load , click consume " hx-get="/test">Requests: 0</div>')
     div.innerHTML.should.equal('Requests: 0')
     this.server.respond()
     div.innerHTML.should.equal('Requests: 1')


### PR DESCRIPTION
## Description
Handle any additional whitespace placed at the end of a trigger specification by ignoring it.

Corresponding issue:
#2897 

## Testing


## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
