### PR TITLE
adding javalin-htmx examples to server integration examples

### DIFF
--- a/www/content/server-examples.md
+++ b/www/content/server-examples.md
@@ -60,8 +60,14 @@ These examples may make it a bit easier to get started using htmx with your plat
 ### py4web
 
 - <https://github.com/jpsteil/py4web_htmx_demo>
+- <https://github.com/erwindrsno/simple-to-do-list>
 
 ## Java
+
+### Javalin
+
+- <https://github.com/AussieGuy0/java-htmx-todo/>
+- <https://github.com/erwindrsno/simple-to-do-list>
 
 ### Spring Boot
 


### PR DESCRIPTION
Adding two examples of using htmx and java with the javalin server library

## Description
Adding two server-integration examples for java. Both of these examples use javalin and present a simpler approach to getting started with htmx and java than the current examples which use Spring Boot and Quarkus.

Corresponding issue:

https://github.com/bigskysoftware/htmx/issues/3099

## Testing
I have reviewed a preview of my edits to this file. 

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [NA] I ran the test suite locally (`npm run test`) and verified that it succeeded
