### PR TITLE
[bug] load trigger stops hx-disabled-elt getting re-enabled

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2549,7 +2549,11 @@ var htmx = (function() {
         handler(elt)
       }
     }
-    getWindow().setTimeout(load, delay || 0)
+    if (delay > 0) {
+      getWindow().setTimeout(load, delay)
+    } else {
+      load()
+    }
   }
 
   /**
@@ -3267,14 +3271,14 @@ var htmx = (function() {
   function removeRequestIndicators(indicators, disabled) {
     forEach(indicators, function(ic) {
       const internalData = getInternalData(ic)
-      internalData.requestCount = (internalData.requestCount || 0) - 1
+      internalData.requestCount = (internalData.requestCount || 1) - 1
       if (internalData.requestCount === 0) {
         ic.classList.remove.call(ic.classList, htmx.config.requestClass)
       }
     })
     forEach(disabled, function(disabledElement) {
       const internalData = getInternalData(disabledElement)
-      internalData.requestCount = (internalData.requestCount || 0) - 1
+      internalData.requestCount = (internalData.requestCount || 1) - 1
       if (internalData.requestCount === 0) {
         disabledElement.removeAttribute('disabled')
         disabledElement.removeAttribute('data-disabled-by-htmx')

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2549,11 +2549,7 @@ var htmx = (function() {
         handler(elt)
       }
     }
-    if (delay > 0) {
-      getWindow().setTimeout(load, delay)
-    } else {
-      load()
-    }
+    getWindow().setTimeout(load, delay || 0)
   }
 
   /**

--- a/test/attributes/hx-disabled-elt.js
+++ b/test/attributes/hx-disabled-elt.js
@@ -80,4 +80,16 @@ describe('hx-disabled-elt attribute', function() {
     b2.hasAttribute('disabled').should.equal(false)
     b3.hasAttribute('disabled').should.equal(false)
   })
+
+  it('load trigger does not prevent disabled element working', function() {
+    this.server.respondWith('GET', '/test', 'Loaded!')
+    var div1 = make('<div id="d1" hx-get="/test" hx-disabled-elt="#b1" hx-trigger="load">Load Me!</div><button id="b1">Demo</button>')
+    var div = byId('d1')
+    var btn = byId('b1')
+    div.innerHTML.should.equal('Load Me!')
+    btn.hasAttribute('disabled').should.equal(true)
+    this.server.respond()
+    div.innerHTML.should.equal('Loaded!')
+    btn.hasAttribute('disabled').should.equal(false)
+  })
 })


### PR DESCRIPTION
## Description
When we init nodes and find a "load" trigger it does the request straight away and this request may disable some elements with hx-disabled-elt.  However if these disabled elements have not yet had their nodeInit() run yet because they are placed lower in the page then when they later init they first de-init their internalData which removes the requestCount counter used to re-enable them again.  So we need it to handle situations where requestCount is not set and currently it defaults this to -1 and no 0 because of the decrement. So to solve this I've just changed it to fall back to 1 which means that if either requestCount is undefined or if it is equal to 0 it will replace it with 1 and then after the decrement will be 0 and trigger the proper code to enable the element again.

Corresponding issue:
#2767 
## Testing
Wrote a test to reproduce the issue with disabled-elt and load together and did a quick test in my test project to prove the disabled button re-enables as expected.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
