### PR TITLE
add back null check for no form in getRelatedFormData

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2864,6 +2864,9 @@ var htmx = (function() {
       return
     }
     const form = getRelatedForm(elt)
+    if (!form) {
+      return
+    }
     return getInternalData(form)
   }
 

--- a/test/core/regressions.js
+++ b/test/core/regressions.js
@@ -384,4 +384,15 @@ describe('Core htmx Regression Tests', function() {
 
     span.click()
   })
+
+  it('check deleting button during click does not trigger exception error in getRelatedFormData when button can no longer find form', function() {
+    var defaultPrevented = 'unset'
+    var form = make('<form><button>delete</button></form>')
+    var button = form.firstChild
+    htmx.on(button, 'click', function(evt) {
+      evt.target.remove()
+    })
+
+    button.click()
+  })
 })


### PR DESCRIPTION
## Description
The null check in getRelatedFormData was removed recently so it no longer checks if the form is null before returning its internalData.  This function can only run on click events for buttons inside forms so this situation should never happen.  But it turns out that if during a click event handler you remove the button from the dom then it loses its form and the htmx click handler then throws an exception.  The exception doesn't cause any issues its just annoying.

The check was removed because It came up in line of code coverage testing and I was unable to trigger it here.  I've now added a simple test that triggers it to maintain 100% code coverage.

Corresponding issue:
#3393 

## Testing
Added regression test to cover this situation

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
