### PR TITLE
update web test-runner and remove temp summaryReporter workaournd

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@types/node": "20.0.0",
         "@types/parse5": "^7.0.0",
-        "@web/test-runner": "^0.20.1",
+        "@web/test-runner": "^0.20.2",
         "@web/test-runner-playwright": "^0.11.0",
         "chai": "^4.5.0",
         "chai-dom": "^1.12.1",
@@ -1251,9 +1251,9 @@
       "dev": true
     },
     "node_modules/@web/test-runner": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@web/test-runner/-/test-runner-0.20.1.tgz",
-      "integrity": "sha512-MTN8D1WCeCdkUWJIeG9yauUbRkk9g0zGFnBbI5smtPE91NpXFMfRd8nShIvxQnHx9fNTmK+OCYKnOSlq5DLLVA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@web/test-runner/-/test-runner-0.20.2.tgz",
+      "integrity": "sha512-zfEGYEDnS0EI8qgoWFjmtkIXhqP15W40NW3dCaKtbxj5eU0a7E53f3GV/tZGD0GlZKF8d4Fyw+AFrwOJU9Z4GA==",
       "dev": true,
       "dependencies": {
         "@web/browser-logs": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "devDependencies": {
     "@types/node": "20.0.0",
     "@types/parse5": "^7.0.0",
-    "@web/test-runner": "^0.20.1",
+    "@web/test-runner": "^0.20.2",
     "@web/test-runner-playwright": "^0.11.0",
     "chai": "^4.5.0",
     "chai-dom": "^1.12.1",

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -61,7 +61,7 @@ const config = {
     'test/attributes/**/*.js',
     'test/core/**/*.js'
   ],
-  reporters: [summaryReporter({ flatten: false }), defaultReporter({ reportTestProgress: true, reportTestResults: false })]
+  reporters: [summaryReporter({ flatten: false, reportTestLogs: false, reportTestErrors: true }), defaultReporter({ reportTestProgress: true, reportTestResults: true })]
 }
 
 export default config

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -1,15 +1,7 @@
 import {
   summaryReporter,
-  defaultReporter,
-  dotReporter
+  defaultReporter
 } from '@web/test-runner'
-
-// There is a bug in the summaryReporter made with this PR https://github.com/modernweb-dev/web/pull/2126
-// It captures the buffered logger into cachedLogger for reuse later for the test run finished error reporting
-// But the buffered logger in finished its buffer flush before this test error reporting so these logs go nowhere
-// to resolve this for now reusing dotReporter which reports errors well but disabled its . test reporting
-const errorReporter = dotReporter()
-delete errorReporter.reportTestFileResults
 
 const config = {
   testRunnerHtml: (testFramework) => `
@@ -69,7 +61,7 @@ const config = {
     'test/attributes/**/*.js',
     'test/core/**/*.js'
   ],
-  reporters: [summaryReporter({ flatten: false }), errorReporter, defaultReporter({ reportTestProgress: true, reportTestResults: false })]
+  reporters: [summaryReporter({ flatten: false }), defaultReporter({ reportTestProgress: true, reportTestResults: false })]
 }
 
 export default config


### PR DESCRIPTION
## Description

Just a minor devops tests fixup.  The @web/test-runner had an issue with one of the reporters I had to workaround to retain proper error reporting.  My PR https://github.com/modernweb-dev/web/pull/2932 to fix it just merged upstream so now able to update and remove my temporary workaround.

Corresponding issue:

## Testing
Re-ran the test via cli and browser with no issues.  Errors and logs are showing as expected

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
