### PR TITLE
Fix illegal invocation for FormData proxy

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -4039,7 +4039,15 @@ var htmx = (function() {
       get: function(target, name) {
         if (typeof name === 'symbol') {
           // Forward symbol calls to the FormData itself directly
-          return Reflect.get(target, name)
+          const result = Reflect.get(target, name)
+          // Wrap in function with apply to correctly bind the FormData context, as a direct call would result in an illegal invocation error
+          if (typeof result === 'function') {
+            return function() {
+              return result.apply(formData, arguments)
+            }
+          } else {
+            return result
+          }
         }
         if (name === 'toJSON') {
           // Support JSON.stringify call on proxy

--- a/test/core/parameters.js
+++ b/test/core/parameters.js
@@ -288,6 +288,14 @@ describe('Core htmx Parameter Handling', function() {
     vals.foo.should.equal('null')
   })
 
+  it('formdata can be used to construct a URLSearchParams instance', function() {
+    var form = make('<input name="foo" value="bar"/>')
+    var vals = htmx._('getInputValues')(form, 'get').values
+    function makeSearchParams() { return new URLSearchParams(vals).toString() }
+    makeSearchParams.should.not.throw()
+    makeSearchParams().should.equal('foo=bar')
+  })
+
   it('order of parameters follows order of input elements', function() {
     this.server.respondWith('GET', '/test?foo=bar&bar=foo&foo=bar&foo2=bar2', function(xhr) {
       xhr.respond(200, {}, 'Clicked!')


### PR DESCRIPTION
## Description
Currently the form data proxy has special handing for if the return value is a function,
but not in the case where the key is a symbol. This omission can cause an error to be thrown.

Fixes constructor for URLSearchParams:
```js
element.addEventListener('htmx:configRequest', function(event) {
    let params = new URLSearchParams(event.detail.parameters);
    console.log(params.toString());
});
```

If I was implementing this from fresh then I would use the more concise:
```js
if (typeof result === 'function') {
    return result.bind(formData)
}
```
but instead I've replicated the existing approach:
```js
if (typeof result === 'function') {
  return function() {
    return result.apply(formData, arguments)
  }
}
```

Corresponding issue: #2995

## Testing
Added a new test to the existing ones for parameters.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
