### PR TITLE
fix vertical alignment of github stars button in all states

### DIFF
--- a/www/themes/htmx-theme/static/css/site.css
+++ b/www/themes/htmx-theme/static/css/site.css
@@ -419,8 +419,9 @@ transition: visibility 0s 1s, opacity 1s linear;
   padding:1em 0;
 }
 
-.github-stars {
-  margin-top: 5px;
+.github-stars span {
+    position: relative;
+    top: 4px;
 }
 
 /* Content */

--- a/www/themes/htmx-theme/templates/base.html
+++ b/www/themes/htmx-theme/templates/base.html
@@ -54,7 +54,7 @@
                     </div>
                     <div>
                         <div class="github-stars" hx-preserve="true" id="github-stars">
-                            <a class="github-button" href="https://github.com/bigskysoftware/htmx" data-color-scheme="no-preference: light; light: light; dark: dark;" data-icon="octicon-star" data-show-count="true" aria-label="Star bigskysoftware/htmx on GitHub">Star</a>
+                            <a class="github-button" href="https://github.com/bigskysoftware/htmx" data-color-scheme="no-preference: light; light: light; dark: dark;" data-icon="octicon-star" data-show-count="true" aria-label="Star bigskysoftware/htmx on GitHub">star</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Description

Without uBlock, the button's alt-text would be 1px lower than the rest
of the nav items, and inconsistently capitalized.

With uBlock, the button would be slightly too high up. Screenshot of problem:

![Screenshot from 2024-11-08 01-52-34](https://github.com/user-attachments/assets/a884ebae-1ccc-4119-8d44-78e46b2c2632)
![Screenshot from 2024-11-08 01-52-00](https://github.com/user-attachments/assets/ae031c95-e2b9-4b12-9731-1e34bc1e7468)

The solution is to apply styles on the `span` that GitHub's JS inserts.
However, using margin will make the entire nav jump during pageload, so
position: relative seems more robust there.


## Testing

Tested in Firefox and Chrome latest

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
