### PR TITLE
feat: trigger oobErrorNoTarget for missing oob swap targets

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1427,7 +1427,7 @@ var htmx = (function() {
     oobElement.removeAttribute('data-hx-swap-oob')
 
     const targets = querySelectorAllExt(rootNode, selector, false)
-    if (targets) {
+    if (targets && targets.length > 0) {
       forEach(
         targets,
         function(target) {
@@ -1457,6 +1457,11 @@ var htmx = (function() {
     } else {
       oobElement.parentNode.removeChild(oobElement)
       triggerErrorEvent(getDocument().body, 'htmx:oobErrorNoTarget', { content: oobElement })
+      if (settleInfo.elts && settleInfo.elts.length > 0) {
+        forEach(settleInfo.elts, function(target) {
+          triggerErrorEvent(target, 'htmx:oobErrorNoTarget', { content: oobElement })
+        })
+      }
     }
     return oobValue
   }


### PR DESCRIPTION
## Description
Currently the parent of an `oob-swap` will not get an `oobErrorNoTarget ` event when added to the `hxOn` event trigger.

Given the following code:

```html
<ul hx-ext="ws" ws-connect="/ws" id="hosts" hx-on:htmx:oob-error-no-target="console.log('error triggered')></ul>
```

And the following message from the server 

```html
<tr id="some-id" hx-swap-oob="outerhtml:#none-existing-id">
```

Nothing will happen. But with this change the `console.log` will run.

Corresponding issue:

## Testing
This was tested manually using a very similar code to the above. I was trying to figure out where a test would fit in `hx-swap-oob.js` but it wasn't immediately obvious to me. If you think the change is correct I will spend more time on figuring out a test for it.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
