### PR TITLE
Typo in addEventListener - use evt instead of event

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2512,7 +2512,7 @@ var htmx = (function() {
             }
           }
           if (triggerSpec.changed) {
-            const node = event.target
+            const node = evt.target
             // @ts-ignore value will be undefined for non-input elements, which is fine
             const value = node.value
             const lastValue = elementData.lastValue.get(triggerSpec)


### PR DESCRIPTION
## Description
In `addEventListener`, when the `triggerSpec.changed` if block was entered, `node` was being set to `event.target`. This technically works, but is deprecated and should use `evt.target` instead like the rest of `addEventListener`.

Corresponding issue: https://github.com/bigskysoftware/htmx/issues/3179

## Testing
Smoke test a basic changed trigger flow. `/hello` should get called as expected (meaning that `node`, and thus `node.value` are still getting assigned as expected):

```
<select id="select">
  <option>1</option>
  <option>2</option>
</select>

<div hx-get="/hello" hx-trigger="click changed from:#select"></div>
```

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
