### PR TITLE
Add Primer.js to the Hypermedia Research section

### DIFF
--- a/www/content/essays/_index.md
+++ b/www/content/essays/_index.md
@@ -67,6 +67,7 @@ page_template = "essay.html"
 * [The First Web Page (1991)](http://info.cern.ch/hypertext/WWW/TheProject.html)
 * [Architectural Styles and the Design of Network-based Software Architectures (Roy Fielding, 2000)](https://ics.uci.edu/~fielding/pubs/dissertation/top.htm)
 * [State of the Art Review on Hypermedia Issues and Applications (2006)](https://paul.luon.net/hypermedia/index.html) [[archive]](https://web.archive.org/web/20240428215142/https://paul.luon.net/hypermedia/index.html)
+* [Facebook - How Primer has changed the way we write JavaScript for the better with Makinde Adeagbo and Tom Occhino](https://www.facebook.com/watch/?v=596368660334) [[archive.org mirror]](https://archive.org/details/facebook-front-end-tech-talk-8-5-2010-primerjs) [[youtube mirror]](https://youtu.be/BZmfCjtv6cM)
 * [Hypermedia Controls: Feral to Formal (ACM HT'24)](https://dl.acm.org/doi/pdf/10.1145/3648188.3675127)
 * [Preserving REST-ful Visibility Of Rich Web Applications With Generalized Hypermedia Controls (ACM SIGWEB Newsletter, Autumn'24)](https://hypermedia.cs.montana.edu/papers/preserving-restful.pdf)
 

--- a/www/content/essays/_index.md
+++ b/www/content/essays/_index.md
@@ -67,7 +67,7 @@ page_template = "essay.html"
 * [The First Web Page (1991)](http://info.cern.ch/hypertext/WWW/TheProject.html)
 * [Architectural Styles and the Design of Network-based Software Architectures (Roy Fielding, 2000)](https://ics.uci.edu/~fielding/pubs/dissertation/top.htm)
 * [State of the Art Review on Hypermedia Issues and Applications (2006)](https://paul.luon.net/hypermedia/index.html) [[archive]](https://web.archive.org/web/20240428215142/https://paul.luon.net/hypermedia/index.html)
-* [Facebook - How Primer has changed the way we write JavaScript for the better with Makinde Adeagbo and Tom Occhino](https://www.facebook.com/watch/?v=596368660334) [[archive.org mirror]](https://archive.org/details/facebook-front-end-tech-talk-8-5-2010-primerjs) [[youtube mirror]](https://youtu.be/BZmfCjtv6cM)
+* [How Primer has changed the way we write JavaScript for the better at Facebook (Makinde Adeagbo and Tom Occhino, 2010)](https://www.facebook.com/watch/?v=596368660334) [[archive.org mirror]](https://archive.org/details/facebook-front-end-tech-talk-8-5-2010-primerjs) [[youtube mirror]](https://youtu.be/BZmfCjtv6cM)
 * [Hypermedia Controls: Feral to Formal (ACM HT'24)](https://dl.acm.org/doi/pdf/10.1145/3648188.3675127)
 * [Preserving REST-ful Visibility Of Rich Web Applications With Generalized Hypermedia Controls (ACM SIGWEB Newsletter, Autumn'24)](https://hypermedia.cs.montana.edu/papers/preserving-restful.pdf)
 


### PR DESCRIPTION
## Description

Adds the Primer.js talk to the Hypermedia Research section

I've included the original talk link https://www.facebook.com/watch/?v=596368660334 and the Archive.org mirror and the YouTube mirror that I made. I've decided to "prioritize" the Facebook URL because it is the source video, but because Facebook's player seems a tad bit wonky to me (audio, for some reason, does not work to me, Facebook says that the video does not have sound) and because you need to login to watch it, I've decided to also include both mirrors.

I could remove one of the mirrors, *especially* the YouTube mirror because it has worse quality compared to the archive.org mirror, but I decided to keep it for convenience.

I also thought about including the JSConf X talk, but I thought it would be redundant considering that the Facebook talk goes way more in-depth, talks more about other infrastructure too (Haste and Bootloader)

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
  * [Carson asked me to PR it on htmx's Discord server :)](https://discord.com/channels/725789699527933952/1174391486222180402/1425485340487061646)
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
  * Didn't run it because it is a website update, not a htmx code change
