### PR TITLE
update indicator style to have visibility:hidden for screen readers

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -5060,12 +5060,14 @@ var htmx = (function() {
   function insertIndicatorStyles() {
     if (htmx.config.includeIndicatorStyles !== false) {
       const nonceAttribute = htmx.config.inlineStyleNonce ? ` nonce="${htmx.config.inlineStyleNonce}"` : ''
+      const indicator = htmx.config.indicatorClass
+      const request = htmx.config.requestClass
       getDocument().head.insertAdjacentHTML('beforeend',
-        '<style' + nonceAttribute + '>\
-      .' + htmx.config.indicatorClass + '{opacity:0}\
-      .' + htmx.config.requestClass + ' .' + htmx.config.indicatorClass + '{opacity:1; transition: opacity 200ms ease-in;}\
-      .' + htmx.config.requestClass + '.' + htmx.config.indicatorClass + '{opacity:1; transition: opacity 200ms ease-in;}\
-      </style>')
+        `<style${nonceAttribute}>` +
+        `.${indicator}{opacity:0;visibility: hidden} ` +
+        `.${request} .${indicator}, .${request}.${indicator}{opacity:1;visibility: visible;transition: opacity 200ms ease-in}` +
+        '</style>'
+      )
     }
   }
 

--- a/www/content/attributes/hx-indicator.md
+++ b/www/content/attributes/hx-indicator.md
@@ -43,17 +43,18 @@ image.  The image also has the `htmx-indicator` class on it, which defines an op
 that will show the spinner:
 
 ```css
-    .htmx-indicator{
-        opacity:0;
-        transition: opacity 500ms ease-in;
+    .htmx-indicator {
+        opacity: 0;
+        visibility: hidden;
     }
-    .htmx-request .htmx-indicator{
-        opacity:1;
-    }
-    .htmx-request.htmx-indicator{
-        opacity:1;
+    .htmx-request .htmx-indicator,
+    .htmx-request.htmx-indicator {
+        opacity: 1;
+        visibility: visible;
+        transition: opacity 200ms ease-in;
     }
 ```
+This default `htmx-indicator` CSS also sets the visiblity to hidden for better screen reader accessability and does a quick fade in of the opacity.
 
 If you would prefer a different effect for showing the spinner you could define and use your own indicator
 CSS.  Here is an example that uses `display` rather than opacity (Note that we use `my-indicator` instead of `htmx-indicator`):
@@ -62,9 +63,7 @@ CSS.  Here is an example that uses `display` rather than opacity (Note that we u
     .my-indicator{
         display:none;
     }
-    .htmx-request .my-indicator{
-        display:inline;
-    }
+    .htmx-request .my-indicator,
     .htmx-request.my-indicator{
         display:inline;
     }
@@ -102,3 +101,8 @@ This simulates what a spinner might look like in that situation:
 ```html
 <meta name="htmx-config" content='{"includeIndicatorStyles": false}'>
 ```
+* the `htmx-indicator` CSS added when this config is not disabled uses an inline style tag which may need you to set `inlineStyleNonce` config if you have a strict nonce based CSP policy for `style-src`
+```html
+<meta name="htmx-config" content='{"inlineStyleNonce": "random-nonce"}'>
+```
+* If your CSP needs to block all inline style tags then disable `includeIndicatorStyles` and host your own CSS file with a copy of your prefered `htmx-indicator` style from above

--- a/www/content/attributes/hx-indicator.md
+++ b/www/content/attributes/hx-indicator.md
@@ -54,7 +54,7 @@ that will show the spinner:
         transition: opacity 200ms ease-in;
     }
 ```
-This default `htmx-indicator` CSS also sets the visiblity to hidden for better screen reader accessability and does a quick fade in of the opacity.
+This default `htmx-indicator` CSS also sets the visibility to hidden for better screen reader accessibility and does a quick fade in of the opacity.
 
 If you would prefer a different effect for showing the spinner you could define and use your own indicator
 CSS.  Here is an example that uses `display` rather than opacity (Note that we use `my-indicator` instead of `htmx-indicator`):
@@ -105,4 +105,4 @@ This simulates what a spinner might look like in that situation:
 ```html
 <meta name="htmx-config" content='{"inlineStyleNonce": "random-nonce"}'>
 ```
-* If your CSP needs to block all inline style tags then disable `includeIndicatorStyles` and host your own CSS file with a copy of your prefered `htmx-indicator` style from above
+* If your CSP needs to block all inline style tags then disable `includeIndicatorStyles` and host your own CSS file with a copy of your preferred `htmx-indicator` style from above


### PR DESCRIPTION
## Description
Updating indicator inline style tag so that it uses visibility:hidden as well as opacity so that screen readers will not announce the invisible indicators to users to improve default accessibility

Note I found the current indicator only does a fade in when it shows and does a instant vanish after the request which has been this way for 2 years since a bug was fixed to prevent the indicators fade out showing briefly on hx-location page loads.  I kept the same behavior but just added visibility.

Also I found there was a lot of wasted white space being added in the old code which impacted minification so resolved this and optimized the duplicate class config variable use with const's.

Also updated the hx-indicator documentation to match the new default style and improved the documentation around how to disable and work around inline style with CSP headers.

Corresponding issue:
#3354 

## Testing
Tested manually to confirm the updated style worked as before for fade in during requests and ran the test suite.  Also inspected the impact on the minified and gz size to make sure it is smaller than the old one

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
