### PR TITLE
Documentation update for hx-select-oob

### DIFF
--- a/www/content/attributes/hx-select-oob.md
+++ b/www/content/attributes/hx-select-oob.md
@@ -28,7 +28,7 @@ which will replace the entire button in the DOM, and, in addition, pick out an e
 in the response and swap it in for div in the DOM with the same ID.
 
 Each value in the comma separated list of values can specify any valid [`hx-swap`](@/attributes/hx-swap.md)
-strategy by separating the selector and the swap strategy with a `:`.
+strategy by separating the selector and the swap strategy with a `:`, with the strategy otherwise defaulting to `outerHTML`.
 
 For example, to prepend the alert content instead of replacing it:
 


### PR DESCRIPTION
## Description
Mention in the docs that the default swap strategy for [`hx-select-oob`](https://htmx.org/attributes/hx-select-oob/) is `outerHTML`.


## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
