### PR TITLE
[Documentation] Add missing htmx:sendAbort event

### DIFF
--- a/www/content/events.md
+++ b/www/content/events.md
@@ -412,6 +412,17 @@ This event is triggered when an HTTP error response occurs
 * `detail.target` - the target of the request
 * `detail.requestConfig` - the configuration of the AJAX request
 
+### Event - `htmx:sendAbort` {#htmx:sendAbort}
+
+This event is triggered when a request is aborted
+
+##### Details
+
+* `detail.xhr` - the `XMLHttpRequest`
+* `detail.elt` - the element that triggered the request
+* `detail.target` - the target of the request
+* `detail.requestConfig` - the configuration of the AJAX request
+
 ### Event - `htmx:sendError` {#htmx:sendError}
 
 This event is triggered when a network error prevents an HTTP request from occurring

--- a/www/content/reference.md
+++ b/www/content/reference.md
@@ -160,6 +160,7 @@ All other attributes available in htmx.
 | [`htmx:prompt`](@/events.md#htmx:prompt)  | triggered after a prompt is shown
 | [`htmx:pushedIntoHistory`](@/events.md#htmx:pushedIntoHistory)  | triggered after an url is pushed into history
 | [`htmx:responseError`](@/events.md#htmx:responseError)  | triggered when an HTTP response error (non-`200` or `300` response code) occurs
+| [`htmx:sendAbort`](@/events.md#htmx:sendAbort)  | triggered when a request is aborted
 | [`htmx:sendError`](@/events.md#htmx:sendError)  | triggered when a network error prevents an HTTP request from happening
 | [`htmx:sseError`](@/events.md#htmx:sseError)  | triggered when an error occurs with a SSE source
 | [`htmx:sseOpen`](/events#htmx:sseOpen)  | triggered when a SSE source is opened


### PR DESCRIPTION
## Description
The event `htmx:sendAbort` is missing from the documentation. The related events `htmx:sendError` and `htmx:timeout` are there, but this one is missing.
Although `htmx:xhr:abort` is already documented. its detail data is different.

## Testing
Tested locally using Zola to ensuring linking works correctly.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
