### PR TITLE
Fix 1103 by evaluating hx-vals with this referring to the element

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3855,7 +3855,7 @@ var htmx = (function() {
       }
       let varsValues
       if (evaluateValue) {
-        varsValues = maybeEval(elt, function() { return Function('return (' + str + ')')() }, {})
+        varsValues = maybeEval(elt, function() { return Function('return (' + str + ')').call(elt) }, {})
       } else {
         varsValues = parseJSON(str)
       }

--- a/test/attributes/hx-vals.js
+++ b/test/attributes/hx-vals.js
@@ -325,4 +325,16 @@ describe('hx-vals attribute', function() {
     this.server.respond()
     div.innerHTML.should.equal('Clicked!')
   })
+
+  it('js: this refers to the element with the hx-vals attribute', function() {
+    this.server.respondWith('POST', '/vars', function(xhr) {
+      var params = getParameters(xhr)
+      params.i1.should.equal('test')
+      xhr.respond(200, {}, 'Clicked!')
+    })
+    var div = make('<div hx-post="/vars" hx-vals="javascript:{ ...this.dataset, }" data-i1="test"></div>')
+    div.click()
+    this.server.respond()
+    div.innerHTML.should.equal('Clicked!')
+  })
 })

--- a/www/content/attributes/hx-vals.md
+++ b/www/content/attributes/hx-vals.md
@@ -43,3 +43,4 @@ In this example, if `foo()` returns an object like `{name: "John", age: 30}`, bo
 * `hx-vals` is inherited and can be placed on a parent element.
 * A child declaration of a variable overrides a parent declaration.
 * Input values with the same name will be overridden by variable declarations.
+* When using `javascript:`, `this` refers to the element with the `hx-vals` attribute


### PR DESCRIPTION
## Description
Fixes #1103 by evaluating `hx-vals` attributes with `this` referring to the current element.

Example:
```html
<div hx-post="/vars" hx-vals="javascript:{ ...this.dataset, }" data-name="a name" data-hello="world"></div>
```
evaluates to `{ "name": "a name", "hello": "world" }` since `this` refers to the div with hx-vals attribute.

*Corresponding issue: #1103*

## Testing
Added a test in test/attributes/hx-vals.js. This tests that `this` acually refers to the current element.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded


Edit: May also fix #1658
