### PR TITLE
Docs: fix highlighting

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -1153,7 +1153,7 @@ An unminified version is also available at `https://cdn.jsdelivr.net/npm/htmx-ex
 While the CDN approach is simple, you may want to consider [not using CDNs in production](https://blog.wesleyac.com/posts/why-not-javascript-cdn). The next easiest way to install htmx extensions is to simply copy them into your project. Download the extension from `https://cdn.jsdelivr.net/npm/htmx-ext-extension-name` (replace `extension-name` with the name of the extension) e.g., https://cdn.jsdelivr.net/npm/htmx-ext-response-targets. Then add it to the appropriate directory in your project and include it where necessary with a `<script>` tag.
 
 For npm-style build systems, you can install htmx extensions via [npm](https://www.npmjs.com/) (replace `extension-name` with the name of the extension):
-```shell
+```sh
 npm install htmx-ext-extension-name
 ```
 After installing, you'll need to use appropriate tooling to bundle `node_modules/htmx-ext-extension-name/dist/extension-name.js` (or `.min.js`). For example, you might bundle the extension with htmx core from `node_modules/htmx.org/dist/htmx.js` and project-specific code.

--- a/www/content/essays/you-cant.md
+++ b/www/content/essays/you-cant.md
@@ -274,7 +274,7 @@ example, a standard action on the web is to show and hide things based on a butt
 show and hide elements with only CSS and HTML, for example, by using an HTML input checkbox to track state. We can style
 an HTML label as a button and give it a `for="checkboxID`" attribute, so clicking the label toggles the checkbox.
 
-```jsx
+```tsx
 <input id="published" class="hidden peer" type="checkbox"/>
 <label for="published" class="btn">toggle content</label>
 

--- a/www/content/extensions/head-support.md
+++ b/www/content/extensions/head-support.md
@@ -29,7 +29,7 @@ An unminified version is also available at https://cdn.jsdelivr.net/npm/htmx-ext
 While the CDN approach is simple, you may want to consider [not using CDNs in production](https://blog.wesleyac.com/posts/why-not-javascript-cdn). The next easiest way to install `head-support` is to simply copy it into your project. Download the extension from `https://cdn.jsdelivr.net/npm/htmx-ext-head-support`, add it to the appropriate directory in your project and include it where necessary with a `<script>` tag.
 
 For npm-style build systems, you can install `head-support` via [npm](https://www.npmjs.com/):
-```shell
+```sh
 npm install htmx-ext-head-support
 ```
 After installing, you'll need to use appropriate tooling to bundle `node_modules/htmx-ext-head-support/dist/head-support.js` (or `.min.js`). For example, you might bundle the extension with htmx core from `node_modules/htmx.org/dist/htmx.js` and project-specific code.

--- a/www/content/extensions/htmx-1-compat.md
+++ b/www/content/extensions/htmx-1-compat.md
@@ -20,7 +20,7 @@ An unminified version is also available at https://cdn.jsdelivr.net/npm/htmx-ext
 While the CDN approach is simple, you may want to consider [not using CDNs in production](https://blog.wesleyac.com/posts/why-not-javascript-cdn). The next easiest way to install `htmx-1-compat` is to simply copy it into your project. Download the extension from `https://cdn.jsdelivr.net/npm/htmx-ext-htmx-1-compat`, add it to the appropriate directory in your project and include it where necessary with a `<script>` tag.
 
 For npm-style build systems, you can install `htmx-1-compat` via [npm](https://www.npmjs.com/):
-```shell
+```sh
 npm install htmx-ext-htmx-1-compat
 ```
 After installing, you'll need to use appropriate tooling to bundle `node_modules/htmx-ext-htmx-1-compat/dist/htmx-1-compat.js` (or `.min.js`). For example, you might bundle the extension with htmx core from `node_modules/htmx.org/dist/htmx.js` and project-specific code.

--- a/www/content/extensions/idiomorph.md
+++ b/www/content/extensions/idiomorph.md
@@ -29,7 +29,7 @@ While the CDN approach is simple, you may want to consider [not using CDNs in pr
 
 For npm-style build systems, you can install `idiomorph` via [npm](https://www.npmjs.com/):
 
-```shell
+```sh
 npm install idiomorph
 ```
 

--- a/www/content/extensions/preload.md
+++ b/www/content/extensions/preload.md
@@ -26,7 +26,7 @@ An unminified version is also available at https://cdn.jsdelivr.net/npm/htmx-ext
 While the CDN approach is simple, you may want to consider [not using CDNs in production](https://blog.wesleyac.com/posts/why-not-javascript-cdn). The next easiest way to install `preload` is to simply copy it into your project. Download the extension from `https://cdn.jsdelivr.net/npm/htmx-ext-preload`, add it to the appropriate directory in your project and include it where necessary with a `<script>` tag.
 
 For npm-style build systems, you can install `preload` via [npm](https://www.npmjs.com/):
-```shell
+```sh
 npm install htmx-ext-preload
 ```
 After installing, you'll need to use appropriate tooling to bundle `node_modules/htmx-ext-preload/dist/preload.js` (or `.min.js`). For example, you might bundle the extension with htmx core from `node_modules/htmx.org/dist/htmx.js` and project-specific code.

--- a/www/content/extensions/response-targets.md
+++ b/www/content/extensions/response-targets.md
@@ -38,7 +38,7 @@ An unminified version is also available at https://cdn.jsdelivr.net/npm/htmx-ext
 While the CDN approach is simple, you may want to consider [not using CDNs in production](https://blog.wesleyac.com/posts/why-not-javascript-cdn). The next easiest way to install `response-targets` is to simply copy it into your project. Download the extension from `https://cdn.jsdelivr.net/npm/htmx-ext-response-targets`, add it to the appropriate directory in your project and include it where necessary with a `<script>` tag.
 
 For npm-style build systems, you can install `response-targets` via [npm](https://www.npmjs.com/):
-```shell
+```sh
 npm install htmx-ext-response-targets
 ```
 After installing, you'll need to use appropriate tooling to bundle `node_modules/htmx-ext-response-targets/dist/response-targets.js` (or `.min.js`). For example, you might bundle the extension with htmx core from `node_modules/htmx.org/dist/htmx.js` and project-specific code.

--- a/www/content/extensions/sse.md
+++ b/www/content/extensions/sse.md
@@ -39,7 +39,7 @@ An unminified version is also available at https://cdn.jsdelivr.net/npm/htmx-ext
 While the CDN approach is simple, you may want to consider [not using CDNs in production](https://blog.wesleyac.com/posts/why-not-javascript-cdn). The next easiest way to install `sse` is to simply copy it into your project. Download the extension from `https://cdn.jsdelivr.net/npm/htmx-ext-sse`, add it to the appropriate directory in your project and include it where necessary with a `<script>` tag.
 
 For npm-style build systems, you can install `sse` via [npm](https://www.npmjs.com/):
-```shell
+```sh
 npm install htmx-ext-sse
 ```
 After installing, you'll need to use appropriate tooling to bundle `node_modules/htmx-ext-sse/dist/sse.js` (or `.min.js`). For example, you might bundle the extension with htmx core from `node_modules/htmx.org/dist/htmx.js` and project-specific code.

--- a/www/content/extensions/ws.md
+++ b/www/content/extensions/ws.md
@@ -33,7 +33,7 @@ An unminified version is also available at https://cdn.jsdelivr.net/npm/htmx-ext
 While the CDN approach is simple, you may want to consider [not using CDNs in production](https://blog.wesleyac.com/posts/why-not-javascript-cdn). The next easiest way to install `ws` is to simply copy it into your project. Download the extension from `https://cdn.jsdelivr.net/npm/htmx-ext-ws`, add it to the appropriate directory in your project and include it where necessary with a `<script>` tag.
 
 For npm-style build systems, you can install `ws` via [npm](https://www.npmjs.com/):
-```shell
+```sh
 npm install htmx-ext-ws
 ```
 After installing, you'll need to use appropriate tooling to bundle `node_modules/htmx-ext-ws/dist/ws.js` (or `.min.js`). For example, you might bundle the extension with htmx core from `node_modules/htmx.org/dist/htmx.js` and project-specific code.


### PR DESCRIPTION
## Description
In PR #1332 the site was moved from Eleventy to Zola. This broke some syntax highlighting, leading to the following build warnings:
```
Warning: Highlight language shell not found in extensions/preload.md
Warning: Highlight language shell not found in extensions/ws.md
Warning: Highlight language jsx not found in essays/you-cant.md
Warning: Highlight language shell not found in extensions/head-support.md
Warning: Highlight language shell not found in extensions/htmx-1-compat.md
Warning: Highlight language shell not found in extensions/idiomorph.md
Warning: Highlight language shell not found in extensions/response-targets.md
Warning: Highlight language http request not found in essays/why-tend-not-to-use-content-negotiation.md
Warning: Highlight language shell not found in extensions/sse.md
Warning: Highlight language shell not found in docs.md
```
This PR changes the language aliases to ones that are common to both site builders (see [here](https://www.getzola.org/documentation/content/syntax-highlighting/) and [here](https://prismjs.com/#languages-list)).

Afterwards we are left with:
```
Warning: Highlight language http request not found in essays/why-tend-not-to-use-content-negotiation.md
```
I think this was using the `http` highlight language with Eleventry and there doesn't seem to be an equivalent with Zola.

Corresponding issue: n/a

## Testing
Visual inspection with Zola to verify they make a difference and checking errors went away in terminal.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
