### PR TITLE
partials should fall back to use transition default

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1352,7 +1352,7 @@ var htmx = (() => {
             let swapPromises = [];
             let transitionTasks = [];
             for (let task of tasks) {
-                if (task.swapSpec?.transition ?? mainSwap?.transition) {
+                if (task.swapSpec?.transition ?? mainSwap?.transition ?? ctx.transition !== false) {
                     transitionTasks.push(task);
                 } else {
                     swapPromises.push(this.__insertContent(task));


### PR DESCRIPTION
## Description
when a response only has hx-partials and no main swap data we skip creating the main swap and this prevents the hx-partials from falling back to getting the default config value for transitions.  So need to add ctx.transition fallback check after it checks the main swap transition setting.  we have partials/oob follow the main swap transition mode by default

Corresponding issue:
#3651

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
