### PR TITLE
Add `hx-prompt-default` to set the default value of a `hx-prompt` (#601)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Using `<button hx-verb="/endpoint" type="reset">` will now reset the associated form (after submitting to `/endpoint`)
 * Using `<button formmethod="dialog">` will no longer submit its associated form
+* Added `hx-prompt-default` to set the default value of a `hx-prompt`
 
 ## [2.0.4] - 2024-12-13
 

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -4325,7 +4325,8 @@ var htmx = (function() {
     }
     const promptQuestion = getClosestAttributeValue(elt, 'hx-prompt')
     if (promptQuestion) {
-      var promptResponse = prompt(promptQuestion)
+      const defaultValue = getClosestAttributeValue(elt, 'hx-prompt-default') || undefined
+      var promptResponse = prompt(promptQuestion, defaultValue)
       // prompt returns null if cancelled and empty string if accepted with no entry
       if (promptResponse === null ||
       !triggerEvent(elt, 'htmx:prompt', { prompt: promptResponse, target })) {

--- a/test/manual/confirm-and-prompt.html
+++ b/test/manual/confirm-and-prompt.html
@@ -20,6 +20,7 @@
 </script>
 <h1>Prompt & Confirm Tests</h1>
 <button hx-get="/prompt" hx-prompt="Enter some text and it should be echoed in this button">Click For Prompt</button>
+<button hx-get="/prompt" hx-prompt="You should see a default text in this prompt:" hx-prompt-default="This is the default value">Click For Prompt (with default value)</button>
 <br/>
 <br/>
 <br/>

--- a/www/content/attributes/hx-prompt-default.md
+++ b/www/content/attributes/hx-prompt-default.md
@@ -1,0 +1,17 @@
++++
+title = "hx-prompt-default"
++++
+
+The `hx-prompt-default` attribute sets the default value for a prompt shown via [`hx-prompt`](@/attributes/hx-prompt.md). 
+
+Here is an example:
+
+```html
+<button hx-patch="/update-name" hx-prompt="Enter a new name" hx-prompt-default="My Thing 123">
+  Update name
+</button>
+```
+
+## Notes
+
+* `hx-prompt-default` is inherited and can be placed on a parent element

--- a/www/content/attributes/hx-prompt.md
+++ b/www/content/attributes/hx-prompt.md
@@ -16,3 +16,4 @@ Here is an example:
 ## Notes
 
 * `hx-prompt` is inherited and can be placed on a parent element
+* Use the optional [`hx-prompt-default`](@/attributes/hx-prompt-default.md) to set the [default value](https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt#defaultvalue) for the prompt

--- a/www/content/reference.md
+++ b/www/content/reference.md
@@ -62,6 +62,7 @@ All other attributes available in htmx.
 | [`hx-patch`](@/attributes/hx-patch.md)               | issues a `PATCH` to the specified URL                                                                                              |
 | [`hx-preserve`](@/attributes/hx-preserve.md)         | specifies elements to keep unchanged between requests                                                                              |
 | [`hx-prompt`](@/attributes/hx-prompt.md)             | shows a `prompt()` before submitting a request                                                                                     |
+| [`hx-prompt-default`](@/attributes/hx-prompt-default.md)             | sets the default value used by `hx-prompt`                                                                                     |
 | [`hx-put`](@/attributes/hx-put.md)                   | issues a `PUT` to the specified URL                                                                                                |
 | [`hx-replace-url`](@/attributes/hx-replace-url.md)   | replace the URL in the browser location bar                                                                                        |
 | [`hx-request`](@/attributes/hx-request.md)           | configures various aspects of the request                                                                                          |


### PR DESCRIPTION
## Description
Added `hx-prompt-default` attribute to (optionally) set the default value of a `hx-prompt`.
Also updated the documentation to include this new attribute.

Corresponding issue: #601 

## Testing
I added a manual test to `confirm-and-prompt.html`.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue **- not explicitly approved**
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
