### PR TITLE
improve parseConfig and append to allow joining json for hx-vals

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -191,7 +191,7 @@ var htmx = (() => {
                 let parent = elt.parentNode?.closest?.(`[${CSS.escape(inheritName)}],[${CSS.escape(inheritAppendName)}]`);
                 if (parent) {
                     let inherited = this.__attributeValue(parent, name, undefined, returnElt);
-                    return returnElt ? inherited : (inherited ? inherited + "," + appendValue : appendValue);
+                    return returnElt ? inherited : (inherited ? (inherited + "," + appendValue).replace(/[{}]/g, '') : appendValue);
                 } else {
                     return returnElt ? elt : appendValue;
                 }
@@ -210,10 +210,10 @@ var htmx = (() => {
 
         __parseConfig(configString) {
             if (configString[0] === '{') return JSON.parse(configString);
-            let configPattern = /([^\s,]+?)(?:\s*:\s*(?:"([^"]*)"|'([^']*)'|<([^>]+)\/>|([^\s,]+)))?(?=\s|,|$)/g;
+            let configPattern = /(?:"([^"]+)"|([^\s,:]+))(?:\s*:\s*(?:"([^"]*)"|'([^']*)'|<([^>]+)\/>|([^\s,]+)))?(?=\s|,|$)/g;
             return [...configString.matchAll(configPattern)].reduce((result, match) => {
-                let keyPath = match[1].split('.');
-                let value = (match[2] ?? match[3] ?? match[4] ?? match[5] ?? 'true').trim();
+                let keyPath = (match[1] ?? match[2]).split('.');
+                let value = (match[3] ?? match[4] ?? match[5] ?? match[6] ?? 'true').trim();
                 if (value === 'true') value = true;
                 else if (value === 'false') value = false;
                 else if (/^\d+$/.test(value)) value = parseInt(value);

--- a/test/tests/attributes/hx-vals.js
+++ b/test/tests/attributes/hx-vals.js
@@ -8,6 +8,18 @@ describe('hx-vals attribute', function() {
         cleanupTest(this.currentTest)
     })
 
-    // TODO - convert to a direct test
+    it('hx-vals:append merges JSON objects correctly', async function() {
+        mockResponse('POST', '/test', 'Success')
+        const div = createProcessedHTML(
+            '<div hx-vals:inherited=\'{"a":1}\'>' +
+            '  <button hx-post="/test" hx-vals:append=\'{"b":"hi"}\'>Click</button>' +
+            '</div>'
+        );
+        const button = div.querySelector('button');
+        button.click();
+        await forRequest()
+        fetchMock.calls[0].request.body.get('a').should.equal('1');
+        fetchMock.calls[0].request.body.get('b').should.equal('hi');
+    });
 
 })

--- a/test/tests/unit/__attributeValue.js
+++ b/test/tests/unit/__attributeValue.js
@@ -27,7 +27,7 @@ describe('__atributeValue() unit tests', function() {
         );
         const button = container.querySelector('button');
         const result = htmx.__attributeValue(button, 'hx-vals');
-        assert.equal(result, '{"a":1},{"b":2}');
+        assert.equal(result, '"a":1,"b":2');
     });
 
     it(':inherited still works normally', function () {

--- a/test/tests/unit/htmx.config.implicitInheritance.js
+++ b/test/tests/unit/htmx.config.implicitInheritance.js
@@ -53,7 +53,7 @@ describe('htmx.config.implicitInheritance test', function() {
         );
         const button = container.querySelector('button');
         const result = htmx.__attributeValue(button, 'hx-vals');
-        assert.equal(result, '{"a":1},{"b":2}');
+        assert.equal(result, '"a":1,"b":2');
     });
 
 });

--- a/www/content/attributes/hx-vals.md
+++ b/www/content/attributes/hx-vals.md
@@ -77,6 +77,21 @@ Combine values from other inputs with computed values:
 </div>
 ```
 
+### Merging Values with `:append`
+
+Use the `:append` modifier to merge child values with inherited parent values:
+
+```html
+<div hx-vals='{"source": "landing-page"}'>
+    <button hx-post="/register"
+            hx-vals:append='{"campaign": "summer-sale"}'>
+        Register
+    </button>
+</div>
+```
+
+The button will send both `source=landing-page` and `campaign=summer-sale` parameters. When using `:append` with JSON objects, the values are merged into a single valid JSON object. If both parent and child define the same parameter name, the child value will override the parent value.
+
 ## Security Considerations
 
 * By default, the value of `hx-vals` must be valid [JSON](https://developer.mozilla.org/en-US/docs/Glossary/JSON).
@@ -86,6 +101,7 @@ Combine values from other inputs with computed values:
 
 ## Notes
 
-* A child declaration of a parameter name will override a parent declaration of the same name.
+* By default in htmx 4.x, child elements do not inherit parent `hx-vals` unless using the `:inherited` or `:append` modifiers, or when `htmx.config.implicitInheritance` is set to `true`.
+* When inheritance is enabled, a child `hx-vals` declaration will completely replace the parent value unless the `:append` modifier is used to merge them.
 * Values from `hx-vals` are added to the request *after* values from the form and `hx-include`, so they can override those values.
 * When using the `js:` prefix, the code has access to the htmx API methods as well as the element as `this`.


### PR DESCRIPTION
## Description
hx-vals json joining with append creates {},{} invalid json format so instead i've made :append strip the {} so that the joined string is valid HCON format and improved parseConfig to handle "" wrapped keys like JSON uses.

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
