### PR TITLE
Follow up to #3234

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "main": "dist/htmx.esm.js",
   "types": "dist/htmx.esm.d.ts",
-  "unpkg": "dist/htmx.min.js",
+  "jsdelivr": "dist/htmx.min.js",
   "web-types": "editors/jetbrains/htmx.web-types.json",
   "scripts": {
     "dist": "./scripts/dist.sh && npm run types-generate && npm run web-types-generate",


### PR DESCRIPTION
## Description
Add missing update for migration from UNPKG to jsDelivr.

PR #3234 uses references to `https://cdn.jsdelivr.net/npm/htmx.org`, relying on the default file in `package.json`.
For UNPKG this relies on the `unpkg` property being set to the non-esm file, but this hasn't been migrated for jsDelivr.
The [docs for jsDelivr](https://www.jsdelivr.com/documentation#id-configuring-a-default-file-in-packagejson) say that there is an equivalent `jsdelivr` property, so switch to using that.

## Testing

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
