### PR TITLE
Cancel vanilla submits from <button[form]/>.

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2400,7 +2400,8 @@ var htmx = (function() {
       if (elt.tagName === 'FORM') {
         return true
       }
-      if (matches(elt, 'input[type="submit"], button') && closest(elt, 'form') !== null) {
+      if (matches(elt, 'input[type="submit"], button') &&
+        (matches(elt, '[form]') || closest(elt, 'form') !== null)) {
         return true
       }
       if (elt instanceof HTMLAnchorElement && elt.href &&

--- a/test/core/internals.js
+++ b/test/core/internals.js
@@ -87,7 +87,7 @@ describe('Core htmx internals Tests', function() {
     var anchorThatShouldCancel = make("<a href='/foo'></a>")
     htmx._('shouldCancel')({ type: 'click' }, anchorThatShouldCancel).should.equal(true)
 
-    var anchorThatShouldCancel = make("<a href='#'></a>")
+    anchorThatShouldCancel = make("<a href='#'></a>")
     htmx._('shouldCancel')({ type: 'click' }, anchorThatShouldCancel).should.equal(true)
 
     var anchorThatShouldNotCancel = make("<a href='#foo'></a>")
@@ -96,12 +96,18 @@ describe('Core htmx internals Tests', function() {
     var form = make('<form></form>')
     htmx._('shouldCancel')({ type: 'submit' }, form).should.equal(true)
 
-    var form = make("<form><input id='i1' type='submit'></form>")
+    form = make("<form><input id='i1' type='submit'></form>")
     var input = byId('i1')
     htmx._('shouldCancel')({ type: 'click' }, input).should.equal(true)
 
-    var form = make("<form><button id='b1' type='submit'></form>")
+    form = make("<form><button id='b1' type='submit'></form>")
     var button = byId('b1')
+    htmx._('shouldCancel')({ type: 'click' }, button).should.equal(true)
+
+    form = make("<form id='f1'></form><input id='i1' form='f1' type='submit'><button id='b1' form='f1' type='submit'>")
+    input = byId('i1')
+    button = byId('b1')
+    htmx._('shouldCancel')({ type: 'click' }, input).should.equal(true)
     htmx._('shouldCancel')({ type: 'click' }, button).should.equal(true)
   })
 


### PR DESCRIPTION
## Description

HTMX wasn't cancelling vanilla form submission from buttons with `form` attributes (e.g., outside of `<form>`). 

Corresponding issue: #2919 can probably be closed with this

## Testing

Added testing in `test/core/internals.js`. After a bit of back and forth on this, Carson agreed that expanding the existing test was appropriate.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
