### PR TITLE
optimize hx-vals and headers async with a callback and fix ws async 

### DIFF
--- a/src/ext/hx-ws.js
+++ b/src/ext/hx-ws.js
@@ -190,7 +190,7 @@
     // MESSAGE SENDING
     // ========================================
     
-    function sendMessage(element, event) {
+    async function sendMessage(element, event) {
         // Find connection URL
         let url = getWsAttribute(element, 'send');
         if (!url) {
@@ -216,7 +216,8 @@
         // Build message
         let form = element.form || element.closest('form');
         let body = api.collectFormData(element, form, event.submitter);
-        api.handleHxVals(element, body);
+        let valsResult = api.handleHxVals(element, body);
+        if (valsResult) await valsResult;
         
         let values = {};
         for (let [key, value] of body) {
@@ -480,7 +481,7 @@
         if (specs.length > 0) {
             let spec = specs[0];
             
-            let handler = (evt) => {
+            let handler = async (evt) => {
                 // Prevent default for forms
                 if (element.matches('form') && evt.type === 'submit') {
                     evt.preventDefault();
@@ -495,7 +496,7 @@
                     }
                 }
                 
-                sendMessage(element, evt);
+                await sendMessage(element, evt);
             };
             
             element.addEventListener(spec.name, handler);

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -376,20 +376,9 @@ var htmx = (() => {
         }
 
         __handleHxHeaders(elt, headers) {
-            let result = this.__getAttributeObject(elt, "hx-headers");
-            if (result) {
-                if (result instanceof Promise) {
-                    return result.then(obj => {
-                        for (let key in obj) {
-                            headers[key] = String(obj[key]);
-                        }
-                    });
-                } else {
-                    for (let key in result) {
-                        headers[key] = String(result[key]);
-                    }
-                }
-            }
+            return this.__getAttributeObject(elt, "hx-headers", obj => {
+                for (let key in obj) headers[key] = String(obj[key]);
+            });
         }
 
         __resolveTarget(elt, selector) {
@@ -1787,7 +1776,7 @@ var htmx = (() => {
             }
         }
 
-        __getAttributeObject(elt, attrName) {
+        __getAttributeObject(elt, attrName, callback) {
             let attrValue = this.__attributeValue(elt, attrName);
             if (!attrValue) return null;
 
@@ -1798,28 +1787,19 @@ var htmx = (() => {
                     javascriptContent = '{' + javascriptContent + '}';
                 }
                 // Return promise for async evaluation
-                return this.__executeJavaScriptAsync(elt, {}, javascriptContent, true);
+                return this.__executeJavaScriptAsync(elt, {}, javascriptContent, true).then(obj => {
+                    callback(obj);
+                });
             } else {
                 // Synchronous path - return the parsed object directly
-                return this.__parseConfig(attrValue);
+                callback(this.__parseConfig(attrValue));
             }
         }
 
         __handleHxVals(elt, body) {
-            let result = this.__getAttributeObject(elt, "hx-vals");
-            if (result) {
-                if (result instanceof Promise) {
-                    return result.then(obj => {
-                        for (let key in obj) {
-                            body.set(key, obj[key])
-                        }
-                    });
-                } else {
-                    for (let key in result) {
-                        body.set(key, result[key])
-                    }
-                }
-            }
+            return this.__getAttributeObject(elt, "hx-vals", obj => {
+                for (let key in obj) body.set(key, obj[key]);
+            });
         }
 
         __stringHyperscriptStyleSelector(selector) {

--- a/test/tests/ext/hx-ws.js
+++ b/test/tests/ext/hx-ws.js
@@ -327,6 +327,27 @@ describe('hx-ws WebSocket extension', function() {
             
             assert.notEqual(firstId, secondId);
         });
+        
+        it('includes async hx-vals (js:) in sent message', async function() {
+            window.testAsyncValue = () => new Promise(resolve => setTimeout(() => resolve('asyncValue'), 10));
+            
+            let div = createProcessedHTML(`
+                <div hx-ws:connect="/ws/test" hx-trigger="load">
+                    <button hx-ws:send hx-vals='js:{asyncField: await testAsyncValue()}' hx-trigger="click">Send</button>
+                </div>
+            `);
+            await htmx.timeout(50);
+            
+            let button = div.querySelector('button');
+            button.click();
+            await htmx.timeout(20);
+            
+            let ws = mockWebSocketInstances[0];
+            let sent = JSON.parse(ws.lastSent);
+            assert.equal(sent.values.asyncField, 'asyncValue');
+            
+            delete window.testAsyncValue;
+        });
     });
     
     // ========================================


### PR DESCRIPTION

## Description
minor code reuse optimization via a callback for hx-vals and hx-headers.  Also fixed async sendMessage handling in ws extension if it has to process hx-vals async.

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
