### PR TITLE
Allow page description with default if missing

### DIFF
--- a/www/content/essays/10-tips-for-SSR-HDA-apps.md
+++ b/www/content/essays/10-tips-for-SSR-HDA-apps.md
@@ -1,5 +1,9 @@
 +++
 title = "10 Tips For Building SSR/HDA applications"
+description = """\
+  In this guide, Carson Gross provides ten practical tips to help developers transition from Single Page Applications \
+  (SPAs) to Server-Side Rendering and Hypermedia-Driven Applications, focusing on essential mindset shifts and \
+  architectural advantages."""
 date = 2022-06-13
 updated = 2023-06-13
 [taxonomies]

--- a/www/content/essays/a-real-world-nextjs-to-htmx-port.md
+++ b/www/content/essays/a-real-world-nextjs-to-htmx-port.md
@@ -1,5 +1,9 @@
 +++
 title = "Next.js to htmx — A Real World Example"
+description = """\
+  In this case study, Pouria Ezzati examines how migrating a URL shortener from Next.js to htmx resulted in \
+  significant improvements in codebase size, dependencies, and developer experience while challenging assumptions \
+  about modern web frameworks."""
 date = 2024-11-07
 updated = 2024-11-07
 [taxonomies]

--- a/www/content/essays/a-real-world-react-to-htmx-port.md
+++ b/www/content/essays/a-real-world-react-to-htmx-port.md
@@ -1,5 +1,10 @@
 +++
 title = "A Real World React -> htmx Port"
+description = """\
+  David Guillot at Contexte gave what we are calling "The Mother of All htmx Demos" at DjangoCon 2022. This essay \
+  summarizes this real-world case study of replacing React with htmx in a SaaS product, demonstrating significant \
+  improvements in code size, performance, and development team efficiency through the adoption of a hypermedia-driven \
+  architecture."""
 date = 2022-09-29
 updated = 2022-10-15
 [taxonomies]

--- a/www/content/essays/a-real-world-wasm-to-htmx-port.md
+++ b/www/content/essays/a-real-world-wasm-to-htmx-port.md
@@ -1,5 +1,9 @@
 +++
 title = "A Real World wasm to htmx Port"
+description = """\
+  In this article, Joe Fioti describes their journey of simplifying their web application architecture by moving from \
+  a complex WebAssembly-based system to a streamlined htmx solution, resulting in significantly reduced code \
+  complexity and improved development efficiency."""
 date = 2025-01-10
 updated = 2025-01-10
 [taxonomies]

--- a/www/content/essays/a-response-to-rich-harris.md
+++ b/www/content/essays/a-response-to-rich-harris.md
@@ -1,5 +1,10 @@
 +++
 title = "A Response To &quot;Have Single-Page Apps Ruined the Web?&quot;"
+description = """\
+  In this essay, Carson Gross gives an analysis of Rich Harris's talk "Have Single-Page Apps Ruined the Web?", \
+  exploring the debate between Single-Page Applications (SPAs) and Multi-Page Applications (MPAs). Carson examines \
+  Harris's criticisms of both approaches and proposes hypermedia-oriented solutions using htmx, while discussing the \
+  broader implications for web development architecture and the future role of JavaScript in web applications."""
 date = 2021-12-24
 updated = 2022-05-27
 [taxonomies]

--- a/www/content/essays/alternatives.md
+++ b/www/content/essays/alternatives.md
@@ -1,5 +1,10 @@
 +++
 title = "Alternatives to htmx"
+description = """\
+  In this article, Carson Gross compares several alternative libraries and frameworks to htmx that embrace a \
+  hypermedia-oriented approach to web development. Carson explores established solutions like Unpoly and Hotwire \
+  Turbo, as well as emerging projects like Triptych and htmz, providing developers with a comprehensive overview of \
+  hypermedia-driven application development options beyond htmx."""
 date = 2025-01-12
 updated = 2024-01-12
 [taxonomies]

--- a/www/content/essays/another-real-world-react-to-htmx-port.md
+++ b/www/content/essays/another-real-world-react-to-htmx-port.md
@@ -1,5 +1,9 @@
 +++
 title = "Another Real World React -> htmx Port"
+description = """\
+  In this article, Carson Gross summarizes a real-world case study of Adrian McPhee porting the OpenUnited platform \
+  from React to htmx, documenting significant reductions in code complexity and development time while highlighting \
+  how content-focused web applications can benefit from a hypermedia architectural approach."""
 date = 2023-09-20
 updated = 2023-09-20
 [taxonomies]

--- a/www/themes/htmx-theme/templates/base.html
+++ b/www/themes/htmx-theme/templates/base.html
@@ -3,9 +3,13 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="htmx gives you access to AJAX, CSS Transitions, WebSockets and Server Sent Events directly in HTML, using attributes, so you can build modern user interfaces with the simplicity and power of hypertext
+    <meta name="description" content="
+    {%- block description -%}
+    htmx gives you access to AJAX, CSS Transitions, WebSockets and Server Sent Events directly in HTML, using attributes, so you can build modern user interfaces with the simplicity and power of hypertext
 
-    htmx is small (~14k min.gz’d), dependency-free, extendable, IE11 compatible & has reduced code base sizes by 67% when compared with react">
+    htmx is small (~14k min.gz’d), dependency-free, extendable, IE11 compatible & has reduced code base sizes by 67% when compared with react
+    {%- endblock description -%}
+    ">
     {# This block should set html_title appropriately -#}
     {% block title %} {% endblock title -%}
     <title>{{ html_title | default(value=config.title) | safe }}</title>

--- a/www/themes/htmx-theme/templates/essay.html
+++ b/www/themes/htmx-theme/templates/essay.html
@@ -6,6 +6,14 @@
   {% endif -%}
 {% endblock title %}
 
+{% block description %}
+  {%- if page.description -%}
+    {{- page.description | safe -}}
+  {%- else -%}
+    {{- super() -}}
+  {%- endif -%}
+{% endblock description %}
+
 {% block content %}
 
   {% if page.extra and page.extra.show_title is defined -%}


### PR DESCRIPTION
## Description
If an essay has a description in the front matter, use that description in the `<meta name="description">` tag.

## Testing
    zola build

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
