### PR TITLE
Remove redundant script tags

### DIFF
--- a/www/content/examples/modal-custom.md
+++ b/www/content/examples/modal-custom.md
@@ -132,8 +132,6 @@ example.
 }
 ```
 
-<script src="https://cdn.jsdelivr.net/npm/htmx.org"></script>
-<script src="https://cdn.jsdelivr.net/npm/hyperscript.org"></script>
 <script type="text/javascript">
 
     //=========================================================================

--- a/www/content/examples/modal-uikit.md
+++ b/www/content/examples/modal-uikit.md
@@ -89,7 +89,6 @@ window.document.getElementById("cancelButton").addEventListener("click", functio
 	@import "https://cdnjs.cloudflare.com/ajax/libs/uikit/3.5.9/css/uikit-core.min.css";
 </style>
 
-<script src="https://cdn.jsdelivr.net/npm/hyperscript.org"></script>
 <script>
     //=========================================================================
     // Fake Server Side Code

--- a/www/content/examples/tabs-javascript.md
+++ b/www/content/examples/tabs-javascript.md
@@ -49,7 +49,6 @@ when the content is swapped into the DOM.
 
 <div id="tab-contents" role="tabpanel" hx-get="/tab1" hx-trigger="load"></div>
 
-<script src="https://cdn.jsdelivr.net/npm/hyperscript.org"></script>
 <script>
 	onGet("/tab1", function() {
 		return `


### PR DESCRIPTION
## Description
The custom model example [page](https://htmx.org/examples/modal-custom/) has script tags for htmx and hyperscript in both the head and the body. Remove the redundant tags from the body.

Additionally removed extra hyperscript script tags from the UIKit example [page](https://htmx.org/examples/modal-uikit/) and the JavaScript tabs example [page](https://htmx.org/examples/tabs-javascript/). For the former this actually fixes a problem with its behavior.

## Testing
I checked the examples still worked when running locally using Zola.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
