### PR TITLE
Update hx-swap.md

### DIFF
--- a/www/content/attributes/hx-swap.md
+++ b/www/content/attributes/hx-swap.md
@@ -2,7 +2,7 @@
 title = "hx-swap"
 description = """\
   The hx-swap attribute in htmx allows you to specify the 'swap strategy', or how the response will be swapped in \
-  relative to the target of an AJAZ request. The default swap strategy is `innerHTML`."""
+  relative to the target of an AJAX request. The default swap strategy is `innerHTML`."""
 +++
 
 The `hx-swap` attribute allows you to specify how the response will be swapped in relative to the


### PR DESCRIPTION
typo

## Description
just a typo in the documentation, `AJAZ` -> `AJAX`


