### PR TITLE
improve hx-boost advanced config to use new mergeConfig for nesting

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -325,9 +325,12 @@ var htmx = (() => {
                     credentials: "same-origin",
                     signal: ac.signal,
                     mode: this.config.mode
-                },
-                ...sourceElement._htmx?.boosted
+                }
             };
+            // Apply boost config overrides
+            if (sourceElement._htmx?.boosted) {
+                this.__mergeConfig(sourceElement._htmx.boosted, ctx);
+            }
             ctx.target = this.__resolveTarget(sourceElement, ctx.target);
 
             // Apply hx-config overrides
@@ -1006,7 +1009,7 @@ var htmx = (() => {
         __maybeBoost(elt) {
             let boostValue = this.__attributeValue(elt, "hx-boost");
             if (boostValue && boostValue !== "false" && this.__shouldBoost(elt)) {
-                elt._htmx = {eventHandler: this.__createHtmxEventHandler(elt), requests: [], boosted: this.__parseConfig(boostValue)}
+                elt._htmx = {eventHandler: this.__createHtmxEventHandler(elt), requests: [], boosted: boostValue}
                 elt.setAttribute('data-htmx-powered', 'true');
                 if (elt.matches('a') && !elt.hasAttribute("target")) {
                     elt.addEventListener('click', (click) => {


### PR DESCRIPTION

## Description
With the recent merge of mergeConfig change we can now fix up the boost advanced support to use this new feature.  This allows overriding nested ctx as well.

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
