### PR TITLE
[4] Small docs fix for <hx-partial>

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -670,13 +670,13 @@ when you want to update multiple parts of the page from one request.
 A `<hx-partial>` tag wraps content that should be swapped into a specific target on the page:
 
 ```html
-<htmx-partial hx-target="#messages" hx-swap="beforeend">
+<hx-partial hx-target="#messages" hx-swap="beforeend">
   <div>New message content</div>
-</htmx-partial>
+</hx-partial>
 
-<htmx-partial hx-target="#notifications" hx-swap="innerHTML">
+<hx-partial hx-target="#notifications" hx-swap="innerHTML">
   <span class="badge">5</span>
-</htmx-partial>
+</hx-partial>
 ```
 
 Each `<hx-partial>` specifies:

--- a/www/content/htmx-4.md
+++ b/www/content/htmx-4.md
@@ -104,10 +104,10 @@ major changes between htmx 2.x and htmx 4.x.
 - Alternative to out-of-band swaps when you want explicit targeting
 - Example:
   ```html
-  <htmx-partial hx-target="#messages" hx-swap="beforeend">
+  <hx-partial hx-target="#messages" hx-swap="beforeend">
     <div>New message</div>
   </partial>
-  <htmx-partial hx-target="#notifications">
+  <hx-partial hx-target="#notifications">
     <span class="badge">5</span>
   </partial>
   ```


### PR DESCRIPTION
## Description
Docs incorrectly mention `<htmx-partial>` instead of `<hx-partial>`

Corresponding issue:
- 
## Testing
- 

## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [X] I ran the test suite locally (`npm run test`) and verified that it succeeded
