### PR TITLE
Fix readyState check

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -5035,22 +5035,13 @@ var htmx = (function() {
   //= ===================================================================
   // Initialization
   //= ===================================================================
-  var isReady = false
-  getDocument().addEventListener('DOMContentLoaded', function() {
-    isReady = true
-  })
-
   /**
    * Execute a function now if DOMContentLoaded has fired, otherwise listen for it.
-   *
-   * This function uses isReady because there is no reliable way to ask the browser whether
-   * the DOMContentLoaded event has already been fired; there's a gap between DOMContentLoaded
-   * firing and readystate=complete.
    */
   function ready(fn) {
     // Checking readyState here is a failsafe in case the htmx script tag entered the DOM by
     // some means other than the initial page load.
-    if (isReady || getDocument().readyState === 'complete') {
+    if (getDocument().readyState !== 'loading') {
       fn()
     } else {
       getDocument().addEventListener('DOMContentLoaded', fn)


### PR DESCRIPTION
## Description

See MDN: https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState

loading -> (prepare DOM tree) -> interactive (DOM tree is ready) -> `DOMContentLoaded` event -> (load sub-resources such as scripts, images, stylesheets and frames) -> complete -> `load` event

Without the fix, there is a bug: if the `htmx` is loaded in `DOMContentLoaded` with `readyState="interactive"` (for example: async chunked import) , then htmx will not initialize.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
