### PR TITLE
handle empty non get actions

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -271,7 +271,7 @@ var htmx = (() => {
                 if (!action) {
                     for (let verb of this.#verbs) {
                         let verbAction = this.__attributeValue(elt, "hx-" + verb);
-                        if (verbAction) {
+                        if (verbAction != null) {
                             action = verbAction;
                             method = verb;
                             break;

--- a/test/tests/attributes/hx-post.js
+++ b/test/tests/attributes/hx-post.js
@@ -18,4 +18,14 @@ describe('hx-post attribute', function() {
         btn.innerHTML.should.equal('Posted!')
     })
 
+    it('issues a POST request with empty string action (current URL)', async function() {
+        mockResponse('POST', /^$/, 'Posted!')
+        let btn = createProcessedHTML('<button hx-post="">Click Me!</button>')
+        btn.click()
+        await forRequest()
+        fetchMock.calls[0].request.method.should.equal('POST');
+        fetchMock.calls[0].url.should.equal('');
+        btn.innerHTML.should.equal('Posted!')
+    })
+
 })


### PR DESCRIPTION
## Description
need to handle empty hx-post/patch/delete to go to  the current url.  Right now because "" is falsey it skips setting action and method which makes it do a GET request instead

Corresponding issue:

## Testing
added test

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
