### PR TITLE
docs: Fix typo

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -1149,7 +1149,7 @@ htmx supports a few "core" extensions, which are supported by the htmx developme
 * [idiomorph](/extensions/idiomorph) - supports the `morph` swap strategy using idiomorph
 * [preload](/extensions/preload) - allows you to preload content for better performance
 * [response-targets](/extensions/response-targets) - allows you to target elements based on HTTP response codes (e.g. `404`)
-* [sse](/extensions/sse) - support for [Serve Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events)
+* [sse](/extensions/sse) - support for [Server Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events)
 * [ws](/extensions/ws) - support for [Web Sockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_client_applications)
 
 You can see all available extensions on the [Extensions](/extensions) page.


### PR DESCRIPTION
## Description
Typo:
"Serve Sent Events" should be "Server Sent Events" on the [docs page](https://htmx.org/docs/)

This is a follow-up to #2983. I believe this section in the docs page was added after the previous pull request was created.

## Testing
Previewed in markdown viewer

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded