### PR TITLE
Add outerHTMLStrip and handle template tag encapsulation

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1478,8 +1478,11 @@ var htmx = (function() {
           fragment = getDocument().createDocumentFragment()
           fragment.appendChild(oobElementClone)
           if (!isInlineSwap(swapStyle, target)) {
-            fragment = asParentNode(oobElementClone) // if this is not an inline swap, we use the content of the node, not the node itself
+            // @ts-ignore if elt is template content will be valid so use as inner content
+            fragment = oobElementClone.content || asParentNode(oobElementClone) // if this is not an inline swap, we use the content of the node, not the node itself
           }
+          // outerHTMLStrip swapStyle will strip wrapping tag above but do outerHTML swap of inner contents
+          swapStyle = swapStyle.replace('Strip', '')
 
           const beforeSwapDetails = { shouldSwap: true, target, fragment }
           if (!triggerEvent(target, 'htmx:oobBeforeSwap', beforeSwapDetails)) return

--- a/test/attributes/hx-swap-oob.js
+++ b/test/attributes/hx-swap-oob.js
@@ -128,6 +128,17 @@ describe('hx-swap-oob attribute', function() {
     byId('d1').innerHTML.should.equal('Swapped5')
   })
 
+  it('handles outerHTMLStrip response properly', function() {
+    this.server.respondWith('GET', '/test', "Clicked<div id='d1' hx-swap-oob='outerHTMLStrip'><div id='d2' foo='bar'>Swapped4.1</div></div>")
+    var div = make('<div hx-get="/test">click me</div>')
+    make('<div id="d1"></div>')
+    div.click()
+    this.server.respond()
+    byId('d2').getAttribute('foo').should.equal('bar')
+    div.innerHTML.should.equal('Clicked')
+    byId('d2').innerHTML.should.equal('Swapped4.1')
+  })
+
   it('oob swaps can be nested in content with config {"allowNestedOobSwaps": true}', function() {
     htmx.config.allowNestedOobSwaps = true
     this.server.respondWith('GET', '/test', "<div>Clicked<div id='d1' foo='bar' hx-swap-oob='innerHTML'>Swapped6</div></div>")
@@ -386,5 +397,14 @@ describe('hx-swap-oob attribute', function() {
     swappedElements.forEach(function(element) {
       element.innerHTML.should.equal('Swapped11')
     })
+  })
+
+  it('handles using template as the encapsulating tag of an inner swap', function() {
+    this.server.respondWith('GET', '/test', '<tbody id="foo" hx-swap-oob="innerHTML"><tr><td>Swapped12</td></tr></tbody>')
+    var div = make('<div hx-get="/test">click me</div>')
+    make('<table><tbody id="foo"></tbody></table>')
+    div.click()
+    this.server.respond()
+    byId('foo').innerHTML.should.equal('<tr><td>Swapped12</td></tr>')
   })
 })

--- a/www/content/attributes/hx-swap-oob.md
+++ b/www/content/attributes/hx-swap-oob.md
@@ -31,7 +31,7 @@ The value of the `hx-swap-oob` can be:
 
 If the value is `true` or `outerHTML` (which are equivalent) the element will be swapped inline.
 
-If a swap value is given, that swap strategy will be used and the encapsulating tag pair will be stripped for all strategies other than `outerHTML`.
+If a swap value is given, that swap strategy will be used and the encapsulating tag pair will be stripped for all strategies other than `outerHTML`. There is also an additional swap value `outerHTMLStrip` that still strips the encapsulating tag but allows the replacment the whole target, like `outerHTML`, with all inner content nodes. 
 
 If a selector is given, all elements matched by that selector will be swapped.  If not, the element with an ID matching the new content will be swapped.
 
@@ -69,6 +69,27 @@ A `<p>` can be encapsulated in `<div>` or `<span>`:
 <span hx-swap-oob="beforeend:#text">
 	<p>...</p>
 </span>
+```
+
+You can also now use `template` tag as this should work for nearly any tag type:
+```html
+<template hx-swap-oob="beforeend:#table tbody">
+	<tr>
+		...
+	</tr>
+</template>
+```
+
+Another new option is the `outerHTMLStrip` swap style that allows you to replace an element with multiple nodes:
+```html
+<div id="foo" hx-swap-oob="outerHTMLStrip">
+	<div id="foo2">
+		Replace original
+	</div>
+    <div>
+        And add something more
+    </div>
+</div>
 ```
 
 ### Troublesome Tables and lists


### PR DESCRIPTION
## Description
This is a possible enhancement Jeremy Howard suggested.  When doing `outerHTML` oob swaps there are situations where you may want to replace an element on the page with multiple nodes and this is currently not possible with `outerHTML` oob swaps as they can only replace it with a single node.  This proposed change would add a new swap type `outerHTMLStrip` that strips the encapsulating tag during swap like all the inner swap styles do but performs a `outerHTML` swap to replace the target with all the inner contents of the oob tagged element.

```HTML
<div id="foo" hx-swap-oob="outerHTMLStrip">
  <div id="foo2">
    One thing
  </div>
  <div>
    Another thing
  </div>
</div>
```

While I found you can do this sometimes with the following response currently:

```HTML
<div id="foo2" hx-swap-oob="outerHTML:#foo">
    One thing
</div>
</div hx-swap-oob="afterend:#foo2:>
  <div>
    Another thing
  </div>
</div>
```
Which will have the same results but it is much harder to discover or understand than just being able to control the tag stripping of the outerHTML swap

To implement this feature I just add this new `outerHTMLStrip` swap style support by letting this swap style be detected as a non inline swap style which means  the parent of the swap data becomes the content itself instead of a wrapping fragment so it uses inner content for the swap and then we just remove the word "Strip" from the swap style to allow it to be processed as outerHTML.  

Another related fix I've included is to get the none inline swaps inner content assignment has a bug where template tags are broken as they have .content and not normal inner content nodes.  So just adding support for template.content and falling back to the old way if its not a template solves this issue

This allows more generic use of oob swaps in templating libraries as you can just use template tags like this now:

```HTML
<template id="foo" hx-swap-oob="outerHTMLStrip">
  <div id="foo2">
    One thing
  </div>
  <div>
    Another thing
  </div>
</template>
```

This allows you to ignore the troublesome tables issues that are a real pain to debug as template tags can contain any element type and you don't have to match the encapsulating tag to be the perfect <table> tag type to match the content type to avoid issues.

Existing <template></template> wrapping use cases work the same as before after this change it just adds more template tag support.

Possible Changes:

The swap name `outerHTMLStrip` could be renamed to something else if a better alternative name can be found
Could split this into two separate PR's

Also I found 
Corresponding issue:
#3316 

## Testing
Added new tests and ran full test suite

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
