### PR TITLE
handle removing request lock on errors

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -4446,6 +4446,7 @@ var htmx = (function() {
     if (!verifyPath(elt, finalPath, requestConfig)) {
       triggerErrorEvent(elt, 'htmx:invalidPath', requestConfig)
       maybeCall(reject)
+      endRequestLock()
       return promise
     }
 
@@ -4508,10 +4509,11 @@ var htmx = (function() {
           }
         }
         maybeCall(resolve)
-        endRequestLock()
       } catch (e) {
         triggerErrorEvent(elt, 'htmx:onLoadError', mergeObjects({ error: e }, responseInfo))
         throw e
+      } finally {
+        endRequestLock()
       }
     }
     xhr.onerror = function() {

--- a/test/core/api.js
+++ b/test/core/api.js
@@ -602,7 +602,7 @@ describe('Core htmx API test', function() {
     htmx.off('htmx:beforeSwap', handler)
   })
 
-  it('ajax api with can pass in custom handler', function() {
+  it('ajax api with can pass in custom handler and handle if it throws error', function() {
     var onLoadError = false
     var handler = htmx.on('htmx:onLoadError', function(event) {
       onLoadError = true
@@ -611,6 +611,15 @@ describe('Core htmx API test', function() {
       xhr.respond(204, {}, 'foo!')
     })
     var div = make('<div></div>')
+    try {
+      htmx.ajax('GET', '/test', { handler: function() { throw new Error('throw') } })
+      this.server.respond()
+    } catch (e) {}
+    div.innerHTML.should.equal('')
+    onLoadError.should.equal(true)
+
+    // repeat the error resonse a 2nd time to make sure request lock removed after error
+    onLoadError = false
     try {
       htmx.ajax('GET', '/test', { handler: function() { throw new Error('throw') } })
       this.server.respond()

--- a/test/core/headers.js
+++ b/test/core/headers.js
@@ -367,8 +367,7 @@ describe('Core htmx AJAX headers', function() {
     htmx.off('bar', handlerBar)
   })
 
-  it.skip('should change body content on HX-Location', function(done) {
-    // this test is disabled because a bug is triggered by an earlier request where it does not remove endRequestLock() on errors blocking all future requests
+  it('should change body content on HX-Location', function(done) {
     this.server.respondWith('GET', '/test', [200, { 'HX-Location': '{"path":"/test2", "target":"#work-area"}' }, ''])
     this.server.respondWith('GET', '/test2', [200, {}, '<div>Yay! Welcome</div>'])
     var div = make('<div id="testdiv" hx-trigger="click" hx-get="/test"></div>')


### PR DESCRIPTION
## Description
During loc coverage testing I found an issue where later tests would start to fail if errors happened in previous tests.  This is because on two of the error paths the xhr request lock is not being removed.  So I've added the end lock command to both of these paths.  If a URL is verified and fails verification because it is say blocked because it is cross domain then it will not remove the lock here and any future requests by that same triggering element will fail.  Also if anyhting in the onload response handler throws an error the same thing will happen and the element will be locked out of all future requests.  This bug has probably not been found before because in most situations retrying would just fail again even if you could retry the request.  But this change allows it to fail in a more graceful way and gives more chances for a user testing their app to retry the request multiple times to find and debug the cause.

This PR plus the other ones I just posted should get us to 100% loc coverage!!!!!

Corresponding issue:

## Testing


## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
