### PR TITLE
Mark the interviews folder as a section

### DIFF
--- a/www/content/essays/interviews/_index.md
+++ b/www/content/essays/interviews/_index.md
@@ -1,0 +1,3 @@
++++
+render = false
++++


### PR DESCRIPTION
Adding `_index.md` to the `interviews` folder will mark this folder as a "section". Pages in this section will now inherit section settings from the parent `essays` section, including rendering using the `essay.html` template instead of the default `page.html` template.

Adding `render = false` to the interview section metadata will suppress generating a page at `/essays/interviews/index.html`
