### PR TITLE
Fix Modified click trigger on form elements prevent default behaviour

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2403,6 +2403,8 @@ var htmx = (function() {
    */
   function shouldCancel(evt, elt) {
     if (evt.type === 'submit' || evt.type === 'click') {
+      // use elt from event that was submitted/clicked where possible to determining if default form/link behavior should be canceled
+      elt = asElement(evt.target) || elt
       if (elt.tagName === 'FORM') {
         return true
       }

--- a/test/core/internals.js
+++ b/test/core/internals.js
@@ -93,8 +93,19 @@ describe('Core htmx internals Tests', function() {
     var anchorThatShouldNotCancel = make("<a href='#foo'></a>")
     htmx._('shouldCancel')({ type: 'click' }, anchorThatShouldNotCancel).should.equal(false)
 
+    var divThatShouldNotCancel = make('<div></div>')
+    htmx._('shouldCancel')({ type: 'click' }, divThatShouldNotCancel).should.equal(false)
+
     var form = make('<form></form>')
-    htmx._('shouldCancel')({ type: 'submit' }, form).should.equal(true)
+    htmx._('shouldCancel')({ type: 'submit', target: form }, form).should.equal(true)
+    htmx._('shouldCancel')({ type: 'click', target: form }, form).should.equal(true)
+
+    // falls back to check elt tag when target is not an element
+    htmx._('shouldCancel')({ type: 'click', target: null }, form).should.equal(true)
+
+    // check that events targeting elements that shouldn't cancel don't cancel
+    htmx._('shouldCancel')({ type: 'submit', target: anchorThatShouldNotCancel }, form).should.equal(false)
+    htmx._('shouldCancel')({ type: 'click', target: divThatShouldNotCancel }, form).should.equal(false)
 
     form = make('<form id="f1">' +
         '<input id="insideInput" type="submit">' +

--- a/test/core/regressions.js
+++ b/test/core/regressions.js
@@ -270,4 +270,25 @@ describe('Core htmx Regression Tests', function() {
       done()
     }, 50)
   })
+
+  it('a modified click trigger on a form does not prevent the default behaviour of other elements - https://github.com/bigskysoftware/htmx/issues/2755', function(done) {
+    var defaultPrevented = 'unset'
+    make('<input type="date" id="datefield">')
+    make('<form hx-trigger="click from:body"></form>')
+
+    htmx.on('#datefield', 'click', function(evt) {
+      // we need to wait so the state of the evt is finalized
+      setTimeout(() => {
+        defaultPrevented = evt.defaultPrevented
+        try {
+          defaultPrevented.should.equal(false)
+          done()
+        } catch (err) {
+          done(err)
+        }
+      }, 0)
+    })
+
+    byId('datefield').click()
+  })
 })


### PR DESCRIPTION
## Description
The fix for a bug got stalled in #2771 so doing it again to address this bug.

The bug that was found is that if you use the from: syntax in a trigger to listen on another element like body for events it still uses the source element for making the decision on if a click event will get canceled/prevented to avoid it firing default form/link behaviour. This can cause all click events to be blocked on checkboxes and other elements in error when only valid form submits or certain link clicks should be prevented.  So this fix changes it to use the events target for deciding which element types to prevent and it falls back to the source element if the event target is not valid.

Corresponding issue:
#2755 

## Testing
Did some manual testing and ran test suite and implemented tests from the original PR

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
