### PR TITLE
Add django-block-fragments to template-fragments essay

### DIFF
--- a/www/content/essays/template-fragments.md
+++ b/www/content/essays/template-fragments.md
@@ -160,6 +160,7 @@ Here are some known implementations of the fragment concept:
   * [chameleon_partials package](https://github.com/mikeckennedy/chameleon_partials)
   * [htmlgenerator](https://github.com/basxsoftwareassociation/htmlgenerator)
   * [django-template-partials](https://pypi.org/project/django-template-partials/) ([repository](https://github.com/carltongibson/django-template-partials))
+  * [django-block-fragments](https://github.com/medihack/django-block-fragments)
 * .NET
   * [Giraffe.ViewEngine.Htmx](https://github.com/bit-badger/Giraffe.Htmx/tree/main/src/ViewEngine.Htmx)
 * Rust


### PR DESCRIPTION
## Description
Add another library to render blocks in Django templates as fragments (@1cg as discussed on Discord).

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
