### PR TITLE
Remove old IE support

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2879,7 +2879,7 @@ var htmx = (function() {
       return
     }
     // Ensure only valid Elements and not shadow DOM roots are inited
-    if (elt instanceof Element) return
+    if (!(elt instanceof Element)) return
     const nodeData = getInternalData(elt)
     const attrHash = attributeHash(elt)
     if (nodeData.initHash !== attrHash) {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -828,7 +828,7 @@ var htmx = (function() {
       path = url.pathname + url.search
     }
     // remove trailing slash, unless index page
-    if (!(/^\/$/.test(path))) {
+    if (path != '/') {
       path = path.replace(/\/+$/, '')
     }
     return path

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2879,41 +2879,40 @@ var htmx = (function() {
       return
     }
     // Ensure only valid Elements and not shadow DOM roots are inited
-    if (elt instanceof Element) {
-      const nodeData = getInternalData(elt)
-      const attrHash = attributeHash(elt)
-      if (nodeData.initHash !== attrHash) {
-        // clean up any previously processed info
-        deInitNode(elt)
+    if (elt instanceof Element) return
+    const nodeData = getInternalData(elt)
+    const attrHash = attributeHash(elt)
+    if (nodeData.initHash !== attrHash) {
+      // clean up any previously processed info
+      deInitNode(elt)
 
-        nodeData.initHash = attrHash
+      nodeData.initHash = attrHash
 
-        triggerEvent(elt, 'htmx:beforeProcessNode')
+      triggerEvent(elt, 'htmx:beforeProcessNode')
 
-        const triggerSpecs = getTriggerSpecs(elt)
-        const hasExplicitHttpAction = processVerbs(elt, nodeData, triggerSpecs)
+      const triggerSpecs = getTriggerSpecs(elt)
+      const hasExplicitHttpAction = processVerbs(elt, nodeData, triggerSpecs)
 
-        if (!hasExplicitHttpAction) {
-          if (getClosestAttributeValue(elt, 'hx-boost') === 'true') {
-            boostElement(elt, nodeData, triggerSpecs)
-          } else if (hasAttribute(elt, 'hx-trigger')) {
-            triggerSpecs.forEach(function(triggerSpec) {
-              // For "naked" triggers, don't do anything at all
-              addTriggerHandler(elt, triggerSpec, nodeData, function() {
-              })
+      if (!hasExplicitHttpAction) {
+        if (getClosestAttributeValue(elt, 'hx-boost') === 'true') {
+          boostElement(elt, nodeData, triggerSpecs)
+        } else if (hasAttribute(elt, 'hx-trigger')) {
+          triggerSpecs.forEach(function(triggerSpec) {
+            // For "naked" triggers, don't do anything at all
+            addTriggerHandler(elt, triggerSpec, nodeData, function() {
             })
-          }
+          })
         }
-
-        // Handle submit buttons/inputs that have the form attribute set
-        // see https://developer.mozilla.org/docs/Web/HTML/Element/button
-        if (elt.tagName === 'FORM' || (getRawAttribute(elt, 'type') === 'submit' && hasAttribute(elt, 'form'))) {
-          initButtonTracking(elt)
-        }
-
-        nodeData.firstInitCompleted = true
-        triggerEvent(elt, 'htmx:afterProcessNode')
       }
+
+      // Handle submit buttons/inputs that have the form attribute set
+      // see https://developer.mozilla.org/docs/Web/HTML/Element/button
+      if (elt.tagName === 'FORM' || (getRawAttribute(elt, 'type') === 'submit' && hasAttribute(elt, 'form'))) {
+        initButtonTracking(elt)
+      }
+
+      nodeData.firstInitCompleted = true
+      triggerEvent(elt, 'htmx:afterProcessNode')
     }
   }
 

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3973,8 +3973,8 @@ var htmx = (function() {
    * @return {boolean}
    */
   function verifyPath(elt, path, requestConfig) {
-    const url = new URL(path, document.location.href)
-    const origin = document.location.origin
+    const url = new URL(path, document.location.protocol !== 'about:' ? document.location.href : window.origin)
+    const origin = document.location.protocol !== 'about:' ? document.location.origin : window.origin
     const sameHost = origin === url.origin
 
     if (htmx.config.selfRequestsOnly) {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3972,8 +3972,8 @@ var htmx = (function() {
    * @return {boolean}
    */
   function verifyPath(elt, path, requestConfig) {
-    const url = new URL(path, document.location.protocol !== 'about:' ? document.location.href : window.origin)
-    const origin = document.location.protocol !== 'about:' ? document.location.origin : window.origin
+    const url = new URL(path, location.protocol !== 'about:' ? location.href : window.origin)
+    const origin = location.protocol !== 'about:' ? location.origin : window.origin
     const sameHost = origin === url.origin
 
     if (htmx.config.selfRequestsOnly) {

--- a/test/attributes/hx-push-url.js
+++ b/test/attributes/hx-push-url.js
@@ -161,9 +161,9 @@ describe('hx-push-url attribute', function() {
     htmx._('saveToHistoryCache')('url1', make('<div>'))
     var cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME))
     cache.length.should.equal(3)
-    cache[0].url.should.equal('url3')
-    cache[1].url.should.equal('url2')
-    cache[2].url.should.equal('url1')
+    cache[0].url.should.equal('/url3')
+    cache[1].url.should.equal('/url2')
+    cache[2].url.should.equal('/url1')
   })
 
   it('htmx:afterSettle is called when replacing outerHTML', function() {

--- a/test/attributes/hx-push-url.js
+++ b/test/attributes/hx-push-url.js
@@ -50,9 +50,7 @@ describe('hx-push-url attribute', function() {
     getWorkArea().textContent.should.equal('second')
     var cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME))
     cache.length.should.equal(2)
-    cache[1].url.should.equal('abc123')
-    // the url should be normalized with a / but this code has an issue right now
-    // cache[1].url.should.equal('/abc123')
+    cache[1].url.should.equal('/abc123')
   })
 
   it('restore should return old value', function() {


### PR DESCRIPTION
## Description
I've looked at all cases of IE fallbacks that can be removed now that IE 11 is no longer supported by htmx 2.x.
I've included all possible old browser compatibility checks I could find but it may be possible to roll back some of these changes

As well as just safely removing dead un-needed fallbacks I also found three bugs that the removals have also forced me to address

1st is NormalizePath() which does not function at all as calling new URL(path) without an origin domain added as a second parameter is designed to throw errors every time causing the IE11 fallback to happen for ALL calls to normalizePath and this fallback does zero normalization.  I don't think this lost functionality would have caused big issues as this function is only used to set and restore paths to history so even if it is broken it was consistently broken so broken paths going into history cache came out with the same non normalized path most of the time.  After this change it normalizes properly again

2nd I found shadow dom tests were calling process/init node on the shadow dom root node itself which are not possible to init properly because this node can't have attributes.  The IE fallback was preventing any errors but it was leaving rubbish htmx internal data on the shadow root nodes then.  only processing elements resolved the shadow dom tests failing.

3rd there is a minor issue where after removing the IE fallback for if verifyPath() I found situations where new URL() will fail if things like srcdoc iframes have invalid origins.  Found using window.origin as a fallback when these null origins from `about:` protocol situations resolved the issue.

Corresponding issue:

## Testing
Performed extensive testing with the test suite and used my work on the loc coverage reporting to track down and test the dead branches.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
