### PR TITLE
Fix broken docs links on quirks page

### DIFF
--- a/www/content/QUIRKS.md
+++ b/www/content/QUIRKS.md
@@ -11,7 +11,7 @@ This is a "quirks" page, based on [SQLite's "Quirks, Caveats, and Gotchas In SQL
 
 ## Attribute Inheritance
 
-Many attributes in htmx are [inherited](/@docs#inheritance): child elements can receive behavior from attributes located 
+Many attributes in htmx are [inherited](@/docs.md#inheritance): child elements can receive behavior from attributes located 
 on parent elements.
 
 As an example, here are two htmx-powered buttons that inherit their [target](@/attributes/hx-target.md) from a parent 
@@ -33,7 +33,7 @@ and it becomes more difficult to understand what an element is doing.
 It is also possible to inadvertently change the behavior of elements by adding attributes to parents.
 
 Some people prefer to disable inheritance in htmx entirely, using the `htmx.config.disableInheritance` 
-[configuration variable](/@docs.md#config).  
+[configuration variable](@/docs.md#config).  
 
 Here is a `meta` tag configuration that does so:
 
@@ -49,7 +49,7 @@ The [`hx-swap`](@/attributes/hx-swap.md) attribute allows you to control how a s
 Many people prefer to use the `outerHTML` strategy as the default instead.
 
 You can change this behavior using the `htmx.config.defaultSwapStyle` 
-[configuration variable](/@docs.md#config).
+[configuration variable](@/docs.md#config).
 
 Here is a `meta` tag configuration that does so:
 


### PR DESCRIPTION
## Description

Three documentation links are currently broken on https://htmx.org/quirks/. This patch fixes them.

Corresponding issue: N/A, this is a trivial website change.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
