### PR TITLE
Fix invisible button text for hx-indicator in dark mode

### DIFF
--- a/www/themes/htmx-theme/static/css/site.css
+++ b/www/themes/htmx-theme/static/css/site.css
@@ -402,7 +402,7 @@ tbody > tr > th[scope="rowgroup"] {
   padding: 1em;
   letter-spacing: .1em;
   text-transform: uppercase;
-  background: white;
+  background: Canvas;
   border: solid;
   cursor:pointer;
   border-radius: 8px;


### PR DESCRIPTION
## Description

Part of #1431. Without this, in dark mode the [hx-indicator](https://htmx.org/attributes/hx-indicator/) demo button has white text on white background. Switching to `Canvas` means the button background will be black in dark mode.

This is a similar fix to #2719, though we can’t use `primary` here as it would make the indicator "bars.svg" image almost invisible.

## Testing

Switch between light and dark themes on [hx-indicator](https://htmx.org/attributes/hx-indicator/). Quick recording of the "before" behavior, and the "after" in dark and light themes:

![hx-indicator-dark-mode gif 05-58-20-179](https://github.com/user-attachments/assets/e7ecee48-fec2-40bb-bfc4-936ccbe288e9)

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* ~[ ] I ran the test suite locally (`npm run test`) and verified that it succeeded~
