### PR TITLE
"Download a Copy" in the doc points to old release 2.0.2; this PR changes it to 2.0.3 as it should be

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -137,7 +137,7 @@ While the CDN approach is extremely simple, you may want to consider
 
 The next easiest way to install htmx is to simply copy it into your project.
 
-Download `htmx.min.js` [from unpkg.com](https://unpkg.com/htmx.org@2.0.2/dist/htmx.min.js) and add it to the appropriate directory in your project
+Download `htmx.min.js` [from unpkg.com](https://unpkg.com/htmx.org@2.0.3/dist/htmx.min.js) and add it to the appropriate directory in your project
 and include it where necessary with a `<script>` tag:
 
 ```html


### PR DESCRIPTION
## Description
Updated link to downlload a copy from unpkg.com to reference correct version 2.0.3

## Testing
Manually tried the link and it succesfully downloaded version 2.0.3

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
