### PR TITLE
Handle newContent properly in insertContent

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1372,6 +1372,12 @@ var htmx = (() => {
                 return;
             }
 
+            if (swapSpec.style === 'textContent') {
+                target.textContent = fragment.textContent;
+                target.classList.remove("htmx-swapping")
+                return;
+            }
+
             let pantry = this.__handlePreservedElements(fragment);
             let parentNode = target.parentNode;
             let newContent = [...fragment.childNodes]
@@ -1383,8 +1389,6 @@ var htmx = (() => {
                         this.__cleanup(child)
                     }
                     target.replaceChildren(...fragment.childNodes);
-                } else if (swapSpec.style === 'textContent') {
-                    target.textContent = fragment.textContent;
                 } else if (swapSpec.style === 'outerHTML') {
                     if (parentNode) {
                         settleTasks = inViewTransition ? [] : this.__startCSSTransitions(fragment, target);
@@ -1397,7 +1401,7 @@ var htmx = (() => {
                     newContent = [...target.childNodes];
                 } else if (swapSpec.style === 'outerMorph') {
                     this.__morph(target, fragment, false);
-                    newContent = [target];
+                    newContent.push(target);
                 } else if (swapSpec.style === 'beforebegin') {
                     if (parentNode) {
                         this.__insertNodes(parentNode, target, fragment);

--- a/test/tests/unit/morph.js
+++ b/test/tests/unit/morph.js
@@ -395,6 +395,62 @@ describe('Morph Swap Styles Tests', function() {
         });
     });
 
+    describe('htmx processing during morph', function() {
+        it('processes new htmx attributes added during innerMorph', async function() {
+            mockResponse('GET', '/test', '<button id="btn" hx-get="/click" hx-target="#result">Updated</button><div id="result"></div>');
+            const div = createProcessedHTML('<div id="target"><button id="btn">Original</button><div id="result"></div></div>');
+            const btn = div.querySelector('#btn');
+            
+            await htmx.ajax('GET', '/test', {target: '#target', swap: 'innerMorph'});
+            
+            assert.equal(btn.getAttribute('data-htmx-powered'), 'true', 'New htmx attributes should be processed');
+            
+            mockResponse('GET', '/click', 'Clicked!');
+            btn.click();
+            await htmx.forEvent('htmx:after:swap', 100);
+            
+            assert.equal(div.querySelector('#result').textContent, 'Clicked!', 'New htmx functionality should work');
+        });
+
+        it('processes new htmx attributes added during outerMorph', async function() {
+            mockResponse('GET', '/test', '<button id="btn" hx-get="/click" hx-target="#result">Updated</button>');
+            const container = createProcessedHTML('<div><button id="btn">Original</button><div id="result"></div></div>');
+            const btn = container.querySelector('#btn');
+            
+            await htmx.ajax('GET', '/test', {target: '#btn', swap: 'outerMorph'});
+            
+            assert.equal(btn.getAttribute('data-htmx-powered'), 'true', 'New htmx attributes should be processed');
+            
+            mockResponse('GET', '/click', 'Clicked!');
+            btn.click();
+            await htmx.forEvent('htmx:after:swap', 100);
+            
+            assert.equal(container.querySelector('#result').textContent, 'Clicked!', 'New htmx functionality should work');
+        });
+
+        it('processes new htmx attributes on inserted elements during innerMorph', async function() {
+            mockResponse('GET', '/test', '<button id="existing">Existing</button><button id="new" hx-get="/new">New Button</button>');
+            const div = createProcessedHTML('<div id="target"><button id="existing">Existing</button></div>');
+            
+            await htmx.ajax('GET', '/test', {target: '#target', swap: 'innerMorph'});
+            
+            const newBtn = div.querySelector('#new');
+            assert.isNotNull(newBtn);
+            assert.equal(newBtn.getAttribute('data-htmx-powered'), 'true', 'New inserted element should be processed');
+        });
+
+        it('processes new htmx attributes on inserted elements during outerMorph', async function() {
+            mockResponse('GET', '/test', '<div id="target"><button id="existing">Existing</button><button id="new" hx-get="/new">New Button</button></div>');
+            const container = createProcessedHTML('<div><div id="target"><button id="existing">Existing</button></div></div>');
+            
+            await htmx.ajax('GET', '/test', {target: '#target', swap: 'outerMorph'});
+            
+            const newBtn = container.querySelector('#new');
+            assert.isNotNull(newBtn);
+            assert.equal(newBtn.getAttribute('data-htmx-powered'), 'true', 'New inserted element should be processed');
+        });
+    });
+
     describe('htmx integration', function() {
         it('preserves data-htmx-powered attribute during innerMorph', async function() {
             mockResponse('GET', '/test', '<button id="btn" hx-get="/click">Updated</button>');


### PR DESCRIPTION
## Description
newContent processing and settle has issues with some swap styles.  morph needs to set the correct newContent so that newly morphed target nodes are processed properly. for outerMorph adding the target to the existing newContent solves this by processing the final morphed target plus any newContent nodes that were also swapped in.

delete, textContent and none swap styles need early return paths to avoid settle logic and avoid newContent processing etc.

handle_swap custom extension point needs the option to return a node array for newContent processing if needed but if you return true it can just fall back to processing newContent nodes instead. 

Corresponding issue:
#3606 

## Testing
Added tests for morphing to make sure it now processes moprhed content properly.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
