### PR TITLE
Add mergeConfig support and remove + hx-config merging

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -118,17 +118,7 @@ var htmx = (() => {
             }
             let metaConfig = document.querySelector('meta[name="htmx:config"]');
             if (metaConfig) {
-                let content = metaConfig.content;
-                let overrides = this.__parseConfig(content);
-                // Deep merge nested config objects
-                for (let key in overrides) {
-                    let val = overrides[key];
-                    if (val && typeof val === 'object' && !Array.isArray(val) && this.config[key]) {
-                        Object.assign(this.config[key], val);
-                    } else {
-                        this.config[key] = val;
-                    }
-                }
+                this.__mergeConfig(metaConfig.content, this.config);
             }
             this.__approvedExt = this.config.extensions;
         }
@@ -232,6 +222,19 @@ var htmx = (() => {
             }, {});
         }
 
+        __mergeConfig(configString, target) {
+            let parsed = this.__parseConfig(configString);
+            for (let key in parsed) {
+                let val = parsed[key];
+                if (val && typeof val === 'object' && !Array.isArray(val) && target[key]) {
+                    Object.assign(target[key], val);
+                } else {
+                    target[key] = val;
+                }
+            }
+            return target;
+        }
+
         __parseTriggerSpecs(spec) {
             return spec.split(',').map(s => {
                 let m = s.match(/^\s*(\S+\[[^\]]*\]|\S+)\s*(.*?)\s*$/);
@@ -328,22 +331,9 @@ var htmx = (() => {
             // Apply hx-config overrides
             let configAttr = this.__attributeValue(sourceElement, "hx-config");
             if (configAttr) {
-                let configOverrides = this.__parseConfig(configAttr);
-                let req = ctx.request;
-                for (let key in configOverrides) {
-                    if (key.startsWith('+')) {
-                        let actualKey = key.substring(1);
-                        if (req[actualKey] && typeof req[actualKey] === 'object') {
-                            Object.assign(req[actualKey], configOverrides[key]);
-                        } else {
-                            req[actualKey] = configOverrides[key];
-                        }
-                    } else {
-                        req[key] = configOverrides[key];
-                    }
-                }
-                if (req.etag) {
-                    (sourceElement._htmx ||= {}).etag ||= req.etag
+                this.__mergeConfig(configAttr, ctx.request);
+                if (ctx.request.etag) {
+                    (sourceElement._htmx ||= {}).etag ||= ctx.request.etag
                 }
             }
             if (sourceElement._htmx?.etag) {
@@ -368,7 +358,7 @@ var htmx = (() => {
             }
             let headersAttribute = this.__attributeValue(elt, "hx-headers");
             if (headersAttribute) {
-                Object.assign(headers, this.__parseConfig(headersAttribute));
+                this.__mergeConfig(headersAttribute, headers);
             }
             return headers;
         }
@@ -2093,7 +2083,7 @@ var htmx = (() => {
                 }
                 let statusValue = this.__attributeValue(ctx.sourceElement, "hx-status:" + pattern);
                 if (statusValue) {
-                    Object.assign(ctx, this.__parseConfig(statusValue));
+                    this.__mergeConfig(statusValue, ctx);
                     return;
                 }
             }

--- a/test/tests/attributes/hx-config.js
+++ b/test/tests/attributes/hx-config.js
@@ -136,20 +136,6 @@ describe('hx-config attribute', function() {
         assert.isNull(ctx.request.select)
     })
 
-    it('merges non-object values with + prefix', async function () {
-        mockResponse('GET', '/newpath', 'Done')
-        let ctx = null
-        document.addEventListener('htmx:config:request', function(e) {
-            ctx = e.detail.ctx
-        }, {once: true})
-
-        // When using + on a non-object (action is a string), it should set it on request
-        let btn = createProcessedHTML('<button hx-get="/test" hx-trigger="click" hx-config=\'{"+action": "/newpath"}\'>Click</button>');
-        btn.click()
-        await forRequest()
-        assert.isTrue(ctx.request.action.startsWith('/newpath'))
-    })
-
     it('handles complex nested JSON structures', async function () {
         mockResponse('GET', '/test', 'Done')
         let ctx = null
@@ -232,14 +218,14 @@ describe('hx-config attribute', function() {
         assert.equal(ctx.request.action, '/child')
     })
 
-    it('merges headers with + prefix', async function () {
+    it('merges headers by default', async function () {
         mockResponse('GET', '/test', 'Done')
         let ctx = null
         document.addEventListener('htmx:config:request', function(e) {
             ctx = e.detail.ctx
         }, {once: true})
 
-        let btn = createProcessedHTML('<button hx-get="/test" hx-config=\'{"+headers": {"X-Custom": "value"}}\'>Click</button>');
+        let btn = createProcessedHTML('<button hx-get="/test" hx-config=\'{"headers": {"X-Custom": "value"}}\'>Click</button>');
         btn.click()
         await forRequest()
         assert.equal(ctx.request.headers['X-Custom'], 'value')


### PR DESCRIPTION
## Description
several places we parse config strings into an object and then merge them into ctx or other config objects and we can instead use a helper mergeConfig function to do this for us.  The function can handle nested ojbects and merge these properly so you don't overwrite objects like headers and instead merge into them as you would expect.  Before we had manual support for this in hx-config so that headers could be merged with a + before the name of the object.  But I think it is much simpler just to always merge objects and avoid manual + syntax as for headers we should always retain the existing headers when merging anyway.

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
