### PR TITLE
Fixing a typo in confirm.md

### DIFF
--- a/www/content/examples/confirm.md
+++ b/www/content/examples/confirm.md
@@ -39,7 +39,7 @@ which is then picked up by `hx-trigger`.
     // The event is triggered on every trigger for a request, so we need to check if the element
     // that triggered the request has a hx-confirm attribute, if not we can return early and let
     // the default behavior happen
-    if (!evt.detail.target.hasAttribute('hx-confirm')) return
+    if (!e.detail.target.hasAttribute('hx-confirm')) return
 
     // This will prevent the request from being issued to later manually issue it
     e.preventDefault()


### PR DESCRIPTION

## Description
Fixing up a typo in the custom confirmation documentation. 

`evt` is not the correct variable name here - it should be `e`.

Addresses issue #2989 

## Testing
Tested locally. Worked A-OK

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
