### PR TITLE
Add talkpython HTMX + Django training

### DIFF
--- a/www/content/talk/index.md
+++ b/www/content/talk/index.md
@@ -37,6 +37,7 @@ You can find the htmx webring [here](@/webring.md)
 ## Training
 
 [HTMX + Flask: Modern Python Web Apps, Hold the JavaScript Course by Michael Kennedy](https://training.talkpython.fm/courses/htmx-flask-modern-python-web-apps-hold-the-javascript)
+[HTMX + Django: Modern Python Web Apps, Hold the JavaScript Course by Christopher Trudeau](https://training.talkpython.fm/courses/htmx-django-modern-python-web-apps-hold-the-javascript)
 
 ## Atom Feed (Announcements & Essays)
 

--- a/www/content/talk/index.md
+++ b/www/content/talk/index.md
@@ -37,6 +37,7 @@ You can find the htmx webring [here](@/webring.md)
 ## Training
 
 [HTMX + Flask: Modern Python Web Apps, Hold the JavaScript Course by Michael Kennedy](https://training.talkpython.fm/courses/htmx-flask-modern-python-web-apps-hold-the-javascript)
+
 [HTMX + Django: Modern Python Web Apps, Hold the JavaScript Course by Christopher Trudeau](https://training.talkpython.fm/courses/htmx-django-modern-python-web-apps-hold-the-javascript)
 
 ## Atom Feed (Announcements & Essays)


### PR DESCRIPTION
## Description

Add a link to the [HTMX + Django: Modern Python Web Apps, Hold the JavaScript Course
](https://training.talkpython.fm/courses/htmx-django-modern-python-web-apps-hold-the-javascript) 


Corresponding issue: fix #3322 


## Testing

Do not apply

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
