### PR TITLE
Add an example of evaluated values passed to hx-headers.

### DIFF
--- a/www/content/attributes/hx-headers.md
+++ b/www/content/attributes/hx-headers.md
@@ -7,10 +7,14 @@ The `hx-headers` attribute allows you to add to the headers that will be submitt
 By default, the value of this attribute is a list of name-expression values in [JSON (JavaScript Object Notation)](https://www.json.org/json-en.html) 
 format.
 
+```html
+  <div hx-get="/example" hx-headers='{"myHeader": "My Value"}'>Get Some HTML, Including A Custom Header in the Request</div>
+```
+
 If you wish for `hx-headers` to *evaluate* the values given, you can prefix the values with `javascript:` or `js:`.
 
 ```html
-  <div hx-get="/example" hx-headers='{"myHeader": "My Value"}'>Get Some HTML, Including A Custom Header in the Request</div>
+  <body hx-headers='js:{ "Locale" : new Intl.DateTimeFormat().resolvedOptions().locale }'>...</body>
 ```
 
 ## Security Considerations

--- a/www/content/attributes/hx-headers.md
+++ b/www/content/attributes/hx-headers.md
@@ -2,27 +2,25 @@
 title = "hx-headers"
 +++
 
-The `hx-headers` attribute allows you to add to the headers that will be submitted with an AJAX request.  
+The `hx-headers` attribute allows you to add to the headers that will be submitted with an AJAX request.
 
-By default, the value of this attribute is a list of name-expression values in [JSON (JavaScript Object Notation)](https://www.json.org/json-en.html) 
+By default, the value of this attribute is a list of name-expression values in [JSON (JavaScript Object Notation)](https://www.json.org/json-en.html)
 format.
-
-```html
-  <div hx-get="/example" hx-headers='{"myHeader": "My Value"}'>Get Some HTML, Including A Custom Header in the Request</div>
-```
 
 If you wish for `hx-headers` to *evaluate* the values given, you can prefix the values with `javascript:` or `js:`.
 
 ```html
-  <body hx-headers='js:{ "Locale" : new Intl.DateTimeFormat().resolvedOptions().locale }'>...</body>
+  <div hx-get="/example" hx-headers='{"myHeader": "My Value"}'>Get Some HTML, Including A Custom Header in the Request</div>
+
+  <div hx-get="/example" hx-headers='js:{myVal: calculateValue()}'>Get Some HTML, Including a Dynamic Custom Header from Javascript in the Request</div>
 ```
 
 ## Security Considerations
 
-* By default, the value of `hx-headers` must be valid [JSON](https://developer.mozilla.org/en-US/docs/Glossary/JSON). 
+* By default, the value of `hx-headers` must be valid [JSON](https://developer.mozilla.org/en-US/docs/Glossary/JSON).
   It is **not** dynamically computed.  If you use the `javascript:` prefix, be aware that you are introducing
-  security considerations, especially when dealing with user input such as query strings or user-generated content, 
-  which could introduce a [Cross-Site Scripting (XSS)](https://owasp.org/www-community/attacks/xss/) vulnerability. 
+  security considerations, especially when dealing with user input such as query strings or user-generated content,
+  which could introduce a [Cross-Site Scripting (XSS)](https://owasp.org/www-community/attacks/xss/) vulnerability.
 
 ## Notes
 


### PR DESCRIPTION
Add an example of evaluated values passed to hx-headers.

## Description
I haven't been clear from the documentation how to exactly have the javascript in the attribute evaluated as I'm not such a web dev expert. Perhaps it could help someone else if it's more explicit.

The example is more or less taken from my use case. Please feel free to suggest something else!

HTMX works great with Swift, BTW.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
