### PR TITLE
Documentation update for hx-trigger

### DIFF
--- a/www/content/attributes/hx-trigger.md
+++ b/www/content/attributes/hx-trigger.md
@@ -86,12 +86,12 @@ but with a target filter for a child element
   * `all` - queue all events (issue a request for each event)
   * `none` - do not queue new events
 
-Here is an example of a search box that searches on `keyup`, but only if the search value has changed
+Here is an example of a search box that searches on `input`, but only if the search value has changed
 and the user hasn't typed anything new for 1 second:
 
 ```html
 <input name="q"
-       hx-get="/search" hx-trigger="keyup changed delay:1s"
+       hx-get="/search" hx-trigger="input changed delay:1s"
        hx-target="#search-results"/>
 ```
 


### PR DESCRIPTION
## Description
Based upon a discussion in Discord.

Users tend to copy from the docs, so update the `hx-trigger` example to use the `input` event rather than `keyup`, since that will also react to other activity such as via a mouse (e.g. drag to select text, right click and cut). 

## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
