### PR TITLE
Fix htmx:beforeHistorySave docs

### DIFF
--- a/www/content/events.md
+++ b/www/content/events.md
@@ -305,10 +305,6 @@ This event is triggered before the content is saved in the history api.
 * `detail.path` - the path and query of the page being restored
 * `detail.historyElt` - the history element being restored into
 
-##### Details
-
-* `detail.config` - the config that will be passed to the `EventSource` constructor
-
 ### Event - `htmx:load` {#htmx:load}
 
 This event is triggered when a new node is loaded into the DOM by htmx.


### PR DESCRIPTION
## Description
Removed duplicated and incorrect details section from htmx:beforeHistorySave docs

Corresponding issue: N/A

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  soxurce changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
