### PR TITLE
Fix type for event parameter

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -5237,7 +5237,7 @@ var htmx = (function() {
  * @see https://github.com/bigskysoftware/htmx-extensions/blob/main/README.md
  * @typedef {Object} HtmxExtension
  * @property {(api: any) => void} init
- * @property {(name: string, event: Event|CustomEvent) => boolean} onEvent
+ * @property {(name: string, event: CustomEvent) => boolean} onEvent
  * @property {(text: string, xhr: XMLHttpRequest, elt: Element) => string} transformResponse
  * @property {(swapStyle: HtmxSwapStyle) => boolean} isInlineSwap
  * @property {(swapStyle: HtmxSwapStyle, target: Node, fragment: Node, settleInfo: HtmxSettleInfo) => boolean|Node[]} handleSwap


### PR DESCRIPTION
## Description
The typescript type claims that the `event` parameter for `HtmxExtension.onEvent` can take `Event|CustomEvent`, but that's not true it can only ever receive a `CustomEvent`. Fix this since it's not a requirement for extensions to deal with an `Event` and the definition of that type doesn't have a `detail` property.

## Testing
Ran `npm run types-check`, the dist script and `npm run types-generate` to verify the type is now correct.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
