### PR TITLE
fix: normalize onLoad event name with metaCharacter

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1455,7 +1455,7 @@ var htmx = (() => {
         }
 
         onLoad(callback) {
-            this.on("htmx:after:process", (evt) => {
+            this.on(this.__maybeAdjustMetaCharacter("htmx:after:process"), (evt) => {
                 callback(evt.target)
             })
         }

--- a/test/tests/unit/htmx.config.metaCharacter.js
+++ b/test/tests/unit/htmx.config.metaCharacter.js
@@ -43,6 +43,13 @@ describe('htmx.config.metaCharacter functionality', function() {
         assert.equal(result, '"a":1,"b":2,"c":3');
     });
 
+    it('onLoad works with custom meta character', function() {
+        let fired = false;
+        htmx.onLoad(() => fired = true);
+        createProcessedHTML('<div hx-get="/test">Test</div>');
+        assert.isTrue(fired);
+    });
+
     it('works with hx-on events using custom meta character', async function() {
         let eventFired = false;
         createProcessedHTML('<button id="btn" hx-on-click="window.testEvent = true">Click</button>');


### PR DESCRIPTION
## Description
`onLoad` hardcodes `"htmx:after:process"` as the event name when registering
its listener, bypassing `__maybeAdjustMetaCharacter`. This means `onLoad`
callbacks never fire when a custom `metaCharacter` is configured,

Fix: wrap the event name with `this.__maybeAdjustMetaCharacter(...)`.

## Testing
Added a test in `htmx.config.metaCharacter.js` that sets `metaCharacter = "-"`
and verifies `htmx.onLoad` callback fires when `htmx.process()` runs.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
