### PR TITLE
Documentation update to include the use of hx-headers to prevent CSRF

### DIFF
--- a/www/content/attributes/hx-headers.md
+++ b/www/content/attributes/hx-headers.md
@@ -24,7 +24,10 @@ If you wish for `hx-headers` to *evaluate* the values given, you can prefix the 
   security considerations, especially when dealing with user input such as query strings or user-generated content,
   which could introduce a [Cross-Site Scripting (XSS)](https://owasp.org/www-community/attacks/xss/) vulnerability.
 
+* Whilst far from being a foolproof solution to [Cross-Site Request Forgery](https://owasp.org/www-community/attacks/csrf), the `hx-headers` attribute can support backend services to provide [CSRF prevention](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html). For more information see the [CSRF Prevention](https://htmx.org/docs/#csrf-prevention) section.
+
 ## Notes
 
 * `hx-headers` is inherited and can be placed on a parent element.
 * A child declaration of a header overrides a parent declaration.
+* The value of the attribute needs to be a valid JSON string.

--- a/www/content/attributes/hx-headers.md
+++ b/www/content/attributes/hx-headers.md
@@ -30,4 +30,3 @@ If you wish for `hx-headers` to *evaluate* the values given, you can prefix the 
 
 * `hx-headers` is inherited and can be placed on a parent element.
 * A child declaration of a header overrides a parent declaration.
-* The value of the attribute needs to be a valid JSON string.

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -1660,6 +1660,25 @@ with application security.
 A full discussion of CSPs is beyond the scope of this document, but the [MDN Article](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) provide a good jumping off point
 for exploring this topic.
 
+### CSRF Prevention
+
+The assignment and checking of CSRF tokens are typically backend responsibilities, but `htmx` can support returning the CSRF token automatically with every request using the `hx-headers` attribute. The attribute needs to be added to the element issuing the request or one of its ancestor elements. This makes the `html` and `body` elements effective global vehicles for adding the CSRF token to the `HTTP` request header, as illustarted below. 
+
+```html
+<html lang="en" hx-headers='{"X-CSRF-TOKEN": "CSRF_TOKEN_INSERTED_HERE"}'>
+    :
+</html>
+```
+
+```html
+    <body hx-headers='{"X-CSRF-TOKEN": "CSRF_TOKEN_INSERTED_HERE"}'>
+        :
+    </body>
+```
+
+The above elements are usually unique in an HTML document and should be easy to locate within templates. 
+
+
 ## Configuring htmx {#config}
 
 Htmx has some configuration options that can be accessed either programmatically or declaratively.  They are


### PR DESCRIPTION
## Description
This Pull Request provides updates to the htmx document regarding the use of the `hx-headers` attribute as part of a CSRF prevention strategy. 

Corresponding issue: #70 (now closed)

## Testing
Review only

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
