### PR TITLE
fix document fragment parsing of full page responses for live script support

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1133,18 +1133,18 @@ var htmx = (() => {
             let response = text.replace(/<hx-([a-z]+)(\s+|>)/gi, '<template hx type="$1"$2').replace(/<\/hx-[a-z]+>/gi, '</template>');
             let title = '';
             response = response.replace(/<title[^>]*>[\s\S]*?<\/title>/i, m => (title = this.__parseHTML(m).title, ''));
-            let responseWithNoHead = response.replace(/<head(\s[^>]*)?>[\s\S]*?<\/head>/i, '');
-            let startTag = responseWithNoHead.match(/<([a-z][^\/>\x20\t\r\n\f]*)/i)?.[1]?.toLowerCase();
+            response = response.replace(/<head(\s[^>]*)?>[\s\S]*?<\/head>/i, '');
+            let startTag = response.match(/<([a-z][^\/>\x20\t\r\n\f]*)/i)?.[1]?.toLowerCase();
 
             let doc, fragment;
-            if (startTag === 'html') {
+            if (startTag === 'html' || startTag === 'body') {
                 doc = this.__parseHTML(response);
-                fragment = doc.body;
-            } else if (startTag === 'body') {
-                doc = this.__parseHTML(responseWithNoHead);
-                fragment = doc.body;
+                fragment = document.createDocumentFragment();
+                while (doc.body.childNodes.length > 0) {
+                    fragment.append(doc.body.childNodes[0]);
+                }
             } else {
-                doc = this.__parseHTML(`<template>${responseWithNoHead}</template>`);
+                doc = this.__parseHTML(`<template>${response}</template>`);
                 fragment = doc.querySelector('template').content;
             }
             this.__processScripts(fragment);
@@ -1469,6 +1469,7 @@ var htmx = (() => {
                 this.process(elt);
                 this.__handleAutoFocus(elt);
             }
+            
             this.__handleScroll(swapSpec, target);
         }
 

--- a/test/tests/unit/swap.js
+++ b/test/tests/unit/swap.js
@@ -228,6 +228,20 @@ describe('swap() unit tests', function() {
         delete window.testVar;
     })
 
+    it('executes script when wrapped in html tag', async function () {
+        window.testVar = 0;
+        await htmx.swap({"target":"#test-playground", "text":"<html><body><script>window.testVar = 9</script><div>Content</div></body></html>"})
+        window.testVar.should.equal(9);
+        delete window.testVar;
+    })
+
+    it('executes script when wrapped in body tag', async function () {
+        window.testVar = 0;
+        await htmx.swap({"target":"#test-playground", "text":"<body><script>window.testVar = 10</script><div>Content</div></body>"})
+        window.testVar.should.equal(10);
+        delete window.testVar;
+    })
+
     it('replaces attributes when swapping element with same id', async function () {
         createProcessedHTML("<div id='d1' class='old' data-value='1'></div>")
         await htmx.swap({"target":"#d1", "text":"<div id='d1' class='new' data-value='2'>Content</div>", "swap":"outerHTML"})


### PR DESCRIPTION


## Description
There is an issue with live script processing with full page responses wrapped in html/body tags.  It was using the parsed document which seems to not support live script tags even if you re-process them.  htmx2 was creating a new document fragment and moving the parsed document nodes  over to this to work around this issue so I have done the same here

Corresponding issue:
#3625 

## Testing
seems we were missing tests for script tags wrapped in html/body tags so added these tests

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
