### PR TITLE
[Documentation] Update location of ws/sse demo server

### DIFF
--- a/www/content/extensions/sse.md
+++ b/www/content/extensions/sse.md
@@ -137,8 +137,9 @@ browser's automatic reconnection, so that your SSE streams will always be as rel
 ### Testing SSE Connections with the Demo Server
 
 Htmx includes a demo SSE server written in Node.js that will help you to see SSE in action, and begin bootstrapping your
-own SSE code. It is located in the /test/ws-sse folder of the htmx distribution. Look at /test/ws-sse/README.md for
-instructions on running and using the test server.
+own SSE code. It is located in the /test/ws-sse folder of
+the [`htmx-extensions`](https://github.com/bigskysoftware/htmx-extensions) repository. Look at /test/ws-sse/README.md
+for instructions on running and using the test server.
 
 ### Migrating from Previous Versions
 

--- a/www/content/extensions/ws.md
+++ b/www/content/extensions/ws.md
@@ -241,8 +241,9 @@ specified element, namely `htmx:wsBeforeSend` and `htmx:wsAfterSend` events when
 ### Testing with the Demo Server
 
 Htmx includes a demo WebSockets server written in Node.js that will help you to see WebSockets in action, and begin
-bootstrapping your own WebSockets code. It is located in the /test/ws-sse folder of the htmx distribution. Look at
-/test/ws-sse/README.md for instructions on running and using the test server.
+bootstrapping your own WebSockets code. It is located in the /test/ws-sse folder of
+the [`htmx-extensions`](https://github.com/bigskysoftware/htmx-extensions) repository. Look at /test/ws-sse/README.md
+for instructions on running and using the test server.
 
 ### Migrating from Previous Versions
 


### PR DESCRIPTION
The docs refer to a demo server for ws and sse extensions. This was recently moved into the `htmx-extensions` repo and no longer works in the main repository. Updated the docs to prevent future confusion.

Corresponding issue: https://github.com/bigskysoftware/htmx/pull/2750
