### PR TITLE
fix bug with empty response after partial removal detection

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1325,7 +1325,7 @@ var htmx = (() => {
             // Create main task if needed
             let swapSpec = this.__parseSwapSpec(ctx.swap || this.config.defaultSwap);
             // skip creating main swap if extracting partials resulted in empty response except for delete style
-            if (swapSpec.style === 'delete' || /\S/.test(fragment.innerHTML || '') || !partialTasks.length) {
+            if (swapSpec.style === 'delete' || fragment.childElementCount > 0 || /\S/.test(fragment.textContent) || !partialTasks.length) {
                 if (ctx.select) {
                     let selected = fragment.querySelectorAll(ctx.select);
                     fragment = document.createDocumentFragment();

--- a/test/tests/unit/swap.js
+++ b/test/tests/unit/swap.js
@@ -363,4 +363,54 @@ describe('swap() unit tests', function() {
         document.activeElement.id.should.equal("i1")
     })
 
+    it('swaps both main target and partial target when both are present', async function () {
+        createProcessedHTML("<div id='target'>Hello</div><div id='target_oob'>OOB</div>")
+        await htmx.swap({
+            "target":"#target", 
+            "text":"<div>Hello me!</div><hx-partial hx-target='#target_oob' hx-swap='innerHTML'><div>OOB swap!</div></hx-partial>"
+        })
+        find('#target').innerText.should.equal("Hello me!");
+        find('#target_oob').innerText.should.equal("OOB swap!");
+    })
+
+    it('swaps only partial target when response contains only partial', async function () {
+        createProcessedHTML("<div id='target'>Original</div><div id='target_oob'>OOB Original</div>")
+        await htmx.swap({
+            "target":"#target", 
+            "text":"<hx-partial hx-target='#target_oob' hx-swap='innerHTML'><div>OOB Updated</div></hx-partial>"
+        })
+        find('#target').innerText.should.equal("Original");
+        find('#target_oob').innerText.should.equal("OOB Updated");
+    })
+
+    it('does not swap main target when only whitespace and partial present', async function () {
+        createProcessedHTML("<div id='target'>Original</div><div id='target_oob'>OOB</div>")
+        await htmx.swap({
+            "target":"#target", 
+            "text":"\n  <hx-partial hx-target='#target_oob' hx-swap='innerHTML'><div>OOB swap!</div></hx-partial>  \n"
+        })
+        find('#target').innerText.should.equal("Original");
+        find('#target_oob').innerText.should.equal("OOB swap!");
+    })
+
+    it('swaps both targets when empty element and partial present', async function () {
+        createProcessedHTML("<div id='target'>Original</div><div id='target_oob'>OOB</div>")
+        await htmx.swap({
+            "target":"#target", 
+            "text":"<p></p><hx-partial hx-target='#target_oob' hx-swap='innerHTML'><div>OOB swap!</div></hx-partial>"
+        })
+        find('#target').querySelector('p').should.not.be.null;
+        find('#target_oob').innerText.should.equal("OOB swap!");
+    })
+  
+    it('swaps both targets when plain text and partial present', async function () {
+        createProcessedHTML("<div id='target'>Original</div><div id='target_oob'>OOB</div>")
+        await htmx.swap({
+            "target":"#target", 
+            "text":"Hello<hx-partial hx-target='#target_oob' hx-swap='innerHTML'><div>OOB swap!</div></hx-partial>"
+        })
+        find('#target').textContent.should.equal("Hello");
+        find('#target_oob').innerText.should.equal("OOB swap!");
+    })
+
 })


### PR DESCRIPTION
## Description
FastHTML guys found a bug where main swap does not happen if there is a hx-partial.  It is meant to detect if no content remains after removeing the hx-partials and prevent the main swap to avoid blanking the target in error.  But the fragment.innerHTML is the wrong way to check and you have to use a more complicated check to find if a fragment has no full elements and its text content is only whitespace.

Corresponding issue:

## Testing
Added tests for the various hx-partial plus content situations 


## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
