### PR TITLE
fix firefox not handling script tags in templates

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1250,6 +1250,7 @@ var htmx = (() => {
                 
                 if (type === 'partial') {
                     let target = templateElt.getAttribute(this.__prefix('hx-target')) || (templateElt.id ? '#' + CSS.escape(templateElt.id) : null);
+                    this.__processScripts(templateElt.content);
                     tasks.push({
                         type: 'partial',
                         fragment: templateElt.content.cloneNode(true),

--- a/test/tests/attributes/hx-status.js
+++ b/test/tests/attributes/hx-status.js
@@ -24,7 +24,7 @@ describe('hx-status attribute tests', function() {
         let button = find('button');
         button.click();
         await forRequest();
-        assert.equal(find('#target').innerText, 'Server Error');
+        assert.equal(find('#target').textContent, 'Server Error');
     });
 
     it('can change target based on status', async function() {
@@ -53,8 +53,8 @@ describe('hx-status attribute tests', function() {
         let button = find('button');
         button.click();
         await forRequest();
-        assert.equal(find('#errors').innerText, 'Invalid input');
-        assert.equal(find('#main').innerText, '');
+        assert.equal(find('#errors').textContent, 'Invalid input');
+        assert.equal(find('#main').textContent, '');
     });
 
     it('prefers exact match over wildcard', async function() {
@@ -83,7 +83,7 @@ describe('hx-status attribute tests', function() {
         let button = find('button');
         button.click();
         await forRequest();
-        assert.equal(find('#target').innerText, 'Server Error');
+        assert.equal(find('#target').textContent, 'Server Error');
     });
 
     it('does not apply when status does not match', async function() {
@@ -92,7 +92,7 @@ describe('hx-status attribute tests', function() {
         let button = find('button');
         button.click();
         await forRequest();
-        assert.equal(find('#target').innerText, 'Success');
+        assert.equal(find('#target').textContent, 'Success');
     });
 
     it('can set swap to none on error', async function() {

--- a/test/tests/unit/swap.js
+++ b/test/tests/unit/swap.js
@@ -384,8 +384,8 @@ describe('swap() unit tests', function() {
             "target":"#target", 
             "text":"<div>Hello me!</div><hx-partial hx-target='#target_oob' hx-swap='innerHTML'><div>OOB swap!</div></hx-partial>"
         })
-        find('#target').innerText.should.equal("Hello me!");
-        find('#target_oob').innerText.should.equal("OOB swap!");
+        find('#target').textContent.should.equal("Hello me!");
+        find('#target_oob').textContent.should.equal("OOB swap!");
     })
 
     it('swaps only partial target when response contains only partial', async function () {
@@ -394,8 +394,8 @@ describe('swap() unit tests', function() {
             "target":"#target", 
             "text":"<hx-partial hx-target='#target_oob' hx-swap='innerHTML'><div>OOB Updated</div></hx-partial>"
         })
-        find('#target').innerText.should.equal("Original");
-        find('#target_oob').innerText.should.equal("OOB Updated");
+        find('#target').textContent.should.equal("Original");
+        find('#target_oob').textContent.should.equal("OOB Updated");
     })
 
     it('does not swap main target when only whitespace and partial present', async function () {
@@ -404,8 +404,8 @@ describe('swap() unit tests', function() {
             "target":"#target", 
             "text":"\n  <hx-partial hx-target='#target_oob' hx-swap='innerHTML'><div>OOB swap!</div></hx-partial>  \n"
         })
-        find('#target').innerText.should.equal("Original");
-        find('#target_oob').innerText.should.equal("OOB swap!");
+        find('#target').textContent.should.equal("Original");
+        find('#target_oob').textContent.should.equal("OOB swap!");
     })
 
     it('swaps both targets when empty element and partial present', async function () {
@@ -415,7 +415,7 @@ describe('swap() unit tests', function() {
             "text":"<p></p><hx-partial hx-target='#target_oob' hx-swap='innerHTML'><div>OOB swap!</div></hx-partial>"
         })
         find('#target').querySelector('p').should.not.be.null;
-        find('#target_oob').innerText.should.equal("OOB swap!");
+        find('#target_oob').textContent.should.equal("OOB swap!");
     })
   
     it('swaps both targets when plain text and partial present', async function () {


### PR DESCRIPTION
## Description
hx-partial tags are converted and parsed as template tags and while the fragment is processed to make script tags live it seems firefox has different handling for template tags.  This was not an issue in htmx 2 without hx-partial tags with the way we processed scripts.  Adding an extra call to process scripts in the partial template contents just before cloning into the fragment should fix this.

Corresponding issue:
#3649 

## Testing
Found alternative browser tests for test:firefox were reporting the issue.  Re-ran all browser tests and picked up a few minor webkit issues as well with innerText containing extra /n here so switched these to textContent to allow all browser tests to pass.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
