### PR TITLE
minor spelling fix in htmx.js and api.md

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -280,7 +280,7 @@ var htmx = (function() {
        */
       historyRestoreAsHxRequest: true,
       /**
-       * Weather to report input validation errors to the end user and update focus to the first input that fails validation.
+       * Whether to report input validation errors to the end user and update focus to the first input that fails validation.
        * This should always be enabled as this matches default browser form submit behaviour
        * @type boolean
        * @default false

--- a/www/content/api.md
+++ b/www/content/api.md
@@ -143,7 +143,7 @@ Note that using a [meta tag](@/docs.md#config) is the preferred mechanism for se
 * `htmx.config.responseHandling:[...]` - HtmxResponseHandlingConfig[]: the default [Response Handling](@/docs.md#response-handling) behavior for response status codes can be configured here to either swap or error
 * `htmx.config.allowNestedOobSwaps:true` -  boolean: whether to process OOB swaps on elements that are nested within the main response element. See [Nested OOB Swaps](@/attributes/hx-swap-oob.md#nested-oob-swaps).
 * `htmx.config.historyRestoreAsHxRequest:true` -  Whether to treat history cache miss full page reload requests as a "HX-Request" by returning this response header. This should always be disabled when using HX-Request header to optionally return partial responses
-* `htmx.config.reportValidityOfForms:false` -  Weather to report input validation errors to the end user and update focus to the first input that fails validation. This should always be enabled as this matches default browser form submit behaviour
+* `htmx.config.reportValidityOfForms:false` -  Whether to report input validation errors to the end user and update focus to the first input that fails validation. This should always be enabled as this matches default browser form submit behaviour
 ##### Example
 
 ```js


### PR DESCRIPTION
## Description
Weather/Whether spelling fix already done for reference.md in #3469 but needs to be done in a couple of other places

Corresponding issue:

## Testing
Just spelling fix

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
