### PR TITLE
Fixes issue 1537 - OOB does not escape query selector - updated version

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1444,7 +1444,7 @@ var htmx = (function() {
    */
   function oobSwap(oobValue, oobElement, settleInfo, rootNode) {
     rootNode = rootNode || getDocument()
-    let selector = '#' + getRawAttribute(oobElement, 'id')
+    let selector = '#' + CSS.escape(getRawAttribute(oobElement, 'id'))
     /** @type HtmxSwapStyle */
     let swapStyle = 'outerHTML'
     if (oobValue === 'true') {

--- a/test/attributes/hx-swap-oob.js
+++ b/test/attributes/hx-swap-oob.js
@@ -364,4 +364,27 @@ describe('hx-swap-oob attribute', function() {
     div.click()
     this.server.respond()
   })
+
+  it('handles elements with IDs containing special characters properly', function () {
+    this.server.respondWith("GET", "/test", "<div id='foo-/bar/' hx-swap-oob='innerHTML'>Swapped10</div>");
+    var div = make('<div hx-get="/test">click me</div>');
+    make('<div id="foo-/bar/">Existing Content</div>');
+    div.click();
+    this.server.respond();
+    var swappedElement = document.querySelector('[id="foo-/bar/"]');
+    swappedElement.innerHTML.should.equal("Swapped10");
+  })
+
+  it('handles one swap into multiple elements with the same ID properly', function () {
+    this.server.respondWith("GET", "/test", "<div id='foo-/bar/' hx-swap-oob='innerHTML'>Swapped11</div>");
+    var div = make('<div hx-get="/test">click me</div>');
+    make('<div id="foo-/bar/">Existing Content 1</div>');
+    make('<div id="foo-/bar/">Existing Content 2</div>');
+    div.click();
+    this.server.respond();
+    var swappedElements = document.querySelectorAll('[id="foo-/bar/"]');
+    swappedElements.forEach(function(element) {
+        element.innerHTML.should.equal("Swapped11");
+    });
+  })    
 })

--- a/test/attributes/hx-swap-oob.js
+++ b/test/attributes/hx-swap-oob.js
@@ -365,26 +365,26 @@ describe('hx-swap-oob attribute', function() {
     this.server.respond()
   })
 
-  it('handles elements with IDs containing special characters properly', function () {
-    this.server.respondWith("GET", "/test", "<div id='foo-/bar/' hx-swap-oob='innerHTML'>Swapped10</div>");
-    var div = make('<div hx-get="/test">click me</div>');
-    make('<div id="foo-/bar/">Existing Content</div>');
-    div.click();
-    this.server.respond();
-    var swappedElement = document.querySelector('[id="foo-/bar/"]');
-    swappedElement.innerHTML.should.equal("Swapped10");
+  it('handles elements with IDs containing special characters properly', function() {
+    this.server.respondWith('GET', '/test', '<div id="foo-/bar/" hx-swap-oob="innerHTML">Swapped10</div>')
+    var div = make('<div hx-get="/test">click me</div>')
+    make('<div id="foo-/bar/">Existing Content</div>')
+    div.click()
+    this.server.respond()
+    var swappedElement = document.querySelector('[id="foo-/bar/"]')
+    swappedElement.innerHTML.should.equal('Swapped10')
   })
 
-  it('handles one swap into multiple elements with the same ID properly', function () {
-    this.server.respondWith("GET", "/test", "<div id='foo-/bar/' hx-swap-oob='innerHTML'>Swapped11</div>");
-    var div = make('<div hx-get="/test">click me</div>');
-    make('<div id="foo-/bar/">Existing Content 1</div>');
-    make('<div id="foo-/bar/">Existing Content 2</div>');
-    div.click();
-    this.server.respond();
-    var swappedElements = document.querySelectorAll('[id="foo-/bar/"]');
+  it('handles one swap into multiple elements with the same ID properly', function() {
+    this.server.respondWith('GET', '/test', '<div id="foo-/bar/" hx-swap-oob="innerHTML">Swapped11</div>')
+    var div = make('<div hx-get="/test">click me</div>')
+    make('<div id="foo-/bar/">Existing Content 1</div>')
+    make('<div id="foo-/bar/">Existing Content 2</div>')
+    div.click()
+    this.server.respond()
+    var swappedElements = document.querySelectorAll('[id="foo-/bar/"]')
     swappedElements.forEach(function(element) {
-        element.innerHTML.should.equal("Swapped11");
-    });
-  })    
+      element.innerHTML.should.equal('Swapped11')
+    })
+  })
 })


### PR DESCRIPTION
## Description
This change alters how the oobSwap function builds the query selector string.  Problem is usage of raw_id value obtained from getRawAttribute(oobElement, "id") without escaping.

> Original PR by https://github.com/FraserChapman is here: https://github.com/bigskysoftware/htmx/pull/2319 but there is no activity, so I decided to take over.

This fix allows the call querySelectorAll to return the nodelist of all elements with the ids such as "foo-/bar" - without getting "Failed to execute 'querySelectorAll' on 'Document': '#foo-/bar' is not a valid selector, and whilst not limiting the selection to the first matching id in the document.

Corresponding issue:
https://github.com/bigskysoftware/htmx/issues/1537

## Testing
I ran the htmx.js test suite Version: 2.0.4 and got 0 failures
I also manually tested ids such as "foo-/bar" and it all seems to be working as expected.

Further to this I've added test cases for

'handles elements with IDs containing special characters properly'

and

'handles one swap into multiple elements with the same ID properly'

And re- ran the htmx.js test suite Version: 2.0.4 and got 0 failures

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
