### PR TITLE
docs: Fix typo in URL to prevent broken link redirect #2961

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -999,7 +999,7 @@ If you wanted to swap everything, regardless of HTTP response code, you could us
 <meta name="htmx-config" content='{"responseHandling": [{"code":".*", "swap": true}]}' /> <!--all responses are swapped-->
 ```
 
-Finally, it is worth considering using the [Response Targets](/extensions/reponse-targets)
+Finally, it is worth considering using the [Response Targets](/extensions/response-targets)
 extension, which allows you to configure the behavior of response codes declaratively via attributes.
 
 ### CORS


### PR DESCRIPTION
## Description
I fixed typo in URL to prevent broken link redirect

Corresponding issue: #2961

## Testing
Only by displaying the documentation page.

## Checklist

* -[x] I have read the contribution guidelines
* -[x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* -[x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* -[x] I ran the test suite locally (`npm run test`) and verified that it succeeded
