### PR TITLE
Write title as innerText instead of innerHTML

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -4686,6 +4686,7 @@ var htmx = (function() {
     if (title) {
       const titleElt = find('title')
       if (titleElt) {
+        /** @type HTMLElement */
         titleElt.innerText = title
       } else {
         window.document.title = title

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -4686,8 +4686,7 @@ var htmx = (function() {
     if (title) {
       const titleElt = find('title')
       if (titleElt) {
-        /** @type HTMLElement */
-        titleElt.innerText = title
+        titleElt.textContent = title
       } else {
         window.document.title = title
       }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -4686,7 +4686,7 @@ var htmx = (function() {
     if (title) {
       const titleElt = find('title')
       if (titleElt) {
-        titleElt.innerHTML = title
+        titleElt.innerText = title
       } else {
         window.document.title = title
       }


### PR DESCRIPTION
## Description
Changing the title update to use `innerText` instead of `innerHTML` calms some security checks such as GitHub's own code checking.

`tsc` is grumpy now though with the error `Property 'innerText' does not exist on type 'Element'.`

Not sure if i agree with `tsc` fully.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
