### PR TITLE
Add FreePascal server example with Pas2JS

### DIFF
--- a/www/content/server-examples.md
+++ b/www/content/server-examples.md
@@ -131,12 +131,14 @@ These examples may make it a bit easier to get started using htmx with your plat
 - <https://github.com/paultuckey/example-todo-app-rust-htmx>
 
 ## Scala
-  
+
 ### http4s
+
 - <https://github.com/martinprobson/http4s-htmx-demo>
 - <https://github.com/eikek/htmx4s>
 
 ### zio-http
+
 - <https://github.com/rockthejvm/scalatags-htmx-demo>
 
 ## Kotlin
@@ -164,7 +166,6 @@ These examples may make it a bit easier to get started using htmx with your plat
 ### CodeIgniter 4
 
 - <https://github.com/michalsn/codeigniter-htmx-demo>
-
 
 ### Laravel
 
@@ -226,3 +227,7 @@ These examples may make it a bit easier to get started using htmx with your plat
 
 - <https://github.com/danieleteti/delphi-dmvcframework-htmx-todo>
 - <https://github.com/danieleteti/delphimvcframework/tree/master/samples/htmx>
+
+## FreePascal with Pas2JS
+
+- <https://github.com/zendrael/create_pas2js_app>


### PR DESCRIPTION
## Description
Adding Free Pascal example of using htmX with Pas2JS

Corresponding issue:

## Checklist

* [ x] I have read the contribution guidelines
* [ x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ x] I ran the test suite locally (`npm run test`) and verified that it succeeded
