### PR TITLE
docs: update htmx.find and htmx.findAll

### DIFF
--- a/www/content/api.md
+++ b/www/content/api.md
@@ -217,7 +217,7 @@ Finds an element matching the selector
 
 or
 
-* `elt` - the root element to find the matching element in, inclusive
+* `elt` - the root element to search inside of (not including the root itself)
 * `selector` - the selector to match
 
 ##### Example
@@ -240,7 +240,7 @@ Finds all elements matching the selector
 
 or
 
-* `elt` - the root element to find the matching elements in, inclusive
+* `elt` - the root element to find the matching elements inside of (not including the root itself)
 * `selector` - the selector to match
 
 ##### Example

--- a/www/content/api.md
+++ b/www/content/api.md
@@ -217,7 +217,7 @@ Finds an element matching the selector
 
 or
 
-* `elt` - the root element to search inside of (not including the root itself)
+* `elt` - the root element to find the matching element inside of (not including the root itself)
 * `selector` - the selector to match
 
 ##### Example


### PR DESCRIPTION
## Description

Just updated htmx.find and htmx.findAll docs, so it does not cause any confusion. The search is not inclusive, as this methods are basically querySelector wrappers

Corresponding issue: https://github.com/bigskysoftware/htmx/issues/3392

## Checklist

* [*] I have read the contribution guidelines
* [*] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [*] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
