### PR TITLE
Add a link to the extensions site on the docs page

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -1128,7 +1128,9 @@ the [`hx-ext`](@/attributes/hx-ext.md) attribute:
 </div>
 ```
 
-If you are interested in adding your own extension to htmx, please [see the extension docs](https://github.com/bigskysoftware/htmx-extensions/tree/main?tab=readme-ov-file#defining-an-extension)
+For existing extensions, please [see the extensions site](https://extensions.htmx.org).
+
+If you are interested in adding your own extension to htmx, please [see the extension docs](https://github.com/bigskysoftware/htmx-extensions/tree/main?tab=readme-ov-file#defining-an-extension).
 
 ## Events & Logging {#events}
 


### PR DESCRIPTION
## Description
On the docs page, discovery of existing extensions and their documentation is impeded by the lack of an appropriate link.

Although other pages include a link, it makes sense that the docs page also includes it. since it already has an extensions section and so it should not be omitted from there.


## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
