### PR TITLE
Document fragment/full response render logic

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -937,16 +937,25 @@ In the event of a connection error, the [`htmx:sendError`](@/events.md#htmx:send
 
 ### Rendering Response HTML {#response-html}
 
-Warning: the logic described below will not work if you use
-[hx-select](@/attributes/hx-select.md) because there is no way for the backend
-server to automatically tell if a full page or a fragment should be rendered.
-Only you, the developer, know.
-
 As mentioned [above](#requests), htmx normally expects responses to be fragments
-of HTML. However, when you use htmx, not all requests from your site to its
+of HTML. There are two main exceptions:
+
+- The [hx-select](@/attributes/hx-select.md) attribute is used. In this case
+  there is no way to programmatically determine whether a fragment or a full HTML
+  document should be rendered. It's up to the developer to decide in each
+  individual usage.
+- The [hx-boost](@/attributes/hx-boost.md) attribute is used. In this case the
+  developer could intend for it to fetch a full HTML document or just a fragment;
+  the backend server can't tell from the request sent.
+
+Having said that, let's for now assume that all requests from htmx should fetch
+an HTML fragment response. However, not all requests from your site to its
 backend server will actually be from htmx. Some will be from the browser itself,
 ie normal HTTP requests for full page loads. In this case the browser will be
 loading the response HTML as a full page, and htmx will not be touching it at all.
+Also, some requests from htmx are _always_ intended to fetch a HTML document, not
+just a partial.
+
 This can happen eg when you use [history support](#history) or
 [boosting](#boosting); the fetched URL gets pushed into the URL bar. Once there,
 it can be bookmarked and loaded later, copied and pasted, suspended/resumed by
@@ -960,15 +969,14 @@ Fortunately, you can render either a fragment or a full page for any given path
 with a small amount of server-side logic that checks the request headers:
 
 - Render fragment if
-  - `HX-Request` header is _present_
-  - `HX-Target` header is _present_
+  - `HX-Request` header is _present,_ and
   - `HX-History-Restore-Request` header is _absent._
 - Render full page otherwise.
 
 With this rendered response (either fragment or full), be sure to set the
-`Vary: HX-Request, HX-Target, HX-History-Restore-Request` response header so that
-the correct response will be cached for each request. (This is not something
-specific to htmx, it's just part of the HTTP [caching](#caching) mechanism.)
+`Vary: HX-Request, HX-History-Restore-Request` response header so that the
+correct response will be cached for each request. (This is not something specific
+to htmx, it's just part of the HTTP [caching](#caching) mechanism.)
 
 Now, for any given URL, it will be loaded correctly (either a fragment swapped in
 by htmx, or a full page loaded by the browser).

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -937,6 +937,11 @@ In the event of a connection error, the [`htmx:sendError`](@/events.md#htmx:send
 
 ### Rendering Response HTML {#response-html}
 
+Warning: the logic described below will not work if you use
+[hx-select](@/attributes/hx-select.md) because there is no way for the backend
+server to automatically tell if a full page or a fragment should be rendered.
+Only you, the developer, know.
+
 As mentioned [above](#requests), htmx normally expects responses to be fragments
 of HTML. However, when you use htmx, not all requests from your site to its
 backend server will actually be from htmx. Some will be from the browser itself,
@@ -954,14 +959,16 @@ It would be a confusing user experience.
 Fortunately, you can render either a fragment or a full page for any given path
 with a small amount of server-side logic that checks the request headers:
 
-- Render fragment if `HX-Request` header is _present_ and
-  `HX-History-Restore-Request` header is _absent._
+- Render fragment if
+  - `HX-Request` header is _present_
+  - `HX-Target` header is _present_
+  - `HX-History-Restore-Request` header is _absent._
 - Render full page otherwise.
 
 With this rendered response (either fragment or full), be sure to set the
-`Vary: HX-Request, HX-History-Restore-Request` response header so that the
-correct response will be cached for each request. (This is not something specific
-to htmx, it's just part of the HTTP [caching](#caching) mechanism.)
+`Vary: HX-Request, HX-Target, HX-History-Restore-Request` response header so that
+the correct response will be cached for each request. (This is not something
+specific to htmx, it's just part of the HTTP [caching](#caching) mechanism.)
 
 Now, for any given URL, it will be loaded correctly (either a fragment swapped in
 by htmx, or a full page loaded by the browser).

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -937,14 +937,15 @@ In the event of a connection error, the [`htmx:sendError`](@/events.md#htmx:send
 
 ### Rendering Response HTML {#response-html}
 
-As mentioned above, htmx expects responses to be fragments of HTML. However, when
-you use htmx, not all requests from your site to its backend server will actually
-be from htmx. Some will be from the browser itself, ie normal HTTP requests for
-full page loads. In this case the browser will be loading the response HTML as a
-full page, not as a fragment to be swapped in. This happens eg when you use
-[history support](#history) or [boosting](#boosting); the fetched URL gets pushed
-into the URL bar. Once there, it can be bookmarked and loaded later, copied and
-pasted, suspended/resumed by the browser, etc.
+As mentioned [above](#requests), htmx normally expects responses to be fragments
+of HTML. However, when you use htmx, not all requests from your site to its
+backend server will actually be from htmx. Some will be from the browser itself,
+ie normal HTTP requests for full page loads. In this case the browser will be
+loading the response HTML as a full page, and htmx will not be touching it at all.
+This can happen eg when you use [history support](#history) or
+[boosting](#boosting); the fetched URL gets pushed into the URL bar. Once there,
+it can be bookmarked and loaded later, copied and pasted, suspended/resumed by
+the browser, etc.
 
 When this happens, the server needs to render a _full page,_ not just a fragment.
 Because if only a fragment were loaded, it would have no styling and no context.
@@ -959,7 +960,8 @@ with a small amount of server-side logic that checks the request headers:
 
 With this rendered response (either fragment or full), be sure to set the
 `Vary: HX-Request, HX-History-Restore-Request` response header so that the
-correct response will be cached for each request.
+correct response will be cached for each request. (This is not something specific
+to htmx, it's just part of the HTTP [caching](#caching) mechanism.)
 
 Now, for any given URL, it will be loaded correctly (either a fragment swapped in
 by htmx, or a full page loaded by the browser).
@@ -1587,14 +1589,12 @@ If your server adds the
 [`Last-Modified`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified)
 HTTP response header to the response for a given URL, the browser will automatically add the
 [`If-Modified-Since`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Modified-Since)
-request HTTP header to the next requests to the same URL. Be mindful that if
-your server can render different content for the same URL depending on some other
+request HTTP header to the next requests to the same URL.
+
+Be mindful that if your server can render different content for the same URL depending on some other
 headers, you need to use the [`Vary`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#vary)
-response HTTP header. For example, if your server renders the full HTML when the
-`HX-Request` header is missing or `false`, and it renders a fragment of that HTML
-when `HX-Request: true`, you need to add `Vary: HX-Request`. That causes the cache to be
-keyed based on a composite of the response URL and the `HX-Request` request header —
-rather than being based just on the response URL.
+response HTTP header. For example, if your server renders an HTML fragment or the
+full HTML depending on htmx headers. See [above](#response-html) for details.
 
 If you are unable (or unwilling) to use the `Vary` header, you can alternatively set the configuration parameter
 `getCacheBusterParam` to `true`.  If this configuration variable is set, htmx will include a cache-busting parameter


### PR DESCRIPTION
## Description

Document the exact logic needed by backend servers to decide whether to render an HTML fragment or a full HTML document.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded