### PR TITLE
Correction for confirm example

### DIFF
--- a/www/content/examples/confirm.md
+++ b/www/content/examples/confirm.md
@@ -37,9 +37,9 @@ which is then picked up by `hx-trigger`.
 <script>
   document.addEventListener("htmx:confirm", function(e) {
     // The event is triggered on every trigger for a request, so we need to check if the element
-    // that triggered the request has a hx-confirm attribute, if not we can return early and let
-    // the default behavior happen
-    if (!e.detail.elt.hasAttribute('hx-confirm')) return
+    // that triggered the request has a confirm question set via the hx-confirm attribute,
+    // if not we can return early and let the default behavior happen
+    if (!e.detail.question) return
 
     // This will prevent the request from being issued to later manually issue it
     e.preventDefault()


### PR DESCRIPTION
## Description
Update `htmx:confirm` example to take inheritance into account when checking for `hx-confirm` usage.

Corresponding issue: #3242

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
