### PR TITLE
fix(essay): Fix typo in Symfony mention in Paris 2024 essay

### DIFF
--- a/www/content/essays/paris-2024-olympics-htmx-network-automation.md
+++ b/www/content/essays/paris-2024-olympics-htmx-network-automation.md
@@ -83,7 +83,7 @@ Private VLAN, and Shared Internet Access.
 
 ## Web Dev with HTMX
 
-HTMX is somewhat a return to the roots of web development, and regardless of the web framework: Django, ROR, Symphony...
+HTMX is somewhat a return to the roots of web development, and regardless of the web framework: Django, ROR, Symfony...
 You rediscover everything that makes a web framework useful rather than turning it into a mere JSON provider. Sending
 HTML directly to the browser, storing the app state directly in the HTML. That's what true REST is, and it's so much
 simpler to manage.


### PR DESCRIPTION
## Description

Simple typo change. The essay mention web frameworks Django, ROR and **Symphony**. 

This is a typo as the framework is named **Symfony**. 

Check https://symfony.com for relevance.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded

Thanks