### PR TITLE
Trims only the first leading space in a SSE field value (#3588)

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -716,7 +716,9 @@ var htmx = (() => {
                         if (colonIndex <= 0) continue;
 
                         let field = line.slice(0, colonIndex);
-                        let value = line.slice(colonIndex + 1).trimStart();
+
+                        let value = line.slice(colonIndex + 1)
+                        if (value[0] === ' ') value = value.slice(1);
 
                         if (field === 'data') {
                             message.data += (message.data ? '\n' : '') + value;

--- a/test/tests/end2end/sse.js
+++ b/test/tests/end2end/sse.js
@@ -458,4 +458,22 @@ describe('Server-Sent Events', function() {
 
         stream.close();
     });
+
+    it('only trims single space after colon', async function() {
+        const stream = mockStreamResponse('/sse-whitespace');
+        createProcessedHTML('<button id="ws-btn" hx-get="/sse-whitespace" hx-swap="innerHTML">Whitespace</button>');
+
+        find('#ws-btn').click();
+        await htmx.timeout(1);
+
+        stream.send('   \ttext-with-two-leading-spaces');
+        await waitForEvent('htmx:after:sse:message');
+        assertTextContentIs('#ws-btn', '   \ttext-with-two-leading-spaces');
+
+        stream.send('NoTrim');
+        await waitForEvent('htmx:after:sse:message');
+        assertTextContentIs('#ws-btn', 'NoTrim');
+
+        stream.close();
+    });
 });


### PR DESCRIPTION
## Description
Fixes #3588 

## Testing
Added a new test case to `test/tests/end2end/sse.js`

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
