### PR TITLE
Submitting a form using GET: discrepancy between htmx and browser

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -3630,7 +3630,8 @@ var htmx = (function() {
     (elt.tagName === 'INPUT' && getRawAttribute(elt, 'type') === 'submit')) {
       const button = internalData.lastButtonClicked || (/** @type HTMLInputElement|HTMLButtonElement */(elt))
       const name = getRawAttribute(button, 'name')
-      addValueToFormData(name, button.value, priorityFormData)
+      const selectedFormData = verb === 'get' ? formData : priorityFormData
+      addValueToFormData(name, button.value, selectedFormData)
     }
 
     // include any explicit includes

--- a/test/core/ajax.js
+++ b/test/core/ajax.js
@@ -1121,6 +1121,35 @@ describe('Core htmx AJAX Tests', function() {
     values.should.deep.equal({ action: ['A', 'C'] })
   })
 
+  it('properly handles clicked submit button with a value stacking with regular input and method is GET', function() {
+    const theHtml = '<form hx-get="/test">' +
+                    '<input type="hidden" name="action" value="A">' +
+                    '<button id="btnA" type="submit">A</button>' +
+                    '<button id="btnB" type="submit" name="action" value="B">B</button>' +
+                    '<button id="btnC" type="submit" name="action" value="C">C</button>' +
+                    '</form>'
+
+    this.server.respondWith('GET', /\/test.*/, function(xhr) {
+      xhr.respond(200, {}, theHtml)
+    })
+
+    make(theHtml)
+
+    byId('btnA').click()
+    this.server.respond()
+    this.server.requests[0].url.should.contain('action=A')
+
+    byId('btnB').click()
+    this.server.respond()
+    this.server.requests[1].url.should.contain('action=A')
+    this.server.requests[1].url.should.contain('action=B')
+
+    byId('btnC').click()
+    this.server.respond()
+    this.server.requests[2].url.should.contain('action=A')
+    this.server.requests[2].url.should.contain('action=C')
+  })
+
   it('properly handles clicked submit input with a value stacking with regular input', function() {
     var values
     this.server.respondWith('Post', '/test', function(xhr) {
@@ -1146,6 +1175,35 @@ describe('Core htmx AJAX Tests', function() {
     byId('btnC').click()
     this.server.respond()
     values.should.deep.equal({ action: ['A', 'C'] })
+  })
+
+  it('properly handles clicked submit input with a value stacking with regular input and method is GET', function() {
+    const theHtml = '<form hx-get="/test">' +
+                    '<input type="hidden" name="action" value="A">' +
+                    '<input id="btnA" type="submit">A</input>' +
+                    '<input id="btnB" type="submit" name="action" value="B">B</input>' +
+                    '<input id="btnC" type="submit" name="action" value="C">C</input>' +
+                    '</form>'
+
+    this.server.respondWith('GET', /\/test.*/, function(xhr) {
+      xhr.respond(200, {}, theHtml)
+    })
+
+    make(theHtml)
+
+    byId('btnA').click()
+    this.server.respond()
+    this.server.requests[0].url.should.contain('action=A')
+
+    byId('btnB').click()
+    this.server.respond()
+    this.server.requests[1].url.should.contain('action=A')
+    this.server.requests[1].url.should.contain('action=B')
+
+    byId('btnC').click()
+    this.server.respond()
+    this.server.requests[2].url.should.contain('action=A')
+    this.server.requests[2].url.should.contain('action=C')
   })
 
   it('properly handles clicked submit button with a value inside a form, referencing another form', function() {


### PR DESCRIPTION
## Description

Given this form:

```
<form action="/test" method="get">
  <input type="hidden" name="action" value="A">
  <button id="btnB" type="submit" name="action" value="B">B</button>
</form>
```

When clicking the button,
The browser's behavior is to _append_ both values, resulting in a query string as "action=A&action=B".

But, when using HTMX, given this form:
```
<form hx-get="/test">
  <input type="hidden" name="action" value="A">
  <button id="btnB" type="submit" name="action" value="B">B</button>
</form>
```
When clicking the button,
HTMX issues a GET request, where the button's value _overrides_ any other form data with the same `name`; the resulting query string is just "action=B". This is _unexpected_ behavior.

This patch tries to bring HTMX in line with default browser behavior.

Now, I think this solution is rather hacky. Why is there differentiation between GET and non-GET requests in `getInputValues()` in the first place? I don't know the intricacies of HTMX, explanations are appreciated. I am open to iterate on this PR if the solution is below quality expectation.

Corresponding issue: 
#1541 This issue brought it up, but was then closed due to #1559. However, that PR didn't fix it for the case of `GET`.

## Testing
I tested it using the test suite. I added relevant test-cases that triggered the bug, and then verified the fix by running the tests with `npm run test`

## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [X] I ran the test suite locally (`npm run test`) and verified that it succeeded
