### PR TITLE
Fix wording in `changed` modifier description in hx-trigger.md

### DIFF
--- a/www/content/attributes/hx-trigger.md
+++ b/www/content/attributes/hx-trigger.md
@@ -56,7 +56,7 @@ for a global symbol with the name `foo`
 Standard events can also have modifiers that change how they behave.  The modifiers are:
 
 * `once` - the event will only trigger once (e.g. the first click)
-* `changed` - the event will only change if the value of the element has changed. Please pay attention `change` is the name of the event and `changed` is the name of the modifier.
+* `changed` - the event will only fire if the value of the element has changed. Please pay attention `change` is the name of the event and `changed` is the name of the modifier.
 * `delay:<timing declaration>` - a delay will occur before an event triggers a request.  If the event
 is seen again it will reset the delay.
 * `throttle:<timing declaration>` - a throttle will occur after an event triggers a request. If the event


### PR DESCRIPTION
## Description
Update the description of the `changed` event modifier from "the event will only change" to "the event will only fire" to clarify that the modifier controls when the `change` event triggers, improving accuracy and readability. Addresses a potential documentation error.

Fixes #3218

## Testing
N/A

## Checklist

* [x ] I have read the contribution guidelines
* [ x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
