### PR TITLE
docs: improve hx-vals documentation for use with hx-post

### DIFF
--- a/www/content/attributes/hx-vals.md
+++ b/www/content/attributes/hx-vals.md
@@ -33,6 +33,36 @@ You can also use the spread operator to dynamically specify values. This allows 
 
 In this example, if `foo()` returns an object like `{name: "John", age: 30}`, both `name` and `age` will be included as parameters in the request.
 
+## Using hx-vals with hx-post
+
+The `hx-vals` attribute works with all HTTP methods, including `hx-post`, `hx-put`, `hx-patch`, and `hx-delete`:
+
+```html
+  <button hx-post="/submit" hx-vals='{"action": "save", "draft": "true"}'>
+    Save as Draft
+  </button>
+```
+
+When used with non-GET requests (POST, PUT, PATCH, DELETE), the values from `hx-vals` are included in the request body.
+When used with GET requests, they are appended as query parameters.
+
+## JSON Syntax Requirements
+
+The `hx-vals` attribute requires **valid JSON syntax**. A common mistake is using single quotes inside the JSON, which will cause the values to be silently ignored:
+
+```html
+  <!-- WRONG: Single quotes inside JSON are invalid -->
+  <div hx-post="/example" hx-vals="{'myVal': 'value'}">This will NOT work</div>
+
+  <!-- CORRECT: Use double quotes inside JSON, single quotes for the attribute -->
+  <div hx-post="/example" hx-vals='{"myVal": "value"}'>This works correctly</div>
+
+  <!-- CORRECT: Or escape the double quotes if using double quotes for the attribute -->
+  <div hx-post="/example" hx-vals="{&quot;myVal&quot;: &quot;value&quot;}">This also works</div>
+```
+
+If your `hx-vals` JSON is malformed, htmx will silently ignore it without any error message, which can make debugging difficult.
+
 ## Security Considerations
 
 * By default, the value of `hx-vals` must be valid [JSON](https://developer.mozilla.org/en-US/docs/Glossary/JSON).


### PR DESCRIPTION
## Description

Improve the `hx-vals` documentation to address common user confusion, especially regarding its use with `hx-post` and other non-GET HTTP methods.

**Changes made:**

1. **Added "Using hx-vals with hx-post" section**
   - Example showing `hx-vals` with `hx-post`
   - Clarified that `hx-vals` works with all HTTP methods (POST, PUT, PATCH, DELETE)
   - Explained the difference: non-GET requests include values in the request body, while GET requests append them as query parameters

2. **Added "JSON Syntax Requirements" section**
   - Documented a common pitfall: using single quotes inside JSON (`{'key': 'value'}`) which silently fails
   - Provided correct examples using double quotes inside JSON
   - Warned that malformed JSON is silently ignored, making debugging difficult

These additions address user feedback in issue #1134, where multiple users reported spending significant time debugging issues that could have been avoided with clearer documentation.

Corresponding issue: #1134

## Testing

This is a documentation-only change. No functional code was modified.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
