### PR TITLE
fix select and strip and title handling

### DIFF
--- a/test/test.html
+++ b/test/test.html
@@ -152,6 +152,7 @@
     <script src="./tests/e2e/core.js"></script>
     <script src="./tests/e2e/oob.js"></script>
     <script src="./tests/e2e/sse.js"></script>
+    <script src="./tests/e2e/strip.js"></script>
 
     <!-- History Tests -->
     <script src="./tests/history/basic-history.js"></script>

--- a/test/tests/attributes/hx-select.js
+++ b/test/tests/attributes/hx-select.js
@@ -12,21 +12,21 @@ describe('hx-select', function() {
         mockResponse('GET', '/test', '<div><div id="content">Selected</div><div id="other">Not selected</div></div>')
         let div = createProcessedHTML('<div hx-get="/test" hx-select="#content" hx-swap="innerHTML">Old</div>');
         await clickAndWait(div)
-        assert.equal(div.innerHTML, 'Selected')
+        assert.equal(div.innerHTML, '<div id="content">Selected</div>')
     })
 
     it('selects nested content from response', async function () {
         mockResponse('GET', '/test', '<html><body><nav>Nav</nav><main id="main">Main content</main><footer>Footer</footer></body></html>')
         let div = createProcessedHTML('<div hx-get="/test" hx-select="#main" hx-swap="innerHTML">Old</div>');
         await clickAndWait(div)
-        assert.equal(div.innerHTML, 'Main content')
+        assert.equal(div.innerHTML, '<main id="main">Main content</main>')
     })
 
     it('does not affect OOB swaps', async function () {
         mockResponse('GET', '/test', '<div><div id="content">Selected</div><div id="oob" hx-swap-oob="true">OOB content</div></div>')
         let div = createProcessedHTML('<div hx-get="/test" hx-select="#content" hx-swap="innerHTML">Old</div><div id="oob">Old OOB</div>');
         await clickAndWait(div)
-        assert.equal(div.innerHTML, 'Selected')
+        assert.equal(div.innerHTML, '<div id="content">Selected</div>')
         assert.equal(document.getElementById('oob').innerHTML, 'OOB content')
     })
 
@@ -41,7 +41,7 @@ describe('hx-select', function() {
         mockResponse('GET', '/test', '<div><div class="selected">Selected</div><div class="other">Not selected</div></div>')
         let div = createProcessedHTML('<div hx-get="/test" hx-select=".selected" hx-swap="innerHTML">Old</div>');
         await clickAndWait(div)
-        assert.equal(div.innerHTML, 'Selected')
+        assert.equal(div.innerHTML, '<div class="selected">Selected</div>')
     })
 
     it('works with complex selectors', async function () {

--- a/test/tests/e2e/strip.js
+++ b/test/tests/e2e/strip.js
@@ -1,0 +1,254 @@
+describe('Strip Modifier', function() {
+    afterEach(function() {
+        cleanupTest()
+    })
+
+    // ========================================================================
+    // Main Swap Tests
+    // ========================================================================
+
+    it('Main swap with strip:true extracts children', async function() {
+        mockResponse('GET', '/api', '<wrapper><p>A</p><p>B</p></wrapper>');
+        createProcessedHTML('<button id="btn" hx-get="/api" hx-target="#target" hx-swap="innerHTML strip:true">Get</button><div id="target"></div>');
+        await clickAndWait('#btn');
+        
+        // Should have both paragraphs, no wrapper
+        const target = findElt('#target');
+        assert.equal(target.children.length, 2);
+        assert.equal(target.children[0].tagName, 'P');
+        assert.equal(target.children[0].textContent, 'A');
+        assert.equal(target.children[1].tagName, 'P');
+        assert.equal(target.children[1].textContent, 'B');
+        assert.isUndefined(findElt('#target wrapper'));
+    })
+
+    it('Main swap with strip:false keeps wrapper', async function() {
+        mockResponse('GET', '/api', '<wrapper><p>A</p><p>B</p></wrapper>');
+        createProcessedHTML('<button id="btn" hx-get="/api" hx-target="#target" hx-swap="innerHTML strip:false">Get</button><div id="target"></div>');
+        await clickAndWait('#btn');
+        
+        // Should have wrapper
+        const wrapper = findElt('#target wrapper');
+        assert.exists(wrapper);
+        assert.equal(wrapper.children.length, 2);
+    })
+
+    it('Main swap without strip modifier keeps wrapper (default)', async function() {
+        mockResponse('GET', '/api', '<wrapper><p>A</p><p>B</p></wrapper>');
+        createProcessedHTML('<button id="btn" hx-get="/api" hx-target="#target" hx-swap="innerHTML">Get</button><div id="target"></div>');
+        await clickAndWait('#btn');
+        
+        // Should have wrapper (default is no strip)
+        const wrapper = findElt('#target wrapper');
+        assert.exists(wrapper);
+    })
+
+    // ========================================================================
+    // hx-select Tests
+    // ========================================================================
+
+    it('hx-select with strip:true extracts children', async function() {
+        mockResponse('GET', '/api', '<div class="content"><span>X</span><span>Y</span></div>');
+        createProcessedHTML('<button id="btn" hx-get="/api" hx-target="#target" hx-select=".content" hx-swap="innerHTML strip:true">Get</button><div id="target"></div>');
+        await clickAndWait('#btn');
+        
+        // Default strip:true for hx-select - should have spans, no .content wrapper
+        const target = findElt('#target');
+        assert.equal(target.children.length, 2);
+        assert.equal(target.children[0].tagName, 'SPAN');
+        assert.isUndefined(findElt('#target .content'));
+    })
+
+    it('hx-select with default keeps selected element', async function() {
+        mockResponse('GET', '/api', '<div class="content"><span>X</span><span>Y</span></div>');
+        createProcessedHTML('<button id="btn" hx-get="/api" hx-target="#target" hx-select=".content">Get</button><div id="target"></div>');
+        await clickAndWait('#btn');
+        
+        // Should keep the .content wrapper
+        const content = findElt('#target .content');
+        assert.exists(content);
+        assert.equal(content.children.length, 2);
+    })
+
+    // ========================================================================
+    // OOB Swap Tests
+    // ========================================================================
+
+    it('OOB innerHTML with default strip extracts children', async function() {
+        mockResponse('GET', '/api', '<div id="main">Main</div><div hx-swap-oob="innerHTML:#oob"><p>OOB A</p><p>OOB B</p></div>');
+        createProcessedHTML('<button id="btn" hx-get="/api" hx-target="#main">Get</button><div id="oob">Original</div>');
+        await clickAndWait('#btn');
+        
+        // Default strip:true for OOB innerHTML - strips the OOB div, inserts its children
+        const oob = findElt('#oob');
+        assert.equal(oob.children.length, 2);
+        assert.equal(oob.children[0].tagName, 'P');
+        assert.equal(oob.children[0].textContent, 'OOB A');
+    })
+
+    it('OOB innerHTML with strip:false keeps wrapper', async function() {
+        mockResponse('GET', '/api', '<div id="main">Main</div><article hx-swap-oob="innerHTML target:#oob strip:false"><h1>Title</h1><p>Text</p></article>');
+        createProcessedHTML('<button id="btn" hx-get="/api" hx-target="#main">Get</button><div id="oob">Original</div>');
+        await clickAndWait('#btn');
+        
+        // Should keep the article wrapper
+        const article = findElt('#oob article');
+        assert.exists(article);
+        assert.equal(article.children.length, 2);
+    })
+
+    it('OOB beforeend with default strip extracts children', async function() {
+        mockResponse('GET', '/api', '<div id="main">Main</div><div hx-swap-oob="beforeend:#list"><li>Item A</li><li>Item B</li></div>');
+        createProcessedHTML('<button id="btn" hx-get="/api" hx-target="#main">Get</button><ul id="list"><li>Existing</li></ul>');
+        await clickAndWait('#btn');
+        
+        // Default strip:true - strips the OOB div, inserts its children
+        const list = findElt('#list');
+        assert.equal(list.children.length, 3); // Existing + 2 new
+        assert.equal(list.children[1].tagName, 'LI');
+        assert.equal(list.children[1].textContent, 'Item A');
+    })
+
+    it('OOB beforeend with strip:false keeps wrapper element', async function() {
+        mockResponse('GET', '/api', '<div id="main">Main</div><li hx-swap-oob="beforeend target:#list strip:false"><strong>Item</strong></li>');
+        createProcessedHTML('<button id="btn" hx-get="/api" hx-target="#main">Get</button><ul id="list"><li>Existing</li></ul>');
+        await clickAndWait('#btn');
+        
+        // Should keep the li wrapper
+        const list = findElt('#list');
+        assert.equal(list.children.length, 2);
+        assert.equal(list.children[1].tagName, 'LI');
+        assert.equal(list.children[1].children[0].tagName, 'STRONG');
+    })
+
+    it('OOB outerHTML with default (no strip) keeps wrapper', async function() {
+        mockResponse('GET', '/api', '<div id="main">Main</div><wrapper hx-swap-oob="outerHTML:#target"><section>A</section><section>B</section></wrapper>');
+        createProcessedHTML('<button id="btn" hx-get="/api" hx-target="#main">Get</button><div id="target">Old</div>');
+        await clickAndWait('#btn');
+        
+        // Default strip:false for outerHTML - should have wrapper
+        const wrapper = findElt('wrapper');
+        assert.exists(wrapper);
+        assert.equal(wrapper.children.length, 2);
+    })
+
+    it('OOB outerHTML with strip:true replaces with multiple children', async function() {
+        mockResponse('GET', '/api', '<div id="main">Main</div><wrapper hx-swap-oob="outerHTML strip:true target:#target"><section>A</section><section>B</section><aside>C</aside></wrapper>');
+        createProcessedHTML('<button id="btn" hx-get="/api" hx-target="#main">Get</button><div id="target">Old</div>');
+        await clickAndWait('#btn');
+        
+        // Should replace #target with all children (no wrapper)
+        assert.isUndefined(findElt('#target'));
+        assert.isUndefined(findElt('wrapper'));
+        const sections = playground().querySelectorAll('section');
+        assert.equal(sections.length, 2);
+        const aside = findElt('aside');
+        assert.exists(aside);
+    })
+
+    // ========================================================================
+    // SVG Namespace Tests
+    // ========================================================================
+
+    it('OOB with SVG and default strip preserves namespace', async function() {
+        mockResponse('GET', '/api', '<div id="main">Main</div><svg hx-swap-oob="beforeend:#canvas"><circle cx="50" cy="50" r="20"></circle><circle cx="100" cy="100" r="30"><circle></svg>');
+        createProcessedHTML('<button id="btn" hx-get="/api" hx-target="#main">Get</button><svg id="canvas" xmlns="http://www.w3.org/2000/svg"></svg>');
+        await clickAndWait('#btn');
+        
+        // Default strip:true - strips the g element, inserts circles in SVG namespace
+        const canvas = findElt('#canvas');
+        assert.equal(canvas.children.length, 2);
+        assert.equal(canvas.children[0].tagName, 'circle');
+        assert.equal(canvas.children[0].namespaceURI, 'http://www.w3.org/2000/svg');
+    })
+
+    it('OOB with SVG and strip:false creates nested SVG', async function() {
+        mockResponse('GET', '/api', '<div id="main">Main</div><svg hx-swap-oob="beforeend target:#canvas strip:false" xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="20"></circle></svg>');
+        createProcessedHTML('<button id="btn" hx-get="/api" hx-target="#main">Get</button><svg id="canvas" xmlns="http://www.w3.org/2000/svg"></svg>');
+        await clickAndWait('#btn');
+        
+        // Should have nested svg
+        const canvas = findElt('#canvas');
+        const nestedSvg = canvas.querySelector('svg');
+        assert.exists(nestedSvg);
+        assert.equal(nestedSvg.children.length, 1);
+        assert.equal(nestedSvg.children[0].tagName, 'circle');
+    })
+
+    // ========================================================================
+    // Partial Tests
+    // ========================================================================
+
+    it('Partial with strip:true extracts children', async function() {
+        mockResponse('GET', '/api', '<div id="main">Main</div><partial hx-target="#target" hx-swap="innerHTML strip:true"><wrapper><span>A</span><span>B</span></wrapper></partial>');
+        createProcessedHTML('<button id="btn" hx-get="/api" hx-target="#main">Get</button><div id="target">Original</div>');
+        await clickAndWait('#btn');
+        
+        // Should have spans, no wrapper
+        const target = findElt('#target');
+        assert.equal(target.children.length, 2);
+        assert.equal(target.children[0].tagName, 'SPAN');
+        assert.isUndefined(findElt('#target wrapper'));
+    })
+
+    it('Partial with strip:false keeps wrapper', async function() {
+        mockResponse('GET', '/api', '<div id="main">Main</div><partial hx-target="#target" hx-swap="innerHTML strip:false"><wrapper><span>A</span><span>B</span></wrapper></partial>');
+        createProcessedHTML('<button id="btn" hx-get="/api" hx-target="#main">Get</button><div id="target">Original</div>');
+        await clickAndWait('#btn');
+        
+        // Should keep wrapper
+        const wrapper = findElt('#target wrapper');
+        assert.exists(wrapper);
+        assert.equal(wrapper.children.length, 2);
+    })
+
+    it('Partial without strip modifier keeps wrapper (default)', async function() {
+        mockResponse('GET', '/api', '<div id="main">Main</div><partial hx-target="#target" hx-swap="innerHTML"><wrapper><span>A</span><span>B</span></wrapper></partial>');
+        createProcessedHTML('<button id="btn" hx-get="/api" hx-target="#main">Get</button><div id="target">Original</div>');
+        await clickAndWait('#btn');
+        
+        // Default is no strip for partials
+        const wrapper = findElt('#target wrapper');
+        assert.exists(wrapper);
+    })
+
+    it('Partial with SVG and strip:true extracts circles', async function() {
+        mockResponse('GET', '/api', '<div id="main">Main</div><partial hx-target="#canvas" hx-swap="innerHTML strip:true"><svg xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="20"/><circle cx="100" cy="100" r="30"/></svg></partial>');
+        createProcessedHTML('<button id="btn" hx-get="/api" hx-target="#main">Get</button><svg id="canvas" xmlns="http://www.w3.org/2000/svg"></svg>');
+        await clickAndWait('#btn');
+        
+        // Should strip svg wrapper, insert circles in SVG namespace
+        const canvas = findElt('#canvas');
+        assert.equal(canvas.children.length, 2);
+        assert.equal(canvas.children[0].tagName, 'circle');
+        assert.equal(canvas.children[0].namespaceURI, 'http://www.w3.org/2000/svg');
+    })
+
+    // ========================================================================
+    // Edge Cases
+    // ========================================================================
+
+    it('Strip with single text node extracts text', async function() {
+        mockResponse('GET', '/api', '<wrapper>Just text</wrapper>');
+        createProcessedHTML('<button id="btn" hx-get="/api" hx-target="#target" hx-swap="innerHTML strip:true">Get</button><div id="target"></div>');
+        await clickAndWait('#btn');
+        
+        // Should extract text node
+        const target = findElt('#target');
+        assert.equal(target.textContent, 'Just text');
+        assert.equal(target.children.length, 0); // No element children
+    })
+
+    it('Strip only removes one level', async function() {
+        mockResponse('GET', '/api', '<outer><inner><p>Content</p></inner></outer>');
+        createProcessedHTML('<button id="btn" hx-get="/api" hx-target="#target" hx-swap="innerHTML strip:true">Get</button><div id="target"></div>');
+        await clickAndWait('#btn');
+        
+        // Should only strip outer, keep inner
+        const target = findElt('#target');
+        const inner = findElt('#target inner');
+        assert.exists(inner);
+        assert.isUndefined(findElt('#target outer'));
+        assert.equal(inner.children[0].tagName, 'P');
+    })
+})

--- a/test/tests/unit/morph.js
+++ b/test/tests/unit/morph.js
@@ -437,7 +437,7 @@ describe('Morph Swap Styles Tests', function() {
             await htmx.ajax('GET', '/test', {target: '#target', swap: 'innerMorph'});
             
             btn.click();
-            await new Promise(resolve => setTimeout(resolve, 50));
+            await htmx.forEvent('htmx:after:swap', 100);
             
             assert.equal(result.textContent, 'Clicked!', 'htmx functionality should still work');
         });


### PR DESCRIPTION
## Description
Handle hx-select strip style and simplify the strip modifier handling so it is all done in one place.  this reduces and simplifies the code a little.

Also added proper title handling and tests

Corresponding issue:

## Testing
more tests added

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
