### PR TITLE
Fix morph error with empty id attributes

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2156,11 +2156,13 @@ var htmx = (() => {
         __createPersistentIds(oldIdElements, newIdElements) {
             let duplicateIds = new Set(), oldIdTagNameMap = new Map();
             for (const {id, tagName} of oldIdElements) {
+                if (!id) continue; // Skip empty IDs
                 if (oldIdTagNameMap.has(id)) duplicateIds.add(id);
                 else oldIdTagNameMap.set(id, tagName);
             }
             let persistentIds = new Set();
             for (const {id, tagName} of newIdElements) {
+                if (!id) continue; // Skip empty IDs
                 if (persistentIds.has(id)) duplicateIds.add(id);
                 else if (oldIdTagNameMap.get(id) === tagName) persistentIds.add(id);
             }

--- a/test/tests/unit/morph.js
+++ b/test/tests/unit/morph.js
@@ -240,10 +240,25 @@ describe('Morph Swap Styles Tests', function() {
             mockResponse('GET', '/test', '<div><hr id="1"></div>');
             const div = createProcessedHTML('<div id="target"><hr id="1"></div>');
             const hr = div.querySelector('#\\31');
-            
+
             await htmx.ajax('GET', '/test', {target: '#target', swap: 'innerMorph'});
-            
+
             assert.equal(div.querySelector('#\\31'), hr);
+        });
+
+        it('does not treat empty id="" as a persistent id', async function() {
+            // When both old and new content have <h1 id="">, the empty string should NOT
+            // be treated as a persistent ID that needs to be preserved/matched.
+            // Previously this caused HierarchyRequestError when sibling elements differed,
+            // because the algorithm tried to reuse the h1 based on the "" id match.
+            mockResponse('GET', '/test', '<h1 id="">B</h1><div>Y</div>');
+            const div = createProcessedHTML('<div id="target"><h1 id="">A</h1><section>X</section></div>');
+
+            await htmx.ajax('GET', '/test', {target: '#target', swap: 'innerMorph'});
+
+            assert.equal(div.querySelector('h1').textContent, 'B');
+            assert.isNotNull(div.querySelector('div'));
+            assert.isNull(div.querySelector('section'));
         });
     });
 


### PR DESCRIPTION
## Summary

- Skip elements with `id=""` when building the persistent ID set during morphing

## Problem

When both old and new content have elements like `<h1 id="">`, the empty string was being treated as a valid persistent ID. This caused `HierarchyRequestError` when sibling elements differed between pages (e.g. `<section>` vs `<div>`).

## Minimal reproduction

**Page A:**
```html
<body hx-boost:inherited="true" hx-swap:inherited="innerMorph">
  <h1 id="">A</h1>
  <section>X</section>
  <a href="/b">Go to B</a>
</body>
```

**Page B:**
```html
<body hx-boost:inherited="true" hx-swap:inherited="innerMorph">
  <h1 id="">B</h1>
  <div>Y</div>
  <a href="/a">Go to A</a>
</body>
```

Navigating from A to B throws:
```
HierarchyRequestError: Failed to execute 'insertBefore' on 'Node': The new child element contains the parent.
```

## Test plan

- Added test case for empty id handling
- All existing morph tests pass