### PR TITLE
fix up several test issues and bugs

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -163,7 +163,7 @@ var htmx = (() => {
         }
 
         __queryEltAndDescendants(elt, selector) {
-            let results = [...elt.querySelectorAll(selector)];
+            let results = [...(elt.querySelectorAll?.(selector) ?? [])];
             if (elt.matches?.(selector)) {
                 results.unshift(elt);
             }
@@ -1019,10 +1019,6 @@ var htmx = (() => {
             let response = text.replace(/<hx-([a-z]+)(\s+|>)/gi, '<template hx type="$1"$2').replace(/<\/hx-[a-z]+>/gi, '</template>');
             let title = '';
             response = response.replace(/<head(\s[^>]*)?>[\s\S]*?<\/head>/i, m => (title = this.__parseHTML(m).title, ''));
-            if (!title) {
-                let m = response.match(/<title[\s>]([\s\S]*?)<\/title>/i);
-                if (m && !response.slice(0, m.index).includes('<svg')) title = m[1].trim();
-            }
             let startTag = response.match(/<([a-z][^\/>\x20\t\r\n\f]*)/i)?.[1]?.toLowerCase();
 
             let doc, fragment;
@@ -1036,6 +1032,15 @@ var htmx = (() => {
                 doc = this.__parseHTML(`<template>${response}</template>`);
                 fragment = doc.querySelector('template').content;
             }
+
+            if (!title) {
+                let titleElt = fragment.querySelector('title:not(svg title)');
+                if (titleElt) {
+                    title = titleElt.textContent;
+                    titleElt.remove();
+                }
+            }
+
             this.__processScripts(fragment);
 
             return {
@@ -1139,7 +1144,7 @@ var htmx = (() => {
         }
 
         __handleAutoFocus(elt) {
-            let autofocus = elt.querySelector?.("[autofocus]");
+            let autofocus = this.__queryEltAndDescendants(elt, '[autofocus]')[0];
             if (autofocus) {
                 this.__setFocus(autofocus);
             }
@@ -1211,7 +1216,7 @@ var htmx = (() => {
             let swapPromises = [];
             let transitionTasks = [];
             for (let task of tasks) {
-                if (task.swapSpec?.transition ?? mainSwap?.transition ?? (ctx.transition !== false)) {
+                if (task.swapSpec?.transition ?? mainSwap?.transition ?? ctx.transition) {
                     transitionTasks.push(task);
                 } else {
                     swapPromises.push(this.__insertContent(task));
@@ -1254,7 +1259,7 @@ var htmx = (() => {
                     target: this.__resolveTarget(ctx.sourceElement || document.body, swapSpec.target || ctx.target),
                     swapSpec,
                     sourceElement: ctx.sourceElement,
-                    transition: (ctx.transition !== false) && (swapSpec.transition !== false)
+                    transition: ctx.transition && swapSpec.transition !== false
                 };
                 return mainSwap;
             }
@@ -1590,14 +1595,14 @@ var htmx = (() => {
                 replace = hx.replaceurl;
             }
 
+            // if this is a boosted element, default to pushing
+            if (push == null && replace == null && this.__isBoosted(sourceElement)) {
+                push = 'true';
+            }
+            
             // normalize "false" to null
             if (push === 'false' || push === false) push = null;
             if (replace === 'false' || replace === false) replace = null;
-
-            // if this is a boosted element, default to pushing
-            if (!push && !replace && this.__isBoosted(sourceElement)) {
-                push = 'true';
-            }
 
             if (!push && !replace) return null;
 
@@ -1927,13 +1932,15 @@ var htmx = (() => {
             }
             insertionPoint ||= oldParent.firstChild;
 
-            for (const newChild of [...newParent.childNodes]) {
+            let newChild = newParent.firstChild;
+            while (newChild) {
+                let matchedNode;
                 if (insertionPoint && insertionPoint != endPoint) {
-                    let bestMatch = this.__findBestMatch(ctx, newChild, insertionPoint, endPoint);
-                    if (bestMatch) {
-                        if (bestMatch !== insertionPoint) {
+                    matchedNode = this.__findBestMatch(ctx, newChild, insertionPoint, endPoint);
+                    if (matchedNode) {
+                        if (matchedNode !== insertionPoint) {
                             let cursor = insertionPoint;
-                            while (cursor && cursor !== bestMatch) {
+                            while (cursor && cursor !== matchedNode) {
                                 let tempNode = cursor;
                                 cursor = cursor.nextSibling;
                                 // remove nodes unless they match upcoming content in which case move them to end for later use
@@ -1944,32 +1951,33 @@ var htmx = (() => {
                                 }
                             }
                         }
-                        this.__morphNode(bestMatch, newChild, ctx);
-                        insertionPoint = bestMatch.nextSibling;
-                        continue;
                     }
                 }
 
-                if (newChild instanceof Element && ctx.persistentIds.has(newChild.id)) {
+                if (!matchedNode && newChild instanceof Element && ctx.persistentIds.has(newChild.id)) {
                     let escapedId = CSS.escape(newChild.id);
-                    let target = (ctx.target.id === newChild.id && ctx.target) ||
+                    matchedNode = (ctx.target.id === newChild.id && ctx.target) ||
                         ctx.target.querySelector(`[id="${escapedId}"]`) ||
                         ctx.pantry.querySelector(`[id="${escapedId}"]`);
-                    let elementId = target.id;
-                    let element = target;
+                    let element = matchedNode;
                     while ((element = element.parentNode)) {
                         let idSet = ctx.idMap.get(element);
                         if (idSet) {
-                            idSet.delete(elementId);
+                            idSet.delete(matchedNode.id);
                             if (!idSet.size) ctx.idMap.delete(element);
                         }
                     }
-                    this.__moveBefore(oldParent, target, insertionPoint);
-                    this.__morphNode(target, newChild, ctx);
-                    insertionPoint = target.nextSibling;
+                    this.__moveBefore(oldParent, matchedNode, insertionPoint);
+                }
+
+                if (matchedNode) {
+                    this.__morphNode(matchedNode, newChild, ctx);
+                    insertionPoint = matchedNode.nextSibling;
+                    newChild = newChild.nextSibling;
                     continue;
                 }
 
+                let nextNewChild = newChild.nextSibling;
                 if (ctx.idMap.has(newChild)) {
                     let placeholder = document.createElement(newChild.tagName);
                     oldParent.insertBefore(placeholder, insertionPoint);
@@ -1979,6 +1987,7 @@ var htmx = (() => {
                     oldParent.insertBefore(newChild, insertionPoint);
                     insertionPoint = newChild.nextSibling;
                 }
+                newChild = nextNewChild;
             }
 
             while (insertionPoint && insertionPoint != endPoint) {

--- a/test/lib/helpers.js
+++ b/test/lib/helpers.js
@@ -215,7 +215,7 @@ function find(selector) {
 // ==============================================================================
 
 function assertPropertyIs(css, property, content) {
-  let elt = find(css);
+  let elt = playground().querySelector(css);
   if (!elt) {
     assert.fail("Could not find element with css '" + css + "' in :\n\n" + playground().innerHTML + "\n\n")
   }

--- a/test/tests/attributes/hx-boost.js
+++ b/test/tests/attributes/hx-boost.js
@@ -138,6 +138,21 @@ describe('hx-boost attribute', async function() {
         find('#result').innerHTML.should.equal('Clicked')
     })
 
+    it('hx-boost with hx-push-url=false does not push history', async function() {
+        let pushCount = 0
+        let originalPushState = history.pushState.bind(history)
+        history.pushState = (...args) => { pushCount++; originalPushState(...args) }
+        try {
+            mockResponse('GET', '/test', 'Clicked')
+            createProcessedHTML('<div id="result"></div><a hx-boost="true" hx-push-url="false" hx-target="#result" id="a1" href="/test">Click Me</a>')
+            find('#a1').click()
+            await forRequest()
+            pushCount.should.equal(0)
+        } finally {
+            history.pushState = originalPushState
+        }
+    })
+
     // // it('overriding default swap style does not effect boosting', async function() {
     // //     htmx.config.defaultSwapStyle = 'afterend'
     // //     try {


### PR DESCRIPTION
## Description
Went though failing tests and fixed up some issues I found.  many of the browser test.html tests had issues while the cli tests passed fine 

Head title extraction was failing tests because title can have escaped characters which were in raw form.  Also title tag was not being removed as it was in the tests.  Using dom methods to extract title is simpler and more reliable than regex

Autofocus moved to __queryEltAndDescendants which solved one swap test that was silently failing

htmx.swap() tests were always using transitions true because ctx.transition is undefined so it treats as true as it was !== false before

hx-boost was not respecting hx-push-url=false

refactor of morph to do newContent better broke alpine x-for tests because it used a fixed snapshot of children but alpine can mutate newParent children by design so we need a better way to iterate on the newChild nodes which meant refactor time in morph.

browser only tests were failing because assertPropertyIs does not search just the playground area properly so header div's keep breaking tests.



Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
