### PR TITLE
Handle Invalid template content

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1889,7 +1889,7 @@ var htmx = (function() {
       // oob swaps
       findAndSwapOobElements(fragment, settleInfo, rootNode)
       forEach(findAll(fragment, 'template'), /** @param {HTMLTemplateElement} template */function(template) {
-        if (findAndSwapOobElements(template.content, settleInfo, rootNode)) {
+        if (template.content && findAndSwapOobElements(template.content, settleInfo, rootNode)) {
           // Avoid polluting the DOM with empty templates that were only used to encapsulate oob swap
           template.remove()
         }


### PR DESCRIPTION
## Description
When trying to handle template tags inside svg tags in a htmx swap it can cause htmx to process the invalid template which is missing its template.content template fragment data causing a swap error.  It seems v2 now scans all templates for oob swap data to handle situations where you need to wrap content in templates but this now causes issues for these invalid templates.

To fix this I've just added a null/undefined check before processing templates in case they have no valid template content data.

Corresponding issue:
#3059 

## Testing
To test this I've reproduced the problem in the linked issue and made sure this added null check avoids the error message.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
