### PR TITLE
optimize oob and fix partial tests

### DIFF
--- a/test/tests/end2end/strip.js
+++ b/test/tests/end2end/strip.js
@@ -193,7 +193,7 @@ describe('Strip Modifier', function() {
     // ========================================================================
 
     it('Partial with strip:true extracts children', async function() {
-        mockResponse('GET', '/api', '<div id="main">Main</div><partial hx-target="#target" hx-swap="innerHTML strip:true"><wrapper><span>A</span><span>B</span></wrapper></partial>');
+        mockResponse('GET', '/api', '<div id="main">Main</div><hx-partial hx-target="#target" hx-swap="innerHTML strip:true"><wrapper><span>A</span><span>B</span></wrapper></hx-partial>');
         createProcessedHTML('<button id="btn" hx-get="/api" hx-target="#main">Get</button><div id="target">Original</div>');
         find('#btn').click()
         await forRequest();
@@ -206,7 +206,7 @@ describe('Strip Modifier', function() {
     })
 
     it('Partial with strip:false keeps wrapper', async function() {
-        mockResponse('GET', '/api', '<div id="main">Main</div><partial hx-target="#target" hx-swap="innerHTML strip:false"><wrapper><span>A</span><span>B</span></wrapper></partial>');
+        mockResponse('GET', '/api', '<div id="main">Main</div><hx-partial hx-target="#target" hx-swap="innerHTML strip:false"><wrapper><span>A</span><span>B</span></wrapper></hx-partial>');
         createProcessedHTML('<button id="btn" hx-get="/api" hx-target="#main">Get</button><div id="target">Original</div>');
         find('#btn').click()
         await forRequest();
@@ -218,7 +218,7 @@ describe('Strip Modifier', function() {
     })
 
     it('Partial without strip modifier keeps wrapper (default)', async function() {
-        mockResponse('GET', '/api', '<div id="main">Main</div><partial hx-target="#target" hx-swap="innerHTML"><wrapper><span>A</span><span>B</span></wrapper></partial>');
+        mockResponse('GET', '/api', '<div id="main">Main</div><hx-partial hx-target="#target" hx-swap="innerHTML"><wrapper><span>A</span><span>B</span></wrapper></hx-partial>');
         createProcessedHTML('<button id="btn" hx-get="/api" hx-target="#main">Get</button><div id="target">Original</div>');
         find('#btn').click()
         await forRequest();
@@ -229,7 +229,7 @@ describe('Strip Modifier', function() {
     })
 
     it('Partial with SVG and strip:true extracts circles', async function() {
-        mockResponse('GET', '/api', '<div id="main">Main</div><partial hx-target="#canvas" hx-swap="innerHTML strip:true"><svg xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="20"/><circle cx="100" cy="100" r="30"/></svg></partial>');
+        mockResponse('GET', '/api', '<div id="main">Main</div><hx-partial hx-target="#canvas" hx-swap="innerHTML strip:true"><svg xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="20"/><circle cx="100" cy="100" r="30"/></svg></hx-partial>');
         createProcessedHTML('<button id="btn" hx-get="/api" hx-target="#main">Get</button><svg id="canvas" xmlns="http://www.w3.org/2000/svg"></svg>');
         find('#btn').click()
         await forRequest();

--- a/test/tests/unit/__makeFragment.js
+++ b/test/tests/unit/__makeFragment.js
@@ -29,7 +29,7 @@ describe('__makeFragment unit tests', function() {
     })
 
     it('converts partial tags to template', function () {
-        let {fragment} = htmx.__makeFragment('<partial hx-target="#foo">Content</partial>');
+        let {fragment} = htmx.__makeFragment('<hx-partial hx-target="#foo">Content</hx-partial>');
         fragment.children[0].tagName.should.equal('TEMPLATE');
         fragment.children[0].hasAttribute('partial').should.be.true;
     })

--- a/test/tests/unit/swap.js
+++ b/test/tests/unit/swap.js
@@ -197,19 +197,19 @@ describe('swap() unit tests', function() {
     })
 
     it('swaps partial with default target', async function () {
-        await htmx.swap({"target":"#test-playground", "text":"<partial hx-target='#test-playground'>Partial</partial>"})
+        await htmx.swap({"target":"#test-playground", "text":"<hx-partial hx-target='#test-playground'>Partial</hx-partial>"})
         playground().innerText.should.equal("Partial");
     })
 
     it('swaps partial with custom target', async function () {
         createProcessedHTML("<div id='d1'></div><div id='d2'></div>")
-        await htmx.swap({"target":"#d1", "text":"<partial hx-target='#d2'>Partial</partial>"})
+        await htmx.swap({"target":"#d1", "text":"<hx-partial hx-target='#d2'>Partial</hx-partial>"})
         find('#d2').innerText.should.equal("Partial");
     })
 
     it('swaps partial with custom swap style', async function () {
         createProcessedHTML("<div id='d1'>Existing</div>")
-        await htmx.swap({"target":"#test-playground", "text":"<partial hx-target='#d1' hx-swap='beforeend'>Partial</partial>"})
+        await htmx.swap({"target":"#test-playground", "text":"<hx-partial hx-target='#d1' hx-swap='beforeend'>Partial</hx-partial>"})
         find('#d1').innerText.should.equal("ExistingPartial");
     })
 
@@ -223,7 +223,7 @@ describe('swap() unit tests', function() {
 
     it('executes script in partial', async function () {
         window.testVar = 0;
-        await htmx.swap({"target":"#test-playground", "text":"<partial hx-target='#test-playground'><script>window.testVar = 8</script></partial>"})
+        await htmx.swap({"target":"#test-playground", "text":"<hx-partial hx-target='#test-playground'><script>window.testVar = 8</script></hx-partial>"})
         window.testVar.should.equal(8);
         delete window.testVar;
     })
@@ -332,7 +332,7 @@ describe('swap() unit tests', function() {
     it('sets title with partial swap', async function () {
         let originalTitle = document.title;
         createProcessedHTML("<div id='d1'></div>")
-        await htmx.swap({"target":"#test-playground", "text":"<title>Partial Title</title><partial hx-target='#d1'>Partial Content</partial>"})
+        await htmx.swap({"target":"#test-playground", "text":"<title>Partial Title</title><hx-partial hx-target='#d1'>Partial Content</hx-partial>"})
         document.title.should.equal('Partial Title');
         document.title = originalTitle;
     })


### PR DESCRIPTION
## Description
Just a tidy up of oob code to use a few ticks to simplify code with no function changes.  who knew you could split on a trivial regex like this!

fixed hx-partial tests

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
