### PR TITLE
Update hx-trigger.md

### DIFF
--- a/www/content/attributes/hx-trigger.md
+++ b/www/content/attributes/hx-trigger.md
@@ -11,6 +11,8 @@ value can be one of the following:
 
 ### Standard Events
 
+Standard events refer to [web API events](https://developer.mozilla.org/en-US/docs/Web/API/Element#events) (e.g. click, keydown, mouseup, load).
+
 A standard event, such as `click` can be specified as the trigger like so:
 
 ```html
@@ -155,3 +157,4 @@ The AJAX request can be triggered via JavaScript [`htmx.trigger()`](@/api.md#tri
 * `hx-trigger` is not inherited
 * `hx-trigger` can be used without an AJAX request, in which case it will only fire the `htmx:trigger` event
 * In order to pass a CSS selector that contains whitespace (e.g. `form input`) to the `from`- or `target`-modifier, surround the selector in parentheses or curly brackets (e.g. `from:(form input)` or `from:closest (form input)`)
+* Reset triggers only on the second successive event (e.g. 2 clicks on reset button) when hx-trigger contains other triggers (e.g. hx-trigger="change, reset"). Add any delay to reset as a workaround (e.g. hx-trigger="change, reset delay:0.01s").  

--- a/www/content/attributes/hx-trigger.md
+++ b/www/content/attributes/hx-trigger.md
@@ -157,4 +157,4 @@ The AJAX request can be triggered via JavaScript [`htmx.trigger()`](@/api.md#tri
 * `hx-trigger` is not inherited
 * `hx-trigger` can be used without an AJAX request, in which case it will only fire the `htmx:trigger` event
 * In order to pass a CSS selector that contains whitespace (e.g. `form input`) to the `from`- or `target`-modifier, surround the selector in parentheses or curly brackets (e.g. `from:(form input)` or `from:closest (form input)`)
-* Reset triggers only on the second successive event (e.g. 2 clicks on reset button) when hx-trigger contains other triggers (e.g. hx-trigger="change, reset"). Add any delay to reset as a workaround (e.g. hx-trigger="change, reset delay:0.01s").  
+* A reset event in hx-trigger (e.g. hx-trigger="change, reset") might not work as intended, since HTMX builds its values and sends a request before the browser resets the form values. As a workaround, add a delay to let the browser reset the form before making the request (e.g. hx-trigger="change, reset delay:0.01s"). 


### PR DESCRIPTION
## Description

Creating this PR as a follow-up action to my original question: https://github.com/bigskysoftware/htmx/issues/3062

- Added a point of clarification in the notes to suggest adding a delay when adding reset to hx-trigger.

-  I also propose to clarify the part on standard events, by adding a reference to MDN's list of web API events. As someone new to HTMX in the past I found it weird that the docs didn't clarify what standard events were for hx-trigger and had to Google for a bit.

## Checklist

- [x] I have read the contribution guidelines
- [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
- [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
- [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
