### PR TITLE
Adding Raku / Cro Templates to Fragments list

### DIFF
--- a/www/content/essays/template-fragments.md
+++ b/www/content/essays/template-fragments.md
@@ -165,5 +165,7 @@ Here are some known implementations of the fragment concept:
   * [Giraffe.ViewEngine.Htmx](https://github.com/bit-badger/Giraffe.Htmx/tree/main/src/ViewEngine.Htmx)
 * Rust
   * [MiniJinja](https://docs.rs/minijinja/latest/minijinja/struct.State.html#method.render_block)
+* Raku
+  * [Cro Templates](https://github.com/croservices/cro-website/blob/main/docs/reference/cro-webapp-template-syntax.md#fragments)
 
 Please [let me know](/discord) if you know of others, so I can add them to this list.


### PR DESCRIPTION
## Description

[17:31]librasteve: hello, we recently added fragment to the Raku Cro Templates (as inspired by HTMX LOB) and I thought you may like to add to the list of fragments at https://htmx.org/essays/template-fragments/, something like Raku / Cro Template (https://github.com/croservices/cro-website/blob/main/docs/reference/cro-webapp-template-syntax.md#fragments) ~librasteve
[18:15]1cg: Hi there
[18:16]1cg: That looks great, yes, can you create a PR here w/ a link to that page: https://github.com/bigskysoftware/htmx/blob/master/www/content/essays/template-fragments.md
[18:16]1cg: and then send me a link to the PR and I'll integrate it
[19:17]librasteve: cool - will do

Corresponding issue:
n/a

## Testing
n/a

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
