### PR TITLE
Documentation 3xx redirects can't send headers

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -1028,13 +1028,13 @@ htmx includes a number of useful headers in requests:
 | `HX-Trigger-Name` | the `name` of the triggered element if it exists
 | `HX-Trigger` | the `id` of the triggered element if it exists
 
-### Response Headers
+### Response Headers {#response_headers}
 
 htmx supports some htmx-specific response headers:
 
 * [`HX-Location`](@/headers/hx-location.md) - allows you to do a client-side redirect that does not do a full page reload
 * [`HX-Push-Url`](@/headers/hx-push-url.md) - pushes a new url into the history stack
-* `HX-Redirect` - can be used to do a client-side redirect to a new location
+* [`HX-Redirect`](@/headers/hx-redirect.md) - can be used to do a client-side redirect to a new location
 * `HX-Refresh` - if set to "true" the client-side will do a full refresh of the page
 * [`HX-Replace-Url`](@/headers/hx-replace-url.md) - replaces the current URL in the location bar
 * `HX-Reswap` - allows you to specify how the response will be swapped. See [hx-swap](@/attributes/hx-swap.md) for possible values
@@ -1048,6 +1048,8 @@ For more on the `HX-Trigger` headers, see [`HX-Trigger` Response Headers](@/head
 
 Submitting a form via htmx has the benefit of no longer needing the [Post/Redirect/Get Pattern](https://en.wikipedia.org/wiki/Post/Redirect/Get).
 After successfully processing a POST request on the server, you don't need to return a [HTTP 302 (Redirect)](https://en.wikipedia.org/wiki/HTTP_302). You can directly return the new HTML fragment.
+
+Also the response headers above are not provided to htmx for processing with 3xx Redirect response codes like [HTTP 302 (Redirect)](https://en.wikipedia.org/wiki/HTTP_302). Instead, the browser will intercept the redirection internally and return the headers and response from the redirected URL. Where possible use alternative response codes like 200 to allow returning of these response headers.
 
 ### Request Order of Operations {#request-operations}
 

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -1028,7 +1028,7 @@ htmx includes a number of useful headers in requests:
 | `HX-Trigger-Name` | the `name` of the triggered element if it exists
 | `HX-Trigger` | the `id` of the triggered element if it exists
 
-### Response Headers {#response_headers}
+### Response Headers
 
 htmx supports some htmx-specific response headers:
 

--- a/www/content/headers/hx-location.md
+++ b/www/content/headers/hx-location.md
@@ -31,4 +31,4 @@ Path is required and is url to load the response from. The rest of the data mirr
 
 ## Notes
 
-Response headers are not processed on 3xx response codes. see [Response Headers](@/docs.md#response_headers)
+Response headers are not processed on 3xx response codes. see [Response Headers](@/docs.md#response-headers)

--- a/www/content/headers/hx-location.md
+++ b/www/content/headers/hx-location.md
@@ -28,3 +28,7 @@ Path is required and is url to load the response from. The rest of the data mirr
 * `values` - values to submit with the request
 * `headers` - headers to submit with the request
 * `select` - allows you to select the content you want swapped from a response
+
+## Notes
+
+Response headers are not processed on 3xx response codes. see [Response Headers](@/docs.md#response_headers)

--- a/www/content/headers/hx-push-url.md
+++ b/www/content/headers/hx-push-url.md
@@ -13,3 +13,7 @@ The possible values for this header are:
 1. A URL to be pushed into the location bar.
    This may be relative or absolute, as per [`history.pushState()`](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState).
 2. `false`, which prevents the browser’s history from being updated.
+
+## Notes
+
+Response headers are not processed on 3xx response codes. see [Response Headers](@/docs.md#response_headers)

--- a/www/content/headers/hx-push-url.md
+++ b/www/content/headers/hx-push-url.md
@@ -16,4 +16,4 @@ The possible values for this header are:
 
 ## Notes
 
-Response headers are not processed on 3xx response codes. see [Response Headers](@/docs.md#response_headers)
+Response headers are not processed on 3xx response codes. see [Response Headers](@/docs.md#response-headers)

--- a/www/content/headers/hx-redirect.md
+++ b/www/content/headers/hx-redirect.md
@@ -1,0 +1,17 @@
++++
+title = "HX-Redirect Response Header"
++++
+
+This response header can be used to trigger a client side redirection to a new url that will do a full reload of the whole page. It uses the browser to redirect to the new location which can be useful when redirecting to non htmx endpoints that may contain different HTML `head` content or scripts.  See [`HX-Location`](@/headers/hx-location.md) if you want more control over the redirect or want to use ajax requests instead of full browser reloads. 
+
+A sample response would be:
+
+```html
+HX-Redirect: /test
+```
+
+Which would push the client to test as if the user had entered this url manually or clicked on a non-boosted link `<a href="/test">`
+
+## Notes
+
+Response headers are not processed on 3xx response codes. see [Response Headers](@/docs.md#response_headers)

--- a/www/content/headers/hx-redirect.md
+++ b/www/content/headers/hx-redirect.md
@@ -14,4 +14,4 @@ Which would push the client to test as if the user had entered this url manually
 
 ## Notes
 
-Response headers are not processed on 3xx response codes. see [Response Headers](@/docs.md#response_headers)
+Response headers are not processed on 3xx response codes. see [Response Headers](@/docs.md#response-headers)

--- a/www/content/headers/hx-replace-url.md
+++ b/www/content/headers/hx-replace-url.md
@@ -16,4 +16,4 @@ The possible values for this header are:
 
 ## Notes
 
-Response headers are not processed on 3xx response codes. see [Response Headers](@/docs.md#response_headers)
+Response headers are not processed on 3xx response codes. see [Response Headers](@/docs.md#response-headers)

--- a/www/content/headers/hx-replace-url.md
+++ b/www/content/headers/hx-replace-url.md
@@ -13,3 +13,7 @@ The possible values for this header are:
 1. A URL to replace the current URL in the location bar.
    This may be relative or absolute, as per [`history.replaceState()`](https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState), but must have the same origin as the current URL.
 2. `false`, which prevents the browser’s current URL from being updated.
+
+## Notes
+
+Response headers are not processed on 3xx response codes. see [Response Headers](@/docs.md#response_headers)

--- a/www/content/headers/hx-trigger.md
+++ b/www/content/headers/hx-trigger.md
@@ -78,3 +78,7 @@ You may also trigger multiple events with no additional details by sending event
 `HX-Trigger: event1, event2`
 
 Using events gives you a lot of flexibility to add functionality to normal htmx responses.
+
+## Notes
+
+Response headers are not processed on 3xx response codes. see [Response Headers](@/docs.md#response_headers)

--- a/www/content/headers/hx-trigger.md
+++ b/www/content/headers/hx-trigger.md
@@ -81,4 +81,4 @@ Using events gives you a lot of flexibility to add functionality to normal htmx 
 
 ## Notes
 
-Response headers are not processed on 3xx response codes. see [Response Headers](@/docs.md#response_headers)
+Response headers are not processed on 3xx response codes. see [Response Headers](@/docs.md#response-headers)

--- a/www/content/reference.md
+++ b/www/content/reference.md
@@ -112,7 +112,7 @@ All other attributes available in htmx.
 |------------------------------------------------------|-------------|
 | [`HX-Location`](@/headers/hx-location.md)            | allows you to do a client-side redirect that does not do a full page reload
 | [`HX-Push-Url`](@/headers/hx-push-url.md)            | pushes a new url into the history stack
-| `HX-Redirect`                                        | can be used to do a client-side redirect to a new location
+| [`HX-Redirect`](@/headers/hx-redirect.md)            | can be used to do a client-side redirect to a new location
 | `HX-Refresh`                                         | if set to "true" the client-side will do a full refresh of the page
 | [`HX-Replace-Url`](@/headers/hx-replace-url.md)      | replaces the current URL in the location bar
 | `HX-Reswap`                                          | allows you to specify how the response will be swapped. See [hx-swap](@/attributes/hx-swap.md) for possible values


### PR DESCRIPTION
## Description
Added some documentation for how response headers are not received or processed when 3xx response codes are returned.

Corresponding issue:
#2879 

## Testing

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
