### PR TITLE
Fix ajax api body test

### DIFF
--- a/test/core/api.js
+++ b/test/core/api.js
@@ -278,15 +278,17 @@ describe('Core htmx API test', function() {
     div.innerHTML.should.equal('foo!')
   })
 
-  // it('ajax api falls back to targeting body if target and source not set', function() {
-  //   this.server.respondWith('GET', '/test', 'foo!')
-  //   var div = make("<div id='d1'></div>")
-  //   const saveBody = document.body.innerHTML
-  //   htmx.ajax('GET', '/test', {})
-  //   this.server.respond()
-  //   document.body.innerHTML.should.equal('foo!')
-  //   document.body.innerHTML = saveBody
-  // })
+  it('ajax api falls back to targeting body if target and source not set', function() {
+    var target
+    this.server.respondWith('GET', '/test', 'foo!')
+    htmx.on(document.body, 'htmx:configRequest', function(evt) {
+      target = evt.detail.target
+      return false
+    })
+    htmx.ajax('GET', '/test', { swap: 'none' })
+    this.server.respond()
+    target.should.equal(document.body)
+  })
 
   it('ajax api works with swapSpec', function() {
     this.server.respondWith('GET', '/test', "<p class='test'>foo!</p>")


### PR DESCRIPTION
## Description
ajax api test for body was causing problems possibly as it was swapping and then reverting body.  Change this test so it just checks if the body is the target but uses a swap of none so it won't possibly cause issues to the body state.

Corresponding issue:

## Testing
Ran tests locally to make sure they still pass.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
