### PR TITLE
move to pigz -11 for better Zopfli compression

### DIFF
--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -14,7 +14,11 @@ cp $HTMX_SRC dist/htmx.js
 uglifyjs -m eval -o dist/htmx.min.js dist/htmx.js
 
 # Generate gzipped script
-gzip -9 -k -f dist/htmx.min.js > dist/htmx.min.js.gz
+if command -v pigz >&2; then
+  pigz -11 -k -f dist/htmx.min.js > dist/htmx.min.js.gz
+else
+  gzip -9 -k -f dist/htmx.min.js > dist/htmx.min.js.gz
+fi
 
 # Generate AMD script
 cat > dist/htmx.amd.js << EOF

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -18,6 +18,7 @@ if command -v pigz >&2; then
   pigz -11 -k -f dist/htmx.min.js > dist/htmx.min.js.gz
 else
   gzip -9 -k -f dist/htmx.min.js > dist/htmx.min.js.gz
+  echo Falling back to gzip compression. Install pigz for improved Zopfli Compression
 fi
 
 # Generate AMD script


### PR DESCRIPTION
## Description
move the final distribution step to use pigz -11 to apply Zopfli compression to reduce the size of the zipped minified distribution version.  Saves a few % in file size at the one of small cpu cost.  Added fall back to gzip if pigz not installed 

Corresponding issue:
#2998

## Testing
Tested to make sure the gz file was about .5k smaller and can be uncompressed fine with gzip -d

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
