### PR TITLE
Fix broken link in SSE extension docs

### DIFF
--- a/www/content/extensions/sse.md
+++ b/www/content/extensions/sse.md
@@ -10,7 +10,7 @@ your htmx webpage in real-time.
 SSE is a lightweight alternative to WebSockets that works over existing HTTP connections, so it is easy to use through
 proxy servers and firewalls. Remember, SSE is a uni-directional service, so you cannot send any messages to an SSE
 server once the connection has been established. If you need bi-directional communication, then you should consider
-using [WebSockets](@web-sockets.md) instead.
+using [WebSockets](@/extensions/ws.md) instead.
 
 This extension replaces the experimental `hx-sse` attribute built into previous versions of htmx. For help migrating
 from older versions, see the migration guide at the bottom of this page.


### PR DESCRIPTION
## Description
Fix 404 for link to WS extension from SSE extension. Now behaves the same as V1 docs.

Corresponding issue: #3238

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
