### PR TITLE
handle newContent processing of outerMorph that inserts new nodes

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1892,7 +1892,7 @@ var htmx = (() => {
             }
             insertionPoint ||= oldParent.firstChild;
 
-            for (const newChild of newParent.childNodes) {
+            for (const newChild of [...newParent.childNodes]) {
                 if (insertionPoint && insertionPoint != endPoint) {
                     let bestMatch = this.__findBestMatch(ctx, newChild, insertionPoint, endPoint);
                     if (bestMatch) {
@@ -1934,16 +1934,15 @@ var htmx = (() => {
                     continue;
                 }
 
-                let tempChild;
                 if (ctx.idMap.has(newChild)) {
-                    tempChild = document.createElement(newChild.tagName);
-                    oldParent.insertBefore(tempChild, insertionPoint);
-                    this.__morphNode(tempChild, newChild, ctx);
+                    let placeholder = document.createElement(newChild.tagName);
+                    oldParent.insertBefore(placeholder, insertionPoint);
+                    this.__morphNode(placeholder, newChild, ctx);
+                    insertionPoint = placeholder.nextSibling;
                 } else {
-                    tempChild = document.importNode(newChild, true);
-                    oldParent.insertBefore(tempChild, insertionPoint);
+                    oldParent.insertBefore(newChild, insertionPoint);
+                    insertionPoint = newChild.nextSibling;
                 }
-                insertionPoint = tempChild.nextSibling;
             }
 
             while (insertionPoint && insertionPoint != endPoint) {

--- a/test/tests/unit/morph.js
+++ b/test/tests/unit/morph.js
@@ -464,6 +464,25 @@ describe('Morph Swap Styles Tests', function() {
             assert.isNotNull(newBtn);
             assert.equal(newBtn.getAttribute('data-htmx-powered'), 'true', 'New inserted element should be processed');
         });
+
+        it('processes new htmx attributes on tag-changing outerMorph (span to div)', async function() {
+            mockResponse('GET', '/test', '<div id="target" hx-get="/click" hx-target="#result">Updated</div>');
+            const container = createProcessedHTML('<div><span id="target">Original</span><div id="result"></div></div>');
+
+            await htmx.ajax('GET', '/test', {target: '#target', swap: 'outerMorph'});
+
+            const newDiv = container.querySelector('#target');
+            assert.isNotNull(newDiv, 'New div should exist in DOM');
+            assert.equal(newDiv.tagName, 'DIV', 'Element should now be a div');
+            assert.equal(newDiv.getAttribute('data-htmx-powered'), 'true', 'New div should be processed');
+
+            mockResponse('GET', '/click', 'Clicked!');
+            newDiv.click();
+            await htmx.forEvent('htmx:after:swap', 100);
+
+            assert.equal(container.querySelector('#result').textContent, 'Clicked!', 'htmx actions on new div should work');
+        });
+
     });
 
     describe('htmx integration', function() {


### PR DESCRIPTION
## Description
During outerMorph swap style we make the newContent for later processing by using the fragment childNodes and adding in the target node so that either the existing morphed node or the newly inserted nodes will always be processed properly.  But inside the morph we actually can clone the nodes with importNode() when inserting new nodes leaving the fragment childNodes disconnected and preventing the cloned in node being processed.  To solve this I've removed the importNode which was done to prevent parent node mutations and instead captured the parent node children in the for loop to make the loop stable this way.

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
