### PR TITLE
Add substr lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,10 @@
       "no-useless-call": 0,
       "no-useless-escape": 0,
       "no-unused-expressions": 0,
+      "no-restricted-properties": ["error", {
+        "property": "substr",
+        "message": "Use .slice or .substring instead of .substr"
+      }],
       "space-before-function-paren": [
         "error",
         "never"


### PR DESCRIPTION
## Description
Follow up to #2951 and #3074.

At the time of writing, all usages of the deprecated `String.prototype.substr` have been removed from htmx.
Add a lint rule to prevent it being reintroduced in the future.

## Testing
Manually checked succeeding and failing with the new rule

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
