### PR TITLE
Fix relative URLs to be considered as sameHost

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -4007,7 +4007,7 @@ var htmx = (function() {
     } else {
     // IE11 doesn't support URL
       url = path
-      sameHost = startsWith(path, document.location.origin)
+      sameHost = startsWith(path, "/") || startsWith(path, document.location.origin)
     }
 
     if (htmx.config.selfRequestsOnly) {


### PR DESCRIPTION
## Description

when the URL function is not used for the URL validation and the path is a relative URL
`startsWith(path, document.location.origin)` would return `false`.

Since we can guarantee that relative URLs must be on the same host, I wanted to move the check earlier up the code and return early but unsure if it is a desired pattern.

Corresponding issue:

## Testing

We had a site that was working normally but somehow a GoogleTagManager JS that we have no control over was removing the native `URL` function from the browser (which is wild)

Was implementing a workaround on our end but I thought this might break on IE11 right now if URL is really not available.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
