### PR TITLE
website: add Askama to the list of template engines that support template fragments

### DIFF
--- a/www/content/essays/template-fragments.md
+++ b/www/content/essays/template-fragments.md
@@ -166,6 +166,7 @@ Here are some known implementations of the fragment concept:
   * [Giraffe.ViewEngine.Htmx](https://github.com/bit-badger/Giraffe.Htmx/tree/main/src/ViewEngine.Htmx)
 * Rust
   * [MiniJinja](https://docs.rs/minijinja/latest/minijinja/struct.State.html#method.render_block)
+  * [Askama](https://askama.readthedocs.io/en/stable/template_syntax.html#block-fragments)
 * Raku
   * [Cro Templates](https://github.com/croservices/cro-website/blob/main/docs/reference/cro-webapp-template-syntax.md#fragments)
 


### PR DESCRIPTION
## Description
The title says it all.

## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
