### PR TITLE
Remove obsolete npm command + fix links to ws/sse extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## introduction
 
 htmx allows you to access  [AJAX](https://htmx.org/docs#ajax), [CSS Transitions](https://htmx.org/docs#css_transitions),
-[WebSockets](https://htmx.org/docs#websockets) and [Server Sent Events](https://htmx.org/docs#sse)
+[WebSockets](https://htmx.org/extensions/ws/) and [Server Sent Events](https://htmx.org/extensions/sse/)
 directly in HTML, using [attributes](https://htmx.org/reference#attributes), so you can build
 [modern user interfaces](https://htmx.org/examples) with the [simplicity](https://en.wikipedia.org/wiki/HATEOAS) and
 [power](https://www.ics.uci.edu/~fielding/pubs/dissertation/rest_arch_style.htm) of hypertext
@@ -98,8 +98,6 @@ At this point you can modify `/src/htmx.js` to add features, and then add tests 
 
 htmx uses the [mocha](https://mochajs.org/) testing framework, the [chai](https://www.chaijs.com/) assertion framework
 and [sinon](https://sinonjs.org/releases/v9/fake-xhr-and-server/) to mock out AJAX requests.  They are all OK.
-
-You can also run live tests and demo of the WebSockets and Server-Side Events extensions with `npm run ws-tests`
 
 ## haiku
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "types-check": "tsc src/htmx.js --noEmit --checkJs --target es6 --lib dom,dom.iterable",
     "types-generate": "tsc dist/htmx.esm.js --declaration --emitDeclarationOnly --allowJs --outDir dist",
     "test": "npm run lint && npm run types-check && mocha-chrome test/index.html",
-    "ws-tests": "cd ./test/ws-sse && node ./server.js",
     "www": "bash ./scripts/www.sh",
     "sha": "bash ./scripts/sha.sh"
   },


### PR DESCRIPTION
Follow-up to #3052 , when we moved the ws/sse test suite to the extensions repo, we forgot some obsolete links/mentions behind