### PR TITLE
Allow removing extension inheritance with this-only: option

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -4928,9 +4928,9 @@ var htmx = (function() {
           extensionsToIgnore.push(extensionName.slice(7))
           return
         }
-        if (extensionName.indexOf('local:') === 0) {
+        if (extensionName.indexOf('this-only:') === 0) {
           if (isParentScan) return
-          extensionName = extensionName.slice(6)
+          extensionName = extensionName.slice(10)
         }
         if (extensionsToIgnore.indexOf(extensionName) < 0) {
           const extension = extensions[extensionName]

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -4910,22 +4910,27 @@ var htmx = (function() {
    * @returns {HtmxExtension[]}
    */
   function getExtensions(elt, extensionsToReturn, extensionsToIgnore) {
-    if (extensionsToReturn == undefined) {
+    const isParentScan = !!extensionsToReturn
+    if (!extensionsToReturn) {
       extensionsToReturn = []
     }
-    if (elt == undefined) {
+    if (!elt) {
       return extensionsToReturn
     }
-    if (extensionsToIgnore == undefined) {
+    if (!extensionsToIgnore) {
       extensionsToIgnore = []
     }
     const extensionsForElement = getAttributeValue(elt, 'hx-ext')
     if (extensionsForElement) {
       forEach(extensionsForElement.split(','), function(extensionName) {
-        extensionName = extensionName.replace(/ /g, '')
-        if (extensionName.slice(0, 7) == 'ignore:') {
+        extensionName = extensionName.trim()
+        if (extensionName.indexOf('ignore:') === 0) {
           extensionsToIgnore.push(extensionName.slice(7))
           return
+        }
+        if (extensionName.indexOf('local:') === 0) {
+          if (isParentScan) return
+          extensionName = extensionName.slice(6)
         }
         if (extensionsToIgnore.indexOf(extensionName) < 0) {
           const extension = extensions[extensionName]

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -4929,7 +4929,9 @@ var htmx = (function() {
           return
         }
         if (extensionName.indexOf('this-only:') === 0) {
-          if (isParentScan) return
+          if (isParentScan) {
+            return
+          }
           extensionName = extensionName.slice(10)
         }
         if (extensionsToIgnore.indexOf(extensionName) < 0) {

--- a/test/attributes/hx-ext.js
+++ b/test/attributes/hx-ext.js
@@ -160,7 +160,7 @@ describe('hx-ext attribute', function() {
   it('Extensions can be local properly', function() {
     this.server.respondWith('GET', '/test', 'Clicked!')
 
-    make('<div id="div-AA" hx-ext="ext-1,ext-2,ext-5" hx-get="/test" foo="foo" hx-trigger="click">Click Me!' +
+    make('<div id="div-AA" hx-ext="local:ext-1,ext-2,ext-5" hx-get="/test" foo="foo" hx-trigger="click">Click Me!' +
             '<div id="div-BB" hx-ext="ignore:ext-5"><button id="btn-BB" hx-get="/test" foo="foo" hx-trigger="click consume"></button></div></div>')
 
     var div1 = byId('div-AA')
@@ -168,13 +168,13 @@ describe('hx-ext attribute', function() {
 
     btn2.click()
     this.server.respond()
-    ext1Calls.should.equal(1)
+    ext1Calls.should.equal(0)
     ext2Calls.should.equal(1)
     ext3Calls.should.equal(0)
 
     div1.click()
     this.server.respond()
-    ext1Calls.should.equal(2)
+    ext1Calls.should.equal(1)
     ext2Calls.should.equal(2)
     ext3Calls.should.equal(0)
 

--- a/test/attributes/hx-ext.js
+++ b/test/attributes/hx-ext.js
@@ -156,4 +156,28 @@ describe('hx-ext attribute', function() {
 
     ext5Calls.should.equal(1)
   })
+
+  it('Extensions can be local properly', function() {
+    this.server.respondWith('GET', '/test', 'Clicked!')
+
+    make('<div id="div-AA" hx-ext="local:ext-1,ext-2,ext-5" hx-get="/test" foo="foo">Click Me!' +
+            '<div id="div-BB" hx-ext="ignore:ext-5"><button id="btn-BB" hx-get="/test" foo="foo"></button></div></div>')
+
+    var div1 = byId('div-AA')
+    var btn2 = byId('btn-BB')
+
+    btn2.click()
+    this.server.respond()
+    ext1Calls.should.equal(0)
+    ext2Calls.should.equal(1)
+    ext3Calls.should.equal(0)
+
+    div1.click()
+    this.server.respond()
+    ext1Calls.should.equal(1)
+    ext2Calls.should.equal(2)
+    ext3Calls.should.equal(0)
+
+    ext5Calls.should.equal(1)
+  })
 })

--- a/test/attributes/hx-ext.js
+++ b/test/attributes/hx-ext.js
@@ -157,10 +157,10 @@ describe('hx-ext attribute', function() {
     ext5Calls.should.equal(1)
   })
 
-  it('Extensions can be local properly', function() {
+  it('Extensions can be applied to this element only properly', function() {
     this.server.respondWith('GET', '/test', 'Clicked!')
 
-    make('<div id="div-AA" hx-ext="local:ext-1,ext-2,ext-5" hx-get="/test" foo="foo" hx-trigger="click">Click Me!' +
+    make('<div id="div-AA" hx-ext="this-only:ext-1,ext-2,ext-5" hx-get="/test" foo="foo" hx-trigger="click">Click Me!' +
             '<div id="div-BB" hx-ext="ignore:ext-5"><button id="btn-BB" hx-get="/test" foo="foo" hx-trigger="click consume"></button></div></div>')
 
     var div1 = byId('div-AA')

--- a/test/attributes/hx-ext.js
+++ b/test/attributes/hx-ext.js
@@ -160,21 +160,21 @@ describe('hx-ext attribute', function() {
   it('Extensions can be local properly', function() {
     this.server.respondWith('GET', '/test', 'Clicked!')
 
-    make('<div id="div-AA" hx-ext="local:ext-1,ext-2,ext-5" hx-get="/test" foo="foo">Click Me!' +
-            '<div id="div-BB" hx-ext="ignore:ext-5"><button id="btn-BB" hx-get="/test" foo="foo"></button></div></div>')
+    make('<div id="div-AA" hx-ext="ext-1,ext-2,ext-5" hx-get="/test" foo="foo" hx-trigger="click">Click Me!' +
+            '<div id="div-BB" hx-ext="ignore:ext-5"><button id="btn-BB" hx-get="/test" foo="foo" hx-trigger="click consume"></button></div></div>')
 
     var div1 = byId('div-AA')
     var btn2 = byId('btn-BB')
 
     btn2.click()
     this.server.respond()
-    ext1Calls.should.equal(0)
+    ext1Calls.should.equal(1)
     ext2Calls.should.equal(1)
     ext3Calls.should.equal(0)
 
     div1.click()
     this.server.respond()
-    ext1Calls.should.equal(1)
+    ext1Calls.should.equal(2)
     ext2Calls.should.equal(2)
     ext3Calls.should.equal(0)
 

--- a/www/content/attributes/hx-ext.md
+++ b/www/content/attributes/hx-ext.md
@@ -14,8 +14,7 @@ and on the `body` tag for it to apply to all htmx requests.
 * `hx-ext` is both inherited and merged with parent elements, so you can specify extensions on any element in the DOM 
 hierarchy and it will apply to all child elements. 
 
-* You can ignore an extension that is defined by a parent node using `hx-ext="ignore:extensionName"` 
-
+* You can ignore an extension that is defined by a parent element using `hx-ext="ignore:extensionName"` 
 
 ```html
 <div hx-ext="example">
@@ -26,3 +25,12 @@ hierarchy and it will apply to all child elements.
 </div>
 ```
 
+* If an extension needs to apply only to a single element you can override inheritance on an element using `hx-ext="local:extensionName"` 
+
+```html
+<div hx-ext="local:example"> <!-- "Example" extension is used just on this element -->
+  <div>
+    ... but it will not be used in this part.
+  </div>
+</div>
+```

--- a/www/content/attributes/hx-ext.md
+++ b/www/content/attributes/hx-ext.md
@@ -25,10 +25,10 @@ hierarchy and it will apply to all child elements.
 </div>
 ```
 
-* If an extension needs to apply only to a single element you can override inheritance on an element using `hx-ext="local:extensionName"` 
+* If an extension needs to apply only to a single element you can override inheritance on an element using `hx-ext="this-only:extensionName"` 
 
 ```html
-<div hx-ext="local:example"> <!-- "Example" extension is used just on this element -->
+<div hx-ext="this-only:example"> <!-- "Example" extension is used just on this element only -->
   <div>
     ... but it will not be used in this part.
   </div>


### PR DESCRIPTION
## Description
Allow hx-ext extension inheritance to be disabled on an element with a new `this-only:` prefix instead of having to use `ignore:` on all children.  

It works by setting isParentScan to track when scanning parent nodes recursively and then ignoring recursive calls that have ignore: prefix.  Otherwise it strips the ignore: prefix.

Also improved readability/performance/minification by:
  removing un-needed explicit undefined checks
  moving replace => trim
  moving slice => indexOf

Corresponding issue: #3016 

## Testing
Added test to confirm extension with this-only: prefix does not get inherited as expected.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
