### PR TITLE
Update parseHTML to use Document.parseHTMLUnsafe where supported

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -509,6 +509,9 @@ var htmx = (function() {
    * @returns {Document}
    */
   function parseHTML(resp) {
+    if ('parseHTMLUnsafe' in Document) {
+      return Document.parseHTMLUnsafe(resp)
+    }
     const parser = new DOMParser()
     return parser.parseFromString(resp, 'text/html')
   }


### PR DESCRIPTION
## Description
Updates parseHTML to use Document.parseHTMLUnsafe where supported

This allows HTMX to support declarative shadow dom

Corresponding issue: #2682

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
