### PR TITLE
Allow build commands to run under Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   ],
   "scripts": {
     "build": "npm run build:iife && npm run build:esm && npm run build:minify && npm run build:compress",
-    "build:iife": "sed 's/__/#/g' src/htmx.js > dist/htmx.js",
-    "build:esm": "sed 's/this\\.__/this.#/g; s/^        __/        #/g' src/htmx.js > dist/htmx.esm.js && echo '' >> dist/htmx.esm.js && echo 'export default htmx' >> dist/htmx.esm.js",
+    "build:iife": "node -e \"process.stdout.write(fs.readFileSync('src/htmx.js', {encoding:'UTF-8'}).replace(/__/g, '#'))\" > dist/htmx.js",
+    "build:esm": "node -e \"process.stdout.write(fs.readFileSync('src/htmx.js', {encoding:'UTF-8'}).replace(/this\\.__/g, 'this.#').replace(/^        __/gm, '        #') + `${os.EOL}export default htmx${os.EOL}`)\" > dist/htmx.esm.js",
     "build:minify": "terser --compress --mangle --source-map -o dist/htmx.min.js dist/htmx.js && terser --compress --mangle --source-map -o dist/htmx.esm.min.js dist/htmx.esm.js",
-    "build:compress": "brotli-cli compress dist/*.js",
+    "build:compress": "brotli-cli compress -g dist/*.js",
 
     "test": "npm run test:chrome",
     "test:chrome": "web-test-runner --browsers chromium --config test/web-test-runner.config.mjs --playwright",


### PR DESCRIPTION
## Description
Allow running the build commands on Windows.

On Windows, even under WSL, it can't find `sed` from within the `package.json` scripts.
In addition, Windows doesn't have glob expansion, so instead it needs to get `brotli-cli` to do it.

Due to line ending differences, the brotli versions of the non-minified JS files don't match exactly when generated on Windows. (Minification seems to auto-convert Windows line endings to Linux ones, but the brotlification doesn't.) I tried playing about with Git auto eol conversation config, but I didn't manage to win that battle.

## Testing
I wiped out the contents of the dist folder, ran `npm run build` and then looked at the git diffs to see what changed.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
