### PR TITLE
docs: add `htmx.logNone()` to reference documentation

### DIFF
--- a/www/content/reference.md
+++ b/www/content/reference.md
@@ -195,6 +195,7 @@ All other attributes available in htmx.
 | [`htmx.find()`](@/api.md#find)  | Finds a single element matching the selector
 | [`htmx.findAll()` `htmx.findAll(elt, selector)`](@/api.md#find)  | Finds all elements matching a given selector
 | [`htmx.logAll()`](@/api.md#logAll)  | Installs a logger that will log all htmx events
+| [`htmx.logNone()`](@/api.md#logAll)  | Disables logger if it was previously enabled
 | [`htmx.logger`](@/api.md#logger)  | A property set to the current logger (default is `null`)
 | [`htmx.off()`](@/api.md#off)  | Removes an event listener from the given element
 | [`htmx.on()`](@/api.md#on)  | Creates an event listener on the given element, returning it


### PR DESCRIPTION
## Description
`logNone` is included in [the API docs](https://htmx.org/api/#logNone) but not in [the reference docs](https://htmx.org/reference/#api).

Corresponding issue: I didn't make one 🫣, feel free to close if this breaks your process

## Checklist

* [ ] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
