### PR TITLE
Fix closing tags for hx-partial in htmx-4.md

### DIFF
--- a/www/content/htmx-4.md
+++ b/www/content/htmx-4.md
@@ -118,10 +118,10 @@ major changes between htmx 2.x and htmx 4.x.
   ```html
   <hx-partial hx-target="#messages" hx-swap="beforeend">
     <div>New message</div>
-  </partial>
+  </hx-partial>
   <hx-partial hx-target="#notifications">
     <span class="badge">5</span>
-  </partial>
+  </hx-partial>
   ```
 - Each partial specifies its own target and swap strategy
 - More explicit than OOB swaps which rely on matching `id` attributes


### PR DESCRIPTION
Corrected closing tags for hx-partial elements in the example.

## Description
*Please describe what changes you made, and why you feel they are necessary. Make sure to include
code examples, where applicable.*

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
