### PR TITLE
Fix error in quirks documentation for htmx config

### DIFF
--- a/www/content/QUIRKS.md
+++ b/www/content/QUIRKS.md
@@ -115,7 +115,7 @@ If you want to specifically allow `422` responses to swap, you can use this conf
 Here is a meta tag allowing all responses to swap:
 
 ```html
-  <meta name="htmx-config" content='{"responseHandling": [{"code":"...", "swap": true}]'>
+  <meta name="htmx-config" content='{"responseHandling": [{"code":"...", "swap": true}]}'>
 ```
 
 ## `GET` Requests on Non-Form Elements Do Not Include Form Values by Default


### PR DESCRIPTION
## Description
*Please describe what changes you made, and why you feel they are necessary. Make sure to include
code examples, where applicable.*

The docs suggest adding an `htmx-config` with invalid JSON that causes an error when copy/pasting the snippet in.

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
