### PR TITLE
Fix broken link in extensions table for "optimistic" extension.

### DIFF
--- a/www/content/extensions/_index.md
+++ b/www/content/extensions/_index.md
@@ -131,7 +131,7 @@ htmx extensions are split into two categories:
       <td>{% markdown() %}  Allows dynamic URL path templating using `{varName}` placeholders, resolved via configurable custom function or `window.` fallback. It does not rely on `hx-vals`. Useful when needing to perform requests to paths that depend on application state.  {% end %}</td>
     </tr>
     <tr>
-      <td>{% markdown() %}  [optimistic]([https://github.com/FumingPower3925/htmx-dynamic-url](https://github.com/lorenseanstewart/hx-optimistic/blob/main/README.md)  {% end %}</td>
+      <td>{% markdown() %}  [optimistic](https://github.com/lorenseanstewart/hx-optimistic/blob/main/README.md)  {% end %}</td>
       <td>{% markdown() %}  This extension provides a way to optimistically update the UI to increase perceived performance  {% end %}</td>
     </tr>
   </tbody>


### PR DESCRIPTION
## Description

Markdown link for `optimistic` is broken on extensions page.

Corresponding issue:

## Testing

Fixed the markdown link. Looks like a bad merge.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
