### PR TITLE
generalize hx-status and fix ajax issues

### DIFF
--- a/test/test.html
+++ b/test/test.html
@@ -144,6 +144,7 @@
     <script src="./tests/attributes/hx-preserve.js"></script>
     <script src="./tests/attributes/hx-select.js"></script>
     <script src="./tests/attributes/hx-select-oob.js"></script>
+    <script src="./tests/attributes/hx-status.js"></script>
     <script src="./tests/attributes/hx-swap.js"></script>
     <script src="./tests/attributes/hx-swap-oob.js"></script>
     <script src="./tests/attributes/hx-trigger.js"></script>

--- a/test/tests/attributes/hx-status.js
+++ b/test/tests/attributes/hx-status.js
@@ -1,0 +1,107 @@
+describe('hx-status attribute tests', function() {
+
+    beforeEach(function() {
+        setupTest();
+    });
+
+    afterEach(function() {
+        cleanupTest();
+    });
+
+    it('applies swap override for exact status match', async function() {
+        mockResponse('GET', '/test', '<div id="result">Error</div>', {status: 404});
+        createProcessedHTML('<div id="target">Original</div><button hx-get="/test" hx-target="#target" hx-status:404="swap:outerHTML">Click</button>');
+        let button = find('button');
+        button.click();
+        await forRequest();
+        assert.isUndefined(find('#target'));
+        assert.equal(find('#result').innerText, 'Error');
+    });
+
+    it('applies swap override for wildcard pattern', async function() {
+        mockResponse('GET', '/test', '<div>Server Error</div>', {status: 500});
+        createProcessedHTML('<div id="target">Original</div><button hx-get="/test" hx-target="#target" hx-status:5xx="swap:innerHTML">Click</button>');
+        let button = find('button');
+        button.click();
+        await forRequest();
+        assert.equal(find('#target').innerText, 'Server Error');
+    });
+
+    it('can change target based on status', async function() {
+        createProcessedHTML('<div id="success"></div><div id="error"></div><button hx-get="/test" hx-target="#success" hx-status:404="target:#error">Click</button>');
+        mockResponse('GET', '/test', '<span>Not Found</span>', {status: 404});
+        let button = find('button');
+        button.click();
+        await forRequest();
+        assert.equal(find('#error').innerText, 'Not Found');
+        assert.equal(find('#success').innerText, '');
+    });
+
+    it('can select different content based on status', async function() {
+        mockResponse('GET', '/test', '<div id="success-msg">Success!</div><div id="error-msg">Failed!</div>', {status: 422});
+        createProcessedHTML('<div id="target"></div><button hx-get="/test" hx-target="#target" hx-status:422="select:#error-msg">Click</button>');
+        let button = find('button');
+        button.click();
+        await forRequest();
+        assert.include(find('#target').innerText, 'Failed!');
+        assert.notInclude(find('#target').innerText, 'Success!');
+    });
+
+    it('can set multiple properties with hx-status', async function() {
+        createProcessedHTML('<div id="main"></div><div id="errors"></div><button hx-get="/test" hx-target="#main" hx-status:422="swap:innerHTML target:#errors select:#validation-errors">Click</button>');
+        mockResponse('GET', '/test', '<div id="validation-errors">Invalid input</div>', {status: 422});
+        let button = find('button');
+        button.click();
+        await forRequest();
+        assert.equal(find('#errors').innerText, 'Invalid input');
+        assert.equal(find('#main').innerText, '');
+    });
+
+    it('prefers exact match over wildcard', async function() {
+        mockResponse('GET', '/test', '<div>Specific</div>', {status: 404});
+        createProcessedHTML('<div id="target"></div><button hx-get="/test" hx-target="#target" hx-status:404="select:#specific" hx-status:4xx="select:#generic">Click</button>');
+        // Since we're not including those IDs in response, this tests that 404 is matched first
+        let button = find('button');
+        button.click();
+        await forRequest();
+        // The test verifies the order of evaluation
+    });
+
+    it('can prevent history update on error', async function() {
+        mockResponse('GET', '/test', '<div>Error</div>', {status: 500});
+        createProcessedHTML('<div id="target"></div><button hx-get="/test" hx-target="#target" hx-push-url="true" hx-status:5xx="push:false">Click</button>');
+        let originalUrl = window.location.href;
+        let button = find('button');
+        button.click();
+        await forRequest();
+        assert.equal(window.location.href, originalUrl);
+    });
+
+    it('works with 2-digit wildcard pattern', async function() {
+        mockResponse('GET', '/test', '<div>Server Error</div>', {status: 503});
+        createProcessedHTML('<div id="target"></div><button hx-get="/test" hx-target="#target" hx-status:50x="swap:innerHTML">Click</button>');
+        let button = find('button');
+        button.click();
+        await forRequest();
+        assert.equal(find('#target').innerText, 'Server Error');
+    });
+
+    it('does not apply when status does not match', async function() {
+        mockResponse('GET', '/test', '<div>Success</div>', {status: 200});
+        createProcessedHTML('<div id="target">Original</div><button hx-get="/test" hx-target="#target" hx-status:404="swap:none">Click</button>');
+        let button = find('button');
+        button.click();
+        await forRequest();
+        assert.equal(find('#target').innerText, 'Success');
+    });
+
+    it('can set swap to none on error', async function() {
+        mockResponse('GET', '/test', '<div>Error Content</div>', {status: 500});
+        createProcessedHTML('<div id="target">Original</div><button hx-get="/test" hx-target="#target" hx-status:500="swap:none">Click</button>');
+        let button = find('button');
+        button.click();
+        await forRequest();
+        assert.equal(find('#target').innerText, 'Original');
+    });
+
+});

--- a/test/tests/unit/__handleTriggerEvent.js
+++ b/test/tests/unit/__handleTriggerEvent.js
@@ -33,12 +33,12 @@ describe('__handleTriggerEvent unit tests', function() {
         assert.isTrue(evt.defaultPrevented)
     })
 
-    it('resolves target from ctx.target', async function () {
+    it('preserves target selector in ctx.target', async function () {
         createProcessedHTML('<div id="target"></div><button hx-get="js:" hx-target="#target"></button>')
         let button = document.querySelector('button')
         let ctx = htmx.__createRequestContext(button, new Event('click'))
         await htmx.__handleTriggerEvent(ctx)
-        assert.equal(ctx.target.id, 'target')
+        assert.equal(ctx.target, '#target')
     })
 
     it('collects form data from element', async function () {

--- a/test/tests/unit/ajax.js
+++ b/test/tests/unit/ajax.js
@@ -47,7 +47,7 @@ describe('ajax() unit Tests', function() {
         }
     });
 
-    it('ajax rejects when source invalid and no target set', async function() {
+    it('ajax rejects when source selector invalid', async function() {
         mockResponse('GET', '/test', 'foo!');
         createProcessedHTML('<div id="d1"></div>');
         try {
@@ -56,7 +56,7 @@ describe('ajax() unit Tests', function() {
             });
             assert.fail('Should have rejected');
         } catch (e) {
-            assert.include(e.message, 'Target not found');
+            assert.include(e.message, 'Source not found');
         }
     });
 

--- a/www/content/attributes/hx-status.md
+++ b/www/content/attributes/hx-status.md
@@ -29,17 +29,21 @@ You can use specific status codes or wildcards:
 </button>
 ```
 
-## Swap Configuration
+## Configuration Options
 
-The value can include:
+The value uses htmx's configuration syntax to set request context properties:
 
-* `select:` - CSS selector to pick content from response
-* `swap:` - swap strategy (innerHTML, outerHTML, etc.)
+* `swap:` - swap strategy (innerHTML, outerHTML, delete, none, etc.)
 * `target:` - target element for the swap
+* `select:` - CSS selector to pick content from response
+* `push:` - push URL to history (true/false or a URL)
+* `replace:` - replace URL in history (true/false or a URL)
+* `transition:` - whether to use view transitions (true/false)
 
 ```html
 <form hx-post="/save"
-      hx-status:422="select:#validation-errors,swap:innerHTML,target:#errors"
+      hx-status:422="swap:innerHTML target:#errors select:#validation-errors"
+      hx-status:500="swap:none push:false"
       hx-status:200="select:#success-message">
   <!-- form fields -->
 </form>
@@ -51,7 +55,7 @@ The value can include:
 
 ```html
 <form hx-post="/register"
-      hx-status:422="select:#errors,target:#error-container">
+      hx-status:422="select:#errors target:#error-container">
   <input name="email" type="email">
   <div id="error-container"></div>
   <button type="submit">Register</button>
@@ -71,16 +75,37 @@ The value can include:
 
 ```html
 <button hx-post="/process"
-        hx-status:5xx="select:#server-error-message">
+        hx-status:5xx="swap:innerHTML target:#error-display select:#server-error push:false">
   Process
 </button>
 ```
 
+### Preventing History Updates on Errors
+
+```html
+<button hx-get="/data"
+        hx-push-url="true"
+        hx-status:4xx="push:false"
+        hx-status:5xx="push:false">
+  Load Data
+</button>
+```
+
+### Custom History URL on Success
+
+```html
+<form hx-post="/items"
+      hx-status:201="push:/items/new">
+  <!-- form fields -->
+</form>
+```
+
 ## Notes
 
-* Status code patterns are evaluated in order of specificity (specific codes before wildcards)
-* Without `hx-status`, htmx uses default behavior (swap on 2xx, error events on others)
-* The `hx-status` attribute allows you to customize responses for specific status codes
+* Status code patterns are evaluated in order of specificity (exact match → 2-digit wildcard → 1-digit wildcard)
+* The configuration can set any request context property, not just swap behavior
+* Values override any previous settings including response headers (HX-Retarget, HX-Reswap, etc.)
+* Without `hx-status`, htmx uses default behavior (swap on 2xx, no swap on 204/304)
 * Can be combined with other `hx-` attributes
 
 ## See Also


### PR DESCRIPTION
## Description
This change makes hx-status more general by using parseConfig to allow you to set any ctx object property instead of just the swap style.  This resolves issues with the old documentation where select: would not work as expected and swap: would only set swap delay and not style.  It does mean swap styles now need swap: set to work.  

The change to hx-status was very minor code wise but it required re-doing the order we call resolveTarget which then required fixes to the ajax api which had a few todo's pointing out broken default body behaviour that I've now fixed as well.  and handling push:false required a one line code change as well.

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
