### PR TITLE
Update CSRF recommendation

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -1697,6 +1697,8 @@ for exploring this topic.
 
 The assignment and checking of CSRF tokens are typically backend responsibilities, but `htmx` can support returning the CSRF token automatically with every request using the `hx-headers` attribute. The attribute needs to be added to the element issuing the request or one of its ancestor elements. This makes the `html` and `body` elements effective global vehicles for adding the CSRF token to the `HTTP` request header, as illustrated below. 
 
+Note: `hx-boost` does not not update the `<html>` or `<body>` tags; if using this feature with `hx-boost`, make sure to include the CSRF token on an element that _will_ get replaced. Many web frameworks support automatically inserting the CSRF token as a hidden input in HTML forms. This is encouraged whenever possible.
+
 ```html
 <html lang="en" hx-headers='{"X-CSRF-TOKEN": "CSRF_TOKEN_INSERTED_HERE"}'>
     :


### PR DESCRIPTION
Recommend using a form with a hidden input or an adjacent CSRF token in the header. Stop recommending a global token in the `html` or `body` tags as those may not work with `hx-boost`.

Fix #3379