### PR TITLE
Correct the integrity hash of the scripts 'Integrity' key for htmx-ext-ws.

### DIFF
--- a/www/content/extensions/ws.md
+++ b/www/content/extensions/ws.md
@@ -24,7 +24,7 @@ The fastest way to install `ws` is to load it via a CDN. Remember to always incl
 ```HTML
 <head>
     <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.6/dist/htmx.min.js" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/htmx-ext-ws@2.0.2" integrity="sha384-vuKxTKv5TX/b3lLzDKP2U363sOAoRo5wSvzzc3LJsbaQRSBSS+3rKKHcOx5J8doU" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/htmx-ext-ws@2.0.2" integrity="sha384-0RHpPqZ4QLJXG/ALtieEL/G+NuAI98LYSkT9s6FgciveUhAdo/6wab5NU1tm2Bxs" crossorigin="anonymous"></script>
 </head>
 <body hx-ext="ws">
 ```


### PR DESCRIPTION
Looks like there is a % typo on the end of the integrity field in the documentation only.

This is likely because a command was used like this:

➜ cat htmx-ext-ws@2.0.2 | openssl dgst -sha384 -binary | openssl base64 -A 0RHpPqZ4QLJXG/ALtieEL/G+NuAI98LYSkT9s6FgciveUhAdo/6wab5NU1tm2Bxs%

Note that it adds a % on the end, this is the shell end character being added.

To prevent this, you can instruct your shell to add a newline after the command's output. The easy to do this is to add an echo command after the pipeline.

➜ cat htmx-ext-ws@2.0.2 | openssl dgst -sha384 -binary | openssl base64 -A; echo

0RHpPqZ4QLJXG/ALtieEL/G+NuAI98LYSkT9s6FgciveUhAdo/6wab5NU1tm2Bxs

This only addresses the documentation, I don't know if you have tooling that generates the value in the docs.
 

## Description

I tried copy and pasting the demonstration headers into my code, My browser refused to download and use it because the integrity checksum was incorrect.

I was able to see an error message in the browsers console, letting me know the generated checksum does not match the provided checksum.

If my below information is unacceptable in any way, feel free to just discard this and close the issue.  I'm reaching maximum care level and I think that its likely more work than I'm willing to put in.

## Testing

I tested this failed by looking at the looking at the browser console for errors.
I tested my fix worked by changing the integrity value and looking at the browser console.


## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes) (well i forked master, made a new branch, then made this ?)
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue

I got the CEO of htmx to approve this issue here: https://github.com/bigskysoftware/htmx/issues/3427

* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded

I didnt change any code, I am unsure why this would matter.

It didnt succeed, but this is javascript and I don't have infinite resources to fix the ecosystem, so I will not chase this rabbit hole forever because I care about my sanity.

Here is the "output" on my machine. (for whatever its supposed to be ?)

 ✗ npm run test

> htmx.org@2.0.6 test
> npm run lint && npm run types-check && npm run test:chrome


> htmx.org@2.0.6 lint
> eslint src/htmx.js test/attributes/ test/core/ test/util/ scripts/*.mjs


Oops! Something went wrong! :(

ESLint: 9.34.0

ESLint couldn't find an eslint.config.(js|mjs|cjs) file.

From ESLint v9.0.0, the default configuration file is now eslint.config.js.
If you are using a .eslintrc.* file, please follow the migration guide
to update your configuration file to the new format:

https://eslint.org/docs/latest/use/configure/migration-guide

If you still have problems after following the migration guide, please stop by
https://eslint.org/chat/help to chat with the team.
