### PR TITLE
ajax helper with no source or target defaults to body

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3905,9 +3905,9 @@ var htmx = (function() {
         })
       } else {
         let resolvedTarget = resolveTarget(context.target)
-        // If target is supplied but can't resolve OR both target and source can't be resolved
+        // If target is supplied but can't resolve OR source is supplied but both target and source can't be resolved
         // then use DUMMY_ELT to abort the request with htmx:targetError to avoid it replacing body by mistake
-        if ((context.target && !resolvedTarget) || (!resolvedTarget && !resolveTarget(context.source))) {
+        if ((context.target && !resolvedTarget) || (context.source && !resolvedTarget && !resolveTarget(context.source))) {
           resolvedTarget = DUMMY_ELT
         }
         return issueAjaxRequest(verb, path, resolveTarget(context.source), context.event,

--- a/test/core/api.js
+++ b/test/core/api.js
@@ -278,6 +278,16 @@ describe('Core htmx API test', function() {
     div.innerHTML.should.equal('foo!')
   })
 
+  it('ajax api falls back to targeting body if target and source not set', function() {
+    this.server.respondWith('GET', '/test', 'foo!')
+    var div = make("<div id='d1'></div>")
+    const saveBody = document.body.innerHTML
+    htmx.ajax('GET', '/test', {})
+    this.server.respond()
+    document.body.innerHTML.should.equal('foo!')
+    document.body.innerHTML = saveBody
+  })
+
   it('ajax api works with swapSpec', function() {
     this.server.respondWith('GET', '/test', "<p class='test'>foo!</p>")
     var div = make("<div><div id='target'></div></div>")


### PR DESCRIPTION
## Description
recent change #2878 has caused the default behavior of the ajax helper function for when no source or target is supplied to change to error on a target error instead of targeting body as it should do by default.  The recent fix was put in to handle situations where an invalid source or target were supplied which would previously fall back to targeting body in error but the logic for that fix did not handle the case where nothing is supplied for source or target.

Corresponding issue:
#2945 

## Testing
Added test for when both source and target not set to make sure it targets body as expected

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
