### PR TITLE
fix es6 tsc checks complaining on newer s regex flag

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -583,7 +583,7 @@ var htmx = (function() {
    */
   function makeFragment(response) {
     // strip head tag to determine shape of response we are dealing with
-    const responseWithNoHead = response.replace(/<head(\s[^>]*)?>.*?<\/head>/is, '')
+    const responseWithNoHead = response.replace(/<head(\s[^>]*)?>[\s\S]*?<\/head>/i, '')
     const startTag = getStartTag(responseWithNoHead)
     /** @type DocumentFragmentWithTitle */
     let fragment


### PR DESCRIPTION
## Description
gitlab pipeline seems to be reporting tsc error
```
> htmx.org@2.0.3 types-check
> tsc src/htmx.js --noEmit --checkJs --target es6 --lib dom,dom.iterable

Error: src/htmx.js(586,79): error TS[15](https://github.com/bigskysoftware/htmx/actions/runs/11154764763/job/31004572782#step:5:16)01: This regular expression flag is only available when targeting 'es2018' or later.
Error: Process completed with exit code 2.
```

removing the s from the regex fixes the issue along with updating the regex to not need this flag by having [\s\S] which is all characters including newline which "." does not include unless you add the newer s flag to the regex which is only supported in 2018+ browsers.

Alternative solution is to change package.json type-check line to target es2018 or newer

```json
"types-check": "tsc src/htmx.js --noEmit --checkJs --target es2018 --lib dom,dom.iterable",
```

Corresponding issue:
#2781 

## Testing
Ran though all head-support extension manual tests to make sure they work as expected after regex change as well as manually testing regex change in JS console

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
