### PR TITLE
docs: update minified gzip size from ~14k to ~16k

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ directly in HTML, using [attributes](https://htmx.org/reference#attributes), so 
 [modern user interfaces](https://htmx.org/examples) with the [simplicity](https://en.wikipedia.org/wiki/HATEOAS) and
 [power](https://www.ics.uci.edu/~fielding/pubs/dissertation/rest_arch_style.htm) of hypertext
 
-htmx is small ([~14k min.gz'd](https://cdn.jsdelivr.net/npm/htmx.org/dist/)),
+htmx is small ([~16k min.gz'd](https://cdn.jsdelivr.net/npm/htmx.org/dist/)),
 [dependency-free](https://github.com/bigskysoftware/htmx/blob/master/package.json) &
 [extendable](https://htmx.org/extensions)
 

--- a/www/themes/htmx-theme/templates/base.html
+++ b/www/themes/htmx-theme/templates/base.html
@@ -7,7 +7,7 @@
     {%- block description -%}
     htmx gives you access to AJAX, CSS Transitions, WebSockets and Server Sent Events directly in HTML, using attributes, so you can build modern user interfaces with the simplicity and power of hypertext
 
-    htmx is small (~14k min.gz’d), dependency-free, extendable, IE11 compatible & has reduced code base sizes by 67% when compared with react
+    htmx is small (~16k min.gz'd), dependency-free, extendable, IE11 compatible & has reduced code base sizes by 67% when compared with react
     {%- endblock description -%}
     ">
     {# This block should set html_title appropriately -#}


### PR DESCRIPTION
## Description

Update the minified gzip size claim from `~14k` to `~16k` in README.md and the website template.

The actual size of htmx.min.js gzipped is approximately 16.2 KB according to jsDelivr CDN, not ~14k as previously stated.

**Files changed:**
- `README.md` - Updated size claim in introduction section
- `www/themes/htmx-theme/templates/base.html` - Updated size claim in meta description

Corresponding issue: #3239

## Testing

This is a documentation-only change (updating text values). No functional code was modified.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded