### PR TITLE
handle no id found with hx-preserve

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1092,10 +1092,12 @@ var htmx = (() => {
             let newPreservedElts = fragment.querySelectorAll?.(`[${this.__prefix('hx-preserve')}]`) || [];
             for (let preservedElt of newPreservedElts) {
                 let currentElt = document.getElementById(preservedElt.id);
-                if (pantry.moveBefore) {
-                    pantry.moveBefore(currentElt, null);
-                } else {
-                    pantry.appendChild(currentElt);
+                if (currentElt) {
+                    if (pantry.moveBefore) {
+                        pantry.moveBefore(currentElt, null);
+                    } else {
+                        pantry.appendChild(currentElt);
+                    }
                 }
             }
             return pantry
@@ -1104,13 +1106,15 @@ var htmx = (() => {
         __restorePreservedElements(pantry) {
             for (let preservedElt of pantry.children) {
                 let newElt = document.getElementById(preservedElt.id);
-                if (newElt.parentNode.moveBefore) {
-                    newElt.parentNode.moveBefore(preservedElt, newElt);
-                } else {
-                    newElt.replaceWith(preservedElt);
+                if (newElt) {
+                    if (newElt.parentNode.moveBefore) {
+                        newElt.parentNode.moveBefore(preservedElt, newElt);
+                    } else {
+                        newElt.replaceWith(preservedElt);
+                    }
+                    this.__cleanup(newElt)
+                    newElt.remove()
                 }
-                this.__cleanup(newElt)
-                newElt.remove()
             }
             pantry.remove();
         }

--- a/test/tests/attributes/hx-preserve.js
+++ b/test/tests/attributes/hx-preserve.js
@@ -24,4 +24,12 @@ describe('hx-preserve attribute', function() {
         await forRequest()
         assert.equal(find('#inp').value, 'modified')
     })
+
+    it('handles hx-preserve when element does not exist in current page', async function () {
+        mockResponse('GET', '/test', '<div id="new-preserved" hx-preserve>New Preserved</div><div>Content</div>')
+        let div = createProcessedHTML('<div hx-get="/test"><div>Original Content</div></div>');
+        div.click()
+        await forRequest()
+        assertTextContentIs('#new-preserved', 'New Preserved')
+    })
 })


### PR DESCRIPTION
## Description
There is a bug where hx-preserve does not check the id exists in the DOM before trying to move it leading to an exception.  simply adding a if check should solve this.

Corresponding issue:
#3599 

## Testing
Added test for missing id with hx-preserve

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
