### PR TITLE
Fix typo in quirks page markdown link

### DIFF
--- a/www/content/QUIRKS.md
+++ b/www/content/QUIRKS.md
@@ -74,7 +74,7 @@ response code to indicate that a form was not filled out properly.
 This can be very confusing when it is first encountered.
 
 You can configure the response behavior of htmx via the [`htmx:beforeSwap`](@/docs.md#modifying_swapping_behavior_with_events) 
-event or [via the `htmx.config.responseHandling` config array]https://htmx.org/docs/#response-handling.
+event or [via the `htmx.config.responseHandling` config array](https://htmx.org/docs/#response-handling).
 
 Here is the default configuration:
 


### PR DESCRIPTION
## Description
*Please describe what changes you made, and why you feel they are necessary. Make sure to include
code examples, where applicable.*

Typo found in the docs where the markdown link was wrong.

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
