### PR TITLE
Do not execute hx-trigger="load" on re-initialization of an existing node

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -693,7 +693,7 @@ var htmx = (function() {
    * @property {XMLHttpRequest} [xhr]
    * @property {(() => void)[]} [queuedRequests]
    * @property {boolean} [abortable]
-   * @property {boolean} [firstInit]
+   * @property {boolean} [firstInitCompleted]
    *
    * Event data
    * @property {HtmxTriggerSpecification} [triggerSpec]
@@ -1629,7 +1629,7 @@ var htmx = (function() {
       })
     }
     deInitOnHandlers(element)
-    forEach(Object.keys(internalData), function(key) { if (key !== 'firstInit') delete internalData[key] })
+    forEach(Object.keys(internalData), function(key) { if (key !== 'firstInitCompleted') delete internalData[key] })
   }
 
   /**
@@ -2635,7 +2635,7 @@ var htmx = (function() {
       }, observerOptions)
       observer.observe(asElement(elt))
       addEventListener(asElement(elt), handler, nodeData, triggerSpec)
-    } else if (nodeData.firstInit && triggerSpec.trigger === 'load') {
+    } else if (!nodeData.firstInitCompleted && triggerSpec.trigger === 'load') {
       if (!maybeFilterEvent(triggerSpec, elt, makeEvent('load', { elt }))) {
         loadImmediately(asElement(elt), handler, nodeData, triggerSpec.delay)
       }
@@ -2844,10 +2844,6 @@ var htmx = (function() {
     const nodeData = getInternalData(elt)
     const attrHash = attributeHash(elt)
     if (nodeData.initHash !== attrHash) {
-      if (nodeData.initHash === undefined) {
-        nodeData.firstInit = true
-      }
-
       // clean up any previously processed info
       deInitNode(elt)
 
@@ -2876,7 +2872,7 @@ var htmx = (function() {
         initButtonTracking(elt)
       }
 
-      nodeData.firstInit = false
+      nodeData.firstInitCompleted = true
       triggerEvent(elt, 'htmx:afterProcessNode')
     }
   }

--- a/test/core/api.js
+++ b/test/core/api.js
@@ -383,6 +383,17 @@ describe('Core htmx API test', function() {
     div.innerHTML.should.equal('delete')
   })
 
+  it('does not trigger load on re-init of an existing element', function() {
+    this.server.respondWith('GET', '/test', 'test')
+    var div = make('<div hx-get="/test" hx-trigger="load" hx-swap="beforeend"></div>')
+    this.server.respond()
+    div.innerHTML.should.equal('test')
+    div.setAttribute('hx-swap', 'afterbegin')
+    htmx.process(div)
+    this.server.respond()
+    div.innerHTML.should.equal('test')
+  })
+
   it('onLoad is called... onLoad', function() {
     // also tests on/off
     this.server.respondWith('GET', '/test', "<div id='d1' hx-get='/test'></div>")


### PR DESCRIPTION
## Description
Sometimes, requests that should be only triggered once at load (with `hx-trigger="load"`) are executed twice. This happens for example when calling htmx.process on an existing node (or a parent node) after changing an attribute on the element with `hx-trigger="load"`.
This PR adds a `firstInitCompleted` flag to an element's internalData and adds a check for that flag when handling the `load` triggerEvent.

Corresponding issue:
#2973 

## Testing
Added a test scenario that changes `hx-swap="afterbegin"` to `hx-swap="beforeend"` on an element with `hx-trigger="load"`, followed by a call to `htmx.process` and checks whether the innerHTML of the element  stayed the same.
This test fails on the dev branch, and passes with this fix.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
