### PR TITLE
Fixed TwinSpark link in alternatives

### DIFF
--- a/www/content/essays/alternatives.md
+++ b/www/content/essays/alternatives.md
@@ -74,7 +74,7 @@ Amazing!
 [TwinSpark](https://twinspark.js.org/) is a library created by [Alexander Solovyov](https://solovyov.net/) that is 
 similar to htmx, and includes features such as [morphing](https://twinspark.js.org/api/ts-swap/#morph).
 
-It is being [used in production](https://https://twinspark.js.org#who-is-using-this) on sites with 100k+ daily users.
+It is being [used in production](https://twinspark.js.org#who-is-using-this) on sites with 100k+ daily users.
 
 ## jQuery
 


### PR DESCRIPTION
## Description
Fixed a broken link URL for TwinSpark in the alternatives essay (duplicate `https://`)

Corresponding issue:

## Testing
N/A

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
