### PR TITLE
Feat/hx reselect support unset

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -4854,7 +4854,7 @@ var htmx = (function() {
           }
 
           swap(target, serverResponse, swapSpec, {
-            select: selectOverride || select,
+            select: selectOverride === 'unset' ? null : selectOverride || select,
             selectOOB,
             eventInfo: responseInfo,
             anchor: responseInfo.pathInfo.anchor,

--- a/test/core/headers.js
+++ b/test/core/headers.js
@@ -286,6 +286,16 @@ describe('Core htmx AJAX headers', function() {
     div.innerHTML.should.equal('<div id="d2">bar</div>')
   })
 
+  it('should handle HX-Reselect unset', function() {
+    this.server.respondWith('GET', '/test', [200, { 'HX-Reselect': 'unset' }, 'bar'])
+
+    var div = make('<div hx-get="/test" hx-select="#d2"></div>')
+    div.click()
+    this.server.respond()
+
+    div.innerHTML.should.equal('bar')
+  })
+
   it('should handle simple string HX-Trigger-After-Swap response header properly w/ outerHTML swap', function() {
     this.server.respondWith('GET', '/test', [200, { 'HX-Trigger-After-Swap': 'foo' }, ''])
 


### PR DESCRIPTION
## Description

`HX-Reselect `currently does not support `unset` like the attribute `hx-select` does. I think an htmx user would expect that, and for me it is quite handy to have that feature.

I hope it is okay for me to open a PR to illustrate the linked issue, since it's somewhere in-between a feature and a bugfix I would say.

Corresponding issue: #3152

## Testing

Basically already using this in one of my projects to have server-side rendering of redirects. 

If the server would trigger a redirect, I just render the response of the redirected view and use `HX-Reselect`, `HX-Retarget`, `HX-Reswap` for swapping. Saves me one round trip and let's me use redirects more freely. And for full body swaps I need to use `unset`.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
