### PR TITLE
Allow use of "this" when evaluating hx-vals

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3878,9 +3878,9 @@ var htmx = (function() {
       if (evaluateValue) {
         varsValues = maybeEval(elt, function() {
           if (event) {
-            return Function('event', 'return (' + str + ')')(event)
+            return Function('event', 'return (' + str + ')').call(elt, event)
           } else { // allow window.event to be accessible
-            return Function('return (' + str + ')')()
+            return Function('return (' + str + ')').call(elt)
           }
         }, {})
       } else {

--- a/test/attributes/hx-vals.js
+++ b/test/attributes/hx-vals.js
@@ -364,4 +364,16 @@ describe('hx-vals attribute', function() {
     this.server.respond()
     div.innerHTML.should.equal('Clicked!')
   })
+
+  it('js: this refers to the element with the hx-vals attribute', function() {
+    this.server.respondWith('POST', '/vars', function(xhr) {
+      var params = getParameters(xhr)
+      params.i1.should.equal('test')
+      xhr.respond(200, {}, 'Clicked!')
+    })
+    var div = make('<div hx-post="/vars" hx-vals="javascript:{ ...this.dataset }" data-i1="test"></div>')
+    div.click()
+    this.server.respond()
+    div.innerHTML.should.equal('Clicked!')
+  })
 })

--- a/www/content/attributes/hx-vals.md
+++ b/www/content/attributes/hx-vals.md
@@ -45,3 +45,4 @@ In this example, if `foo()` returns an object like `{name: "John", age: 30}`, bo
 * `hx-vals` is inherited and can be placed on a parent element.
 * A child declaration of a variable overrides a parent declaration.
 * Input values with the same name will be overridden by variable declarations.
+* When using `javascript:`, `this` refers to the element with the `hx-vals` attribute


### PR DESCRIPTION
## Description
This is a replacement to PR #3139 since its merge conflicts haven't been fixed after a month.

Example:
```html
<div hx-post="/vars" hx-vals="javascript:{ ...this.dataset }" data-name="a name" data-hello="world"></div>
```
We want it to evaluate to `{ "name": "a name", "hello": "world" }` where `this` refers to the div with the hx-vals attribute.

_Note:
The PR makes `this` refer to the `hx-vals` element, rather than the triggering element, and is hence similar to the behavior of `this` when used with [`hx-on`](https://htmx.org/attributes/hx-on/), [`hx-target`](https://htmx.org/attributes/hx-target/) and [`hx-sync`](https://htmx.org/attributes/hx-sync/)._

Corresponding issue: None. _(Although it was mentioned as #1103 in PR #3139, the original problem described there doesn't correspond with this fix / enhancement.)_

## Testing
Added a test in `test/attributes/hx-vals.js`

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
