### PR TITLE
[Documentation] Fix link in web socket extension docs

### DIFF
--- a/www/content/extensions/ws.md
+++ b/www/content/extensions/ws.md
@@ -185,7 +185,7 @@ If the event is cancelled, no further processing will occur and no messages will
 
 * `detail.parameters` - the parameters that will be submitted in the request
 * `detail.unfilteredParameters` - the parameters that were found before filtering
-  by [`hx-select`](https://htmx.org/reference/hx-select.md)
+  by [`hx-params`](https://htmx.org/attributes/hx-params)
 * `detail.headers` - the request headers. Will be attached to the body in `HEADERS` property, if not falsy
 * `detail.errors` - validation errors. Will prevent sending and
   trigger [`htmx:validation:halted`](https://htmx.org/events#htmx:validation:halted) event if not empty


### PR DESCRIPTION
## Description
This link in [web socket extension docs](https://htmx.org/extensions/ws/) didn't work and was also incorrect.
Corrects the `unfilteredParameters` property for the [htmx:wsConfigSend](https://htmx.org/extensions/ws/#htmx:wsConfigSend) event incorrectly trying to link to [hx-select](https://htmx.org/attributes/hx-select/) instead of [hx-params](https://htmx.org/attributes/hx-params/).

Similar fix to #3022.

## Testing
Tested locally using Zola to ensuring linking works correctly.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
