### PR TITLE
docs(essays): add templ to list of template languages that support fragments

### DIFF
--- a/www/content/essays/template-fragments.md
+++ b/www/content/essays/template-fragments.md
@@ -142,6 +142,7 @@ Here are some known implementations of the fragment concept:
 
 * Go
   * [Standard Library (use block actions)](https://pkg.go.dev/text/template) [[demo]](https://gist.github.com/benpate/f92b77ea9b3a8503541eb4b9eb515d8a)
+  * [templ](https://templ.guide) [[Fragment documentation]](https://templ.guide/syntax-and-usage/fragments) [[repo]](https://github.com/a-h/templ)
 * Java
   * [Thymeleaf](https://www.thymeleaf.org/doc/tutorials/3.0/usingthymeleaf.html#fragment-specification-syntax)
   * [Chill Templates (currently in early alpha)](https://github.com/bigskysoftware/chill/tree/master/chill-script)


### PR DESCRIPTION
## Description

- Small update to essay to add a tool.

Corresponding issue:

- No issue.

## Testing

- Looked at the markdown files in the Github rendering display to check the markdown rendered as expected.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
  - I didn't run the test suite, because I didn't clone the repo, just used Github's markdown editor to propose the change.