### PR TITLE
fix: use reportValidity instead of checkValidity in validateElement 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "htmx.org",
-  "version": "2.0.2",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "htmx.org",
-      "version": "2.0.2",
+      "version": "2.0.4",
       "license": "0BSD",
       "devDependencies": {
         "@types/node": "20.0.0",

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3492,7 +3492,7 @@ var htmx = (function() {
     const element = /** @type {HTMLElement & ElementInternals} */ (elt)
     if (element.willValidate) {
       triggerEvent(element, 'htmx:validation:validate')
-      if (!element.checkValidity()) {
+      if (!element.reportValidity()) {
         errors.push({ elt: element, message: element.validationMessage, validity: element.validity })
         triggerEvent(element, 'htmx:validation:failed', { message: element.validationMessage, validity: element.validity })
       }


### PR DESCRIPTION
## Description
Replaced `checkValidity` with `reportValidity` as described here https://github.com/bigskysoftware/htmx/issues/2372#issuecomment-2418842309

Corresponding issue:
https://github.com/bigskysoftware/htmx/issues/2372

## Testing
Tested manually in the scratch demo

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
