### PR TITLE
Fix v4 - ctx.isSSE is already set from the response headers at line 522

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -529,8 +529,7 @@ var htmx = (() => {
                     return
                 }
 
-                let isSSE = response.headers.get("Content-Type")?.includes('text/event-stream');
-                if (isSSE) {
+                if (ctx.isSSE) {
                     // SSE response
                     await this.__handleSSE(ctx, elt, response);
                 } else {


### PR DESCRIPTION
The local `isSSE` variable at line 532 re-reads the same Content-Type header already captured in `ctx.isSSE` at line 522.

## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [X] I ran the test suite locally (`npm run test`) and verified that it succeeded
