### PR TITLE
Properly resolve referenced forms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.0.5] - 2025-??-??
+
+* Using `<button hx-verb="/endpoint" type="reset">` will now reset the associated form (after submitting to `/endpoint`).
+
 ## [2.0.4] - 2024-12-13
 
 * Calling `htmx.ajax` with no target or source now defaults to body (previously did nothing)

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2401,7 +2401,7 @@ var htmx = (function() {
         return true
       }
       if (matches(elt, 'input[type="submit"], button') &&
-        (matches(elt, '[form]') || closest(elt, 'form') !== null)) {
+        (/** @type HTMLInputElement|HTMLButtonElement */(elt).form)) {
         return true
       }
       if (elt instanceof HTMLAnchorElement && elt.href &&
@@ -2804,7 +2804,7 @@ var htmx = (function() {
     if (!elt) {
       return
     }
-    const form = resolveTarget('#' + getRawAttribute(elt, 'form'), elt.getRootNode()) || closest(elt, 'form')
+    const form = (/** @type HTMLInputElement|HTMLButtonElement */(elt).form) || closest(elt, 'form')
     if (!form) {
       return
     }
@@ -3523,7 +3523,7 @@ var htmx = (function() {
 
     // for a non-GET include the associated form, which may or may not be a parent element of elt
     if (verb !== 'get') {
-      const form = ('form' in elt && elt.form) || closest(elt, 'form')
+      const form = (/** @type HTMLInputElement|HTMLButtonElement */(elt).form) || closest(elt, 'form')
       processInputValue(processed, priorityFormData, errors, form, validate)
     }
 

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3523,7 +3523,7 @@ var htmx = (function() {
 
     // for a non-GET include the closest form
     if (verb !== 'get') {
-      processInputValue(processed, priorityFormData, errors, closest(elt, 'form'), validate)
+      processInputValue(processed, priorityFormData, errors, ('form' in elt && elt.form) || closest(elt, 'form'), validate)
     }
 
     // include the element itself

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2400,7 +2400,7 @@ var htmx = (function() {
       if (elt.tagName === 'FORM') {
         return true
       }
-      if (matches(elt, 'input[type="submit"], button') &&
+      if (matches(elt, 'input[type=submit], button:not([type=button], [type=reset])') &&
         (/** @type HTMLInputElement|HTMLButtonElement */(elt).form)) {
         return true
       }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3521,9 +3521,10 @@ var htmx = (function() {
       validate = validate && internalData.lastButtonClicked.formNoValidate !== true
     }
 
-    // for a non-GET include the closest form
+    // for a non-GET include the associated form, which may or may not be a parent element of elt
     if (verb !== 'get') {
-      processInputValue(processed, priorityFormData, errors, ('form' in elt && elt.form) || closest(elt, 'form'), validate)
+      const form = ('form' in elt && elt.form) || closest(elt, 'form')
+      processInputValue(processed, priorityFormData, errors, form, validate)
     }
 
     // include the element itself

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2804,16 +2804,12 @@ var htmx = (function() {
   }
 
   /**
-   * @typedef {HTMLElement & { form: HTMLFormElement | null }} FormAssociatedElement
-  */
-
-  /**
    * @param {Element} elt
    * @returns {HTMLFormElement|null}
    */
   function getRelatedForm(elt) {
-    // Get the related form if available, else find the closest parent form
-    return /** @type {FormAssociatedElement} */ (elt).form || /** @type {HTMLFormElement} */ (closest(elt, 'form'))
+    // @ts-ignore Get the related form if available, else find the closest parent form
+    return elt.form || closest(elt, 'form')
   }
 
   /**

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2400,8 +2400,9 @@ var htmx = (function() {
       if (elt.tagName === 'FORM') {
         return true
       }
-      if (matches(elt, 'input[type=submit], button:not([type=button], [type=reset])') &&
-        (/** @type HTMLInputElement|HTMLButtonElement */(elt).form)) {
+      // @ts-ignore Do not cancel on buttons that 1) don't have a related form or 2) have a type attribute of 'reset'/'button'.
+      // The properties will resolve to undefined for elements that don't define 'type' or 'form', which is fine
+      if (elt.form && elt.type === 'submit') {
         return true
       }
       if (elt instanceof HTMLAnchorElement && elt.href &&

--- a/test/core/ajax.js
+++ b/test/core/ajax.js
@@ -1304,4 +1304,40 @@ describe('Core htmx AJAX Tests', function() {
     this.server.respond()
     values.should.deep.equal({ name: '', outside: '' })
   })
+
+  it('properly handles form reset behaviour with a htmx enabled reset button inside a form', function() {
+    var values
+    this.server.respondWith('POST', '/reset', function(xhr) {
+      values = getParameters(xhr)
+      xhr.respond(204, {}, '')
+    })
+
+    make('<form id="externalForm" hx-post="/test">' +
+            '<input id="t1" type="text" name="t1" value="defaultValue">' +
+            '<button hx-post="/reset" id="reset" type="reset" name="b1" value="buttonValue">reset</button>' +
+            '</form>')
+    byId('t1').value = 'otherValue'
+    byId('reset').click()
+    this.server.respond()
+    values.should.deep.equal({ b1: 'buttonValue', t1: 'otherValue' })
+    byId('t1').value.should.equal('defaultValue')
+  })
+
+  it('properly handles form reset behaviour with a htmx enabled reset button outside a form', function() {
+    var values
+    this.server.respondWith('POST', '/reset', function(xhr) {
+      values = getParameters(xhr)
+      xhr.respond(204, {}, '')
+    })
+
+    make('<form id="externalForm" hx-post="/test">' +
+            '<input id="t1" type="text" name="t1" value="defaultValue">' +
+            '</form>' +
+            '<button hx-post="/reset" id="reset" form="externalForm" type="reset" name="b1" value="buttonValue">reset</button>')
+    byId('t1').value = 'otherValue'
+    byId('reset').click()
+    this.server.respond()
+    values.should.deep.equal({ b1: 'buttonValue', t1: 'otherValue' })
+    byId('t1').value.should.equal('defaultValue')
+  })
 })

--- a/test/core/ajax.js
+++ b/test/core/ajax.js
@@ -1184,6 +1184,48 @@ describe('Core htmx AJAX Tests', function() {
     values.should.deep.equal({ t1: 'textValue', b1: ['inputValue', 'buttonValue'] })
   })
 
+  it('sends referenced form values when a button referencing another form is clicked', function() {
+    var values
+    this.server.respondWith('POST', '/test3', function(xhr) {
+      values = getParameters(xhr)
+      xhr.respond(205, {}, '')
+    })
+
+    make('<form id="externalForm" hx-post="/test">' +
+            '<input type="text" name="t1" value="textValue">' +
+            '<input type="hidden" name="b1" value="inputValue">' +
+            '</form>' +
+            '<form hx-post="/test2">' +
+            '<input type="text" name="t1" value="checkValue">' +
+            '<button id="submit" form="externalForm" hx-post="/test3" type="submit" name="b1" value="buttonValue">button</button>' +
+            '</form>')
+
+    byId('submit').click()
+    this.server.respond()
+    values.should.deep.equal({ t1: 'textValue', b1: ['inputValue', 'buttonValue'] })
+  })
+
+  it('sends referenced form values when a submit input referencing another form is clicked', function() {
+    var values
+    this.server.respondWith('POST', '/test3', function(xhr) {
+      values = getParameters(xhr)
+      xhr.respond(204, {}, '')
+    })
+
+    make('<form id="externalForm" hx-post="/test">' +
+            '<input type="text" name="t1" value="textValue">' +
+            '<input type="hidden" name="b1" value="inputValue">' +
+            '</form>' +
+            '<form hx-post="/test2">' +
+            '<input type="text" name="t1" value="checkValue">' +
+            '<input id="submit" form="externalForm" hx-post="/test3" type="submit" name="b1" value="buttonValue">' +
+            '</form>')
+
+    byId('submit').click()
+    this.server.respond()
+    values.should.deep.equal({ t1: 'textValue', b1: ['inputValue', 'buttonValue'] })
+  })
+
   it('properly handles inputs external to form', function() {
     var values
     this.server.respondWith('Post', '/test', function(xhr) {

--- a/test/core/internals.js
+++ b/test/core/internals.js
@@ -96,19 +96,31 @@ describe('Core htmx internals Tests', function() {
     var form = make('<form></form>')
     htmx._('shouldCancel')({ type: 'submit' }, form).should.equal(true)
 
-    form = make("<form><input id='i1' type='submit'></form>")
-    var input = byId('i1')
-    htmx._('shouldCancel')({ type: 'click' }, input).should.equal(true)
+    form = make('<form id="f1">' +
+        '<input id="insideInput" type="submit">' +
+        '<button id="insideFormBtn"></button>' +
+        '<button id="insideSubmitBtn" type="submit"></button>' +
+        '<button id="insideResetBtn" type="reset"></button>' +
+        '<button id="insideButtonBtn" type="button"></button>' +
+        '</form>' +
+        '<input id="outsideInput" form="f1" type="submit">' +
+        '<button id="outsideFormBtn" form="f1"></button>' +
+        '<button id="outsideSubmitBtn" form="f1" type="submit"></button>")' +
+        '<button id="outsideButtonBtn" form="f1" type="button"></button>")' +
+        '<button id="outsideResetBtn" form="f1" type="reset"></button>")' +
+        '<button id="outsideNoFormBtn"></button>")')
+    htmx._('shouldCancel')({ type: 'click' }, byId('insideInput')).should.equal(true)
+    htmx._('shouldCancel')({ type: 'click' }, byId('insideFormBtn')).should.equal(true)
+    htmx._('shouldCancel')({ type: 'click' }, byId('insideSubmitBtn')).should.equal(true)
+    htmx._('shouldCancel')({ type: 'click' }, byId('insideResetBtn')).should.equal(false)
+    htmx._('shouldCancel')({ type: 'click' }, byId('insideButtonBtn')).should.equal(false)
 
-    form = make("<form><button id='b1' type='submit'></form>")
-    var button = byId('b1')
-    htmx._('shouldCancel')({ type: 'click' }, button).should.equal(true)
-
-    form = make("<form id='f1'></form><input id='i1' form='f1' type='submit'><button id='b1' form='f1' type='submit'>")
-    input = byId('i1')
-    button = byId('b1')
-    htmx._('shouldCancel')({ type: 'click' }, input).should.equal(true)
-    htmx._('shouldCancel')({ type: 'click' }, button).should.equal(true)
+    htmx._('shouldCancel')({ type: 'click' }, byId('outsideInput')).should.equal(true)
+    htmx._('shouldCancel')({ type: 'click' }, byId('outsideFormBtn')).should.equal(true)
+    htmx._('shouldCancel')({ type: 'click' }, byId('outsideSubmitBtn')).should.equal(true)
+    htmx._('shouldCancel')({ type: 'click' }, byId('outsideButtonBtn')).should.equal(false)
+    htmx._('shouldCancel')({ type: 'click' }, byId('outsideResetBtn')).should.equal(false)
+    htmx._('shouldCancel')({ type: 'click' }, byId('outsideNoFormBtn')).should.equal(false)
   })
 
   it('unset properly unsets a given attribute', function() {

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -640,8 +640,8 @@ will include the values of all inputs within it.
 
 As with HTML forms, the `name` attribute of the input is used as the parameter name in the request that htmx sends.
 
-Additionally, if the element causes a non-`GET` request, the values of all the inputs of the nearest enclosing form
-will be included.
+Additionally, if the element causes a non-`GET` request, the values of all the inputs of the associated form will be
+included (typically this is the nearest enclosing form, but could be different if e.g. `<button form="associated-form">` is used).
 
 If you wish to include the values of other elements, you can use the [hx-include](@/attributes/hx-include.md) attribute
 with a CSS selector of all the elements whose values you want to include in the request.


### PR DESCRIPTION
## Description

I would like to start off by thanking @scrhartley for their help with this PR.

When a non-GET htmx request is triggered on an element inside a form, htmx includes the other values in the form. However, it is currently including incorrect values when e.g. a `<button form="referenced">` is inside a different form. This PR addresses that bug. Details are explained in the documentation change and the added test. 

Corresponding issue: None

## Testing
Using standard HTML behavior as a reference, consider the following:
```
<form id="externalForm" action="/test" method="post">
    <input type="text" name="t1" value="textValue">
    <input type="hidden" name="b1" value="inputValue">
</form>
<form action="/test2" method="post">
    <input type="text" name="t1" value="checkValue">
    <button id="submit" form="externalForm" formaction="/test3" formmethod="post" type="submit" name="b1" value="buttonValue">button</button>
</form>
```
clicking `#submit` will result in a request whose body contains `t1=textValue&b1=inputValue&b1=buttonValue`, which agrees with the new tests.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
