### PR TITLE
implement reportValidity for reporting proper form validation errors behind config flag

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3553,7 +3553,14 @@ var htmx = (function() {
     if (element.willValidate) {
       triggerEvent(element, 'htmx:validation:validate')
       if (!element.checkValidity()) {
-        if (triggerEvent(element, 'htmx:validation:failed', { message: element.validationMessage, validity: element.validity }) && !errors.length) {
+        if (
+          triggerEvent(element, 'htmx:validation:failed', {
+            message: element.validationMessage,
+            validity: element.validity
+          }) &&
+          !errors.length &&
+          htmx.config.reportValidityOfForms
+        ) {
           element.reportValidity()
         }
         errors.push({ elt: element, message: element.validationMessage, validity: element.validity })

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -278,7 +278,14 @@ var htmx = (function() {
        * @type boolean
        * @default true
        */
-      historyRestoreAsHxRequest: true
+      historyRestoreAsHxRequest: true,
+      /**
+       * Weather to report input validation errors to the end user and update focus to the first input that fails validation.
+       * This should always be enabled as this matches default browser form submit behaviour
+       * @type boolean
+       * @default false
+       */
+      reportValidityOfForms: false
     },
     /** @type {typeof parseInterval} */
     parseInterval: null,
@@ -3546,8 +3553,10 @@ var htmx = (function() {
     if (element.willValidate) {
       triggerEvent(element, 'htmx:validation:validate')
       if (!element.checkValidity()) {
+        if (triggerEvent(element, 'htmx:validation:failed', { message: element.validationMessage, validity: element.validity }) && !errors.length) {
+          element.reportValidity()
+        }
         errors.push({ elt: element, message: element.validationMessage, validity: element.validity })
-        triggerEvent(element, 'htmx:validation:failed', { message: element.validationMessage, validity: element.validity })
       }
     }
   }

--- a/test/core/validation.js
+++ b/test/core/validation.js
@@ -176,6 +176,72 @@ describe('Core htmx client side validation tests', function() {
     calledEvent.should.equal(true)
   })
 
+  it('foucuses on first invalid input and reports error to user when reportValidityOfForms true', function() {
+    htmx.config.reportValidityOfForms = true
+    var form = make('<form hx-post="/test" hx-trigger="click">' +
+            'No Request' +
+            '<input id="i1" name="i1" required>' +
+            '<input id="i2" name="i2" required>' +
+            '</form>')
+    var calledEvent = false
+    var handler = htmx.on(form, 'htmx:validation:failed', function() {
+      calledEvent = true
+    })
+    try {
+      form.click()
+      this.server.respond()
+    } finally {
+      htmx.off(form, handler)
+    }
+    calledEvent.should.equal(true)
+    document.activeElement.should.equal(byId('i1'))
+    htmx.config.reportValidityOfForms = false
+  })
+
+  it('no focus on first invalid input or report errors when reportValidityOfForms false', function() {
+    htmx.config.reportValidityOfForms = false
+    var form = make('<form hx-post="/test" hx-trigger="click">' +
+            'No Request' +
+            '<input id="i1" name="i1" required>' +
+            '<input id="i2" name="i2" required>' +
+            '</form>')
+    var calledEvent = false
+    var handler = htmx.on(form, 'htmx:validation:failed', function() {
+      calledEvent = true
+    })
+    try {
+      form.click()
+      this.server.respond()
+    } finally {
+      htmx.off(form, handler)
+    }
+    calledEvent.should.equal(true)
+    document.activeElement.should.equal(document.body)
+  })
+
+  it('can prevent reportValidity with preventDefault when reportValidityOfForms true', function() {
+    htmx.config.reportValidityOfForms = true
+    var form = make('<form hx-post="/test" hx-trigger="click">' +
+            'No Request' +
+            '<input id="i1" name="i1" required>' +
+            '<input id="i2" name="i2" required>' +
+            '</form>')
+    var calledEvent = false
+    var handler = htmx.on(form, 'htmx:validation:failed', function(evt) {
+      calledEvent = true
+      evt.preventDefault()
+    })
+    try {
+      form.click()
+      this.server.respond()
+    } finally {
+      htmx.off(form, handler)
+    }
+    calledEvent.should.equal(true)
+    document.activeElement.should.equal(document.body)
+    htmx.config.reportValidityOfForms = false
+  })
+
   it('calls htmx:validation:halted on failure', function() {
     var form = make('<form hx-post="/test" hx-trigger="click">' +
             'No Request' +

--- a/www/content/api.md
+++ b/www/content/api.md
@@ -143,7 +143,7 @@ Note that using a [meta tag](@/docs.md#config) is the preferred mechanism for se
 * `htmx.config.responseHandling:[...]` - HtmxResponseHandlingConfig[]: the default [Response Handling](@/docs.md#response-handling) behavior for response status codes can be configured here to either swap or error
 * `htmx.config.allowNestedOobSwaps:true` -  boolean: whether to process OOB swaps on elements that are nested within the main response element. See [Nested OOB Swaps](@/attributes/hx-swap-oob.md#nested-oob-swaps).
 * `htmx.config.historyRestoreAsHxRequest:true` -  Whether to treat history cache miss full page reload requests as a "HX-Request" by returning this response header. This should always be disabled when using HX-Request header to optionally return partial responses
-
+* `htmx.config.reportValidityOfForms:false` -  Weather to report input validation errors to the end user and update focus to the first input that fails validation. This should always be enabled as this matches default browser form submit behaviour
 ##### Example
 
 ```js

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -1090,6 +1090,8 @@ Htmx fires events around validation that can be used to hook in custom validatio
 Non-form elements do not validate before they make requests by default, but you can enable validation by setting
 the [`hx-validate`](@/attributes/hx-validate.md) attribute to "true".
 
+Normal browser form submission alerts the user of any validation errors automatically and auto focuses on the first invalid input. For backwards compatibility reasons htmx does not report the validation to the users by default and you should always enable this option by setting `htmx.config.reportValidityOfForms` to `true` to restore the default browser behavior.
+
 ### Validation Example
 
 Here is an example of an input that uses the [`hx-on`](/attributes/hx-on) attribute to catch the

--- a/www/content/events.md
+++ b/www/content/events.md
@@ -565,7 +565,7 @@ to implement custom validation rules.
 
 ### Event - `htmx:validation:failed` {#htmx:validation:failed}
 
-This event is triggered when an element fails validation.
+This event is triggered when an element fails validation. If `preventDefault()` is invoked on the event, the reportValidity() enabled by `htmx.config.reportValidityOfForms` will not be called.
 
 ##### Details
 

--- a/www/content/reference.md
+++ b/www/content/reference.md
@@ -257,6 +257,7 @@ listed below:
 | `htmx.config.responseHandling`         | the default [Response Handling](@/docs.md#response-handling) behavior for response status codes can be configured here to either swap or error                             |
 | `htmx.config.allowNestedOobSwaps`      | defaults to `true`, whether to process OOB swaps on elements that are nested within the main response element. See [Nested OOB Swaps](@/attributes/hx-swap-oob.md#nested-oob-swaps). |
 | `htmx.config.historyRestoreAsHxRequest`| defaults to `true`, Whether to treat history cache miss full page reload requests as a "HX-Request" by returning this response header. This should always be disabled when using HX-Request header to optionally return partial responses                                                                                                         |
+| `htmx.config.reportValidityOfForms`    | defaults to `false`, Weather to report input validation errors to the end user and update focus to the first input that fails validation. This should always be enabled as this matches default browser form submit behaviour                                                                                                                     |
 
 
 </div>


### PR DESCRIPTION
## Description
Adds support for reportValidity instead of just using checkValidity like it currently does.  Because this could possible alter existing applications that don't expect their htmx activated forms to report invalid inputs and update the focus to the first invalid input currently in htmx i've put it behind a new config item.  This is default browser behaviour so all users should ideally have this config turned on but having it has a config will prevent any change to existing applications while allowing users than want this the option to turn it on.

Also this change also allows disabling the report validity if you use preventDefault in the htmx:validation:failed event.

Also had to ensure that reportValidity only fires on the first invalid input so it focuses the right item.

This could replace PR #3215

Corresponding issue:
#2372 

## Testing
Added tests to ensure it focuses on the first input as expected with reportvalidity

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
