### PR TITLE
fix up handle swap extension point and doco

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1423,9 +1423,9 @@ var htmx = (() => {
             }
             if (!target) return;
             if (swapSpec.strip && fragment.firstElementChild) {
-                let strip = document.createDocumentFragment();
-                strip.append(...(fragment.firstElementChild.content || fragment.firstElementChild).childNodes);
-                fragment = strip;
+                task.unstripped = fragment;
+                fragment = document.createDocumentFragment();
+                fragment.append(...(task.fragment.firstElementChild.content || task.fragment.firstElementChild).childNodes);
             }
 
             let pantry = this.__handlePreservedElements(fragment);
@@ -1468,9 +1468,10 @@ var htmx = (() => {
                 return;
             } else if (swapSpec.style === 'none') {
                 return;
-            } else if (!this.__triggerExtensions(target, 'htmx:handle:swap', task)) {
-                return;
             } else {
+                task.target = target;
+                task.fragment = fragment;
+                if (!this.__triggerExtensions(target, 'htmx:handle:swap', task)) return;
                 throw new Error(`Unknown swap style: ${swapSpec.style}`);
             }
             this.__restorePreservedElements(pantry);

--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -1173,8 +1173,15 @@ the [`hx-validate`](@/attributes/hx-validate.md) attribute to "true".
 
 ## Extensions
 
-In htmx 4, extensions are just libraries that hook into the standard events and use the public API.  There is no longer
-a need for an explicit extension API.
+In htmx 4, extensions hook into standard events rather than callback extension points. They are lightweight with no performance penalty.
+
+Extensions apply page-wide without requiring `hx-ext` on parent elements. They activate via custom attributes where needed.
+
+To restrict which extensions can register, use an allow list:
+
+```html
+<meta name="htmx:config" content='{"extensions": "my-ext,another-ext"}'>
+```
 
 ### Core Extensions
 

--- a/www/content/extensions/building.md
+++ b/www/content/extensions/building.md
@@ -15,7 +15,7 @@ If you're migrating an extension from htmx 2.x, here's a quick reference:
 | `getSelectors()`                      | `htmx_after_init`     | Check `api.attributeValue(elt, "attr")` instead of returning selectors.                |
 | `onEvent(name, evt)`                  | Specific hooks        | Replace with `htmx_before_request`, `htmx_after_swap`, etc. (use underscores)          |
 | `transformResponse(text, xhr, elt)`   | `htmx_after_request`  | Modify `detail.ctx.text` directly (check if exists first as not set for SSE responses) |
-| `isInlineSwap(swapStyle)`             | Not needed            | Move logic into `htmx_handle_swap`                                                     |
+| `isInlineSwap(swapStyle)`             | Not needed            | Move logic into `htmx_handle_swap`. For OOB outer swaps, use `detail.unstripped`       |
 | `handleSwap(style, target, fragment)` | `htmx_handle_swap`    | Access via `detail.swapSpec.style` and `detail.fragment`, return false                 |
 | `encodeParameters(xhr, params, elt)`  | `htmx_config_request` | Modify `detail.ctx.request.body` (FormData) and headers directly                       |
 
@@ -46,14 +46,15 @@ htmx.defineExtension("my-ext", {
 
 ## Extension Approval
 
-Extensions must be approved via the `extensions` config option in a meta tag:
+Extensions can be approved via the `extensions` config option in a meta tag:
 
 ```html
 <meta name="htmx:config" content='{"extensions": "my-ext,another-ext"}'>
 ```
 
-Only approved extensions will be loaded. This prevents unauthorized extensions
-from running.
+If this is set then only approved extensions will be loaded. This prevents
+unauthorized extensions from running. By default without this config set in a
+meta tag all extensions will be approved.
 
 ## Event Hooks
 

--- a/www/content/extensions/migration-guide.md
+++ b/www/content/extensions/migration-guide.md
@@ -270,6 +270,33 @@ isInlineSwap: function(swapStyle) {
 - Not needed in new architecture
 - Custom swap logic handled in `htmx_handle_swap`
 
+**Important for OOB swaps:**
+
+In htmx 2.x, `isInlineSwap` was used to prevent automatic stripping of wrapper elements for custom outer swap styles. In htmx 4, OOB swaps automatically strip the wrapper element for non-outer swap styles (those not starting with "outer"). 
+
+If your custom swap style needs the wrapper element:
+
+**Option 1:** Name your swap style starting with "outer" (e.g., `outerMorph`, `outerCustom`)
+
+**Option 2:** Use `detail.unstripped` to access the original fragment:
+
+```javascript
+htmx_handle_swap: (target, detail) => {
+    if (detail.swapSpec.style === 'my-outer-swap') {
+        // For OOB swaps, use unstripped if available
+        let frag = (detail.type === 'oob' && detail.unstripped) || detail.fragment;
+        target.parentNode.replaceChild(frag.firstElementChild, target);
+        return true;
+    }
+    return false;
+}
+```
+
+**Notes:**
+- `detail.unstripped` contains the original fragment before stripping (only set when stripping occurs)
+- `detail.type` indicates if this is an 'oob', 'main', or 'partial' swap
+- For main swaps, stripping doesn't occur automatically
+
 ---
 
 ### `handleSwap(swapStyle, target, fragment, settleInfo)`


### PR DESCRIPTION
## Description
handle swap was not getting the updated target or stripped fragment.  And also allowed it to have the pre stripped fragment as well which allows it to replace the isInlineSwap old extension point by just detecting and handling the inner/outer mode in the one event now.

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
