### PR TITLE
typing for `defineExtension` should allow partials

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -4881,7 +4881,7 @@ var htmx = (function() {
    * @see https://htmx.org/api/#defineExtension
    *
    * @param {string} name the extension name
-   * @param {HtmxExtension} extension the extension definition
+   * @param {Partial<HtmxExtension>} extension the extension definition
    */
   function defineExtension(name, extension) {
     if (extension.init) {


### PR DESCRIPTION
## Description
Docs for custom extensions show:

https://htmx.org/extensions/building/

> To define an extension you call the htmx.defineExtension() function:
>
> ```html
> <script>
>   htmx.defineExtension('my-ext', {
>     onEvent : function(name, evt) {
>         console.log("Fired event: " + name, evt);
>     }
>   })
> </script>
> ```
> Typically, this is done in a stand-alone javascript file, rather than in an inline script tag.
> ...
> Extensions can override the following default extension points to add or change functionality:

However the current typing doesn't allow this - it requires a fully populated `HtmxExtension` object defining all the methods:
```js
{
    init: function(api) {return null;},
    getSelectors: function() {return null;},
    onEvent : function(name, evt) {return true;},
    transformResponse : function(text, xhr, elt) {return text;},
    isInlineSwap : function(swapStyle) {return false;},
    handleSwap : function(swapStyle, target, fragment, settleInfo) {return false;},
    encodeParameters : function(xhr, parameters, elt) {return null;}
}
```

## Testing
I made a working extension in my project and ignored the typing errors. (This is what prompted making this PR)

Changing the type to `Partial<HtmxExtension>` in my installed copy of `htmx.esm.d.ts` makes the typing errors go away and seems to reflect intended usage.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
