### PR TITLE
fix hx-validate to respect noValidate and validate inputs outside of …

### DIFF
--- a/test/tests/end2end/core.js
+++ b/test/tests/end2end/core.js
@@ -49,6 +49,82 @@ describe('Basic Functionality', () => {
         assertTextContentIs("#result", "Success!");
     })
 
+    it('validation errors prevent submission of a single input with hx-validate=true', async function() {
+        mockResponse('POST', '/demo', '<div id="result">Success!</div>');
+        createProcessedHTML('<input id="i1" required hx-post="/demo" hx-validate="true" name="test" hx-trigger="click"/>');
+        
+        find('#i1').click();
+        assert.equal(fetchMock.pendingRequests.length, 0);
+        
+        find("#i1").value = "foo"
+        find('#i1').click()
+        await forRequestWithDelay();
+        
+        assertTextContentIs("#result", "Success!");
+    })
+
+    it('validation errors prevent submission of hx-included inputs', async function() {
+        mockResponse('POST', '/demo', '<div id="result">Success!</div>');
+        createProcessedHTML('<input id="i1" required name="test1"/><button id="b1" hx-post="/demo" hx-validate="true" hx-include="#i1">Submit</button>');
+        
+        find('#b1').click();
+        assert.equal(fetchMock.pendingRequests.length, 0);
+        
+        find("#i1").value = "foo"
+        find('#b1').click()
+        await forRequestWithDelay();
+        
+        assertTextContentIs("#result", "Success!");
+    })
+
+    it('form with noValidate does not validate by default', async function() {
+        mockResponse('POST', '/demo', '<div id="result">Success!</div>');
+        createProcessedHTML('<form novalidate><input id="i1" required name="test"/><button id="b1" hx-post="/demo">Submit</button></form>');
+        
+        find('#b1').click();
+        await forRequestWithDelay();
+        
+        assertTextContentIs("#result", "Success!");
+    })
+
+    it('form with noValidate can be overridden with hx-validate=true', async function() {
+        mockResponse('POST', '/demo', '<div id="result">Success!</div>');
+        createProcessedHTML('<form novalidate><input id="i1" required name="test"/><button id="b1" hx-post="/demo" hx-validate="true">Submit</button></form>');
+        
+        find('#b1').click();
+        assert.equal(fetchMock.pendingRequests.length, 0);
+        
+        find("#i1").value = "foo"
+        find('#b1').click()
+        await forRequestWithDelay();
+        
+        assertTextContentIs("#result", "Success!");
+    })
+
+    it('submit button with formNoValidate skips validation', async function() {
+        mockResponse('POST', '/demo', '<div id="result">Success!</div>');
+        createProcessedHTML('<form><input id="i1" required name="test"/><button id="b1" hx-post="/demo" formnovalidate>Submit</button></form>');
+        
+        find('#b1').click();
+        await forRequestWithDelay();
+        
+        assertTextContentIs("#result", "Success!");
+    })
+
+    it('form validates by default without hx-validate attribute', async function() {
+        mockResponse('POST', '/demo', '<div id="result">Success!</div>');
+        createProcessedHTML('<form hx-post="/demo"><input id="i1" required name="test"/><button id="b1" type="submit">Submit</button></form>');
+        
+        find('#b1').click();
+        assert.equal(fetchMock.pendingRequests.length, 0);
+        
+        find("#i1").value = "foo"
+        find('#b1').click()
+        await forRequestWithDelay();
+        
+        assertTextContentIs("#result", "Success!");
+    })
+
 //     it('Button added dynamically still triggers fetch and swaps', async function() {
 //         // Set up mock response
 //         fetchMock.mockResponse('/demo', new MockResponse('<div id="d1">Foo</div>'));


### PR DESCRIPTION
…just forms

## Description
form validation did not respect noValidate and formNoValidate built in browser attributes which i've added now.  And also added support to validate inputs even if they are not in a form.

Corresponding issue:
#3552 

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
