### PR TITLE
Replace jsDelivr w/ UNPKG

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ directly in HTML, using [attributes](https://htmx.org/reference#attributes), so 
 [modern user interfaces](https://htmx.org/examples) with the [simplicity](https://en.wikipedia.org/wiki/HATEOAS) and
 [power](https://www.ics.uci.edu/~fielding/pubs/dissertation/rest_arch_style.htm) of hypertext
 
-htmx is small ([~14k min.gz'd](https://unpkg.com/htmx.org/dist/)),
+htmx is small ([~14k min.gz'd](https://cdn.jsdelivr.net/npm/htmx.org/dist/)),
 [dependency-free](https://github.com/bigskysoftware/htmx/blob/master/package.json) &
 [extendable](https://htmx.org/extensions)
 
@@ -32,7 +32,7 @@ By removing these arbitrary constraints htmx completes HTML as a
 ## quick start
 
 ```html
-  <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+  <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.4"></script>
   <!-- have a button POST a click via AJAX -->
   <button hx-post="/clicked" hx-swap="outerHTML">
     Click Me

--- a/www/content/_index.md
+++ b/www/content/_index.md
@@ -104,7 +104,7 @@ directly in HTML, using [attributes](@/reference.md#attributes), so you can buil
 [modern user interfaces](@/examples/_index.md) with the [simplicity](https://en.wikipedia.org/wiki/HATEOAS) and
 [power](https://www.ics.uci.edu/~fielding/pubs/dissertation/rest_arch_style.htm) of hypertext
 
-htmx is small ([~14k min.gz'd](https://unpkg.com/htmx.org/dist/)),
+htmx is small ([~14k min.gz'd](https://cdn.jsdelivr.net/npm/htmx.org/dist/)),
 [dependency-free](https://github.com/bigskysoftware/htmx/blob/master/package.json),
 [extendable](https://htmx.org/extensions) & has **reduced** code base sizes by [67% when compared with react](@/essays/a-real-world-react-to-htmx-port.md)
 
@@ -120,7 +120,7 @@ By removing these constraints, htmx completes HTML as a [hypertext](https://en.w
 <h2>quick start</h2>
 
 ```html
-  <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+  <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.4"></script>
   <!-- have a button POST a click via AJAX -->
   <button hx-post="/clicked" hx-swap="outerHTML">
     Click Me

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -117,19 +117,19 @@ If you are migrating to htmx from intercooler.js, please see the [intercooler mi
 Htmx is a dependency-free, browser-oriented javascript library. This means that using it is as simple as adding a `<script>`
 tag to your document head.  There is no need for a build system to use it.
 
-### Via A CDN (e.g. unpkg.com)
+### Via A CDN (e.g. jsDelivr)
 
 The fastest way to get going with htmx is to load it via a CDN. You can simply add this to
 your head tag and get going:
 
 ```html
-<script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
 ```
 
 An unminified version is also available as well:
 
 ```html
-<script src="https://unpkg.com/htmx.org@2.0.4/dist/htmx.js" integrity="sha384-oeUn82QNXPuVkGCkcrInrS1twIxKhkZiFfr2TdiuObZ3n3yIeMiqcRzkIcguaof1" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.4/dist/htmx.js" integrity="sha384-oeUn82QNXPuVkGCkcrInrS1twIxKhkZiFfr2TdiuObZ3n3yIeMiqcRzkIcguaof1" crossorigin="anonymous"></script>
 ```
 
 While the CDN approach is extremely simple, you may want to consider
@@ -139,7 +139,7 @@ While the CDN approach is extremely simple, you may want to consider
 
 The next easiest way to install htmx is to simply copy it into your project.
 
-Download `htmx.min.js` [from unpkg.com](https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js) and add it to the appropriate directory in your project
+Download `htmx.min.js` [from jsDelivr](https://cdn.jsdelivr.net/npm/htmx.org@2.0.4/dist/htmx.min.js) and add it to the appropriate directory in your project
 and include it where necessary with a `<script>` tag:
 
 ```html
@@ -1139,15 +1139,15 @@ You can see all available extensions on the [Extensions](/extensions) page.
 The fastest way to install htmx extensions created by others is to load them via a CDN. Remember to always include the core htmx library before the extensions and [enable the extension](#enabling-extensions). For example, if you would like to use the [response-targets](/extensions/response-targets) extension, you can add this to your head tag:
 ```HTML
 <head>
-    <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/htmx-ext-response-targets@2.0.2" integrity="sha384-T41oglUPvXLGBVyRdZsVRxNWnOOqCynaPubjUVjxhsjFTKrFJGEMm3/0KGmNQ+Pg" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/htmx-ext-response-targets@2.0.2" integrity="sha384-T41oglUPvXLGBVyRdZsVRxNWnOOqCynaPubjUVjxhsjFTKrFJGEMm3/0KGmNQ+Pg" crossorigin="anonymous"></script>
 </head>
 <body hx-ext="extension-name">
     ...
 ```
-An unminified version is also available at `https://unpkg.com/htmx-ext-extension-name/dist/extension-name.js` (replace `extension-name` with the name of the extension).
+An unminified version is also available at `https://cdn.jsdelivr.net/npm/htmx-ext-extension-name/dist/extension-name.js` (replace `extension-name` with the name of the extension).
 
-While the CDN approach is simple, you may want to consider [not using CDNs in production](https://blog.wesleyac.com/posts/why-not-javascript-cdn). The next easiest way to install htmx extensions is to simply copy them into your project. Download the extension from `https://unpkg.com/htmx-ext-extension-name` (replace `extension-name` with the name of the extension) e.g., https://unpkg.com/htmx-ext-response-targets. Then add it to the appropriate directory in your project and include it where necessary with a `<script>` tag.
+While the CDN approach is simple, you may want to consider [not using CDNs in production](https://blog.wesleyac.com/posts/why-not-javascript-cdn). The next easiest way to install htmx extensions is to simply copy them into your project. Download the extension from `https://cdn.jsdelivr.net/npm/htmx-ext-extension-name` (replace `extension-name` with the name of the extension) e.g., https://cdn.jsdelivr.net/npm/htmx-ext-response-targets. Then add it to the appropriate directory in your project and include it where necessary with a `<script>` tag.
 
 For npm-style build systems, you can install htmx extensions via [npm](https://www.npmjs.com/) (replace `extension-name` with the name of the extension):
 ```shell
@@ -1163,7 +1163,7 @@ import `htmx.org`;
 import `htmx-ext-extension-name`; // replace `extension-name` with the name of the extension 
 ```
 
-Note: [Idiomorph](/extensions/idiomorph) does not follow the naming convention of htmx extensions. Use `idiomorph` instead of `htmx-ext-idiomorph`. For example, `https://unpkg.com/idiomorph` or `npm install idiomorph`.
+Note: [Idiomorph](/extensions/idiomorph) does not follow the naming convention of htmx extensions. Use `idiomorph` instead of `htmx-ext-idiomorph`. For example, `https://cdn.jsdelivr.net/npm/idiomorph` or `npm install idiomorph`.
 
 Note: Community extensions hosted outside this repository might have different installation instructions. Please check the corresponding repository for set-up guidance.
 

--- a/www/content/essays/view-transitions.md
+++ b/www/content/essays/view-transitions.md
@@ -88,7 +88,7 @@ Now, that's my kind of API.
 As luck would have it, it's trivial to wrap this API around the regular htmx swapping model, which allows us to
 start exploring View Transitions in htmx, even before it's generally available in HTML! 
 
-And, as of [htmx 1.9.0](https://unpkg.com/htmx.org@1.9.0), you can start experimenting with the API by adding the 
+And, as of [htmx 1.9.0](https://cdn.jsdelivr.net/npm/htmx.org@1.9.0), you can start experimenting with the API by adding the 
 `transition:true` attribute to an [`hx-swap`](/attributes/hx-swap) attribute.
 
 ## A Practical Example

--- a/www/content/examples/modal-custom.md
+++ b/www/content/examples/modal-custom.md
@@ -132,8 +132,8 @@ example.
 }
 ```
 
-<script src="https://unpkg.com/htmx.org"></script>
-<script src="https://unpkg.com/hyperscript.org"></script>
+<script src="https://cdn.jsdelivr.net/npm/htmx.org"></script>
+<script src="https://cdn.jsdelivr.net/npm/hyperscript.org"></script>
 <script type="text/javascript">
 
     //=========================================================================

--- a/www/content/examples/modal-uikit.md
+++ b/www/content/examples/modal-uikit.md
@@ -89,7 +89,7 @@ window.document.getElementById("cancelButton").addEventListener("click", functio
 	@import "https://cdnjs.cloudflare.com/ajax/libs/uikit/3.5.9/css/uikit-core.min.css";
 </style>
 
-<script src="https://unpkg.com/hyperscript.org"></script>
+<script src="https://cdn.jsdelivr.net/npm/hyperscript.org"></script>
 <script>
     //=========================================================================
     // Fake Server Side Code

--- a/www/content/examples/tabs-javascript.md
+++ b/www/content/examples/tabs-javascript.md
@@ -49,7 +49,7 @@ when the content is swapped into the DOM.
 
 <div id="tab-contents" role="tabpanel" hx-get="/tab1" hx-trigger="load"></div>
 
-<script src="https://unpkg.com/hyperscript.org"></script>
+<script src="https://cdn.jsdelivr.net/npm/hyperscript.org"></script>
 <script>
 	onGet("/tab1", function() {
 		return `

--- a/www/content/extensions/head-support.md
+++ b/www/content/extensions/head-support.md
@@ -18,15 +18,15 @@ a feature of the library.  This extension addresses that shortcoming.
 The fastest way to install `head-support` is to load it via a CDN. Remember to always include the core htmx library before the extension and [enable the extension](#usage).
 ```HTML
 <head>
-    <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/htmx-ext-head-support@2.0.2" integrity="sha384-cvMqHzjCJsOHgGuyB3sWXaUSv/Krm0BdzjuI1rtkjCbL1l1oHJx+cHyVRJhyuEz0" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/htmx-ext-head-support@2.0.2" integrity="sha384-cvMqHzjCJsOHgGuyB3sWXaUSv/Krm0BdzjuI1rtkjCbL1l1oHJx+cHyVRJhyuEz0" crossorigin="anonymous"></script>
 </head>
 <body hx-ext="head-support">
 ...
 ```
-An unminified version is also available at https://unpkg.com/htmx-ext-head-support/dist/head-support.js.
+An unminified version is also available at https://cdn.jsdelivr.net/npm/htmx-ext-head-support/dist/head-support.js.
 
-While the CDN approach is simple, you may want to consider [not using CDNs in production](https://blog.wesleyac.com/posts/why-not-javascript-cdn). The next easiest way to install `head-support` is to simply copy it into your project. Download the extension from `https://unpkg.com/htmx-ext-head-support`, add it to the appropriate directory in your project and include it where necessary with a `<script>` tag.
+While the CDN approach is simple, you may want to consider [not using CDNs in production](https://blog.wesleyac.com/posts/why-not-javascript-cdn). The next easiest way to install `head-support` is to simply copy it into your project. Download the extension from `https://cdn.jsdelivr.net/npm/htmx-ext-head-support`, add it to the appropriate directory in your project and include it where necessary with a `<script>` tag.
 
 For npm-style build systems, you can install `head-support` via [npm](https://www.npmjs.com/):
 ```shell

--- a/www/content/extensions/htmx-1-compat.md
+++ b/www/content/extensions/htmx-1-compat.md
@@ -9,15 +9,15 @@ The `htmx-1-compat` extension allows you to almost seamlessly upgrade from htmx 
 The fastest way to install `htmx-1-compat` is to load it via a CDN. Remember to always include the core htmx library before the extension and enable the extension.
 ```HTML
 <head>
-    <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/htmx-ext-htmx-1-compat@2.0.0" integrity="sha384-lcvVWaNjF5zPPUeeWmC0OkJ2MLqoWLlkAabuGm+EuMSTfGo5WRyHrNaAp0cJr9Pg" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/htmx-ext-htmx-1-compat@2.0.0" integrity="sha384-lcvVWaNjF5zPPUeeWmC0OkJ2MLqoWLlkAabuGm+EuMSTfGo5WRyHrNaAp0cJr9Pg" crossorigin="anonymous"></script>
 </head>
 <body hx-ext="htmx-1-compat">
 ...
 ```
-An unminified version is also available at https://unpkg.com/htmx-ext-htmx-1-compat/dist/htmx-1-compat.js.
+An unminified version is also available at https://cdn.jsdelivr.net/npm/htmx-ext-htmx-1-compat/dist/htmx-1-compat.js.
 
-While the CDN approach is simple, you may want to consider [not using CDNs in production](https://blog.wesleyac.com/posts/why-not-javascript-cdn). The next easiest way to install `htmx-1-compat` is to simply copy it into your project. Download the extension from `https://unpkg.com/htmx-ext-htmx-1-compat`, add it to the appropriate directory in your project and include it where necessary with a `<script>` tag.
+While the CDN approach is simple, you may want to consider [not using CDNs in production](https://blog.wesleyac.com/posts/why-not-javascript-cdn). The next easiest way to install `htmx-1-compat` is to simply copy it into your project. Download the extension from `https://cdn.jsdelivr.net/npm/htmx-ext-htmx-1-compat`, add it to the appropriate directory in your project and include it where necessary with a `<script>` tag.
 
 For npm-style build systems, you can install `htmx-1-compat` via [npm](https://www.npmjs.com/):
 ```shell

--- a/www/content/extensions/idiomorph.md
+++ b/www/content/extensions/idiomorph.md
@@ -15,14 +15,14 @@ extension.
 The fastest way to install `idiomorph` is to load it via a CDN. Remember to always include the core htmx library before the extension and [enable the extension](#usage).
 ```HTML
 <head>
-    <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/idiomorph@0.3.0" integrity="sha384-tg/2Ca9U/RohyxmGCb8qJVR3j9cswtKbdRSXOaPX/aDDOW1bfbeyV+7G9ifYF4bC" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/idiomorph@0.3.0" integrity="sha384-tg/2Ca9U/RohyxmGCb8qJVR3j9cswtKbdRSXOaPX/aDDOW1bfbeyV+7G9ifYF4bC" crossorigin="anonymous"></script>
 </head>
 <body hx-ext="morph">
 ```
-An unminified version is also available at https://unpkg.com/idiomorph/dist/idiomorph.js.
+An unminified version is also available at https://cdn.jsdelivr.net/npm/idiomorph/dist/idiomorph.js.
 
-While the CDN approach is simple, you may want to consider [not using CDNs in production](https://blog.wesleyac.com/posts/why-not-javascript-cdn). The next easiest way to install `idiomorph` is to simply copy it into your project. Download the extension from `https://unpkg.com/idiomorph`, add it to the appropriate directory in your project and include it where necessary with a `<script>` tag.
+While the CDN approach is simple, you may want to consider [not using CDNs in production](https://blog.wesleyac.com/posts/why-not-javascript-cdn). The next easiest way to install `idiomorph` is to simply copy it into your project. Download the extension from `https://cdn.jsdelivr.net/npm/idiomorph`, add it to the appropriate directory in your project and include it where necessary with a `<script>` tag.
 
 For npm-style build systems, you can install `idiomorph` via [npm](https://www.npmjs.com/):
 ```shell

--- a/www/content/extensions/preload.md
+++ b/www/content/extensions/preload.md
@@ -15,15 +15,15 @@ unused requests. Use this extension carefully!
 The fastest way to install `preload` is to load it via a CDN. Remember to always include the core htmx library before the extension and [enable the extension](#usage).
 ```HTML
 <head>
-    <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/htmx-ext-preload@2.1.0" integrity="sha384-fkzubQiTB69M7XTToqW6tplvxAOJkqPl5JmLAbumV2EacmuJb8xEP9KnJafk/rg8" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/htmx-ext-preload@2.1.0" integrity="sha384-fkzubQiTB69M7XTToqW6tplvxAOJkqPl5JmLAbumV2EacmuJb8xEP9KnJafk/rg8" crossorigin="anonymous"></script>
 </head>
 <body hx-ext="preload">
 ...
 ```
-An unminified version is also available at https://unpkg.com/htmx-ext-preload/dist/preload.js.
+An unminified version is also available at https://cdn.jsdelivr.net/npm/htmx-ext-preload/dist/preload.js.
 
-While the CDN approach is simple, you may want to consider [not using CDNs in production](https://blog.wesleyac.com/posts/why-not-javascript-cdn). The next easiest way to install `preload` is to simply copy it into your project. Download the extension from `https://unpkg.com/htmx-ext-preload`, add it to the appropriate directory in your project and include it where necessary with a `<script>` tag.
+While the CDN approach is simple, you may want to consider [not using CDNs in production](https://blog.wesleyac.com/posts/why-not-javascript-cdn). The next easiest way to install `preload` is to simply copy it into your project. Download the extension from `https://cdn.jsdelivr.net/npm/htmx-ext-preload`, add it to the appropriate directory in your project and include it where necessary with a `<script>` tag.
 
 For npm-style build systems, you can install `preload` via [npm](https://www.npmjs.com/):
 ```shell

--- a/www/content/extensions/response-targets.md
+++ b/www/content/extensions/response-targets.md
@@ -27,15 +27,15 @@ The value of each attribute can be:
 The fastest way to install `response-targets` is to load it via a CDN. Remember to always include the core htmx library before the extension and [enable the extension](#usage).
 ```HTML
 <head>
-    <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/htmx-ext-response-targets@2.0.2" integrity="sha384-T41oglUPvXLGBVyRdZsVRxNWnOOqCynaPubjUVjxhsjFTKrFJGEMm3/0KGmNQ+Pg" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/htmx-ext-response-targets@2.0.2" integrity="sha384-T41oglUPvXLGBVyRdZsVRxNWnOOqCynaPubjUVjxhsjFTKrFJGEMm3/0KGmNQ+Pg" crossorigin="anonymous"></script>
 </head>
 <body hx-ext="response-targets">
 ...
 ```
-An unminified version is also available at https://unpkg.com/htmx-ext-response-targets/dist/response-targets.js.
+An unminified version is also available at https://cdn.jsdelivr.net/npm/htmx-ext-response-targets/dist/response-targets.js.
 
-While the CDN approach is simple, you may want to consider [not using CDNs in production](https://blog.wesleyac.com/posts/why-not-javascript-cdn). The next easiest way to install `response-targets` is to simply copy it into your project. Download the extension from `https://unpkg.com/htmx-ext-response-targets`, add it to the appropriate directory in your project and include it where necessary with a `<script>` tag.
+While the CDN approach is simple, you may want to consider [not using CDNs in production](https://blog.wesleyac.com/posts/why-not-javascript-cdn). The next easiest way to install `response-targets` is to simply copy it into your project. Download the extension from `https://cdn.jsdelivr.net/npm/htmx-ext-response-targets`, add it to the appropriate directory in your project and include it where necessary with a `<script>` tag.
 
 For npm-style build systems, you can install `response-targets` via [npm](https://www.npmjs.com/):
 ```shell

--- a/www/content/extensions/sse.md
+++ b/www/content/extensions/sse.md
@@ -29,14 +29,14 @@ Use the following attributes to configure how SSE connections behave:
 The fastest way to install `sse` is to load it via a CDN. Remember to always include the core htmx library before the extension and [enable the extension](#usage).
 ```HTML
 <head>
-    <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/htmx-ext-sse@2.2.2" integrity="sha384-Y4gc0CK6Kg+hmulDc6rZPJu0tqvk7EWlih0Oh+2OkAi1ZDlCbBDCQEE2uVk472Ky" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/htmx-ext-sse@2.2.2" integrity="sha384-Y4gc0CK6Kg+hmulDc6rZPJu0tqvk7EWlih0Oh+2OkAi1ZDlCbBDCQEE2uVk472Ky" crossorigin="anonymous"></script>
 </head>
 <body hx-ext="sse">
 ```
-An unminified version is also available at https://unpkg.com/htmx-ext-sse/dist/sse.js.
+An unminified version is also available at https://cdn.jsdelivr.net/npm/htmx-ext-sse/dist/sse.js.
 
-While the CDN approach is simple, you may want to consider [not using CDNs in production](https://blog.wesleyac.com/posts/why-not-javascript-cdn). The next easiest way to install `sse` is to simply copy it into your project. Download the extension from `https://unpkg.com/htmx-ext-sse`, add it to the appropriate directory in your project and include it where necessary with a `<script>` tag.
+While the CDN approach is simple, you may want to consider [not using CDNs in production](https://blog.wesleyac.com/posts/why-not-javascript-cdn). The next easiest way to install `sse` is to simply copy it into your project. Download the extension from `https://cdn.jsdelivr.net/npm/htmx-ext-sse`, add it to the appropriate directory in your project and include it where necessary with a `<script>` tag.
 
 For npm-style build systems, you can install `sse` via [npm](https://www.npmjs.com/):
 ```shell

--- a/www/content/extensions/ws.md
+++ b/www/content/extensions/ws.md
@@ -23,14 +23,14 @@ Use the following attributes to configure how WebSockets behave:
 The fastest way to install `ws` is to load it via a CDN. Remember to always include the core htmx library before the extension and [enable the extension](#usage).
 ```HTML
 <head>
-    <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/htmx-ext-ws@2.0.2" integrity="sha384-vuKxTKv5TX/b3lLzDKP2U363sOAoRo5wSvzzc3LJsbaQRSBSS+3rKKHcOx5J8doU" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/htmx-ext-ws@2.0.2" integrity="sha384-vuKxTKv5TX/b3lLzDKP2U363sOAoRo5wSvzzc3LJsbaQRSBSS+3rKKHcOx5J8doU" crossorigin="anonymous"></script>
 </head>
 <body hx-ext="ws">
 ```
-An unminified version is also available at https://unpkg.com/htmx-ext-ws/dist/ws.js.
+An unminified version is also available at https://cdn.jsdelivr.net/npm/htmx-ext-ws/dist/ws.js.
 
-While the CDN approach is simple, you may want to consider [not using CDNs in production](https://blog.wesleyac.com/posts/why-not-javascript-cdn). The next easiest way to install `ws` is to simply copy it into your project. Download the extension from `https://unpkg.com/htmx-ext-ws`, add it to the appropriate directory in your project and include it where necessary with a `<script>` tag.
+While the CDN approach is simple, you may want to consider [not using CDNs in production](https://blog.wesleyac.com/posts/why-not-javascript-cdn). The next easiest way to install `ws` is to simply copy it into your project. Download the extension from `https://cdn.jsdelivr.net/npm/htmx-ext-ws`, add it to the appropriate directory in your project and include it where necessary with a `<script>` tag.
 
 For npm-style build systems, you can install `ws` via [npm](https://www.npmjs.com/):
 ```shell

--- a/www/content/posts/2020-10-27-htmx-0.3.0-is-released.md
+++ b/www/content/posts/2020-10-27-htmx-0.3.0-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 0.3.0 Release
 
-I'm pleased to announce the [0.3 release](https://unpkg.com/browse/htmx.org@0.3.0/) of htmx.  Due to a big testing
+I'm pleased to announce the [0.3 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@0.3.0/) of htmx.  Due to a big testing
 push I'm happy to say that htmx now has **98.4%** test coverage.
 
 That said, this release involves some major surgery on trigger parsing, in particular, so please try it out and let

--- a/www/content/posts/2020-11-16-htmx-0.4.0-is-released.md
+++ b/www/content/posts/2020-11-16-htmx-0.4.0-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 0.4.0 Release
 
-I'm pleased to announce the [0.4 release](https://unpkg.com/browse/htmx.org@0.4.0/) of htmx.
+I'm pleased to announce the [0.4 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@0.4.0/) of htmx.
 
 ### Changes
 

--- a/www/content/posts/2020-11-24-htmx-1.0.0-is-released.md
+++ b/www/content/posts/2020-11-24-htmx-1.0.0-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 1.0.0 Release
 
-I'm happy to announce the [1.0.0 release](https://unpkg.com/browse/htmx.org@1.0.0/) of htmx.
+I'm happy to announce the [1.0.0 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@1.0.0/) of htmx.
 
 htmx is now mature enough that I can recommend it as a general replacement for intercooler.js
 projects.  I **don't** think there is a strong reason to port an existing intercooler project to

--- a/www/content/posts/2020-5-15-kutty-0.0.1-is-released.md
+++ b/www/content/posts/2020-5-15-kutty-0.0.1-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## Kutty 0.0.1 Release
 
-I'm pleased to announce the [0.0.1 release](https://unpkg.com/browse/kutty.org@0.0.1/) of kutty, the successor
+I'm pleased to announce the [0.0.1 release](https://cdn.jsdelivr.net/npm/browse/kutty.org@0.0.1/) of kutty, the successor
 to [intercooler.js](http://intercoolerjs.org)!
 
 Like intercooler, kutty brings features of modern browsers that normally require javascript (AJAX, CSS transitions, etc.) 

--- a/www/content/posts/2020-5-17-kutty-er-htmx-0.0.3-is-released.md
+++ b/www/content/posts/2020-5-17-kutty-er-htmx-0.0.3-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 0.0.3 Release
 
-I'm pleased to announce the [0.0.3 release](https://unpkg.com/browse/htmx.org@0.0.3/) of kutty, er, htmx, the successor
+I'm pleased to announce the [0.0.3 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@0.0.3/) of kutty, er, htmx, the successor
 to [intercooler.js](http://intercoolerjs.org)!
 
 #### Why not kutty 0.0.2?

--- a/www/content/posts/2020-5-24-htmx-0.0.4-is-released.md
+++ b/www/content/posts/2020-5-24-htmx-0.0.4-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 0.0.4 Release
 
-I'm pleased to announce the [0.0.4 release](https://unpkg.com/browse/htmx.org@0.0.4/) of htmx, this time with no 
+I'm pleased to announce the [0.0.4 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@0.0.4/) of htmx, this time with no 
 project renaming.
 
 #### Changes

--- a/www/content/posts/2020-6-20-htmx-0.0.6-is-released.md
+++ b/www/content/posts/2020-6-20-htmx-0.0.6-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 0.0.6 Release
 
-I'm pleased to announce the [0.0.6 release](https://unpkg.com/browse/htmx.org@0.0.6/) of htmx.
+I'm pleased to announce the [0.0.6 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@0.0.6/) of htmx.
 
 ### Changes
 

--- a/www/content/posts/2020-6-30-htmx-0.0.7-is-released.md
+++ b/www/content/posts/2020-6-30-htmx-0.0.7-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 0.0.7 Release
 
-I'm pleased to announce the [0.0.7 release](https://unpkg.com/browse/htmx.org@0.0.7/) of htmx.
+I'm pleased to announce the [0.0.7 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@0.0.7/) of htmx.
 
 ### Changes
 

--- a/www/content/posts/2020-7-8-htmx-0.0.8-is-released.md
+++ b/www/content/posts/2020-7-8-htmx-0.0.8-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 0.0.8 Release
 
-I'm pleased to announce the [0.0.8 release](https://unpkg.com/browse/htmx.org@0.0.8/) of htmx.
+I'm pleased to announce the [0.0.8 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@0.0.8/) of htmx.
 
 ### Changes
 

--- a/www/content/posts/2020-9-18-htmx-0.1.0-is-released.md
+++ b/www/content/posts/2020-9-18-htmx-0.1.0-is-released.md
@@ -7,8 +7,8 @@ tag = ["posts", "announcements"]
 
 ## htmx 0.1.2 Release
 
-I'm pleased to announce the [0.1.2 release](https://unpkg.com/browse/htmx.org@0.1.2/) of htmx as well as the first non-alpha hyperscript
-release [0.0.2 hyperscript](https://unpkg.com/hyperscript.org@0.0.2).
+I'm pleased to announce the [0.1.2 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@0.1.2/) of htmx as well as the first non-alpha hyperscript
+release [0.0.2 hyperscript](https://cdn.jsdelivr.net/npm/hyperscript.org@0.0.2).
 
 ### Changes
 

--- a/www/content/posts/2020-9-30-htmx-0.2.0-is-released.md
+++ b/www/content/posts/2020-9-30-htmx-0.2.0-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 0.2.0 Release
 
-I'm pleased to announce the [0.2 release](https://unpkg.com/browse/htmx.org@0.2.0/) of htmx
+I'm pleased to announce the [0.2 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@0.2.0/) of htmx
 
 ### Changes
 

--- a/www/content/posts/2021-1-6-htmx-1.1.0-is-released.md
+++ b/www/content/posts/2021-1-6-htmx-1.1.0-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 1.1.0 Release
 
-I'm happy to announce the [1.1.0 release](https://unpkg.com/browse/htmx.org@1.1.0/) of htmx.
+I'm happy to announce the [1.1.0 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@1.1.0/) of htmx.
 
 This is a surprisingly big release, but the star of the show isn't htmx itself, but rather the new 
 [preload extension](https://github.com/bigskysoftware/htmx-extensions/blob/main/src/preload/README.md) which allows you to preload requests into the cache,

--- a/www/content/posts/2021-10-02-htmx-1.6.0-is-released.md
+++ b/www/content/posts/2021-10-02-htmx-1.6.0-is-released.md
@@ -6,7 +6,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 1.6.0 Release
 
-I'm happy to announce the [1.6.0 release](https://unpkg.com/browse/htmx.org@1.6.0/) of htmx.
+I'm happy to announce the [1.6.0 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@1.6.0/) of htmx.
 
 ### New Features & Major Changes
 

--- a/www/content/posts/2021-11-22-htmx-1.6.1-is-released.md
+++ b/www/content/posts/2021-11-22-htmx-1.6.1-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 1.6.1 Release
 
-I'm happy to announce the [1.6.1 release](https://unpkg.com/browse/htmx.org@1.6.1/) of htmx.
+I'm happy to announce the [1.6.1 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@1.6.1/) of htmx.
 
 ### New Features
 

--- a/www/content/posts/2021-2-13-htmx-1.2.0-is-released.md
+++ b/www/content/posts/2021-2-13-htmx-1.2.0-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 1.2.0 Release
 
-I'm happy to announce the [1.2.0 release](https://unpkg.com/browse/htmx.org@1.2.0/) of htmx.
+I'm happy to announce the [1.2.0 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@1.2.0/) of htmx.
 
 ### New Features & Major Changes
 

--- a/www/content/posts/2021-3-6-htmx-1.3.0-is-released.md
+++ b/www/content/posts/2021-3-6-htmx-1.3.0-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 1.3.0 Release
 
-I'm happy to announce the [1.3.0 release](https://unpkg.com/browse/htmx.org@1.3.0/) of htmx.
+I'm happy to announce the [1.3.0 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@1.3.0/) of htmx.
 
 ### New Features & Major Changes
 

--- a/www/content/posts/2021-5-25-htmx-1.4.0-is-released.md
+++ b/www/content/posts/2021-5-25-htmx-1.4.0-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 1.4.0 Release
 
-I'm happy to announce the [1.4.0 release](https://unpkg.com/browse/htmx.org@1.4.0/) of htmx.
+I'm happy to announce the [1.4.0 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@1.4.0/) of htmx.
 
 ### New Features & Major Changes
 

--- a/www/content/posts/2021-7-12-htmx-1.5.0-is-released.md
+++ b/www/content/posts/2021-7-12-htmx-1.5.0-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 1.5.0 Release
 
-I'm happy to announce the [1.5.0 release](https://unpkg.com/browse/htmx.org@1.5.0/) of htmx.
+I'm happy to announce the [1.5.0 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@1.5.0/) of htmx.
 
 ### New Features & Major Changes
 

--- a/www/content/posts/2022-02-22-htmx-1.7.0-is-released.md
+++ b/www/content/posts/2022-02-22-htmx-1.7.0-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 1.7.0 Release
 
-I'm happy to announce the [1.7.0 release](https://unpkg.com/browse/htmx.org@1.7.0/) of htmx.
+I'm happy to announce the [1.7.0 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@1.7.0/) of htmx.
 
 ### New Features
 

--- a/www/content/posts/2022-07-12-htmx-1.8.0-is-released.md
+++ b/www/content/posts/2022-07-12-htmx-1.8.0-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 1.8.0 Release
 
-I'm happy to announce the [1.8.0 release](https://unpkg.com/browse/htmx.org@1.8.0/) of htmx.
+I'm happy to announce the [1.8.0 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@1.8.0/) of htmx.
 
 **NOTE:**  This was a big release with some changes to very touchy code that is hard to test (e.g. history support) so
 please test thoroughly and let us know if there are any issues.

--- a/www/content/posts/2022-10-11-htmx-1.8.1-is-released.md
+++ b/www/content/posts/2022-10-11-htmx-1.8.1-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 1.8.1 Release
 
-I'm happy to announce the [1.8.1 release](https://unpkg.com/browse/htmx.org@1.8.1/) of htmx.
+I'm happy to announce the [1.8.1 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@1.8.1/) of htmx.
 
 ### New Features
 

--- a/www/content/posts/2022-11-04-htmx-1.8.3-is-released.md
+++ b/www/content/posts/2022-11-04-htmx-1.8.3-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 1.8.3 Release
 
-I'm happy to announce the [1.8.3 release](https://unpkg.com/browse/htmx.org@1.8.3/) of htmx.
+I'm happy to announce the [1.8.3 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@1.8.3/) of htmx.
 
 ### New Features
 

--- a/www/content/posts/2023-01-17-htmx-1.8.5-is-released.md
+++ b/www/content/posts/2023-01-17-htmx-1.8.5-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 1.8.5 Release
 
-I'm happy to announce the [1.8.5 release](https://unpkg.com/browse/htmx.org@1.8.5/) of htmx.
+I'm happy to announce the [1.8.5 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@1.8.5/) of htmx.
 
 ### New Features
 

--- a/www/content/posts/2023-03-02-htmx-1.8.6-is-released.md
+++ b/www/content/posts/2023-03-02-htmx-1.8.6-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 1.8.6 Release
 
-I'm happy to announce the [1.8.6 release](https://unpkg.com/browse/htmx.org@1.8.6/) of htmx.
+I'm happy to announce the [1.8.6 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@1.8.6/) of htmx.
 
 ### New Features
 

--- a/www/content/posts/2023-04-11-htmx-1.9.0-is-released.md
+++ b/www/content/posts/2023-04-11-htmx-1.9.0-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 1.9.0 Release
 
-I'm happy to announce the [1.9.0 release](https://unpkg.com/browse/htmx.org@1.9.0/) of htmx.
+I'm happy to announce the [1.9.0 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@1.9.0/) of htmx.
 
 ### New Features
 

--- a/www/content/posts/2023-07-14-htmx-1.9.3-is-released.md
+++ b/www/content/posts/2023-07-14-htmx-1.9.3-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 1.9.3 Release
 
-I'm happy to announce the [1.9.3 release](https://unpkg.com/browse/htmx.org@1.9.3/) of htmx.
+I'm happy to announce the [1.9.3 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@1.9.3/) of htmx.
 
 ### New Features
 

--- a/www/content/posts/2023-08-25-htmx-1.9.5-is-released.md
+++ b/www/content/posts/2023-08-25-htmx-1.9.5-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 1.9.5 Release
 
-I'm happy to announce the [1.9.5 release](https://unpkg.com/browse/htmx.org@1.9.5/) of htmx.
+I'm happy to announce the [1.9.5 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@1.9.5/) of htmx.
 
 ### New Features
 

--- a/www/content/posts/2023-09-22-htmx-1.9.6-is-released.md
+++ b/www/content/posts/2023-09-22-htmx-1.9.6-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 1.9.6 Release
 
-I'm happy to announce the [1.9.6 release](https://unpkg.com/browse/htmx.org@1.9.6/) of htmx.
+I'm happy to announce the [1.9.6 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@1.9.6/) of htmx.
 
 ### New Features
 

--- a/www/content/posts/2023-11-03-htmx-1.9.7-is-released.md
+++ b/www/content/posts/2023-11-03-htmx-1.9.7-is-released.md
@@ -7,7 +7,7 @@ tag = ["posts", "announcements"]
 
 ## htmx 1.9.7 Release
 
-I'm happy to announce the [1.9.7 release](https://unpkg.com/browse/htmx.org@1.9.7/) of htmx.
+I'm happy to announce the [1.9.7 release](https://cdn.jsdelivr.net/npm/browse/htmx.org@1.9.7/) of htmx.
 
 ### Improvements & Bug fixes
 

--- a/www/content/posts/2024-01-26-htmx-2.0.0-alpha1-is-released.md
+++ b/www/content/posts/2024-01-26-htmx-2.0.0-alpha1-is-released.md
@@ -33,10 +33,10 @@ Note that htmx 2.x will no longer be IE compatible, but 1.x will continue to be 
 The alpha can be installed via a package manager referencing version `2.0.0-alpha1`, or can be linked via a CDN:
 
 ```html
-<script src="https://unpkg.com/htmx.org@2.0.0-alpha1/dist/htmx.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.0-alpha1/dist/htmx.min.js"></script>
 ```
 
-or <a href="https://unpkg.com/htmx.org@2.0.0-alpha1/dist/htmx.min.js" download>Downloaded</a>
+or <a href="https://cdn.jsdelivr.net/npm/htmx.org@2.0.0-alpha1/dist/htmx.min.js" download>Downloaded</a>
 
 ### Extensions
 

--- a/www/content/posts/2024-02-09-htmx-2.0.0-alpha2-is-released.md
+++ b/www/content/posts/2024-02-09-htmx-2.0.0-alpha2-is-released.md
@@ -31,10 +31,10 @@ Note that htmx 2.x will no longer be IE compatible, but 1.x will continue to be 
 The alpha can be installed via a package manager referencing version `2.0.0-alpha2`, or can be linked via a CDN:
 
 ```html
-<script src="https://unpkg.com/htmx.org@2.0.0-alpha2/dist/htmx.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.0-alpha2/dist/htmx.min.js"></script>
 ```
 
-or <a href="https://unpkg.com/htmx.org@2.0.0-alpha1/dist/htmx.min.js" download>Downloaded</a>
+or <a href="https://cdn.jsdelivr.net/npm/htmx.org@2.0.0-alpha1/dist/htmx.min.js" download>Downloaded</a>
 
 ### Extensions
 

--- a/www/content/posts/2024-03-15-htmx-2.0.0-beta1-is-released.md
+++ b/www/content/posts/2024-03-15-htmx-2.0.0-beta1-is-released.md
@@ -31,10 +31,10 @@ Note that htmx 2.x will no longer be IE compatible, but 1.x will continue to be 
 The beta can be installed via a package manager referencing version `2.0.0-beta1`, or can be linked via a CDN:
 
 ```html
-<script src="https://unpkg.com/htmx.org@2.0.0-beta1/dist/htmx.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.0-beta1/dist/htmx.min.js"></script>
 ```
 
-or <a href="https://unpkg.com/htmx.org@2.0.0-beta1/dist/htmx.min.js" download>Downloaded</a>
+or <a href="https://cdn.jsdelivr.net/npm/htmx.org@2.0.0-beta1/dist/htmx.min.js" download>Downloaded</a>
 
 ### Extensions
 

--- a/www/content/posts/2024-04-22-htmx-2.0.0-beta4-is-released.md
+++ b/www/content/posts/2024-04-22-htmx-2.0.0-beta4-is-released.md
@@ -31,10 +31,10 @@ Note that htmx 2.x will no longer be IE compatible, but 1.x will continue to be 
 The beta can be installed via a package manager referencing version `2.0.0-beta4`, or can be linked via a CDN:
 
 ```html
-<script src="https://unpkg.com/htmx.org@2.0.0-beta4/dist/htmx.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.0-beta4/dist/htmx.min.js"></script>
 ```
 
-or <a href="https://unpkg.com/htmx.org@2.0.0-beta4/dist/htmx.min.js" download>Downloaded</a>
+or <a href="https://cdn.jsdelivr.net/npm/htmx.org@2.0.0-beta4/dist/htmx.min.js" download>Downloaded</a>
 
 ### Extensions
 

--- a/www/content/posts/2024-06-17-htmx-2.0.0-is-released.md
+++ b/www/content/posts/2024-06-17-htmx-2.0.0-is-released.md
@@ -59,7 +59,7 @@ If you require IE compatibility, the [1.x](https://v1.htmx.org) will continue to
 htmx 2.0 can be installed via a package manager referencing version `2.0.0`, or can be linked via a CDN:
 
 ```html
-<script src="https://unpkg.com/htmx.org@2.0.0/dist/htmx.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.0/dist/htmx.min.js"></script>
 ```
 
-or <a href="https://unpkg.com/htmx.org@2.0.0/dist/htmx.min.js" download>Downloaded</a>
+or <a href="https://cdn.jsdelivr.net/npm/htmx.org@2.0.0/dist/htmx.min.js" download>Downloaded</a>

--- a/www/static/js/demo/it.js
+++ b/www/static/js/demo/it.js
@@ -82,8 +82,8 @@
             });
 
             log('demo:htmx-loading', "loading htmx & hyperscript...")
-            addScript("https://unpkg.com/htmx.org");
-            addScript("https://unpkg.com/hyperscript.org");
+            addScript("https://cdn.jsdelivr.net/npm/htmx.org");
+            addScript("https://cdn.jsdelivr.net/npm/hyperscript.org");
             initHtmxAndHyperscript();
         }
     }
@@ -91,7 +91,7 @@
     document.addEventListener('DOMContentLoaded', function () {
         disableThings();
         log('demo:mock-request-loading', "loading mock-request library...")
-        addScript("https://unpkg.com/mock-requests@1.3.2/index.js");
+        addScript("https://cdn.jsdelivr.net/npm/mock-requests@1.3.2/index.js");
         initMockRequests();
     }, false);
 })();

--- a/www/templates/demo.html
+++ b/www/templates/demo.html
@@ -19,7 +19,7 @@
     {% set show_title = true %}
   {% endif %}
   {% if show_title %}<h1>{{ page.title | safe }}</h1>{% endif %}
-  <script src="https://unpkg.com/sinon@9.0.2/pkg/sinon.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/sinon@9.0.2/pkg/sinon.js"></script>
   <script src="/js/demo.js"></script>
   {{ page.content | safe }}
 {% endblock content %}


### PR DESCRIPTION
## Description

UNPKG has not been actively maintained and has been down since `Mar 15, 2025` (https://github.com/unpkg/unpkg/issues/412).

The PR replaces UNPKG usage with jsDelivr in the following places:

- Docs
- Previous blog articles
- Demo and Templates

The unpkg.com usage inside the test cases are not replaced/modified.

## Testing

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
