### PR TITLE
Rollback Fix Modified click trigger on form elements prevent default behaviour 

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2430,9 +2430,11 @@ var htmx = (function() {
       if (elt.tagName === 'FORM') {
         return true
       }
+      // find button wrapping the event elt
+      const btn = elt.closest('input[type="submit"], button')
       // @ts-ignore Do not cancel on buttons that 1) don't have a related form or 2) have a type attribute of 'reset'/'button'.
       // The properties will resolve to undefined for elements that don't define 'type' or 'form', which is fine
-      if (elt.form && elt.type === 'submit') {
+      if (btn && btn.form && btn.type === 'submit') {
         return true
       }
       elt = elt.closest('a')

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2425,21 +2425,15 @@ var htmx = (function() {
    */
   function shouldCancel(evt, elt) {
     if (evt.type === 'submit' || evt.type === 'click') {
-      // use elt from event that was submitted/clicked where possible to determining if default form/link behavior should be canceled
-      elt = asElement(evt.target) || elt
       if (elt.tagName === 'FORM') {
         return true
       }
-      // find button wrapping the event elt
-      const btn = elt.closest('input[type="submit"], button')
       // @ts-ignore Do not cancel on buttons that 1) don't have a related form or 2) have a type attribute of 'reset'/'button'.
       // The properties will resolve to undefined for elements that don't define 'type' or 'form', which is fine
-      if (btn && btn.form && btn.type === 'submit') {
+      if (elt.form && elt.type === 'submit') {
         return true
       }
-      elt = elt.closest('a')
-      // @ts-ignore check for a link wrapping the event elt or if elt is a link. elt will be link so href check is fine
-      if (elt && elt.href &&
+      if (elt instanceof HTMLAnchorElement && elt.href &&
         (elt.getAttribute('href') === '#' || elt.getAttribute('href').indexOf('#') !== 0)) {
         return true
       }

--- a/test/core/internals.js
+++ b/test/core/internals.js
@@ -93,24 +93,8 @@ describe('Core htmx internals Tests', function() {
     var anchorThatShouldNotCancel = make("<a href='#foo'></a>")
     htmx._('shouldCancel')({ type: 'click' }, anchorThatShouldNotCancel).should.equal(false)
 
-    var divThatShouldNotCancel = make('<div></div>')
-    htmx._('shouldCancel')({ type: 'click' }, divThatShouldNotCancel).should.equal(false)
-
     var form = make('<form></form>')
-    htmx._('shouldCancel')({ type: 'submit', target: form }, form).should.equal(true)
-    htmx._('shouldCancel')({ type: 'click', target: form }, form).should.equal(true)
-
-    // falls back to check elt tag when target is not an element
-    htmx._('shouldCancel')({ type: 'click', target: null }, form).should.equal(true)
-
-    // check that events targeting elements that shouldn't cancel don't cancel
-    htmx._('shouldCancel')({ type: 'submit', target: anchorThatShouldNotCancel }, form).should.equal(false)
-    htmx._('shouldCancel')({ type: 'click', target: divThatShouldNotCancel }, form).should.equal(false)
-
-    // check elements inside links getting click events should cancel parent links
-    var anchorWithButton = make("<a href='/foo'><button></button></a>")
-    htmx._('shouldCancel')({ type: 'click', target: anchorWithButton.firstChild }, anchorWithButton).should.equal(true)
-    htmx._('shouldCancel')({ type: 'click', target: anchorWithButton.firstChild }, anchorWithButton.firstChild).should.equal(true)
+    htmx._('shouldCancel')({ type: 'submit' }, form).should.equal(true)
 
     form = make('<form id="f1">' +
         '<input id="insideInput" type="submit">' +

--- a/test/core/regressions.js
+++ b/test/core/regressions.js
@@ -271,7 +271,8 @@ describe('Core htmx Regression Tests', function() {
     }, 50)
   })
 
-  it('a modified click trigger on a form does not prevent the default behaviour of other elements - https://github.com/bigskysoftware/htmx/issues/2755', function(done) {
+  // rolled back the fix for this so this fails now
+  it.skip('a modified click trigger on a form does not prevent the default behaviour of other elements - https://github.com/bigskysoftware/htmx/issues/2755', function(done) {
     var defaultPrevented = 'unset'
     make('<input type="date" id="datefield">')
     make('<form hx-trigger="click from:body"></form>')
@@ -313,7 +314,8 @@ describe('Core htmx Regression Tests', function() {
     button.click()
   })
 
-  it('a htmx enabled button clicked inside a link will prevent the link from navigating on click', function(done) {
+  // rolled back the fix for this so this fails now
+  it.skip('a htmx enabled button clicked inside a link will prevent the link from navigating on click', function(done) {
     var defaultPrevented = 'unset'
     var link = make('<a href="/foo"><button hx-get="/foo">test</button></a>')
     var button = link.firstChild

--- a/test/core/regressions.js
+++ b/test/core/regressions.js
@@ -333,4 +333,26 @@ describe('Core htmx Regression Tests', function() {
 
     button.click()
   })
+
+  it('a htmx enabled button containing sub elements will prevent the button submitting a form', function(done) {
+    var defaultPrevented = 'unset'
+    var form = make('<form><button hx-get="/foo"><span>test</span></button></form>')
+    var button = form.firstChild
+    var span = button.firstChild
+
+    htmx.on(button, 'click', function(evt) {
+      // we need to wait so the state of the evt is finalized
+      setTimeout(() => {
+        defaultPrevented = evt.defaultPrevented
+        try {
+          defaultPrevented.should.equal(true)
+          done()
+        } catch (err) {
+          done(err)
+        }
+      }, 0)
+    })
+
+    span.click()
+  })
 })


### PR DESCRIPTION
## Description
This is a possible rollback of the fix we put in to handle modified click triggers on form elements preventing default behaviour.  It has caused a couple of regressions when links and buttons have elements contained inside them so we may want to consider rolling back this change instead of fixing and retaining this fix in place.

Created this PR so we can compare it with the other PR #3368 and decide which one is the best way forward to resolve the issue.  We can close the other PR as we only need one of these merged to resolve the issue.

There is one additional sub bug I found in the last fix up that this will roll back and i've disabled the regression test for this one 
`a htmx enabled button clicked inside a link will prevent the link from navigating on click` which is a edge case that was not handled before where a htmx enabled button clicked inside a link would fire the link full page navigation but this is very edge case.

Corresponding issue:
#3366


## Testing
Rolled back tests but retained some of the regression tests added.  Also left a couple of disabled tests for the fixes this will roll back. 

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
