### PR TITLE
Feature: add extensionsToIgnore to withExtensions

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3009,15 +3009,17 @@ var htmx = (function() {
 
   /**
    * `withExtensions` locates all active extensions for a provided element, then
-   * executes the provided function using each of the active extensions.  It should
+   * executes the provided function using each of the active extensions. You can filter
+   * the element's extensions by giving it a list of extensions to ignore. It should
    * be called internally at every extendable execution point in htmx.
    *
    * @param {Element} elt
    * @param {(extension:HtmxExtension) => void} toDo
+   * @param {string[]=} extensionsToIgnore
    * @returns void
    */
-  function withExtensions(elt, toDo) {
-    forEach(getExtensions(elt), function(extension) {
+  function withExtensions(elt, toDo, extensionsToIgnore) {
+    forEach(getExtensions(elt, [], extensionsToIgnore), function(extension) {
       try {
         toDo(extension)
       } catch (e) {


### PR DESCRIPTION
## Description
`extensionsToIgnore` has been added to `withExtensions` which allows developers to filter the extensions within the internal api. 

Corresponding issue:
https://github.com/bigskysoftware/htmx-extensions/issues/145

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

I've manually tested it by creating an extension `merge-vals` that modifies the parameters through `encodeParameters`, while being used at the same time with `json-enc-custom` like so

```
...
hx-ext="merge-vals,json-enc-custom"
...
```
the extension implementation:

```js
    encodeParameters: function(xhr, parameters, elt) {
      xhr.overrideMimeType("text/json");

      let mergedVals = api.mergeObjects({}, parameters);

      if (elt.hasAttribute("hx-merge-vals")) {
        ...
        // simplified code
      }

      return JSON.stringify(mergedVals);
    }
```

The issue with this implementation is that htmx will only use the first extension that modifies the parameters, so `json-custom-enc` will never be used 

a simple fix would to manually call the extensions like so 


```js
    encodeParameters: function(xhr, parameters, elt) {
      xhr.overrideMimeType("text/json");

      let mergedVals = api.mergeObjects({}, parameters);

     ...
     // simplified code
     
      api.withExtensions(elt, function(extension) {
        mergedVals = JSON.parse(extension.encodeParameters(xhr, mergedVals, elt))
      })

      return JSON.stringify(mergedVals);
    }
```

Now, a different issue arises, `withExtensions` will get all the specified extensions from the element, including `merge-vals` which will cause an infinity loop

This PR introduces `extensionsToIgnore` into `withExntensions` which fixes this issue without the introduction of a breaking change to the logic of encode parameters

```js
    encodeParameters: function(xhr, parameters, elt) {
      xhr.overrideMimeType("text/json");

      let mergedVals = api.mergeObjects({}, parameters);

     ...
     // simplified code
     
      api.withExtensions(elt, function(extension) {
        mergedVals = JSON.parse(extension.encodeParameters(xhr, mergedVals, elt))
      }, ["merge-vals"])

      return JSON.stringify(mergedVals);
    }
```

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
