### PR TITLE
fix click events on elements wrapped by link don't cancel link navigation

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2435,7 +2435,9 @@ var htmx = (function() {
       if (elt.form && elt.type === 'submit') {
         return true
       }
-      if (elt instanceof HTMLAnchorElement && elt.href &&
+      elt = elt.closest('a')
+      // @ts-ignore check for a link wrapping the event elt or if elt is a link. elt will be link so href check is fine
+      if (elt && elt.href &&
         (elt.getAttribute('href') === '#' || elt.getAttribute('href').indexOf('#') !== 0)) {
         return true
       }

--- a/test/core/internals.js
+++ b/test/core/internals.js
@@ -107,6 +107,11 @@ describe('Core htmx internals Tests', function() {
     htmx._('shouldCancel')({ type: 'submit', target: anchorThatShouldNotCancel }, form).should.equal(false)
     htmx._('shouldCancel')({ type: 'click', target: divThatShouldNotCancel }, form).should.equal(false)
 
+    // check elements inside links getting click events should cancel parent links
+    var anchorWithButton = make("<a href='/foo'><button></button></a>")
+    htmx._('shouldCancel')({ type: 'click', target: anchorWithButton.firstChild }, anchorWithButton).should.equal(true)
+    htmx._('shouldCancel')({ type: 'click', target: anchorWithButton.firstChild }, anchorWithButton.firstChild).should.equal(true)
+
     form = make('<form id="f1">' +
         '<input id="insideInput" type="submit">' +
         '<button id="insideFormBtn"></button>' +

--- a/test/core/regressions.js
+++ b/test/core/regressions.js
@@ -291,4 +291,46 @@ describe('Core htmx Regression Tests', function() {
 
     byId('datefield').click()
   })
+
+  it('a button clicked inside an htmx enabled link will prevent the link from navigating on click', function(done) {
+    var defaultPrevented = 'unset'
+    var link = make('<a href="/foo" hx-get="/foo"><button>test</button></a>')
+    var button = link.firstChild
+
+    htmx.on(link, 'click', function(evt) {
+      // we need to wait so the state of the evt is finalized
+      setTimeout(() => {
+        defaultPrevented = evt.defaultPrevented
+        try {
+          defaultPrevented.should.equal(true)
+          done()
+        } catch (err) {
+          done(err)
+        }
+      }, 0)
+    })
+
+    button.click()
+  })
+
+  it('a htmx enabled button clicked inside a link will prevent the link from navigating on click', function(done) {
+    var defaultPrevented = 'unset'
+    var link = make('<a href="/foo"><button hx-get="/foo">test</button></a>')
+    var button = link.firstChild
+
+    htmx.on(link, 'click', function(evt) {
+      // we need to wait so the state of the evt is finalized
+      setTimeout(() => {
+        defaultPrevented = evt.defaultPrevented
+        try {
+          defaultPrevented.should.equal(true)
+          done()
+        } catch (err) {
+          done(err)
+        }
+      }, 0)
+    })
+
+    button.click()
+  })
 })


### PR DESCRIPTION

## Description
A recent change #3336 that just shipped in 2.0.5 has introduced a regression bug where if links contain elements trigger click events it now uses the contained element instead of the wrapping link to make the decision of if the click should prevent a links default navigation behavior.  The fix that broke it was designed to handle situations where you listen for a click event on a higher up element causes checkboxes and other elements to lose their ability to operate with clicks if the active htmx element is a form or a link. And to fix this issue it now checks the element that was clicked for if it is a link to prevent instead of the active htmx element.

To fix this issue i've added a line to the shouldCancel link checking code to located the closest wrapping link (or the event element itself if its a link) 

Also found another edge case issue this resolves that is not working in older htmx versions as well.  If you place htmx attributes on an element like a button and wrap this in a link for progressive enhancment the link would still get triggered unless you move all the htmx attributes up to the link tag instead.  

Corresponding issue:
#3356 

## Testing
Added regression tests for the situation

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
