### PR TITLE
Include target selector in htmx:oobErrorNoTarget event and error log

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1508,7 +1508,7 @@ var htmx = (function() {
       oobElement.parentNode.removeChild(oobElement)
     } else {
       oobElement.parentNode.removeChild(oobElement)
-      triggerErrorEvent(getDocument().body, 'htmx:oobErrorNoTarget', { content: oobElement })
+      triggerErrorEvent(getDocument().body, 'htmx:oobErrorNoTarget', { content: oobElement, target: selector })
     }
     return oobValue
   }
@@ -3111,7 +3111,7 @@ var htmx = (function() {
       htmx.logger(elt, eventName, detail)
     }
     if (detail.error) {
-      logError(detail.error)
+      logError(detail.error + (detail.target ? ', ' + detail.target : ''))
       triggerEvent(elt, 'htmx:error', { errorInfo: detail })
     }
     let eventResult = elt.dispatchEvent(event)

--- a/test/attributes/hx-swap-oob.js
+++ b/test/attributes/hx-swap-oob.js
@@ -348,14 +348,14 @@ describe('hx-swap-oob attribute', function() {
     })
   }
 
-  it.skip('triggers htmx:oobErrorNoTarget when no targets found', function(done) {
-    // this test fails right now because when targets not found it returns an empty array which makes it miss the event as it should be if (targets.length)
+  it('triggers htmx:oobErrorNoTarget when no targets found', function(done) {
     this.server.respondWith('GET', '/test', "Clicked<div id='nonexistent' hx-swap-oob='true'>Swapped</div>")
     var div = make('<div hx-get="/test">click me</div>')
 
     // Define the event listener function so it can be removed later
     var eventListenerFunction = function(event) {
       event.detail.content.innerHTML.should.equal('Swapped')
+      event.detail.target.should.equal('#nonexistent')
       document.body.removeEventListener('htmx:oobErrorNoTarget', eventListenerFunction)
       done()
     }

--- a/www/content/events.md
+++ b/www/content/events.md
@@ -384,6 +384,7 @@ in the DOM to switch with.
 ##### Details
 
 * `detail.content` - the element with the bad oob `id`
+* `detail.target` - the bad CSS selector
 
 ### Event - `htmx:onLoadError` {#htmx:onLoadError}
 


### PR DESCRIPTION
## Description

When an oob swap fails to find its target element, the `htmx:oobErrorNoTarget` error is logged but doesn't indicate *which* selector failed. This makes debugging difficult.

This PR:
- Adds `target` to the `htmx:oobErrorNoTarget` event detail (matching `htmx:targetError` which already has this)
- Includes the target selector in console error output for any error that has a `target` property
- Enables and updates the previously-skipped test
- Updates documentation

Before:
```
htmx:oobErrorNoTarget
htmx:targetError
```
After:
```
htmx:oobErrorNoTarget, #nonexistent-target`
htmx:targetError, #also-does-not-exist`
```

## Testing

- Enabled the previously-skipped test (it was already passing on both dev and master)
- Added assertion for event.detail.target
- Verified with a Python fastHTML app that returns OOB content targeting a non-existent element

<img width="630" height="116" alt="image" src="https://github.com/user-attachments/assets/37e9465d-bf18-4421-b782-ab4a75533a5b" />

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [?] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue **(I'm not sure if you'd consider this a bugfix/new feature...happy to re-open this as an Issue!)**
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
