### PR TITLE
handle duplicates in action query params and form data

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -296,6 +296,8 @@ var htmx = (() => {
 
         __createRequestContext(sourceElement, sourceEvent) {
             let {action, method} = this.__determineMethodAndAction(sourceElement, sourceEvent);
+            let [fullAction, anchor] = (action || '').split('#');
+            let ac = new AbortController();
             let ctx = {
                 sourceElement,
                 sourceEvent,
@@ -310,9 +312,14 @@ var htmx = (() => {
                 confirm: this.__attributeValue(sourceElement, "hx-confirm"),
                 request: {
                     validate: "true" === this.__attributeValue(sourceElement, "hx-validate", sourceElement.matches('form') ? "true" : "false"),
-                    action,
+                    action: fullAction,
+                    anchor,
                     method,
-                    headers: this.__determineHeaders(sourceElement)
+                    headers: this.__determineHeaders(sourceElement),
+                    abort: ac.abort.bind(ac),
+                    credentials: "same-origin",
+                    signal: ac.signal,
+                    mode: this.config.mode
                 }
             };
 
@@ -399,20 +406,11 @@ var htmx = (() => {
                 }
             }
 
-            // Setup abort controller and action
-            let ac = new AbortController()
-            let action = ctx.request.action.replace?.(/#.*$/, '')
-            // TODO - consider how this works with hx-config, move most to __createRequestContext?
+            // Setup event-dependent request details
             Object.assign(ctx.request, {
-                originalAction: ctx.request.action,
-                action,
                 form,
                 submitter: evt.submitter,
-                abort: ac.abort.bind(ac),
-                body,
-                credentials: "same-origin",
-                signal: ac.signal,
-                mode: this.config.mode
+                body
             })
 
             if (!this.__trigger(elt, "htmx:config:request", {ctx: ctx})) return
@@ -420,14 +418,22 @@ var htmx = (() => {
             if (ctx.request.validate && ctx.request.form && !ctx.request.form.reportValidity()) return
 
             let javascriptContent = this.__extractJavascriptContent(ctx.request.action);
-            if (javascriptContent) {
+            if (javascriptContent != null) {
                 let data = Object.fromEntries(ctx.request.body);
                 await this.__executeJavaScriptAsync(ctx.sourceElement, data, javascriptContent, false);
                 return
             } else if (/GET|DELETE/.test(ctx.request.method)) {
-                let params = new URLSearchParams(ctx.request.body);
-                if (params.size) ctx.request.action += (/\?/.test(ctx.request.action) ? "&" : "?") + params
-                ctx.request.body = null
+                let url = new URL(ctx.request.action, document.baseURI);
+                
+                for (let key of ctx.request.body.keys()) {
+                    url.searchParams.delete(key);
+                }
+                for (let [key, value] of ctx.request.body) {
+                    url.searchParams.append(key, value);
+                }
+                
+                ctx.request.action = url.pathname + url.search;
+                ctx.request.body = null;
             } else if (this.__attributeValue(elt, "hx-encoding") !== "multipart/form-data") {
                 ctx.request.body = new URLSearchParams(ctx.request.body);
             }
@@ -1218,9 +1224,8 @@ var htmx = (() => {
         }
 
         __handleAnchorScroll(ctx) {
-            let anchor = ctx.request?.originalAction?.split('#')[1];
-            if (anchor) {
-                document.getElementById(anchor)?.scrollIntoView({block: 'start', behavior: 'auto'});
+            if (ctx.request?.anchor) {
+                document.getElementById(ctx.request.anchor)?.scrollIntoView({block: 'start', behavior: 'auto'});
             }
         }
 
@@ -1588,7 +1593,7 @@ var htmx = (() => {
             if (!path || path === 'false' || path === false) return;
 
             if (path === 'true') {
-                path = ctx.request.originalAction;
+                path = ctx.request.action + (ctx.request.anchor ? '#' + ctx.request.anchor : '');
             }
 
             let type = push ? 'push' : 'replace';

--- a/test/tests/attributes/hx-get.js
+++ b/test/tests/attributes/hx-get.js
@@ -64,4 +64,52 @@ describe('hx-get attribute', function() {
         // TODO: Add assertion for scroll behavior to #foo
     })
 
+    it('GET merges URL params with form data - form data overwrites URL params', async function () {
+        mockResponse('GET', '/test', 'Success')
+        let form = createProcessedHTML('<form hx-get="/test?foo=url&bar=keep" hx-swap="outerHTML"><input name="foo" value="form"/><button>Submit</button></form>');
+        form.requestSubmit()
+        await forRequest();
+        lastFetch().url.should.equal('/test?bar=keep&foo=form');
+    })
+
+    it('GET preserves URL params not in form data', async function () {
+        mockResponse('GET', '/test', 'Success')
+        let form = createProcessedHTML('<form hx-get="/test?a=1&b=2&c=3" hx-swap="outerHTML"><input name="b" value="new"/><button>Submit</button></form>');
+        form.requestSubmit()
+        await forRequest();
+        lastFetch().url.should.equal('/test?a=1&c=3&b=new');
+    })
+
+    it('GET handles array parameters correctly when merging', async function () {
+        mockResponse('GET', '/test', 'Success')
+        let form = createProcessedHTML('<form hx-get="/test?tags=url1&tags=url2" hx-swap="outerHTML"><input name="tags" value="form1"/><input name="tags" value="form2"/><button>Submit</button></form>');
+        form.requestSubmit()
+        await forRequest();
+        lastFetch().url.should.equal('/test?tags=form1&tags=form2');
+    })
+
+    it('GET with no URL params just adds form data', async function () {
+        mockResponse('GET', '/test', 'Success')
+        let form = createProcessedHTML('<form hx-get="/test" hx-swap="outerHTML"><input name="foo" value="bar"/><button>Submit</button></form>');
+        form.requestSubmit()
+        await forRequest();
+        lastFetch().url.should.equal('/test?foo=bar');
+    })
+
+    it('GET with URL params but no form data keeps URL params', async function () {
+        mockResponse('GET', '/test', 'Success')
+        let form = createProcessedHTML('<form hx-get="/test?foo=bar&baz=qux" hx-swap="outerHTML"><button>Submit</button></form>');
+        form.requestSubmit()
+        await forRequest();
+        lastFetch().url.should.equal('/test?foo=bar&baz=qux');
+    })
+
+    it('GET merges params with anchor - form data overwrites, anchor stripped from request', async function () {
+        mockResponse('GET', '/test', 'Success')
+        let form = createProcessedHTML('<form hx-get="/test?foo=url&keep=yes#section" hx-swap="outerHTML"><input name="foo" value="form"/><button>Submit</button></form>');
+        form.requestSubmit()
+        await forRequest();
+        lastFetch().url.should.equal('/test?keep=yes&foo=form');
+    })
+
 })

--- a/test/tests/unit/__handleHistoryUpdate.js
+++ b/test/tests/unit/__handleHistoryUpdate.js
@@ -23,7 +23,7 @@ describe('__handleHistoryUpdate unit tests', function() {
             push: 'false',
             replace: 'false',
             response: { headers: new Headers() },
-            request: { originalAction: '/test' }
+            request: { action: '/test' }
         }
 
         htmx.__handleHistoryUpdate(ctx)
@@ -37,7 +37,7 @@ describe('__handleHistoryUpdate unit tests', function() {
             sourceElement: div,
             push: 'true',
             response: { headers: new Headers() },
-            request: { originalAction: '/test-path' }
+            request: { action: '/test-path' }
         }
 
         htmx.__handleHistoryUpdate(ctx)
@@ -51,7 +51,7 @@ describe('__handleHistoryUpdate unit tests', function() {
             sourceElement: div,
             replace: 'true',
             response: { headers: new Headers() },
-            request: { originalAction: '/replace-path' }
+            request: { action: '/replace-path' }
         }
 
         htmx.__handleHistoryUpdate(ctx)
@@ -65,7 +65,7 @@ describe('__handleHistoryUpdate unit tests', function() {
             sourceElement: div,
             push: '/custom-path',
             response: { headers: new Headers() },
-            request: { originalAction: '/test' }
+            request: { action: '/test' }
         }
 
         htmx.__handleHistoryUpdate(ctx)

--- a/test/tests/unit/__handleTriggerEvent.js
+++ b/test/tests/unit/__handleTriggerEvent.js
@@ -82,11 +82,11 @@ describe('__handleTriggerEvent unit tests', function() {
         assert.equal(ctx.request.action, 'js:')
     })
 
-    it('stores originalAction before stripping anchor', async function () {
+    it('stores anchor separately from action', async function () {
         let div = createProcessedHTML('<div hx-get="js:#anchor"></div>')
         let ctx = htmx.__createRequestContext(div, new Event('click'))
         await htmx.__handleTriggerEvent(ctx)
-        assert.equal(ctx.request.originalAction, 'js:#anchor')
+        assert.equal(ctx.request.anchor, 'anchor')
     })
 
     it('returns early if htmx:config:request cancelled', async function () {
@@ -146,9 +146,11 @@ describe('__handleTriggerEvent unit tests', function() {
     })
 
     it('converts body to URLSearchParams for POST', async function () {
-        let form = createProcessedHTML('<form><input name="field" value="test"><button hx-post="js:"></button></form>')
+        let form = createProcessedHTML('<form><input name="field" value="test"><button hx-post="/test"></button></form>')
         let button = form.querySelector('button')
         let ctx = htmx.__createRequestContext(button, new Event('click'))
+        let originalFetch = ctx.fetch
+        ctx.fetch = async () => ({ status: 200, headers: new Headers(), text: async () => '' })
         await htmx.__handleTriggerEvent(ctx)
         assert.instanceOf(ctx.request.body, URLSearchParams)
     })


### PR DESCRIPTION
## Description
When action urls have query parameters it can cause issues when a form submits the same query parameters creating duplicates.  stripping the duplicates should resolve this issue.  Then form parameters can be merged over top of the remaining parameters.

Also found fragment handling was broken and we need to instead capture just the anchor of the original url so it can be applied correctly to the final url for push true actions.

Also found "js:" actions were broken as these get stripped to "" which is falsy causing a real blank url request to be fired in error when it should complete a blank request instead. 

Corresponding issue:
#2151 

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
