### PR TITLE
Remove extra "2" from unminified v2.0.6 SRI hash

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -129,7 +129,7 @@ your head tag and get going:
 An unminified version is also available as well:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.6/dist/htmx.js" integrity="sha384-2ksKjJrwjL5VxqAkAZAVOPXvMkwAykMaNYegdixAESVr+KqLkKE8XBDoZuwyWVUDv" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.6/dist/htmx.js" integrity="sha384-ksKjJrwjL5VxqAkAZAVOPXvMkwAykMaNYegdixAESVr+KqLkKE8XBDoZuwyWVUDv" crossorigin="anonymous"></script>
 ```
 
 While the CDN approach is extremely simple, you may want to consider


### PR DESCRIPTION
## Description

The SRI hash for the unminified version of htmx from jsdelivr had a `2` at the start which did not belong; this removes that.

Corresponding issue: N/A

## Testing

I verified that the `2` was extraneous by verifying https://cdn.jsdelivr.net/npm/htmx.org@2.0.6/dist/htmx.js at https://www.srihash.org/ . Also, the 2.0.5 hash _did_ start with 2; I suspect it just wasn't selected when the new one was pasted over.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [n/a] I ran the test suite locally (`npm run test`) and verified that it succeeded
