### PR TITLE
allow hx-include/disabled-elt/indicator to be optional

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1134,17 +1134,6 @@ var htmx = (function() {
   }
 
   /**
-   * @param {Node|null} node
-   * @returns {Node[]}
-   */
-  function toNodeArray(node) {
-    if (node) {
-      return [node]
-    }
-    return []
-  }
-
-  /**
    * @param {Node|Element|Document|string} elt
    * @param {string} selector
    * @param {boolean=} global
@@ -1153,17 +1142,17 @@ var htmx = (function() {
   function querySelectorAllExt(elt, selector, global) {
     elt = resolveTarget(elt)
     if (selector.indexOf('closest ') === 0) {
-      return toNodeArray(closest(asElement(elt), normalizeSelector(selector.substr(8))))
+      return [closest(asElement(elt), normalizeSelector(selector.substr(8)))]
     } else if (selector.indexOf('find ') === 0) {
-      return toNodeArray(find(asParentNode(elt), normalizeSelector(selector.substr(5))))
+      return [find(asParentNode(elt), normalizeSelector(selector.substr(5)))]
     } else if (selector === 'next') {
       return [asElement(elt).nextElementSibling]
     } else if (selector.indexOf('next ') === 0) {
-      return toNodeArray(scanForwardQuery(elt, normalizeSelector(selector.substr(5)), !!global))
+      return [scanForwardQuery(elt, normalizeSelector(selector.substr(5)), !!global)]
     } else if (selector === 'previous') {
       return [asElement(elt).previousElementSibling]
     } else if (selector.indexOf('previous ') === 0) {
-      return toNodeArray(scanBackwardsQuery(elt, normalizeSelector(selector.substr(9)), !!global))
+      return [scanBackwardsQuery(elt, normalizeSelector(selector.substr(9)), !!global)]
     } else if (selector === 'document') {
       return [document]
     } else if (selector === 'window') {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1315,25 +1315,22 @@ var htmx = (function() {
   function findAttributeTargets(elt, attrName) {
     let attrTarget = getClosestAttributeValue(elt, attrName)
     if (attrTarget) {
-      const optional = attrTarget.slice(-1) === '?'
-      if (optional) {
-        attrTarget = attrTarget.slice(0, -1)
-      }
-      let result = []
-      forEach(attrTarget.split(','), function(target) {
-        if (attrTarget === 'this') {
-          result.push(findThisElement(elt, attrName))
-        } else {
-          result = result.concat(querySelectorAllExt(elt, target.trim()))
-        }
-      })
-      if (result.length === 0) {
-        if (!optional) {
-          logError('The selector "' + attrTarget + '" on ' + attrName + ' returned no matches!')
-        }
-        return [DUMMY_ELT]
+      if (attrTarget === 'this') {
+        return [findThisElement(elt, attrName)]
       } else {
-        return result
+        const optional = attrTarget.slice(-1) === '?'
+        if (optional) {
+          attrTarget = attrTarget.slice(0, -1)
+        }
+        const result = querySelectorAllExt(elt, attrTarget)
+        if (result.length === 0) {
+          if (!optional) {
+            logError('The selector "' + attrTarget + '" on ' + attrName + ' returned no matches!')
+          }
+          return [DUMMY_ELT]
+        } else {
+          return result
+        }
       }
     }
   }

--- a/test/attributes/hx-disabled-elt.js
+++ b/test/attributes/hx-disabled-elt.js
@@ -80,4 +80,23 @@ describe('hx-disabled-elt attribute', function() {
     b2.hasAttribute('disabled').should.equal(false)
     b3.hasAttribute('disabled').should.equal(false)
   })
+
+  it('find on multiple elts can be disabled', function() {
+    this.server.respondWith('GET', '/test', 'Clicked!')
+    var form = make('<form hx-get="/test" hx-disabled-elt="find input[type=\'text\'], find button" hx-swap="none"><input id="i1" type="text" placeholder="Type here..."><button id="b2" type="submit">Send</button></form>')
+    var i1 = byId('i1')
+    var b2 = byId('b2')
+
+    i1.hasAttribute('disabled').should.equal(false)
+    b2.hasAttribute('disabled').should.equal(false)
+
+    b2.click()
+    i1.hasAttribute('disabled').should.equal(true)
+    b2.hasAttribute('disabled').should.equal(true)
+
+    this.server.respond()
+
+    i1.hasAttribute('disabled').should.equal(false)
+    b2.hasAttribute('disabled').should.equal(false)
+  })
 })

--- a/test/attributes/hx-disabled-elt.js
+++ b/test/attributes/hx-disabled-elt.js
@@ -80,23 +80,4 @@ describe('hx-disabled-elt attribute', function() {
     b2.hasAttribute('disabled').should.equal(false)
     b3.hasAttribute('disabled').should.equal(false)
   })
-
-  it('find on multiple elts can be disabled', function() {
-    this.server.respondWith('GET', '/test', 'Clicked!')
-    var form = make('<form hx-get="/test" hx-disabled-elt="find input[type=\'text\'], find button" hx-swap="none"><input id="i1" type="text" placeholder="Type here..."><button id="b2" type="submit">Send</button></form>')
-    var i1 = byId('i1')
-    var b2 = byId('b2')
-
-    i1.hasAttribute('disabled').should.equal(false)
-    b2.hasAttribute('disabled').should.equal(false)
-
-    b2.click()
-    i1.hasAttribute('disabled').should.equal(true)
-    b2.hasAttribute('disabled').should.equal(true)
-
-    this.server.respond()
-
-    i1.hasAttribute('disabled').should.equal(false)
-    b2.hasAttribute('disabled').should.equal(false)
-  })
 })

--- a/test/attributes/hx-include.js
+++ b/test/attributes/hx-include.js
@@ -224,4 +224,28 @@ describe('hx-include attribute', function() {
     this.server.respond()
     btn.innerHTML.should.equal('Clicked!')
   })
+
+  it('logs error when selector returns no matches', function() {
+    this.server.respondWith('POST', '/include', 'Clicked!')
+    var div = make('<div hx-post="/include" hx-include="input"></div>')
+    const spy = sinon.spy(console, 'error')
+    div.click()
+    this.server.respond()
+    spy.calledOnce.should.equal(true)
+    spy.calledWith('The selector "input" on hx-include returned no matches!').should.equal(true)
+    div.innerHTML.should.equal('Clicked!')
+    spy.restore()
+  })
+
+  it('no error when optional selector returns no matches', function() {
+    this.server.respondWith('POST', '/include', 'Clicked!')
+    var div = make('<div hx-post="/include" hx-include="input?"></div>')
+    const spy = sinon.spy(console, 'error')
+    div.click()
+    this.server.respond()
+    spy.calledOnce.should.equal(false)
+    spy.calledWith('The selector "input" on hx-include returned no matches!').should.equal(false)
+    div.innerHTML.should.equal('Clicked!')
+    spy.restore()
+  })
 })

--- a/www/content/attributes/hx-disabled-elt.md
+++ b/www/content/attributes/hx-disabled-elt.md
@@ -41,5 +41,6 @@ The `hx-disabled-elt` attribute also supports specifying multiple CSS selectors 
 ## Notes
 
 * `hx-disabled-elt` is inherited and can be placed on a parent element
+* If the selector supplied matchs no elements it will log an error to the console which can be avoided by adding a `?` to the end to make it optional e.g. `hx-disabled-elt="find button?"`
 
 [hx-trigger]: https://htmx.org/attributes/hx-trigger/

--- a/www/content/attributes/hx-disabled-elt.md
+++ b/www/content/attributes/hx-disabled-elt.md
@@ -41,6 +41,6 @@ The `hx-disabled-elt` attribute also supports specifying multiple CSS selectors 
 ## Notes
 
 * `hx-disabled-elt` is inherited and can be placed on a parent element
-* If the selector supplied matchs no elements it will log an error to the console which can be avoided by adding a `?` to the end to make it optional e.g. `hx-disabled-elt="find button?"`
+* If the supplied selector doesn't match any element, it will log an error to the console which can be avoided by adding a `?` to the end to make it optional e.g. `hx-disabled-elt="find button?"`
 
 [hx-trigger]: https://htmx.org/attributes/hx-trigger/

--- a/www/content/attributes/hx-include.md
+++ b/www/content/attributes/hx-include.md
@@ -46,7 +46,7 @@ Note that if you include a non-input element, all input elements enclosed in tha
   </div>
   ```
   In the above example, when clicking on the button, the `find input` selector is resolved from the button itself, which
-  does not return any element here, since the button doesn't have any `input` child, thus in this case, raises an error.
+  does not return any element here, since the button doesn't have any `input` child, thus in this case, raises an error. This can be avoided by adding a `?` to the end to make it optional e.g. `hx-include="find input?"`
 * A standard CSS selector resolves
   to [document.querySelectorAll](https://developer.mozilla.org/docs/Web/API/Document/querySelectorAll) and will include
   multiple elements, while the extended selectors such as `find` or `next` only return a single element at most to

--- a/www/content/attributes/hx-indicator.md
+++ b/www/content/attributes/hx-indicator.md
@@ -79,7 +79,7 @@ This simulates what a spinner might look like in that situation:
 ## Notes
 
 * `hx-indicator` is inherited and can be placed on a parent element
-* If the selector supplied matchs no elements it will log an error to the console which can be avoided by adding a `?` to the end to make it optional e.g. `hx-indicator="find img?"`
+* If the supplied selector doesn't match any element, it will log an error to the console which can be avoided by adding a `?` to the end to make it optional e.g. `hx-indicator="find img?"`
 * In the absence of an explicit indicator, the `htmx-request` class will be added to the element triggering the
   request
 * If you want to use your own CSS but still use `htmx-indicator` as class name, then you need to disable `includeIndicatorStyles`. See [Configuring htmx](@/docs.md#config). The easiest way is to add this to the `<head>` of your HTML:

--- a/www/content/attributes/hx-indicator.md
+++ b/www/content/attributes/hx-indicator.md
@@ -79,6 +79,7 @@ This simulates what a spinner might look like in that situation:
 ## Notes
 
 * `hx-indicator` is inherited and can be placed on a parent element
+* If the selector supplied matchs no elements it will log an error to the console which can be avoided by adding a `?` to the end to make it optional e.g. `hx-indicator="find img?"`
 * In the absence of an explicit indicator, the `htmx-request` class will be added to the element triggering the
   request
 * If you want to use your own CSS but still use `htmx-indicator` as class name, then you need to disable `includeIndicatorStyles`. See [Configuring htmx](@/docs.md#config). The easiest way is to add this to the `<head>` of your HTML:


### PR DESCRIPTION
## Description
This is a possible improvement to allow hx-include, hx-disabled-elt and hx-indicator to not report errors to the console when a selector finds no elements.  Because of how some of these properties can inherit the use of find and similar extended selectors can fail to find any elements when triggered from a different element.  When this happens it produces an error message to the console to warn you that it is not working as expected.  I think this warning is still useful but it would be nice to have the option to disable the warning for situation where you expect this to happen. 

So to allow this I've implemented an option to append a '?' to the end of the selector string which disables the error warning similar to how javascript and regex treat ? at the end as meaning optional.

So for example you can now use `hx-include="input?"` and if it can not find any inputs to include it will ignore this and not report any errors.

Corresponding issue:
#2895 

## Testing
Tests added and performed a little manual testing to test and debug the change in a test app

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
