### PR TITLE
Fix target value in htmx:targetError when inheritance has been used

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -4203,7 +4203,7 @@ var htmx = (function() {
     }
     const target = etc.targetOverride || asElement(getTarget(elt))
     if (target == null || target == DUMMY_ELT) {
-      triggerErrorEvent(elt, 'htmx:targetError', { target: getAttributeValue(elt, 'hx-target') })
+      triggerErrorEvent(elt, 'htmx:targetError', { target: getClosestAttributeValue(elt, 'hx-target') })
       maybeCall(reject)
       return promise
     }

--- a/test/core/events.js
+++ b/test/core/events.js
@@ -738,4 +738,36 @@ describe('Core htmx Events', function() {
       htmx.off('htmx:afterSwap', afterSwapHandler)
     }
   })
+
+  it('htmx:targetError should include the hx-target value', function() {
+    var target = null
+    var handler = htmx.on('htmx:targetError', function(evt) {
+      target = evt.detail.target
+    })
+    try {
+      this.server.respondWith('GET', '/test', '')
+      var div = make('<div hx-post="/test" hx-target="#non-existent"></div>')
+      div.click()
+      this.server.respond()
+      target.should.equal('#non-existent')
+    } finally {
+      htmx.off('htmx:targetError', handler)
+    }
+  })
+
+  it('htmx:targetError can include an inherited hx-target value', function() {
+    var target = null
+    var handler = htmx.on('htmx:targetError', function(evt) {
+      target = evt.detail.target
+    })
+    try {
+      this.server.respondWith('GET', '/test', '')
+      make('<div hx-target="#parent-target"><div id="child" hx-post="/test"></div></div>')
+      byId('child').click()
+      this.server.respond()
+      target.should.equal('#parent-target')
+    } finally {
+      htmx.off('htmx:targetError', handler)
+    }
+  })
 })


### PR DESCRIPTION
## Description
When `hx-target` is inherited, currently the value of `event.detail.target` for `htmx:targetError` is null.
This value should instead be the value that htmx was using to try to resolve the target.

## Testing
Added a test for the event when inheritance is not being used, since that seemed to not exist yet.
Then added a test which uses an inherited value for `hx-target`.
(I also manually tested that the event doesn't fire when the inherited target does exist.)

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
