### PR TITLE
fix issue with hx-sync and htmx:abort with shadow DOM

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -5116,7 +5116,7 @@ var htmx = (function() {
       "[hx-trigger='restored'],[data-hx-trigger='restored']"
     )
     body.addEventListener('htmx:abort', function(evt) {
-      const target = evt.target
+      const target = (/** @type {CustomEvent} */(evt)).detail.elt || evt.target
       const internalData = getInternalData(target)
       if (internalData && internalData.xhr) {
         internalData.xhr.abort()


### PR DESCRIPTION
## Description
Fix htmx:abort Event Handling in Shadow DOM

## Problem

The htmx abort functionality was broken when used inside Shadow DOM due to event retargeting. When events bubble up from inside Shadow DOM, the browser automatically retargets `evt.target` to point to the shadow host element instead of the original element that triggered the event. This caused the abort handler to try to abort the wrong element's request.

## Root Cause

The htmx:abort event handler was using `evt.target` to identify which element's request to abort:

In Shadow DOM, evt.target points to the shadow host element, not the actual button inside the shadow DOM that triggered the event.

Solution
htmx events include the original triggering element in evt.detail.elt. The fix uses this property with a fallback to maintain backward compatibility:

```JS
body.addEventListener('htmx:abort', function(evt) {
  const target = (/** @type {CustomEvent} */(evt)).detail.elt || evt.target
  const internalData = getInternalData(target)
  if (internalData && internalData.xhr) {
    internalData.xhr.abort()
  }
})
```

Corresponding issue:
#3419 

## Testing
Added comprehensive tests: Added Shadow DOM tests for:

- Basic hx-sync functionality
- Programmatic abort via htmx.trigger()
- hx-sync abort strategy

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
