### PR TITLE
Allow custom `hx-prompt` dialogs

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -4177,7 +4177,7 @@ var htmx = (function() {
    * @param {Element} elt
    * @param {Event} event
    * @param {HtmxAjaxEtc} [etc]
-   * @param {boolean} [confirmed]
+   * @param {string|boolean} [confirmed]
    * @return {Promise<void>}
    */
   function issueAjaxRequest(verb, path, elt, event, etc, confirmed) {
@@ -4232,7 +4232,11 @@ var htmx = (function() {
     // allow event-based confirmation w/ a callback
     if (confirmed === undefined) {
       const issueRequest = function(skipConfirmation) {
-        return issueAjaxRequest(verb, path, elt, event, etc, !!skipConfirmation)
+        // convert non-empty strings to boolean
+        const skip = (typeof skipConfirmation === 'string' && skipConfirmation.length >  0)
+          ? skipConfirmation
+          : !!skipConfirmation;
+        return issueAjaxRequest(verb, path, elt, event, etc, skip)
       }
       const confirmDetails = { target, elt, path, verb, triggeringEvent: event, etc, issueRequest, question: confirmQuestion }
       if (triggerEvent(elt, 'htmx:confirm', confirmDetails) === false) {
@@ -4325,13 +4329,17 @@ var htmx = (function() {
     }
     const promptQuestion = getClosestAttributeValue(elt, 'hx-prompt')
     if (promptQuestion) {
-      var promptResponse = prompt(promptQuestion)
-      // prompt returns null if cancelled and empty string if accepted with no entry
-      if (promptResponse === null ||
-      !triggerEvent(elt, 'htmx:prompt', { prompt: promptResponse, target })) {
-        maybeCall(resolve)
-        endRequestLock()
-        return promise
+      if (confirmed) {
+        var promptResponse = confirmed
+      } else {
+        var promptResponse = prompt(promptQuestion)
+        // prompt returns null if cancelled and empty string if accepted with no entry
+        if (promptResponse === null ||
+        !triggerEvent(elt, 'htmx:prompt', { prompt: promptResponse, target })) {
+          maybeCall(resolve)
+          endRequestLock()
+          return promise
+        }
       }
     }
 


### PR DESCRIPTION
## Description
This PR closes issue #3376, and allows users to create custom `hx-prompt` dialogs in exactly the same way we make `hx-confirm` dialogs.

To do this, all I had to do was update the input type of `issueRequest()` to accept a `string|false` value rather than `boolean`. 

Corresponding issue: #3376 

## Testing
I tested this with a custom Alpine.js modal, and it worked as expected. If I get traction on this, I will provide a full, working example (for `hx-confirm` and `hx-prompt`.
 
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If you're making a change to just the website, you can omit this section.*

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
~~(Having trouble testing, running on nixos)~~.
