### PR TITLE
Fix ready() to work even when HTMX is loaded async

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -5075,12 +5075,12 @@ var htmx = (function() {
    * but readyState is not "complete".
    */
   function ready(fn) {
-    if (getDocument().readyState === "loading") {
+    if (getDocument().readyState === 'loading') {
       // Loading hasn't finished yet
-      getDocument().addEventListener("DOMContentLoaded", fn);
+      getDocument().addEventListener('DOMContentLoaded', fn)
     } else {
       // `DOMContentLoaded` has already fired
-      fn();
+      fn()
     }
   }
 

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -5064,7 +5064,7 @@ var htmx = (function() {
    * executed now.
    *
    * This is tricky to get right since the DOMContentLoaded event only fires
-   * ones. We need to ensure we always wait for it if the DOM is still loading,
+   * once. We need to ensure we always wait for it if the DOM is still loading,
    * but that we never wait for it if it's already been fired.
    *
    * This is extra tricky if HTMX was loaded using a script tag with the async


### PR DESCRIPTION
## Description

This updates the `ready` function to work correctly even if executing after `DOMContentLoaded` has been fired, but before `readyState` is `"complete"`. This is apparently possible when loading the script async (using the `async` attribute on the script tag.)

Corresponding issue: https://github.com/bigskysoftware/htmx/issues/2329

## Testing

I have a page in another project where, in about half of page-loads, HTMX fails to call the anonymous initialization function passed to `ready`. Whether it happens or not depends no the exact network timing. By putting in breakpoints, I can see that in the cases where it works correctly, it's because `readyState` is `"completed"`. In other cases, that conditional is `false` and it adds the event listener for `DOMContentLoaded`. However the listener is never called. (In all the runs I've looked at, `isReady` is always `false`.)

I verified this fix by making the same change in the copy of HTMX in that project. The page loaded correctly 10 times in a row.

I wasn't able to add new tests since I'm not really sure how to test this.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
