### PR TITLE
implement advanced hx-boost overrides

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -296,7 +296,6 @@ var htmx = (() => {
         }
 
         __createRequestContext(sourceElement, sourceEvent) {
-            let boosted = sourceElement._htmx?.boosted;
             let {action, method} = this.__determineMethodAndAction(sourceElement, sourceEvent);
             let [fullAction, anchor] = (action || '').split('#');
             let ac = new AbortController();
@@ -304,10 +303,10 @@ var htmx = (() => {
                 sourceElement,
                 sourceEvent,
                 status: "created",
-                select: this.__attributeValue(sourceElement, "hx-select") ?? boosted?.select,
+                select: this.__attributeValue(sourceElement, "hx-select"),
                 selectOOB: this.__attributeValue(sourceElement, "hx-select-oob"),
-                target: this.__resolveTarget(sourceElement, this.__attributeValue(sourceElement, "hx-target") ?? boosted?.target),
-                swap: this.__attributeValue(sourceElement, "hx-swap") ?? boosted?.swap ?? this.config.defaultSwap,
+                target: this.__attributeValue(sourceElement, "hx-target"),
+                swap: this.__attributeValue(sourceElement, "hx-swap") ?? this.config.defaultSwap,
                 push: this.__attributeValue(sourceElement, "hx-push-url"),
                 replace: this.__attributeValue(sourceElement, "hx-replace-url"),
                 transition: this.config.transitions,
@@ -322,8 +321,10 @@ var htmx = (() => {
                     credentials: "same-origin",
                     signal: ac.signal,
                     mode: this.config.mode
-                }
+                },
+                ...sourceElement._htmx?.boosted
             };
+            ctx.target = this.__resolveTarget(sourceElement, ctx.target);
 
             // Apply hx-config overrides
             let configAttr = this.__attributeValue(sourceElement, "hx-config");
@@ -1003,7 +1004,7 @@ var htmx = (() => {
 
         __maybeBoost(elt) {
             let boostValue = this.__attributeValue(elt, "hx-boost");
-            if (boostValue && this.__shouldBoost(elt)) {
+            if (boostValue && boostValue !== "false" && this.__shouldBoost(elt)) {
                 elt._htmx = {eventHandler: this.__createHtmxEventHandler(elt), requests: [], boosted: this.__parseConfig(boostValue)}
                 elt.setAttribute('data-htmx-powered', 'true');
                 if (elt.matches('a') && !elt.hasAttribute("target")) {

--- a/test/tests/attributes/hx-boost.js
+++ b/test/tests/attributes/hx-boost.js
@@ -122,13 +122,12 @@ describe('hx-boost attribute', async function() {
         find('#result').innerHTML.should.equal('Success')
     })
 
-    it('explicit attributes override boost config', async function() {
+    it('boost config overrides explicit attributes', async function() {
         mockResponse('GET', '/test', 'Clicked')
         createProcessedHTML('<a hx-boost="swap:outerHTML" hx-swap="innerHTML" hx-target="this" id="a1" href="/test">Click</a>')
         find('#a1').click()
         await forRequest()
-        should.not.equal(document.querySelector('#a1'), null)
-        find('#a1').innerHTML.should.equal('Clicked')
+        should.equal(document.querySelector('#a1'), null)
     })
 
     it('hx-boost true still works as before', async function() {

--- a/www/content/attributes/hx-boost.md
+++ b/www/content/attributes/hx-boost.md
@@ -47,9 +47,20 @@ You can configure boost behavior using an advanced syntax that combines multiple
 ```html
 <body hx-boost:inherited="swap:innerHTML target:#main select:#content">
   <div id="main">
-    <!-- Boosted links use the config -->
+    <!-- Boosted links inherit the config -->
     <a href="/page1">Go To Page 1</a>
     <a href="/page2">Go To Page 2</a>
+    
+    <!-- Override with different boost config -->
+    <div hx-boost:inherited="swap:outerHTML target:#result">
+      <a href="/page3">Page 3 (uses div config)</a>
+      
+      <!-- Disable boost for specific link -->
+      <a href="/external" hx-boost="false">External</a>
+      
+      <!-- Custom boost config overrides all -->
+      <a href="/page4" hx-boost="swap:beforeend target:#list">Page 4</a>
+    </div>
     
     <!-- Non-boosted elements are unaffected -->
     <div hx-get="/data" hx-trigger="load">Loading...</div>
@@ -57,14 +68,24 @@ You can configure boost behavior using an advanced syntax that combines multiple
 </body>
 ```
 
-The key advantage is that the boost config only applies to boosted elements (links and forms), unlike inherited `hx-*` attributes which would affect all descendant elements.
+The key advantage is that boost config only applies to boosted elements (links and forms), unlike inherited `hx-*` attributes which would affect all descendant elements.
+
+### Priority Order
+
+Boost config **overrides** explicit `hx-*` attributes:
+1. Boost config (highest priority)
+2. Explicit `hx-*` attributes
+3. Default values (lowest priority)
+
+This allows you to:
+- Set base defaults with `hx-target`, `hx-swap` on elements
+- Override them with `hx-boost:inherited` at any level
+- Use `hx-boost="true"` or `hx-boost="false"` to enable/disable
 
 Supported modifiers:
 - `swap:STYLE` - Swap strategy (innerHTML, outerHTML, etc.)
 - `target:SELECTOR` - Target element selector
 - `select:SELECTOR` - Content selection from response
-
-Explicit `hx-*` attributes on individual links/forms will override the boost config.
 
 ## Notes
 


### PR DESCRIPTION
## Description
Try out advanced hx-boost where you can specify swap,target and select as overrides instead of just "true" in the hx-boost attribute value.  This lets you have inherited base hx-boost values that redirect all boosted elts to target or select a set element.

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
