### PR TITLE
Add missing htmx:trigger event on load triggers

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2559,6 +2559,7 @@ var htmx = (function() {
     const load = function() {
       if (!nodeData.loaded) {
         nodeData.loaded = true
+        triggerEvent(elt, 'htmx:trigger')
         handler(elt)
       }
     }

--- a/test/attributes/hx-trigger.js
+++ b/test/attributes/hx-trigger.js
@@ -1043,6 +1043,28 @@ describe('hx-trigger attribute', function() {
     }, 50)
   })
 
+  it('fires the htmx:trigger event when the trigger is a load', function(done) {
+    this.server.respondWith(
+      'GET',
+      '/test',
+      '<div hx-trigger="load delay:50ms" hx-on::trigger="this.innerText = \'Done\'">Response</div>'
+    )
+
+    var div = make('<div hx-get="/test">Submit</div>')
+    div.click()
+    this.server.respond()
+    var response = div.children[0]
+    response.innerText.should.equal('Response')
+
+    setTimeout(function() {
+      try {
+        response.innerText.should.equal('Done')
+        done()
+      } finally {
+      }
+    }, 100)
+  })
+
   it('filters support "this" reference to the current element', function() {
     this.server.respondWith('GET', '/test', 'Called!')
     var form = make('<form hx-get="/test" hx-trigger="click[this.classList.contains(\'bar\')]">Not Called</form>')


### PR DESCRIPTION
## Description

The `htmx:trigger` event wasn't firing when the trigger was a load.

## Testing
I added a new test for this scenario, verified that it passes for the fix, and that it doesn't pass without the fix. 

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
