### PR TITLE
Get rid of latest usages of substr

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1160,17 +1160,17 @@ var htmx = (function() {
       const selector = normalizeSelector(parts.shift())
       let item
       if (selector.indexOf('closest ') === 0) {
-        item = closest(asElement(elt), normalizeSelector(selector.substr(8)))
+        item = closest(asElement(elt), normalizeSelector(selector.slice(8)))
       } else if (selector.indexOf('find ') === 0) {
-        item = find(asParentNode(elt), normalizeSelector(selector.substr(5)))
+        item = find(asParentNode(elt), normalizeSelector(selector.slice(5)))
       } else if (selector === 'next' || selector === 'nextElementSibling') {
         item = asElement(elt).nextElementSibling
       } else if (selector.indexOf('next ') === 0) {
-        item = scanForwardQuery(elt, normalizeSelector(selector.substr(5)), !!global)
+        item = scanForwardQuery(elt, normalizeSelector(selector.slice(5)), !!global)
       } else if (selector === 'previous' || selector === 'previousElementSibling') {
         item = asElement(elt).previousElementSibling
       } else if (selector.indexOf('previous ') === 0) {
-        item = scanBackwardsQuery(elt, normalizeSelector(selector.substr(9)), !!global)
+        item = scanBackwardsQuery(elt, normalizeSelector(selector.slice(9)), !!global)
       } else if (selector === 'document') {
         item = document
       } else if (selector === 'window') {

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -71,8 +71,8 @@ function parseParams(str) {
   }
   var params = {}; var e
   if (str) {
-    if (str.substr(0, 1) == '?') {
-      str = str.substr(1)
+    if (str.slice(0, 1) == '?') {
+      str = str.slice(1)
     }
     while (e = re.exec(str)) {
       var k = decode(e[1])


### PR DESCRIPTION
## Description
Follow up to #2951.
Replace more usages of deprecated `String.prototype.substr`.

Should I just keep making these, or perhaps we could make this a lint check or something?

## Testing
Trivial change

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
