### PR TITLE
[Documentation] Fix incorrect link

### DIFF
--- a/www/content/events.md
+++ b/www/content/events.md
@@ -171,7 +171,7 @@ than a single value.
 ##### Details
 
 * `detail.parameters` - the parameters that will be submitted in the request
-* `detail.unfilteredParameters` - the parameters that were found before filtering by [`hx-select`](@/attributes/hx-select.md)
+* `detail.unfilteredParameters` - the parameters that were found before filtering by [`hx-params`](@/attributes/hx-params.md)
 * `detail.headers` - the request headers
 * `detail.elt` - the element that triggered the request
 * `detail.target` - the target of the request


### PR DESCRIPTION
## Description
Correct the `unfilteredParameters` property for the [htmx:configRequest](https://htmx.org/events/#htmx:configRequest) event incorrectly linking to [hx-select](https://htmx.org/attributes/hx-select/) instead of [hx-params](https://htmx.org/attributes/hx-params/).

## Testing
I have verified that the target page and linked markdown files are as expected.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
