### PR TITLE
Update index page with correct link to `jsdelivr`

### DIFF
--- a/www/content/_index.md
+++ b/www/content/_index.md
@@ -141,7 +141,7 @@ By removing these constraints, htmx completes HTML as a [hypertext](https://en.w
 <h2>quick start</h2>
 
 ```html
-  <script src="https://cdn.jsdelivr.net/npm/htmx.org@4.0.0-alpha/dist/htmx.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/htmx.org@4.0.0-alpha1/dist/htmx.min.js"></script>
   <!-- have a button POST a click via AJAX -->
   <button hx-post="/clicked" hx-swap="outerHTML">
     Click Me


### PR DESCRIPTION
## Description

The current link is not working as the specified version doesn't exist as opposed to https://www.jsdelivr.com/package/npm/htmx.org?tab=files&version=4.0.0-alpha1