### PR TITLE
Fix: body hx-boost = true + form tag = Uncaught Type Error: path is null

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ npm test
 
 ## Pull Requests
 ### Technical Requirements
-1. Please lint all proposed changes with the `npm lint-fix` command
+1. Please lint all proposed changes with the `npm run format` command
 1. All PRs must be made against the `dev` branch, except documentation PRs (that only modify the `www/` directory) which can be made against `master`.
 1. Please avoid sending the `dist` files along your PR, only include the `src` ones.
 1. Please include test cases in [`/test`](https://github.com/bigskysoftware/htmx/tree/dev/test) and docs in [`/www`](https://github.com/bigskysoftware/htmx/tree/dev/www).

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2324,7 +2324,7 @@ var htmx = (function() {
         verb = (/** @type HttpVerb */(rawAttribute ? rawAttribute.toLowerCase() : 'get'))
         path = getRawAttribute(elt, 'action')
         if (!path) {
-          return;
+          path = ''
         }
         if (verb === 'get' && path.includes('?')) {
           path = path.replace(/\?[^#]+/, '')

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2323,6 +2323,9 @@ var htmx = (function() {
         const rawAttribute = getRawAttribute(elt, 'method')
         verb = (/** @type HttpVerb */(rawAttribute ? rawAttribute.toLowerCase() : 'get'))
         path = getRawAttribute(elt, 'action')
+        if (!path) {
+          return;
+        }
         if (verb === 'get' && path.includes('?')) {
           path = path.replace(/\?[^#]+/, '')
         }


### PR DESCRIPTION
## Description
I add a check if `path` is `null`, if it's true I set the path with an empty value. It's the only way to avoid future regressions.

Corresponding issue: #3068

## Testing
I tested this fix by running all the unit tests, and locally with same case shared by the person who created the issue.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
