### PR TITLE
Docs: add new FastAPI server libraries with examples

### DIFF
--- a/www/content/server-examples.md
+++ b/www/content/server-examples.md
@@ -49,6 +49,8 @@ These examples may make it a bit easier to get started using htmx with your plat
 
 - <https://github.com/renceInbox/fastapi-todo>
 - <https://github.com/AutomationPanda/bulldoggy-reminders-app>
+- <https://github.com/volfpeter/holm>
+- <https://github.com/volfpeter/fasthx>
 - <https://github.com/volfpeter/fastapi-htmx-tailwind-example>
 
 ### Flask


### PR DESCRIPTION
## Description

I updated `server-examples.md` with two libraries that add HTMX support and server-side rendering to FastAPI. Both libraries are HTMX-first, and have guides and example applications.

*Note: the linked [Awesome Python HTMX](https://github.com/PyHAT-stack/awesome-python-htmx) repo doesn't seem to be maintained anymore.*

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
