### PR TITLE
keep indicators on redirect-refresh

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -543,6 +543,7 @@ var htmx = (() => {
                 if (!this.__trigger(elt, "htmx:after:request", {ctx})) return;
 
                 if(this.__handleHeadersAndMaybeReturnEarly(ctx)){
+                    ctx.keepIndicators = true;
                     return
                 }
 
@@ -561,9 +562,11 @@ var htmx = (() => {
                 this.__trigger(elt, "htmx:error", {ctx, error})
             } finally {
                 clearTimeout(ctx.requestTimeout);
-                this.__hideIndicators(indicators);
-                this.__enableElements(disableElements);
                 this.__trigger(elt, "htmx:finally:request", {ctx})
+                if (!ctx.keepIndicators) {
+                    this.__hideIndicators(indicators);
+                    this.__enableElements(disableElements);
+                }
 
                 requestQueue.finish()
                 if (requestQueue.more()) {

--- a/test/manual/hx-redirect-indicator.html
+++ b/test/manual/hx-redirect-indicator.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script>
+        window.fetch = function(url, options) {
+            return new Promise((resolve) => {
+                setTimeout(() => resolve({
+                    ok: true,
+                    status: 200,
+                    headers: new Headers({'HX-Redirect': 'https://htmx.org'}),
+                    text: () => Promise.resolve(''),
+                    clone() { return this; }
+                }), 1500);
+            });
+        };
+    </script>
+    <script src="../../src/htmx.js"></script>
+</head>
+<body>
+    <h1>HX-Redirect indicator preservation</h1>
+    <p>
+        Click the button. The <code>.htmx-request</code> class and <code>disabled</code> state
+        should remain active during the 1.5s delay <em>and</em> after the response arrives
+        (while the page would normally be redirecting). They should <strong>not</strong> be
+        removed before navigation.
+    </p>
+
+    <button id="btn"
+            hx-post="/redirect"
+            hx-disabled-elt="#btn"
+            hx-indicator="#spinner">
+        Click me
+    </button>
+
+    <span id="spinner" class="htmx-indicator"> ⏳ loading...</span>
+
+    <p>
+        Button should stay <strong>disabled</strong> and spinner should stay
+        <strong>visible</strong> after the response — not flash back to normal.
+    </p>
+
+    <p>
+        <strong>keepIndicators override:</strong> set <code>ctx.keepIndicators = false</code>
+        via event to force cleanup even on redirect:
+    </p>
+
+    <button id="btn2"
+            hx-post="/redirect"
+            hx-disabled-elt="#btn2"
+            hx-indicator="#spinner2"
+            hx-on:htmx:finally:request="event.detail.ctx.keepIndicators = false">
+        Click me (indicators cleared on redirect)
+    </button>
+
+    <span id="spinner2" class="htmx-indicator"> ⏳ loading...</span>
+</body>
+</html>


### PR DESCRIPTION
## Description
during hx-refresh/hx-redirect/hx-location the page is replaced but it removes the indicators and disabled blocks before the redirects happen causing indicators to flash away briefly.  Avoid this with a keepIndicators option.  Also allow manual overriding of ctx.keepIndicators to true/false to override in events if needed.

Corresponding issue:
#3677

## Testing
Added a Manual test to confirm behaviour.

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
