### PR TITLE
enable hx-preserve handing for oob swaps

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1420,6 +1420,7 @@ var htmx = (function() {
    * @returns
    */
   function oobSwap(oobValue, oobElement, settleInfo) {
+    handlePreservedElements(oobElement)
     let selector = '#' + getRawAttribute(oobElement, 'id')
     /** @type HtmxSwapStyle */
     let swapStyle = 'outerHTML'
@@ -1462,6 +1463,7 @@ var htmx = (function() {
       oobElement.parentNode.removeChild(oobElement)
       triggerErrorEvent(getDocument().body, 'htmx:oobErrorNoTarget', { content: oobElement })
     }
+    restorePreservedElements()
     return oobValue
   }
 
@@ -1479,7 +1481,7 @@ var htmx = (function() {
   }
 
   /**
-   * @param {DocumentFragment} fragment
+   * @param {DocumentFragment|Element} fragment
    */
   function handlePreservedElements(fragment) {
     forEach(findAll(fragment, '[hx-preserve], [data-hx-preserve]'), function(preservedElt) {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1420,7 +1420,6 @@ var htmx = (function() {
    * @returns
    */
   function oobSwap(oobValue, oobElement, settleInfo) {
-    handlePreservedElements(oobElement)
     let selector = '#' + getRawAttribute(oobElement, 'id')
     /** @type HtmxSwapStyle */
     let swapStyle = 'outerHTML'
@@ -1451,7 +1450,9 @@ var htmx = (function() {
 
           target = beforeSwapDetails.target // allow re-targeting
           if (beforeSwapDetails.shouldSwap) {
+            handlePreservedElements(fragment)
             swapWithStyle(swapStyle, target, target, fragment, settleInfo)
+            restorePreservedElements()
           }
           forEach(settleInfo.elts, function(elt) {
             triggerEvent(elt, 'htmx:oobAfterSwap', beforeSwapDetails)
@@ -1463,7 +1464,6 @@ var htmx = (function() {
       oobElement.parentNode.removeChild(oobElement)
       triggerErrorEvent(getDocument().body, 'htmx:oobErrorNoTarget', { content: oobElement })
     }
-    restorePreservedElements()
     return oobValue
   }
 
@@ -1481,7 +1481,7 @@ var htmx = (function() {
   }
 
   /**
-   * @param {DocumentFragment|Element} fragment
+   * @param {DocumentFragment|ParentNode} fragment
    */
   function handlePreservedElements(fragment) {
     forEach(findAll(fragment, '[hx-preserve], [data-hx-preserve]'), function(preservedElt) {

--- a/test/attributes/hx-preserve.js
+++ b/test/attributes/hx-preserve.js
@@ -68,15 +68,4 @@ describe('hx-preserve attribute', function() {
     byId('d2').innerHTML.should.equal('')
     byId('d5').innerHTML.should.equal('<div id="d3" hx-preserve="">Old Content</div><div id="d4">New oob Content</div>')
   })
-
-  it('hx-swap-oob elements in response ignore hx-preserve attribute placed on them', function() {
-    // having a hx-preserve directly on an element with hx-swap-oob does not make sense and can't be processed so it will be ignored and a normal oob swap performed
-    this.server.respondWith('GET', '/test', "Normal Content<div id='d2' hx-swap-oob='true' hx-preserve>New oob Content</div>")
-    var div1 = make("<div id='d1' hx-get='/test'>Click Me!</div>")
-    var div2 = make("<div id='d2' hx-preserve>Old Content</div>")
-    div1.click()
-    this.server.respond()
-    byId('d1').innerHTML.should.equal('Normal Content')
-    byId('d2').innerHTML.should.equal('New oob Content')
-  })
 })

--- a/test/attributes/hx-preserve.js
+++ b/test/attributes/hx-preserve.js
@@ -34,4 +34,49 @@ describe('hx-preserve attribute', function() {
     byId('d1').innerHTML.should.equal('Old Content')
     byId('d2').innerHTML.should.equal('New Content')
   })
+
+  it('preserved element should not be swapped if it is part of a oob swap', function() {
+    this.server.respondWith('GET', '/test', "Normal Content<div id='d2' hx-swap-oob='true'><div id='d3' hx-preserve>New oob Content</div><div id='d4'>New oob Content</div></div>")
+    var div1 = make("<div id='d1' hx-get='/test'>Click Me!</div>")
+    var div2 = make("<div id='d2'><div id='d3' hx-preserve>Old Content</div></div>")
+    div1.click()
+    this.server.respond()
+    byId('d1').innerHTML.should.equal('Normal Content')
+    byId('d3').innerHTML.should.equal('Old Content')
+    byId('d4').innerHTML.should.equal('New oob Content')
+  })
+
+  it('preserved element should not be swapped if it is part of a hx-select-oob swap', function() {
+    this.server.respondWith('GET', '/test', "Normal Content<div id='d2'><div id='d3' hx-preserve>New oob Content</div><div id='d4'>New oob Content</div></div>")
+    var div1 = make("<div id='d1' hx-get='/test' hx-select-oob='#d2'>Click Me!</div>")
+    var div2 = make("<div id='d2'><div id='d3' hx-preserve>Old Content</div></div>")
+    div1.click()
+    this.server.respond()
+    byId('d1').innerHTML.should.equal('Normal Content')
+    byId('d3').innerHTML.should.equal('Old Content')
+    byId('d4').innerHTML.should.equal('New oob Content')
+  })
+
+  it('preserved element should relocated unchanged if it is part of a oob swap targeting a different loction', function() {
+    this.server.respondWith('GET', '/test', "Normal Content<div id='d2' hx-swap-oob='innerHTML:#d5'><div id='d3' hx-preserve>New oob Content</div><div id='d4'>New oob Content</div></div>")
+    var div1 = make("<div id='d1' hx-get='/test'>Click Me!</div>")
+    var div2 = make("<div id='d2'><div id='d3' hx-preserve>Old Content</div></div>")
+    var div5 = make("<div id='d5'></div>")
+    div1.click()
+    this.server.respond()
+    byId('d1').innerHTML.should.equal('Normal Content')
+    byId('d2').innerHTML.should.equal('')
+    byId('d5').innerHTML.should.equal('<div id="d3" hx-preserve="">Old Content</div><div id="d4">New oob Content</div>')
+  })
+
+  it('hx-swap-oob elements in response ignore hx-preserve attribute placed on them', function() {
+    // having a hx-preserve directly on an element with hx-swap-oob does not make sense and can't be processed so it will be ignored and a normal oob swap performed
+    this.server.respondWith('GET', '/test', "Normal Content<div id='d2' hx-swap-oob='true' hx-preserve>New oob Content</div>")
+    var div1 = make("<div id='d1' hx-get='/test'>Click Me!</div>")
+    var div2 = make("<div id='d2' hx-preserve>Old Content</div>")
+    div1.click()
+    this.server.respond()
+    byId('d1').innerHTML.should.equal('Normal Content')
+    byId('d2').innerHTML.should.equal('New oob Content')
+  })
 })

--- a/www/content/attributes/hx-preserve.md
+++ b/www/content/attributes/hx-preserve.md
@@ -10,6 +10,18 @@ The response requires an element with the same `id`, but its type and other attr
 Note that some elements cannot unfortunately be preserved properly, such as `<input type="text">` (focus and caret position are lost), iframes or certain types of videos. To tackle some of these cases we recommend the [morphdom extension](https://github.com/bigskysoftware/htmx-extensions/blob/main/src/morphdom-swap/README.md), which does a more elaborate DOM
 reconciliation.
 
+## OOB Swap Usage
+
+You can include `hx-preserve` in the inner response of a [hx-swap-oob](@/attributes/hx-swap-oob.md) and it will preserve the element unchanged during the out of band partial replacement as well. However, you cannot place `hx-preserve` on the same element as the `hx-swap-oob` is placed. For example, here is an oob response that replaces notify but leaves the retain div unchanged.
+
+```html
+<div id="notify" hx-swap-oob="true">
+    <p>The below content will not be changed</p>
+    <div id="retain" hx-preserve>Use the on-page contents</div>
+</div>
+```
+
 ## Notes
 
 * `hx-preserve` is not inherited
+* `hx-preserve` can cause elements to be relocated to a new location when swapping in a partial response


### PR DESCRIPTION
## TL;DR

As found in issue #2922, htmx does not process hx-preserve attributes properly when supplied inside a oob-swap response.  Instead the preserved content is just overwritten with the new content from the oob response.
So I've found that simply wrapping the oobSwap() function with handle and restore preserved elements we can indeed support this with just these two lines.  

## Description

I also tried with simply moving the handlePreservedElements() funciton up before the oob swap handling code and this in fact does mostly work but it has some bad side effects as when it preserves the element into the fragment it removes the hx-swap-oob tags if done wrong and it can bring oob-swap tags from the page into the fragment which can then act as oob swaps in error.  So to avoid this issue I moved the change to just wrap inside the oobSwap() function and it behaves much better.  

What i've found is that with this change their is no way to support hx-preserve on the same element as the hx-swap-oob like:

```html
<div id="foo" hx-swap-oob="true" hx-preserve>dummy data</div>
``` 
This just can't work for several reasons.  I have failed to find a valid reason to even do this as you are asking it to swap foo back into foo with no changes so it is just a null update at best. Some of the other swap styles with additional targeting might do something meaningful but it not only breaks my brain trying to work out how it would work but it also breaks the code if you try and make it work.  But the good news is that the code by default uses a findAll() to run a querySelectorAll() to find all children that match the hx-preserve attribute and this ignores the attribute on the root element of the oob swap. So this is a reasonable safe default to have where it prevents you doing the wrong kind of use case and just treats it as a hx-swap-oob with no preserve if you try this.  Could add code to report an error and ignore the swap if needed but I think this is better fixed with correct documentation.

I also Found some interesting emergent behavior with how hx-preserve works. It base use case is to keep some important client side content from changing while the whole page gets updated and re-arranged around it and this does allow when doing full page reloads like boost's to re-parent the preserved elements to a new page location.  And with standard htmx partial page updates if you include a hx-preserve item in your partial response it can in fact move the preserved item from another location on the page into the new target location allowing you to for example drag a video iframe to a different page location etc.  And with oob swaps you also have this same new re-parenting super power:

```html
Main page content<div id="topleft" hx-swap-oob="beforeend"><div id="video" hx-preserve></div></div>
```
With this simple response we can relocate video element to the end of the topleft div from anywhere on the page without it changing.

```html
<p>Item 6 moved above item 3</p><div id="list-item-3" hx-swap-oob="beforebegin"><div id="list-item-6" hx-preserve></div></div>
```
And here you can move a preserved item up to above item 3 in some list without having to know update or change its contents.

https://michaelwest22.github.io/htmx/index.html here is a quick example of using this oob swaps in practice.  it works best with experimental moveBefore enabled.

I think I just need to add some documentation to the hx-preserve.md page to highlight the basic behaviour when using hx-swap-oob.


Corresponding issue:
#2922

## Testing
Added tests for the basic use cases and performed testing on both canary chrome with moveBefore and normal chrome to confirm oob swaps work as expected.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
