### PR TITLE
feat: add hold as a trigger event modifier

### DIFF
--- a/www/content/attributes/hx-trigger.md
+++ b/www/content/attributes/hx-trigger.md
@@ -61,6 +61,7 @@ Standard events can also have modifiers that change how they behave.  The modifi
 is seen again it will reset the delay.
 * `throttle:<timing declaration>` - a throttle will occur after an event triggers a request. If the event
 is seen again before the delay completes, it is ignored, the element will trigger at the end of the delay.
+* `hold:<timing declaration>` - requires the user to hold the pointer down for the specified duration before triggering the request. Cancels on pointer up or cancel.
 * `from:<Extended CSS selector>` - allows the event that triggers a request to come from another element in the document (e.g. listening to a key event on the body, to support hot keys)
   * A standard CSS selector resolves to all elements matching that selector. Thus, `from:input` would listen on every input on the page.
   * The CSS selector is only evaluated once and is not re-evaluated when the page changes. If you need to detect dynamically added elements use a [standard event filter](#standard-event-filters), for example `hx-trigger="click[event.target.matches('button')] from:body"` which would [catch](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Event_bubbling) click events from every button on the page.

--- a/www/static/src/htmx.js
+++ b/www/static/src/htmx.js
@@ -5209,6 +5209,7 @@ var htmx = (function() {
  * @property {string} [queue]
  * @property {string} [root]
  * @property {string} [threshold]
+ * @property {number} [hold]
  */
 
 /**

--- a/www/themes/htmx-theme/static/js/htmx.js
+++ b/www/themes/htmx-theme/static/js/htmx.js
@@ -5209,6 +5209,7 @@ var htmx = (function() {
  * @property {string} [queue]
  * @property {string} [root]
  * @property {string} [threshold]
+ * @property {number} [hold]
  */
 
 /**


### PR DESCRIPTION
## Description
*Please describe what changes you made, and why you feel they are necessary. Make sure to include
code examples, where applicable.*

adds hold as a trigger event 

Corresponding issue:

None, I wanted to create a hold-to-click interaction and realized how common of a pattern it is, so I decided to take a stab at upstreaming it into HTMX

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

I tried to test as many edge cases as I could, if any reviewer comes up with more, I can try adding those too. :)

## Checklist

* [y] I have read the contribution guidelines
* [i think so] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [n] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [y] I ran the test suite locally (`npm run test`) and verified that it succeeded

