### PR TITLE
[+Extension] `hx-keep`, enables form and html content to persist across reloads.

### DIFF
--- a/www/content/extensions/_index.md
+++ b/www/content/extensions/_index.md
@@ -127,6 +127,10 @@ htmx extensions are split into two categories:
       <td>{% markdown() %}  This extension allows htmx requests to be sent for drag drop  {% end %}</td>
     </tr>
     <tr>
+      <td>{% markdown() %}  [hx-keep](https://www.npmjs.com/package/hx-keep)  {% end %}</td>
+      <td>{% markdown() %}  Cache forms and html content on the client to persist state across refreshes  {% end %}</td>
+    </tr>
+    <tr>
       <td>{% markdown() %}  [dynamic-url](https://github.com/FumingPower3925/htmx-dynamic-url/blob/main/README.md)  {% end %}</td>
       <td>{% markdown() %}  Allows dynamic URL path templating using `{varName}` placeholders, resolved via configurable custom function or `window.` fallback. It does not rely on `hx-vals`. Useful when needing to perform requests to paths that depend on application state.  {% end %}</td>
     </tr>


### PR DESCRIPTION
I've created a library to enable [forms](https://hx-keep.ajanibilby.com/#hx-keepmode) to be cached in `localStorage` to allow them to survive refreshes, accidental tab closures, etc - with the server being able to then clear the cache with http [`hx-keep-evict` header](https://hx-keep.ajanibilby.com/#response-hx-keep-evict) when the data is successfully saved to the server.

![banner](https://hx-keep.ajanibilby.com/images/banner.gif)

It also provides client side APIs to allow frontends like react to hook into it to store their state in a form for custom input elements.

HTML attribute prefix used: [`hx-keep*`](https://hx-keep.ajanibilby.com/#html-attributes) (with support for `data-` prefix)
Respects `hx-history="false"`