### PR TITLE
Fix non chrome view transtions tests

### DIFF
--- a/test/attributes/hx-swap.js
+++ b/test/attributes/hx-swap.js
@@ -311,20 +311,21 @@ describe('hx-swap attribute', function() {
     done()
   })
 
-  it('works with transition:true', function(done) {
-    this.server.respondWith('GET', '/test', 'Clicked!')
-    var div = make(
-      "<div hx-get='/test' hx-swap='innerHTML transition:true'></div>"
-    )
-    div.click()
-    this.server.respond()
-    div.innerText.should.equal('')
-    setTimeout(function() {
-      div.innerText.should.equal('Clicked!')
-      done()
-    }, 30)
-  })
-
+  if (/chrome/i.test(navigator.userAgent)) {
+    it('works with transition:true', function(done) {
+      this.server.respondWith('GET', '/test', 'Clicked!')
+      var div = make(
+        "<div hx-get='/test' hx-swap='innerHTML transition:true'></div>"
+      )
+      div.click()
+      this.server.respond()
+      div.innerText.should.equal('')
+      setTimeout(function() {
+        div.innerText.should.equal('Clicked!')
+        done()
+      }, 50)
+    })
+  }
   it('works with a settle delay', function(done) {
     this.server.respondWith('GET', '/test', "<div id='d1' class='foo' hx-get='/test' hx-swap='outerHTML settle:10ms'></div>")
     var div = make("<div id='d1' hx-get='/test' hx-swap='outerHTML settle:10ms'></div>")

--- a/test/core/api.js
+++ b/test/core/api.js
@@ -494,17 +494,18 @@ describe('Core htmx API test', function() {
     }, 30)
   })
 
-  it('swap works with a view transition', function(done) {
-    var div = make("<div hx-get='/test'></div>")
-    div.innerText.should.equal('')
-    htmx.swap(div, 'jsswapped', { transition: true })
-    div.innerText.should.equal('')
-    setTimeout(function() {
-      div.innerText.should.equal('jsswapped')
-      done()
-    }, 30)
-  })
-
+  if (/chrome/i.test(navigator.userAgent)) {
+    it('swap works with a view transition', function(done) {
+      var div = make("<div hx-get='/test'></div>")
+      div.innerText.should.equal('')
+      htmx.swap(div, 'jsswapped', { transition: true })
+      div.innerText.should.equal('')
+      setTimeout(function() {
+        div.innerText.should.equal('jsswapped')
+        done()
+      }, 50)
+    })
+  }
   it('swaps content properly (with select)', function() {
     var output = make('<output id="output"/>')
     htmx.swap('#output', '<div><p id="select-me">Swapped!</p></div>', { swapStyle: 'innerHTML' }, { select: '#select-me' })


### PR DESCRIPTION
## Description
found `npm run test:all` to perform multi browser tests now has an issue with view transition tests in firefox testing and the timeout of 30ms is too low sometimes in other browsers

Updated timeout and wrapped the tests so they only run in chrome where view transitions work as expected.

Corresponding issue:

## Testing
ran `npm run test:all` to verify multi browser tests still work well

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
