### PR TITLE
Move History storage to sessionStorage and history path to window

### DIFF
--- a/test/attributes/hx-history.js
+++ b/test/attributes/hx-history.js
@@ -4,12 +4,12 @@ describe('hx-history attribute', function() {
   beforeEach(function() {
     this.server = makeServer()
     clearWorkArea()
-    localStorage.removeItem(HTMX_HISTORY_CACHE_NAME)
+    sessionStorage.removeItem(HTMX_HISTORY_CACHE_NAME)
   })
   afterEach(function() {
     this.server.restore()
     clearWorkArea()
-    localStorage.removeItem(HTMX_HISTORY_CACHE_NAME)
+    sessionStorage.removeItem(HTMX_HISTORY_CACHE_NAME)
   })
 
   it('history cache should not contain embargoed content', function() {
@@ -32,8 +32,8 @@ describe('hx-history attribute', function() {
     this.server.respond()
     workArea.textContent.should.equal('test3')
 
-    // embargoed content should NOT be in the localStorage cache
-    var cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME))
+    // embargoed content should NOT be in the sessionStorage cache
+    var cache = JSON.parse(sessionStorage.getItem(HTMX_HISTORY_CACHE_NAME))
     cache.length.should.equal(2)
 
     // on history navigation, embargoed content is retrieved from server

--- a/test/attributes/hx-push-url.js
+++ b/test/attributes/hx-push-url.js
@@ -5,12 +5,12 @@ describe('hx-push-url attribute', function() {
   beforeEach(function() {
     this.server = makeServer()
     clearWorkArea()
-    localStorage.removeItem(HTMX_HISTORY_CACHE_NAME)
+    sessionStorage.removeItem(HTMX_HISTORY_CACHE_NAME)
   })
   afterEach(function() {
     this.server.restore()
     clearWorkArea()
-    localStorage.removeItem(HTMX_HISTORY_CACHE_NAME)
+    sessionStorage.removeItem(HTMX_HISTORY_CACHE_NAME)
   })
 
   it('navigation should push an element into the cache when true', function() {
@@ -22,7 +22,7 @@ describe('hx-push-url attribute', function() {
     div.click()
     this.server.respond()
     getWorkArea().textContent.should.equal('second')
-    var cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME))
+    var cache = JSON.parse(sessionStorage.getItem(HTMX_HISTORY_CACHE_NAME))
     cache[cache.length - 1].url.should.equal('/test')
   })
 
@@ -35,7 +35,7 @@ describe('hx-push-url attribute', function() {
     div.click()
     this.server.respond()
     getWorkArea().textContent.should.equal('second')
-    var cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME))
+    var cache = JSON.parse(sessionStorage.getItem(HTMX_HISTORY_CACHE_NAME))
     should.equal(cache, null)
   })
 
@@ -48,7 +48,7 @@ describe('hx-push-url attribute', function() {
     div.click()
     this.server.respond()
     getWorkArea().textContent.should.equal('second')
-    var cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME))
+    var cache = JSON.parse(sessionStorage.getItem(HTMX_HISTORY_CACHE_NAME))
     cache.length.should.equal(2)
     cache[1].url.should.equal('/abc123')
   })
@@ -68,7 +68,7 @@ describe('hx-push-url attribute', function() {
     this.server.respond()
     workArea.textContent.should.equal('test2')
 
-    var cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME))
+    var cache = JSON.parse(sessionStorage.getItem(HTMX_HISTORY_CACHE_NAME))
 
     cache.length.should.equal(2)
     htmx._('restoreHistory')('/test1')
@@ -106,7 +106,7 @@ describe('hx-push-url attribute', function() {
       byId('d1').click()
       this.server.respond()
     }
-    var cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME))
+    var cache = JSON.parse(sessionStorage.getItem(HTMX_HISTORY_CACHE_NAME))
     cache.length.should.equal(10) // should only be 10 elements
   })
 
@@ -125,10 +125,10 @@ describe('hx-push-url attribute', function() {
     this.server.respond()
     workArea.textContent.should.equal('test2')
 
-    var cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME))
+    var cache = JSON.parse(sessionStorage.getItem(HTMX_HISTORY_CACHE_NAME))
 
     cache.length.should.equal(2)
-    localStorage.removeItem(HTMX_HISTORY_CACHE_NAME) // clear cache
+    sessionStorage.removeItem(HTMX_HISTORY_CACHE_NAME) // clear cache
     htmx._('restoreHistory')('/test1')
     this.server.respond()
     getWorkArea().textContent.should.equal('test1')
@@ -138,7 +138,7 @@ describe('hx-push-url attribute', function() {
     htmx.config.refreshOnHistoryMiss = true
     var refresh = false
     htmx.location = { reload: function() { refresh = true } }
-    localStorage.removeItem(HTMX_HISTORY_CACHE_NAME) // clear cache
+    sessionStorage.removeItem(HTMX_HISTORY_CACHE_NAME) // clear cache
     htmx._('restoreHistory')('/test3')
     refresh.should.equal(true)
     htmx.location = window.location
@@ -152,20 +152,20 @@ describe('hx-push-url attribute', function() {
     div.click()
     this.server.respond()
     getWorkArea().textContent.should.equal('second')
-    var cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME))
+    var cache = JSON.parse(sessionStorage.getItem(HTMX_HISTORY_CACHE_NAME))
     cache.length.should.equal(1)
   })
 
   it('deals with malformed JSON in history cache when getting', function() {
-    localStorage.setItem(HTMX_HISTORY_CACHE_NAME, 'Invalid JSON')
+    sessionStorage.setItem(HTMX_HISTORY_CACHE_NAME, 'Invalid JSON')
     var history = htmx._('getCachedHistory')('url')
     should.equal(history, null)
   })
 
   it('deals with malformed JSON in history cache when saving', function() {
-    localStorage.setItem(HTMX_HISTORY_CACHE_NAME, 'Invalid JSON')
+    sessionStorage.setItem(HTMX_HISTORY_CACHE_NAME, 'Invalid JSON')
     htmx._('saveToHistoryCache')('url', make('<div>'))
-    var cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME))
+    var cache = JSON.parse(sessionStorage.getItem(HTMX_HISTORY_CACHE_NAME))
     cache.length.should.equal(1)
   })
 
@@ -174,17 +174,17 @@ describe('hx-push-url attribute', function() {
     htmx._('saveToHistoryCache')('url2', make('<div>'))
     htmx._('saveToHistoryCache')('url3', make('<div>'))
     htmx._('saveToHistoryCache')('url2', make('<div>'))
-    var cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME))
+    var cache = JSON.parse(sessionStorage.getItem(HTMX_HISTORY_CACHE_NAME))
     cache.length.should.equal(3)
   })
 
   it('setting history cache size to 0 clears cache', function() {
     htmx._('saveToHistoryCache')('url1', make('<div>'))
-    var cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME))
+    var cache = JSON.parse(sessionStorage.getItem(HTMX_HISTORY_CACHE_NAME))
     cache.length.should.equal(1)
     htmx.config.historyCacheSize = 0
     htmx._('saveToHistoryCache')('url2', make('<div>'))
-    cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME))
+    cache = JSON.parse(sessionStorage.getItem(HTMX_HISTORY_CACHE_NAME))
     should.equal(cache, null)
     htmx.config.historyCacheSize = 10
   })
@@ -195,7 +195,7 @@ describe('hx-push-url attribute', function() {
     htmx._('saveToHistoryCache')('url3', make('<div>'))
     htmx._('saveToHistoryCache')('url2', make('<div>'))
     htmx._('saveToHistoryCache')('url1', make('<div>'))
-    var cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME))
+    var cache = JSON.parse(sessionStorage.getItem(HTMX_HISTORY_CACHE_NAME))
     cache.length.should.equal(3)
     cache[0].url.should.equal('/url3')
     cache[1].url.should.equal('/url2')
@@ -246,19 +246,19 @@ describe('hx-push-url attribute', function() {
       bigContent += bigContent
     }
     try {
-      localStorage.removeItem('htmx-history-cache')
+      sessionStorage.removeItem('htmx-history-cache')
       htmx._('saveToHistoryCache')('/dummy', make('<div>' + bigContent + '</div>'), 'Foo', 0)
-      should.equal(localStorage.getItem('htmx-history-cache'), null)
+      should.equal(sessionStorage.getItem('htmx-history-cache'), null)
     } finally {
       // clear history cache afterwards
-      localStorage.removeItem('htmx-history-cache')
+      sessionStorage.removeItem('htmx-history-cache')
     }
   })
 
   if (/chrome/i.test(navigator.userAgent)) {
-    it('when localStorage disabled history not saved fine', function() {
-      var setItem = localStorage.setItem
-      localStorage.setItem = undefined
+    it('when sessionStorage disabled history not saved fine', function() {
+      var setItem = sessionStorage.setItem
+      sessionStorage.setItem = undefined
       this.server.respondWith('GET', '/test', 'second')
       getWorkArea().innerHTML.should.be.equal('')
       var div = make('<div hx-push-url="true" hx-get="/test">first</div>')
@@ -269,7 +269,7 @@ describe('hx-push-url attribute', function() {
       getWorkArea().textContent.should.equal('second')
       var hist = htmx._('getCachedHistory')('/test')
       should.equal(hist, null)
-      localStorage.setItem = setItem
+      sessionStorage.setItem = setItem
     })
   }
 
@@ -277,7 +277,7 @@ describe('hx-push-url attribute', function() {
     // path normalization has a bug breaking it right now preventing this test
     htmx._('saveToHistoryCache')('http://', make('<div>'))
     htmx._('saveToHistoryCache')('http//', make('<div>'))
-    var cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME))
+    var cache = JSON.parse(sessionStorage.getItem(HTMX_HISTORY_CACHE_NAME))
     cache.length.should.equal(2)
     cache[0].url.should.equal('http://') // no normalization as invalid
     cache[1].url.should.equal('/http') // can normalize this one
@@ -285,7 +285,7 @@ describe('hx-push-url attribute', function() {
 
   it('history cache clears out disabled attribute', function() {
     htmx._('saveToHistoryCache')('/url1', make('<div><div data-disabled-by-htmx disabled></div></div>'))
-    var cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME))
+    var cache = JSON.parse(sessionStorage.getItem(HTMX_HISTORY_CACHE_NAME))
     cache.length.should.equal(1)
     cache[0].url.should.equal('/url1')
     cache[0].content.should.equal('<div data-disabled-by-htmx=""></div>')
@@ -306,7 +306,7 @@ describe('hx-push-url attribute', function() {
     } finally {
       htmx.config.getCacheBusterParam = false
     }
-    htmx._('currentPathForHistory').should.equal('/test')
+    window.htmxCurrentPathForHistory.should.equal('/test')
   })
 
   it('ensure history pushState called', function() {
@@ -337,7 +337,7 @@ describe('hx-push-url attribute', function() {
     div1.click()
     this.server.respond()
     div1.innerHTML.should.equal('Result')
-    var cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME))
+    var cache = JSON.parse(sessionStorage.getItem(HTMX_HISTORY_CACHE_NAME))
     cache.length.should.equal(1)
     path.should.equal('/pushpath')
     htmx.off('htmx:pushedIntoHistory', handler)
@@ -353,7 +353,7 @@ describe('hx-push-url attribute', function() {
     div1.click()
     this.server.respond()
     div1.innerHTML.should.equal('Result')
-    var cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME))
+    var cache = JSON.parse(sessionStorage.getItem(HTMX_HISTORY_CACHE_NAME))
     cache.length.should.equal(1)
     path.should.equal('/pushpath')
     htmx.off('htmx:pushedIntoHistory', handler)
@@ -369,7 +369,7 @@ describe('hx-push-url attribute', function() {
     div1.click()
     this.server.respond()
     div1.innerHTML.should.equal('Result')
-    var cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME))
+    var cache = JSON.parse(sessionStorage.getItem(HTMX_HISTORY_CACHE_NAME))
     should.equal(cache, null)
     path.should.equal('')
     htmx.off('htmx:pushedIntoHistory', handler)

--- a/test/attributes/hx-replace-url.js
+++ b/test/attributes/hx-replace-url.js
@@ -4,12 +4,12 @@ describe('hx-replace-url attribute', function() {
   beforeEach(function() {
     this.server = makeServer()
     clearWorkArea()
-    localStorage.removeItem(HTMX_HISTORY_CACHE_NAME)
+    sessionStorage.removeItem(HTMX_HISTORY_CACHE_NAME)
   })
   afterEach(function() {
     this.server.restore()
     clearWorkArea()
-    localStorage.removeItem(HTMX_HISTORY_CACHE_NAME)
+    sessionStorage.removeItem(HTMX_HISTORY_CACHE_NAME)
   })
 
   it('navigation should replace an element into the cache when true', function() {
@@ -21,7 +21,7 @@ describe('hx-replace-url attribute', function() {
     div.click()
     this.server.respond()
     getWorkArea().textContent.should.equal('second')
-    var cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME))
+    var cache = JSON.parse(sessionStorage.getItem(HTMX_HISTORY_CACHE_NAME))
     cache[cache.length - 1].url.should.equal('/test')
   })
 
@@ -35,7 +35,7 @@ describe('hx-replace-url attribute', function() {
     div1.click()
     this.server.respond()
     div1.innerHTML.should.equal('Result')
-    var cache = JSON.parse(localStorage.getItem(HTMX_HISTORY_CACHE_NAME))
+    var cache = JSON.parse(sessionStorage.getItem(HTMX_HISTORY_CACHE_NAME))
     cache.length.should.equal(1)
     path.should.equal('/pushpath')
     htmx.off('htmx:replacedInHistory', handler)

--- a/test/core/perf.js
+++ b/test/core/perf.js
@@ -5,12 +5,12 @@ describe('Core htmx perf Tests', function() {
   beforeEach(function() {
     this.server = makeServer()
     clearWorkArea()
-    localStorage.removeItem(HTMX_HISTORY_CACHE_NAME)
+    sessionStorage.removeItem(HTMX_HISTORY_CACHE_NAME)
   })
   afterEach(function() {
     this.server.restore()
     clearWorkArea()
-    localStorage.removeItem(HTMX_HISTORY_CACHE_NAME)
+    sessionStorage.removeItem(HTMX_HISTORY_CACHE_NAME)
   })
 
   function stringRepeat(str, num) {
@@ -39,8 +39,8 @@ describe('Core htmx perf Tests', function() {
     }
     var start = performance.now()
     var string = JSON.stringify(array)
-    localStorage.setItem(HTMX_HISTORY_CACHE_NAME, string)
-    var reReadString = localStorage.getItem(HTMX_HISTORY_CACHE_NAME)
+    sessionStorage.setItem(HTMX_HISTORY_CACHE_NAME, string)
+    var reReadString = sessionStorage.getItem(HTMX_HISTORY_CACHE_NAME)
     var finalJson = JSON.parse(reReadString)
     var end = performance.now()
     var timeInMs = end - start

--- a/test/manual/history/index.html
+++ b/test/manual/history/index.html
@@ -7,9 +7,9 @@
     <script>
         htmx.on("htmx:beforeHistorySave", function(evt){
             console.log("Saving history : ", evt.detail);
-            console.log("History Cache Before:", JSON.parse(localStorage.getItem("htmx-history-cache")))
+            console.log("History Cache Before:", JSON.parse(sessionStorage.getItem("htmx-history-cache")))
             setTimeout(function () {
-                console.log("History Cache After:", JSON.parse(localStorage.getItem("htmx-history-cache")))
+                console.log("History Cache After:", JSON.parse(sessionStorage.getItem("htmx-history-cache")))
             }, 10);
         })
     </script>

--- a/test/manual/history_regression/index.html
+++ b/test/manual/history_regression/index.html
@@ -6,9 +6,9 @@
     <script>
         htmx.on("htmx:beforeHistorySave", function(evt){
             console.log("Saving history : ", evt.detail);
-            console.log("History Cache Before:", JSON.parse(localStorage.getItem("htmx-history-cache")))
+            console.log("History Cache Before:", JSON.parse(sessionStorage.getItem("htmx-history-cache")))
             setTimeout(function () {
-                console.log("History Cache After:", JSON.parse(localStorage.getItem("htmx-history-cache")))
+                console.log("History Cache After:", JSON.parse(sessionStorage.getItem("htmx-history-cache")))
             }, 10);
         })
     </script>

--- a/test/manual/history_regression/test/index.html
+++ b/test/manual/history_regression/test/index.html
@@ -6,9 +6,9 @@
     <script>
         htmx.on("htmx:beforeHistorySave", function(evt){
             console.log("Saving history : ", evt.detail);
-            console.log("History Cache Before:", JSON.parse(localStorage.getItem("htmx-history-cache")))
+            console.log("History Cache Before:", JSON.parse(sessionStorage.getItem("htmx-history-cache")))
             setTimeout(function () {
-                console.log("History Cache After:", JSON.parse(localStorage.getItem("htmx-history-cache")))
+                console.log("History Cache After:", JSON.parse(sessionStorage.getItem("htmx-history-cache")))
             }, 10);
         })
     </script>

--- a/test/manual/history_regression2/index.html
+++ b/test/manual/history_regression2/index.html
@@ -6,9 +6,9 @@
     <script>
         htmx.on("htmx:beforeHistorySave", function(evt){
             console.log("Saving history : ", evt.detail);
-            console.log("History Cache Before:", JSON.parse(localStorage.getItem("htmx-history-cache")))
+            console.log("History Cache Before:", JSON.parse(sessionStorage.getItem("htmx-history-cache")))
             setTimeout(function () {
-                console.log("History Cache After:", JSON.parse(localStorage.getItem("htmx-history-cache")))
+                console.log("History Cache After:", JSON.parse(sessionStorage.getItem("htmx-history-cache")))
             }, 10);
         })
     </script>

--- a/test/manual/history_regression2/page2.html
+++ b/test/manual/history_regression2/page2.html
@@ -6,9 +6,9 @@
     <script>
         htmx.on("htmx:beforeHistorySave", function(evt){
             console.log("Saving history : ", evt.detail);
-            console.log("History Cache Before:", JSON.parse(localStorage.getItem("htmx-history-cache")))
+            console.log("History Cache Before:", JSON.parse(sessionStorage.getItem("htmx-history-cache")))
             setTimeout(function () {
-                console.log("History Cache After:", JSON.parse(localStorage.getItem("htmx-history-cache")))
+                console.log("History Cache After:", JSON.parse(sessionStorage.getItem("htmx-history-cache")))
             }, 10);
         })
     </script>

--- a/test/manual/history_safari_ios_bug/index.html
+++ b/test/manual/history_safari_ios_bug/index.html
@@ -6,9 +6,9 @@
     <script>
         htmx.on("htmx:beforeHistorySave", function(evt){
             console.log("Saving history : ", evt.detail);
-            console.log("History Cache Before:", JSON.parse(localStorage.getItem("htmx-history-cache")))
+            console.log("History Cache Before:", JSON.parse(sessionStorage.getItem("htmx-history-cache")))
             setTimeout(function () {
-                console.log("History Cache After:", JSON.parse(localStorage.getItem("htmx-history-cache")))
+                console.log("History Cache After:", JSON.parse(sessionStorage.getItem("htmx-history-cache")))
             }, 10);
         })
     </script>

--- a/test/manual/history_safari_ios_bug/page2.html
+++ b/test/manual/history_safari_ios_bug/page2.html
@@ -6,9 +6,9 @@
     <script>
         htmx.on("htmx:beforeHistorySave", function(evt){
             console.log("Saving history : ", evt.detail);
-            console.log("History Cache Before:", JSON.parse(localStorage.getItem("htmx-history-cache")))
+            console.log("History Cache Before:", JSON.parse(sessionStorage.getItem("htmx-history-cache")))
             setTimeout(function () {
-                console.log("History Cache After:", JSON.parse(localStorage.getItem("htmx-history-cache")))
+                console.log("History Cache After:", JSON.parse(sessionStorage.getItem("htmx-history-cache")))
             }, 10);
         })
     </script>

--- a/test/manual/history_safari_ios_bug/page3.html
+++ b/test/manual/history_safari_ios_bug/page3.html
@@ -6,9 +6,9 @@
     <script>
         htmx.on("htmx:beforeHistorySave", function(evt){
             console.log("Saving history : ", evt.detail);
-            console.log("History Cache Before:", JSON.parse(localStorage.getItem("htmx-history-cache")))
+            console.log("History Cache Before:", JSON.parse(sessionStorage.getItem("htmx-history-cache")))
             setTimeout(function () {
-                console.log("History Cache After:", JSON.parse(localStorage.getItem("htmx-history-cache")))
+                console.log("History Cache After:", JSON.parse(sessionStorage.getItem("htmx-history-cache")))
             }, 10);
         })
     </script>

--- a/test/manual/history_style/index.html
+++ b/test/manual/history_style/index.html
@@ -7,9 +7,9 @@
     <script>
         htmx.on("htmx:beforeHistorySave", function(evt){
             console.log("Saving history : ", evt.detail);
-            console.log("History Cache Before:", JSON.parse(localStorage.getItem("htmx-history-cache")))
+            console.log("History Cache Before:", JSON.parse(sessionStorage.getItem("htmx-history-cache")))
             setTimeout(function () {
-                console.log("History Cache After:", JSON.parse(localStorage.getItem("htmx-history-cache")))
+                console.log("History Cache After:", JSON.parse(sessionStorage.getItem("htmx-history-cache")))
             }, 10);
         })
     </script>

--- a/test/util/scratch_server.js
+++ b/test/util/scratch_server.js
@@ -1,5 +1,5 @@
 var server = makeServer()
-var autoRespond = localStorage.getItem('hx-scratch-autorespond') == 'true'
+var autoRespond = sessionStorage.getItem('hx-scratch-autorespond') == 'true'
 server.autoRespond = autoRespond
 ready(function() {
   if (autoRespond) {
@@ -8,10 +8,10 @@ ready(function() {
 })
 function toggleAutoRespond() {
   if (server.autoRespond) {
-    localStorage.removeItem('hx-scratch-autorespond')
+    sessionStorage.removeItem('hx-scratch-autorespond')
     server.autoRespond = false
   } else {
-    localStorage.setItem('hx-scratch-autorespond', 'true')
+    sessionStorage.setItem('hx-scratch-autorespond', 'true')
     server.autoRespond = true
   }
 }


### PR DESCRIPTION
## Description
moving history cache to sessionStorage and fixing storage of current history path

Currently htmx stores its history cache in localStorage. However the native browser bfcache we are trying to simulate treats its cache like sessionStorage where it is stored per browser session tab and not in permanent site storage like localStorage.  I think when the feature was first implemented localStorage was picked because it was more familiar.  When localStorage is used the cache persists between sessions and browser restarts and between multiple tabs for the same domain.  The means the cache is constantly fill with old cache state from previous sessions which can't be accessed as only url's pushed and popped in the current session will work and these will update these urls cache data.  As well as the old inaccessable cache data stored there is also the risk that a user opening multiple tabs and going back on one tab will end up restoring the page state data from another tab which is undesirable.  

Simply renaming localStorage to sessionStorage in the code resolves this issue but I've left the internalAPI.canAccessLocalStorage function with the old name to avoid breaking any use of this api. local and session storage will either both be enabled or disabled together so I don't think the naming is critical.

The other Issue I've addressed is the currentPathForHistory state variable.  This variable is used to save the current URL you are on when a back/forward action popstates and changes the url so the current page can be captured against this URL for restoration later.  This variable needs to stay intact during history restoration process and it is currently just a local to htmx let variable.  If htmx script is re-executed during history navigation when the script is placed in the body this variable state is lost and htmx can backup history with the wrong URL causing wierd history navigations.  We could move this path string to sessionStorage but I found this doable but a bit cumbersome.  I think this variable makes sense to instead hoist into the window scope with a htmx prefixed name htmxCurrentPathForHistory which resolves all these issues.  

Corresponding issue:
#2865 

## Testing
Ran test suite and also had to test history back forward actions in a test application to to validate it works as expected.

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
