### PR TITLE
Documentation update for events

### DIFF
--- a/www/content/events.md
+++ b/www/content/events.md
@@ -111,6 +111,7 @@ This event is triggered before an AJAX request is issued.  If you call `preventD
 * `detail.elt` - the element that dispatched the request
 * `detail.xhr` - the `XMLHttpRequest`
 * `detail.target` - the target of the request
+* `detail.boosted` - true if the request is via an element using boosting
 * `detail.requestConfig` - the configuration of the AJAX request
 
 ### Event - `htmx:beforeSend` {#htmx:beforeSend}
@@ -137,6 +138,7 @@ See the documentation on [configuring swapping](@/docs.md#modifying_swapping_beh
 
 * `detail.elt` - the target of the swap
 * `detail.xhr` - the `XMLHttpRequest`
+* `detail.boosted` - true if the request is via an element using boosting
 * `detail.requestConfig` - the configuration of the AJAX request
 * `detail.requestConfig.elt` - the element that dispatched the request
 * `detail.shouldSwap` - if the content will be swapped (defaults to `false` for non-200 response codes)
@@ -157,6 +159,7 @@ happen instead.
 
 * `detail.elt` - the element that dispatched the request
 * `detail.xhr` - the `XMLHttpRequest`
+* `detail.boosted` - true if the request is via an element using boosting
 * `detail.requestConfig` - the configuration of the AJAX request
 * `detail.shouldSwap` - if the content will be swapped (defaults to `false` for non-200 response codes)
 * `detail.target` - the target of the swap


### PR DESCRIPTION
## Description
Document `event.detail.boosted` for the events `htmx:beforeRequest`, `htmx:beforeSwap` and `htmx:beforeTransition`.


## Testing
Manually checked that these events do include this property.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
