### PR TITLE
fix moveBefore pantry losing content with hx-swap none or hx-select

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1493,8 +1493,8 @@ var htmx = (function() {
             getDocument().body.insertAdjacentHTML('afterend', "<div id='--htmx-preserve-pantry--'></div>")
             pantry = find('#--htmx-preserve-pantry--')
           }
-          // @ts-ignore - use proposed moveBefore feature
           existingElement.insertAdjacentHTML('beforebegin', `<div id="${id}"></div>`)
+          // @ts-ignore - use proposed moveBefore feature
           pantry.moveBefore(existingElement, null)
         } else {
           preservedElt.parentNode.replaceChild(existingElement, preservedElt)

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1469,7 +1469,13 @@ var htmx = (function() {
     const pantry = find('#--htmx-preserve-pantry--')
     if (pantry) {
       for (const preservedElt of pantry.children) {
-        const existingElement = find('#' + preservedElt.id)
+        const placeholder = find('#hx-preserve-' + preservedElt.id)
+        let existingElement = find('#' + preservedElt.id)
+        if (!existingElement) {
+          existingElement = placeholder
+        } else {
+          placeholder.remove()
+        }
         // @ts-ignore - use proposed moveBefore feature
         existingElement.parentNode.moveBefore(preservedElt, existingElement)
         existingElement.remove()
@@ -1493,7 +1499,7 @@ var htmx = (function() {
             getDocument().body.insertAdjacentHTML('afterend', "<div id='--htmx-preserve-pantry--'></div>")
             pantry = find('#--htmx-preserve-pantry--')
           }
-          existingElement.insertAdjacentHTML('beforebegin', `<div id="${id}"></div>`)
+          existingElement.insertAdjacentHTML('beforebegin', `<div id="hx-preserve-${id}"></div>`)
           // @ts-ignore - use proposed moveBefore feature
           pantry.moveBefore(existingElement, null)
         } else {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1494,7 +1494,7 @@ var htmx = (function() {
             pantry = find('#--htmx-preserve-pantry--')
           }
           // @ts-ignore - use proposed moveBefore feature
-          existingElement.insertAdjacentHTML('beforebegin', `<template id="${id}"></template>`)
+          existingElement.insertAdjacentHTML('beforebegin', `<div id="${id}"></div>`)
           pantry.moveBefore(existingElement, null)
         } else {
           preservedElt.parentNode.replaceChild(existingElement, preservedElt)

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1494,7 +1494,7 @@ var htmx = (function() {
             pantry = find('#--htmx-preserve-pantry--')
           }
           // @ts-ignore - use proposed moveBefore feature
-          existingElement.insertAdjacentHTML('beforebegin', `<template id="${id}"/>`)
+          existingElement.insertAdjacentHTML('beforebegin', `<template id="${id}"></template>`)
           pantry.moveBefore(existingElement, null)
         } else {
           preservedElt.parentNode.replaceChild(existingElement, preservedElt)

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1494,6 +1494,7 @@ var htmx = (function() {
             pantry = find('#--htmx-preserve-pantry--')
           }
           // @ts-ignore - use proposed moveBefore feature
+          existingElement.insertAdjacentHTML('beforebegin', `<template id="${id}"/>`)
           pantry.moveBefore(existingElement, null)
         } else {
           preservedElt.parentNode.replaceChild(existingElement, preservedElt)

--- a/test/manual/move-before/index.html
+++ b/test/manual/move-before/index.html
@@ -13,6 +13,12 @@
             hx-target="#video-container">
         Load Video Layout 2
     </button>
+    <button hx-get="video2.html"
+    hx-push-url="true"
+    hx-swap="none"
+    hx-target="#video-container">
+        Test none swap keeps preserve content
+    </button>
     &dot;&dot;
     <hr/>
     <div id="video-container">


### PR DESCRIPTION
## Description
The new experimental moveBefore to pantry code for the hx-preserve attribute has an issue where if you use hx-swap="none" or the hx-select feature the content moved out to the htmx-preserve-pantry will not be swapped into the main content as expected and therefore it will have no anchor element in the body left to restore the preserved element.  So to fix this we need to leave a dummy element in the preserved elements original location that will be replaced by the preserved element at the end of the swap.

Just need to create the following simple element next to the element before we move it out:
`<div id="${id}"></div>`

Corresponding issue:

## Testing
Performed manual testing to confirm it works and adjusted the move-before manual test to test a none swap that reproduced the issue where before the fix the preserved video would be removed.  Also did some performance testing in chrome to test what element type worked best as the placeholder element as I considered using `<template>` because it does not render anything visible but div seemed a little faster. 

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
