### PR TITLE
[4] Bind window context for Firefox compatibility

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -483,7 +483,7 @@ var htmx = (() => {
                     }
                 }
 
-                ctx.fetch ||= window.fetch
+                ctx.fetch ||= window.fetch.bind(window)
                 if (!this.__trigger(elt, "htmx:before:request", {ctx})) return;
 
                 let response = await (ctx.fetchOverride || ctx.fetch(ctx.request.action, ctx.request));


### PR DESCRIPTION
## Description
Causes `'fetch' called on an object that does not implement interface Window` otherwise.
Likely not caught in tests due to mocking via `test/lib/fetch-mock.js`.

Corresponding issue:
None

## Testing
- tested manually on firefox
- ran tests

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
  * four :tada: 
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
  * it's a bugfix
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
```
Chromium: |██████████████████████████████| 56/56 test files | 634 passed, 0 failed, 3 skipped

Code coverage: 96.43 %
View full coverage report at coverage/lcov-report/index.html

Finished running tests in 9.4s, all tests passed! 🎉
```
