### PR TITLE
Preserves pre-disabled elements with hx-disabled-elt on other element

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3389,8 +3389,10 @@ var htmx = (function() {
     forEach(disabledElts, function(disabledElement) {
       const internalData = getInternalData(disabledElement)
       internalData.requestCount = (internalData.requestCount || 0) + 1
-      disabledElement.setAttribute('disabled', '')
-      disabledElement.setAttribute('data-disabled-by-htmx', '')
+      if (!disabledElement.hasAttribute('disabled')) {
+        disabledElement.setAttribute('disabled', '')
+        disabledElement.setAttribute('data-disabled-by-htmx', '')
+      }
     })
     return disabledElts
   }
@@ -3412,7 +3414,7 @@ var htmx = (function() {
     })
     forEach(disabled, function(disabledElement) {
       const internalData = getInternalData(disabledElement)
-      if (internalData.requestCount === 0) {
+      if (internalData.requestCount === 0 && disabledElement.hasAttribute('data-disabled-by-htmx')) {
         disabledElement.removeAttribute('disabled')
         disabledElement.removeAttribute('data-disabled-by-htmx')
       }

--- a/test/attributes/hx-disabled-elt.js
+++ b/test/attributes/hx-disabled-elt.js
@@ -39,6 +39,18 @@ describe('hx-disabled-elt attribute', function() {
     fieldset.hasAttribute('disabled').should.equal(false)
   })
 
+  it('preserve pre-disabled elements', function() {
+    this.server.respondWith('GET', '/test', 'ok')
+    const b1 = make('<button hx-get="/test" hx-disabled-elt="#b2">Click Me!</button>')
+    const b2 = make('<button id="b2" disabled></button>')
+    b2.hasAttribute('disabled').should.equal(true)
+    b2.hasAttribute('data-disabled-by-htmx').should.equal(false)
+    b1.click()
+    b2.hasAttribute('disabled').should.equal(true)
+    this.server.respond()
+    b2.hasAttribute('disabled').should.equal(true)
+  })
+
   it('multiple requests with same disabled elt are handled properly', function() {
     this.server.respondWith('GET', '/test', 'Clicked!')
     var b1 = make('<button hx-get="/test" hx-disabled-elt="#b3">Click Me!</button>')


### PR DESCRIPTION
## Description
Elements with `hx-disabled-elt` that were already disabled before sending request will now keep the disabled attribute after server has responded or timed out. 

A good chunk of the users are probably thinking that this doesn't matter because their html will always swap after request has completed but if they have set `htmx.config.timeout` the request can time out and elements that are supposed to be disabled will not be disabled anymore.

The attribute `data-disabled-by-htmx` isn't set if the element already was disabled.

### Questions
Should I add a note to the documentation https://htmx.org/attributes/hx-disabled-elt/? Something like "Already disabled elements will not be affected"?

Corresponding issue: https://github.com/bigskysoftware/htmx/issues/3437

## Testing
Test added: `preserve pre-disabled elements`.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
