### PR TITLE
Add script tag processing in swapWithHtmx function

### DIFF
--- a/src/ext/hx-ws.js
+++ b/src/ext/hx-ws.js
@@ -511,16 +511,31 @@
         }
         return element;
     }
-    
+
+    function processScriptTags(container) {
+        let scripts = container.querySelectorAll('script');
+        for (let oldScript of scripts) {
+            let newScript = document.createElement('script');
+            for (let attr of oldScript.attributes) {
+                newScript.setAttribute(attr.name, attr.value);
+            }
+            newScript.textContent = oldScript.textContent;
+            oldScript.parentNode.replaceChild(newScript, oldScript);
+        }
+    }
+
     function swapWithHtmx(target, content, sourceElement, envelopeSwap) {
         // Determine swap style from envelope, element attribute, or default
         let swapStyle = envelopeSwap || api.attributeValue(sourceElement, 'hx-swap') || htmx.config.defaultSwap;
-        
+
         // Create a document fragment from the HTML content
         let template = document.createElement('template');
         template.innerHTML = content || '';
         let fragment = template.content;
-        
+
+        // Process script tags to ensure they execute
+        processScriptTags(fragment);
+
         // Use htmx's internal insertContent which handles:
         // - All swap styles correctly
         // - Processing new content with htmx.process()
@@ -532,7 +547,7 @@
             swapSpec: swapStyle,  // Can be a string - insertContent will parse it
             fragment: fragment
         };
-        
+
         api.insertContent(task);
     }
     


### PR DESCRIPTION
This update introduces a new function, processScriptTags, which ensures that script tags within the content are properly executed after being swapped. The function replaces old script elements with new ones, preserving their attributes and content. This enhancement improves the handling of dynamic content in the htmx framework.

## Description
*Please describe what changes you made, and why you feel they are necessary. Make sure to include
code examples, where applicable.*

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
