### PR TITLE
Update sse.md

### DIFF
--- a/www/content/extensions/sse.md
+++ b/www/content/extensions/sse.md
@@ -30,7 +30,7 @@ The fastest way to install `sse` is to load it via a CDN. Remember to always inc
 ```HTML
 <head>
     <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/htmx-ext-sse@2.2.2" integrity="sha384-Y4gc0CK6Kg+hmulDc6rZPJu0tqvk7EWlih0Oh+2OkAi1ZDlCbBDCQEE2uVk472Ky" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/htmx-ext-sse@2.2.3" integrity="sha384-Y4gc0CK6Kg+hmulDc6rZPJu0tqvk7EWlih0Oh+2OkAi1ZDlCbBDCQEE2uVk472Ky" crossorigin="anonymous"></script>
 </head>
 <body hx-ext="sse">
 ```


### PR DESCRIPTION
version of sse extension does not match the sha384 hash, i believe it to be the newer 2.2.3 version of htmx-ext-sse

## Description

changed version from 2.2.2 to 2.2.3

Corresponding issue:

## Testing

have run it with a local django deployment, browser insists that hashes match and executes extension

## Checklist

* [ x] I have read the contribution guidelines
* [ x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
