### PR TITLE
Fix ws extension CDN URL and hash in example

### DIFF
--- a/www/content/extensions/ws.md
+++ b/www/content/extensions/ws.md
@@ -24,7 +24,7 @@ The fastest way to install `ws` is to load it via a CDN. Remember to always incl
 ```HTML
 <head>
     <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.7/dist/htmx.min.js" integrity="sha384-ZBXiYtYQ6hJ2Y0ZNoYuI+Nq5MqWBr+chMrS/RkXpNzQCApHEhOt2aY8EJgqwHLkJ" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/htmx-ext-ws@2.0.2" integrity="sha384-vuKxTKv5TX/b3lLzDKP2U363sOAoRo5wSvzzc3LJsbaQRSBSS+3rKKHcOx5J8doU" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/htmx-ext-ws@2.0.3/dist/ws.min.js" integrity="sha384-UQRM5X6/SG8fQYKt4K+MgCmlaxETMLkkEH8yiky5TdOZzNY0EQ8RjP/S0kMU+w6r" crossorigin="anonymous"></script>
 </head>
 <body hx-ext="ws">
 ```


### PR DESCRIPTION
## Description

I used `<script>` tags from the example on the WS extension page (https://htmx.org/extensions/ws/#installing) and first got an invalid computed hash error, once that was fixed, there was an error about import statements (because the default file delivered is based on `ws.esm.js`).

I switched to `ws.min.js`, latest version and updated the computed hash.

Corresponding issue:

## Testing

n/a

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
