### PR TITLE
Update ws extension to use htmx.swap

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1222,10 +1222,11 @@ var htmx = (() => {
                 let type = templateElt.getAttribute('type');
                 
                 if (type === 'partial') {
+                    let target = templateElt.getAttribute(this.__prefix('hx-target')) || (templateElt.id ? '#' + CSS.escape(templateElt.id) : null);
                     tasks.push({
                         type: 'partial',
                         fragment: templateElt.content.cloneNode(true),
-                        target: templateElt.getAttribute(this.__prefix('hx-target')),
+                        target,
                         swapSpec: this.__parseSwapSpec(templateElt.getAttribute(this.__prefix('hx-swap')) || this.config.defaultSwap),
                         sourceElement: ctx.sourceElement
                     });

--- a/test/tests/ext/hx-ws.js
+++ b/test/tests/ext/hx-ws.js
@@ -415,9 +415,9 @@ describe('hx-ws WebSocket extension', function() {
             assert.equal(document.getElementById('content').textContent, 'New');
         });
         
-        it('respects hx-swap attribute', async function() {
+        it('respects hx-swap attribute on partial', async function() {
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load" hx-target="#list" hx-swap="beforeend">
+                <div hx-ws:connect="/ws/test" hx-trigger="load" hx-target="#list">
                     <div id="list"><p>Item 1</p></div>
                 </div>
             `);
@@ -427,7 +427,7 @@ describe('hx-ws WebSocket extension', function() {
             ws.simulateMessage({
                 channel: 'ui',
                 format: 'html',
-                payload: '<hx-partial id="list"><p>Item 2</p></hx-partial>'
+                payload: '<hx-partial id="list" hx-swap="beforeend"><p>Item 2</p></hx-partial>'
             });
             await htmx.timeout(20);
             
@@ -1095,7 +1095,7 @@ describe('hx-ws WebSocket extension', function() {
         
         it('handles live notifications pattern', async function() {
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/notifications" hx-trigger="load" hx-target="#notifications" hx-swap="afterbegin">
+                <div hx-ws:connect="/ws/notifications" hx-trigger="load" hx-target="#notifications">
                     <div id="notifications"></div>
                 </div>
             `);
@@ -1107,14 +1107,14 @@ describe('hx-ws WebSocket extension', function() {
             ws.simulateMessage({
                 channel: 'ui',
                 format: 'html',
-                payload: '<hx-partial id="notifications"><div class="notif">Notification 1</div></hx-partial>'
+                payload: '<hx-partial id="notifications" hx-swap="afterbegin"><div class="notif">Notification 1</div></hx-partial>'
             });
             await htmx.timeout(20);
             
             ws.simulateMessage({
                 channel: 'ui',
                 format: 'html',
-                payload: '<hx-partial id="notifications"><div class="notif">Notification 2</div></hx-partial>'
+                payload: '<hx-partial id="notifications" hx-swap="afterbegin"><div class="notif">Notification 2</div></hx-partial>'
             });
             await htmx.timeout(20);
             


### PR DESCRIPTION
## Description
This possible change update the web socket extension to use htmx.swap as its swapping method instead of insertContent.  This allows hx-partial tags and oob swaps to work as normal.  Also the ws extension had a custom hx-partial format with id= attribute which did not match with the core htmx hx-partial design so I've updated the core htmx design to allow this natural id format which allows simple use cases like:

```html
<hx-partial id="foo">New Inner Content</hx-partial>
```
which will just do a default innerHTML swap of the contents of the element with id foo.

This change allows most of the existing ws tests to remain as id only hx-partial's

There is one other breaking change and that is that before the swap style of the active element or from the JSON wrapper would set the default hx-partial swap style which is not how existing hx-partial normal works where each one is treated as innerHTML default and you have to be explicit in its swap method so that hx-partials are fully self contained.  


Corresponding issue:

## Testing
Updated tests.

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
