### PR TITLE
Fix TypeError on null path variable

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2323,7 +2323,7 @@ var htmx = (function() {
         const rawAttribute = getRawAttribute(elt, 'method')
         verb = (/** @type HttpVerb */(rawAttribute ? rawAttribute.toLowerCase() : 'get'))
         path = getRawAttribute(elt, 'action')
-        if (verb === 'get' && path.includes('?')) {
+        if (verb === 'get' && path && path.includes('?')) {
           path = path.replace(/\?[^#]+/, '')
         }
       }

--- a/test/attributes/hx-boost.js
+++ b/test/attributes/hx-boost.js
@@ -143,4 +143,30 @@ describe('hx-boost attribute', function() {
     this.server.respond()
     div.innerHTML.should.equal('Boosted!')
   })
+
+  it('form get with an unset action property', function() {
+    this.server.respondWith('GET', /\/*/, function(xhr) {
+      should.equal(undefined, getParameters(xhr).foo)
+      xhr.respond(200, {}, 'Boosted!')
+    })
+
+    var div = make('<div hx-target="this" hx-boost="true"><form id="f1" method="get"><button id="b1">Submit</button></form></div>')
+    var btn = byId('b1')
+    btn.click()
+    this.server.respond()
+    div.innerHTML.should.equal('Boosted!')
+  })
+
+  it('form get with an empty action property', function() {
+    this.server.respondWith('GET', /\/*/, function(xhr) {
+      should.equal(undefined, getParameters(xhr).foo)
+      xhr.respond(200, {}, 'Boosted!')
+    })
+
+    var div = make('<div hx-target="this" hx-boost="true"><form id="f1" action="" method="get"><button id="b1">Submit</button></form></div>')
+    var btn = byId('b1')
+    btn.click()
+    this.server.respond()
+    div.innerHTML.should.equal('Boosted!')
+  })
 })


### PR DESCRIPTION
## Description
I check if the `path` is null or empty when the user hasn't set the action property or has left it empty.

Corresponding issue: #2963

## Testing
I added two tests that check if everything is OK in two cases (action is unset or is empty)

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
