### PR TITLE
Fix JSDoc of getRespCodeTarget

### DIFF
--- a/dist/ext/response-targets.js
+++ b/dist/ext/response-targets.js
@@ -17,7 +17,7 @@
 
     /**
      * @param {HTMLElement} elt
-     * @param {number} respCode
+     * @param {number} respCodeNumber
      * @returns {HTMLElement | null}
      */
     function getRespCodeTarget(elt, respCodeNumber) {


### PR DESCRIPTION
## Description

> Parameter respCode described in JSDoc does not appear in function signature

Corresponding issue: —
 
## Testing

—

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
