### PR TITLE
Add 404 page

### DIFF
--- a/www/templates/404.html
+++ b/www/templates/404.html
@@ -1,0 +1,11 @@
+{% extends "htmx-theme/templates/base.html" %}
+
+{% block title %}
+  {% set html_title = "&lt;/&gt; htmx ~ 404 Not found " %}
+{% endblock title %}
+
+{% block content %}
+  <h1 style="margin-bottom: 500px;">
+    404 Not Found
+  </h1>
+{% endblock content %}

--- a/www/themes/htmx-theme/templates/base.html
+++ b/www/themes/htmx-theme/templates/base.html
@@ -9,7 +9,7 @@
     {# This block should set html_title appropriately -#}
     {% block title %} {% endblock title -%}
     <title>{{ html_title | default(value=config.title) | safe }}</title>
-    <link rel="canonical" href="{{ current_url | safe }}">
+    {% if current_url %} <link rel="canonical" href="{{ current_url | safe }}"> {% endif %}
     {#TODO: only generate this for the home page #}
     <link rel="alternate" type="application/atom+xml" title="Sitewide Atom feed" href="/atom.xml">
     <link rel="stylesheet" href="/css/site.css">


### PR DESCRIPTION
## Description

Added a 404 page using base template. Users no longer have to manually navigate back to site on 404.

Had to add a check for `current_url` to use the base template as [Zola does not set this variable on 404](https://www.getzola.org/documentation/templates/overview/).