### PR TITLE
proxy window.location for testing and extension overrides

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -275,6 +275,11 @@ var htmx = (function() {
     },
     /** @type {typeof parseInterval} */
     parseInterval: null,
+    /**
+     * proxy of window.location used for page reload functions
+     * @type location
+     */
+    location,
     /** @type {typeof internalEval} */
     _: null,
     version: '2.0.4'
@@ -2367,7 +2372,7 @@ var htmx = (function() {
         if (path == null || path === '') {
           // if there is no action attribute on the form set path to current href before the
           // following logic to properly clear parameters on a GET (not on a POST!)
-          path = getDocument().location.href
+          path = location.href
         }
         if (verb === 'get' && path.includes('?')) {
           path = path.replace(/\?[^#]+/, '')
@@ -3201,7 +3206,7 @@ var htmx = (function() {
       saveToHistoryCache(path, elt)
     }
 
-    if (htmx.config.historyEnabled) history.replaceState({ htmx: true }, getDocument().title, window.location.href)
+    if (htmx.config.historyEnabled) history.replaceState({ htmx: true }, getDocument().title, location.href)
   }
 
   /**
@@ -3248,7 +3253,7 @@ var htmx = (function() {
     request.open('GET', path, true)
     request.setRequestHeader('HX-Request', 'true')
     request.setRequestHeader('HX-History-Restore-Request', 'true')
-    request.setRequestHeader('HX-Current-URL', getDocument().location.href)
+    request.setRequestHeader('HX-Current-URL', location.href)
     request.onload = function() {
       if (this.status >= 200 && this.status < 400) {
         triggerEvent(getDocument().body, 'htmx:historyCacheMissLoad', details)
@@ -3297,7 +3302,7 @@ var htmx = (function() {
       if (htmx.config.refreshOnHistoryMiss) {
         // @ts-ignore: optional parameter in reload() function throws error
         // noinspection JSUnresolvedReference
-        window.location.reload(true)
+        htmx.location.reload(true)
       } else {
         loadHistoryFromServer(path)
       }
@@ -3621,7 +3626,7 @@ var htmx = (function() {
       'HX-Trigger': getRawAttribute(elt, 'id'),
       'HX-Trigger-Name': getRawAttribute(elt, 'name'),
       'HX-Target': getAttributeValue(target, 'id'),
-      'HX-Current-URL': getDocument().location.href
+      'HX-Current-URL': location.href
     }
     getValuesForElement(elt, 'hx-headers', false, headers)
     if (prompt !== undefined) {
@@ -4368,7 +4373,7 @@ var htmx = (function() {
 
     // behavior of anchors w/ empty href is to use the current URL
     if (path == null || path === '') {
-      path = getDocument().location.href
+      path = location.href
     }
 
     /**
@@ -4730,14 +4735,14 @@ var htmx = (function() {
 
     if (hasHeader(xhr, /HX-Redirect:/i)) {
       responseInfo.keepIndicators = true
-      location.href = xhr.getResponseHeader('HX-Redirect')
-      shouldRefresh && location.reload()
+      htmx.location.href = xhr.getResponseHeader('HX-Redirect')
+      shouldRefresh && htmx.location.reload()
       return
     }
 
     if (shouldRefresh) {
       responseInfo.keepIndicators = true
-      location.reload()
+      htmx.location.reload()
       return
     }
 

--- a/test/attributes/hx-push-url.js
+++ b/test/attributes/hx-push-url.js
@@ -136,7 +136,7 @@ describe('hx-push-url attribute', function() {
     getWorkArea().textContent.should.equal('test1')
   })
 
-  it('cache miss should refresh whe refreshOnHistoryMiss true', function() {
+  it('cache miss should refresh when refreshOnHistoryMiss true', function() {
     htmx.config.refreshOnHistoryMiss = true
     var refresh = false
     htmx.location = { reload: function() { refresh = true } }

--- a/test/attributes/hx-push-url.js
+++ b/test/attributes/hx-push-url.js
@@ -136,6 +136,17 @@ describe('hx-push-url attribute', function() {
     getWorkArea().textContent.should.equal('test1')
   })
 
+  it('cache miss should refresh whe refreshOnHistoryMiss true', function() {
+    htmx.config.refreshOnHistoryMiss = true
+    var refresh = false
+    htmx.location = { reload: function() { refresh = true } }
+    localStorage.removeItem(HTMX_HISTORY_CACHE_NAME) // clear cache
+    htmx._('restoreHistory')('/test3')
+    refresh.should.equal(true)
+    htmx.location = window.location
+    htmx.config.refreshOnHistoryMiss = false
+  })
+
   it('navigation should push an element into the cache  w/ data-* prefix', function() {
     this.server.respondWith('GET', '/test', 'second')
     getWorkArea().innerHTML.should.be.equal('')

--- a/test/core/headers.js
+++ b/test/core/headers.js
@@ -381,6 +381,27 @@ describe('Core htmx AJAX headers', function() {
     }, 30)
   })
 
+  it('should refresh page on HX-Refresh', function() {
+    var refresh = false
+    htmx.location = { reload: function() { refresh = true } }
+    this.server.respondWith('GET', '/test', [200, { 'HX-Refresh': 'true' }, ''])
+    var div = make('<div id="testdiv" hx-trigger="click" hx-get="/test"></div>')
+    div.click()
+    this.server.respond()
+    refresh.should.equal(true)
+    htmx.location = window.location
+  })
+
+  it('should update location.href on HX-Redirect', function() {
+    htmx.location = { href: window.location.href }
+    this.server.respondWith('GET', '/test', [200, { 'HX-Redirect': 'https://htmx.org/headers/hx-redirect/' }, ''])
+    var div = make('<div id="testdiv" hx-trigger="click" hx-get="/test"></div>')
+    div.click()
+    this.server.respond()
+    htmx.location.href.should.equal('https://htmx.org/headers/hx-redirect/')
+    htmx.location = window.location
+  })
+
   it('request to restore history should include the HX-Request header', function() {
     this.server.respondWith('GET', '/test', function(xhr) {
       xhr.requestHeaders['HX-Request'].should.be.equal('true')


### PR DESCRIPTION
## Description
To allow loc coverage testing of hard reloads and refreshes I've proxied window.location into htmx.location that is used for .reload() and setting href.  This can then be replaced if needed to allow full testing of the reload features and also this would allow future extensions to override page reloading if required.

Also found instances of document.location usage which should all be just location to minify code.

Corresponding issue:

## Testing
Added new tests for HX-Refresh and HX-Redirect and history cache miss

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
