### PR TITLE
Added htmx before transition reference link

### DIFF
--- a/www/content/reference.md
+++ b/www/content/reference.md
@@ -142,6 +142,7 @@ All other attributes available in htmx.
 | [`htmx:beforeRequest`](@/events.md#htmx:beforeRequest)  | triggered before an AJAX request is made
 | [`htmx:beforeSwap`](@/events.md#htmx:beforeSwap)  | triggered before a swap is done, allows you to configure the swap
 | [`htmx:beforeSend`](@/events.md#htmx:beforeSend)  | triggered just before an ajax request is sent
+| [`htmx:beforeTransition`](@/events.md#htmx:beforeTransition)  | triggered before the [View Transition](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API) wrapped swap occurs
 | [`htmx:configRequest`](@/events.md#htmx:configRequest)  | triggered before the request, allows you to customize parameters, headers
 | [`htmx:confirm`](@/events.md#htmx:confirm)  | triggered after a trigger occurs on an element, allows you to cancel (or delay) issuing the AJAX request
 | [`htmx:historyCacheError`](@/events.md#htmx:historyCacheError)  | triggered on an error during cache writing


### PR DESCRIPTION
## Description

Hello. :wave: This is missing from the reference page but properly documented on the events page. This simply links the two together so anyone can quickly jump between the two.

Corresponding issue: N/A. I ended up fixing this outright instead of logging an issue.

## Testing

I couldn't find a corresponding unit test for this change so visually verified by running `zola serve` locally. Here's a quick screencast that demonstrates the change works:

https://github.com/user-attachments/assets/b5b35afb-7a1d-4917-bb32-b75b76007d1b

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
