### PR TITLE
Update Node Versions and types to fix latest tsc upgrade issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.7",
       "license": "0BSD",
       "devDependencies": {
-        "@types/node": "20.0.0",
+        "@types/node": "^22.18.8",
         "@types/parse5": "^7.0.0",
         "@web/test-runner": "^0.20.2",
         "@web/test-runner-playwright": "^0.11.0",
@@ -20,10 +20,10 @@
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-mocha": "^10.5.0",
         "fs-extra": "^9.1.0",
-        "mocha": "^11.1.0",
+        "mocha": "^11.7.4",
         "mock-socket": "^9.3.1",
         "sinon": "^10.0.1",
-        "typescript": "^5.5.4",
+        "typescript": "^5.9.3",
         "uglify-js": "^3.19.3",
         "ws": "^8.18.1"
       }
@@ -981,11 +981,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.0.0.tgz",
-      "integrity": "sha512-cD2uPTDnQQCVpmRefonO98/PPijuOnnEy5oytWJFPY1N9aJCz2wJ5kSGWO+zJoed2cY2JxQh6yBuUq4vIn61hw==",
+      "version": "22.18.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.8.tgz",
+      "integrity": "sha512-pAZSHMiagDR7cARo/cch1f3rXy0AEXwsVsVH09FcyeJVAzCnGgmYis7P3JidtTUjyadhTeSo8TgRPswstghDaw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/parse5": {
       "version": "7.0.0",
@@ -5505,9 +5508,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.7.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.2.tgz",
-      "integrity": "sha512-lkqVJPmqqG/w5jmmFtiRvtA2jkDyNVUcefFJKb2uyX4dekk8Okgqop3cgbFiaIvj8uCRJVTP5x9dfxGyXm2jvQ==",
+      "version": "11.7.4",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.4.tgz",
+      "integrity": "sha512-1jYAaY8x0kAZ0XszLWu14pzsf4KV740Gld4HXkhNTXwcHx4AUEDkPzgEHg9CM5dVcW+zv036tjpsEbLraPJj4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5519,6 +5522,7 @@
         "find-up": "^5.0.0",
         "glob": "^10.4.5",
         "he": "^1.2.0",
+        "is-path-inside": "^3.0.3",
         "js-yaml": "^4.1.0",
         "log-symbols": "^4.1.0",
         "minimatch": "^9.0.5",
@@ -7372,9 +7376,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
-      "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7617,9 +7621,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -7671,6 +7675,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dist": "./scripts/dist.sh && npm run types-generate && npm run web-types-generate",
     "lint": "eslint src/htmx.js test/attributes/ test/core/ test/util/ scripts/*.mjs",
     "format": "eslint --fix src/htmx.js test/attributes/ test/core/ test/util/ scripts/*.mjs",
-    "types-check": "tsc src/htmx.js --noEmit --checkJs --target es6 --lib dom,dom.iterable",
+    "types-check": "tsc src/htmx.js --noEmit --checkJs --target es6 --lib dom,dom.iterable --moduleResolution node",
     "types-generate": "tsc dist/htmx.esm.js --declaration --emitDeclarationOnly --allowJs --outDir dist",
     "test": "npm run lint && npm run types-check && npm run test:chrome",
     "test:debug": "web-test-runner --manual --open",
@@ -70,8 +70,8 @@
       "no-useless-escape": 0,
       "no-unused-expressions": 0,
       "no-restricted-properties": ["error", {
-        "property": "substr",
-        "message": "Use .slice or .substring instead of .substr"
+          "property": "substr",
+          "message": "Use .slice or .substring instead of .substr"
       }],
       "space-before-function-paren": [
         "error",
@@ -80,7 +80,7 @@
     }
   },
   "devDependencies": {
-    "@types/node": "20.0.0",
+    "@types/node": "^22.18.8",
     "@types/parse5": "^7.0.0",
     "@web/test-runner": "^0.20.2",
     "@web/test-runner-playwright": "^0.11.0",
@@ -91,10 +91,10 @@
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-mocha": "^10.5.0",
     "fs-extra": "^9.1.0",
-    "mocha": "^11.1.0",
+    "mocha": "^11.7.4",
     "mock-socket": "^9.3.1",
     "sinon": "^10.0.1",
-    "typescript": "^5.5.4",
+    "typescript": "^5.9.3",
     "uglify-js": "^3.19.3",
     "ws": "^8.18.1"
   }


### PR DESCRIPTION
## Description
Typescript locked version got accidently updated to 5.9.2 which causes problems with node internal buffer types because of recent generics handling somehow.  This throws errors in tsc type checking preventing blocking all github pipelines running.  Instead of just rolling back typescript and leaving this as a problem for our future selves i've updated to the latest tsc version and updated the very old @types/node that was stuck on an old backwards compatible version before.  To allow us to update types without issues I had to add --moduleResolution node to the tsc run to support the modern way types are handled.  This should prevent future problems with tsc not working as things change.

Corresponding issue:

## Testing
Ran tests and types-check to make sure it runs ok after the upgrades

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
