### PR TITLE
Wrap the bootstrap process in a function and expose it in the public api

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -320,6 +320,7 @@ var htmx = (function() {
   htmx.logNone = logNone
   htmx.parseInterval = parseInterval
   htmx._ = internalEval
+  htmx.bootstrap = bootstrap
 
   const internalAPI = {
     addTriggerHandler,
@@ -5108,8 +5109,13 @@ var htmx = (function() {
     }
   }
 
-  // initialize the document
-  ready(function() {
+  let isBootstrapped = false
+  function bootstrap() {
+    if (isBootstrapped) {
+      return
+    }
+    isBootstrapped = true
+    // initialize the document
     mergeMetaConfig()
     insertIndicatorStyles()
     let body = getDocument().body
@@ -5146,7 +5152,9 @@ var htmx = (function() {
       triggerEvent(body, 'htmx:load', {}) // give ready handlers a chance to load up before firing this event
       body = null // kill reference for gc
     }, 0)
-  })
+  }
+
+  ready(bootstrap)
 
   return htmx
 })()


### PR DESCRIPTION
## Description

I'm working on implementing streaming responses in my app similarly to React Suspense. The main body of the page is returned first and then blocks of content are streamed and replaced in the page.

This method works great in practice but HTMX is not compatible with it because it waits on the DOMContentLoaded event to initialize itself. However, using this technique, the event only occurs once the request is finished. This is a problem as the user has a fully rendered page in front of his eyes, than can already be interacted with but HTMX is still not loaded.

My propose change exposes an htmx.bootstrap() function that allows to manually bootstrap htmx at a choosen time. The function can be safely called multiple times but it will only execute once. It will automatically trigger on DOMContentLoaded like it does today.

The change is minimal but allows greater control, needed for the streaming use case.

## Testing

Tested manually + ran "npm run test"
Minimal change.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
