### PR TITLE
[Documentation] Add missing default extension points

### DIFF
--- a/www/content/extensions/building.md
+++ b/www/content/extensions/building.md
@@ -22,6 +22,8 @@ Extensions can override the following default extension points to add or change 
 
 ```javascript
 {
+    init: function(api) {return null;},
+    getSelectors: function() {return null;},
     onEvent : function(name, evt) {return true;},
     transformResponse : function(text, xhr, elt) {return text;},
     isInlineSwap : function(swapStyle) {return false;},


### PR DESCRIPTION
## Description
On the page [Building htmx Extensions](https://htmx.org/extensions/building/) it includes an incomplete list of the extension points available to override. These are `init`, which I can see is used by official htmx extensions, and `getSelectors` which has a test covering its usage.

## Testing
Coped from source code, which is already covered by tests.
I cross references this with how they're invoked to make sure I wasn't missing any parameters.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
