### PR TITLE
Fix missing TypeScript property

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -4355,6 +4355,7 @@ var htmx = (function() {
       unfilteredFormData: allFormData,
       unfilteredParameters: formDataProxy(allFormData),
       headers,
+      elt,
       target,
       verb,
       errors,
@@ -5164,6 +5165,7 @@ var htmx = (function() {
  * @property {FormData} unfilteredFormData
  * @property {Object} unfilteredParameters unfilteredFormData proxy
  * @property {HtmxHeaderSpecification} headers
+ * @property {Element} elt
  * @property {Element} target
  * @property {HttpVerb} verb
  * @property {HtmxElementValidationError[]} errors


### PR DESCRIPTION
## Description
Even though it's in the docs for  [`htmx:beforeSwap`](https://htmx.org/events/#htmx:beforeSwap) and the event relies on it, the property `detail.requestConfig.elt` is missing from the TypeScript definition of HtmxRequestConfig.

Looking at the code it's not obvious where it's coming from:
after `requestConfig` is defined, `triggerEvent` is immediately called which adds `elt` to the passed in object.

Fix the type definition and explicitly add `elt` to the `requestConfig` definition to lessen the confusion.

## Testing
Ran dist to make sure the type turned up in the generated .d.ts file.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
