### PR TITLE
Improve Morph matching

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2076,6 +2076,8 @@ var htmx = (() => {
             if (!(node instanceof Element)) return null;
             let softMatch = null, displaceMatchCount = 0, scanLimit = this.config.morphScanLimit;
             let newSet = ctx.idMap.get(node), nodeMatchCount = newSet?.size || 0;
+            // If node has a non-persistent ID, insert instead of soft matching
+            if (node.id && !newSet) return null;
             let cursor = startPoint;
             while (cursor && cursor != endPoint) {
                 let oldSet = ctx.idMap.get(cursor);


### PR DESCRIPTION
## Description
Here are some core improvements to the htmx 4 morphing algorithm based on some ideas and learnings from morphlex

# Improvements

It now skips finding best node to match for non element text nodes because from testing the time to search and then morph these text only nodes is actually slower than just inserting new text nodes and there is no state to lose here.  only morphing elements makes morph node simpler.

If node has a non persistent ID instead of doing a full scan to find a non id'ed node ( because it is not persistent we know it won't match a id'ed node) to soft match and morph over top of we can just return null and insert this probably new node straight away saving some time.

When removing content to make way for the placement of the best found match instead of just removing the nodes it now scans forward scan limit nodes to find if these nodes are perfect matches with future new content.  If they are then it marks them as future matches and moves them to the end of the parent to be matched later.  This allows reordering of non id nodes without having to remove and re-create the nodes.

Removed the old 2 next sibling look ahead logic and instead replace it with a system where if we couldn't find a perfect match and fall back to the first softmatch we can check if this softmatch is a perfect future match for some upcoming new content sibling and if it is don't softmatch and insert the current node instead as this softmatch will match later.  This allows multiple nodes to be inserted without them morphing over upcoming matching nodes.

We still have a 10 node default scan limit so it will not search all siblings for better large list performance.

Corresponding issue:

## Testing
Most of my testing for these changes was done manually or with idiomorph test suites that we don't have fully in htmx yet. 

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
