### PR TITLE
fix: skip If-None-Match for boosted navigation with morph swap

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -375,8 +375,8 @@ var htmx = (() => {
                     this.__htmxProp(sourceElement).etag ||= ctx.request.etag
                 }
             }
-            if (sourceElement._htmx?.etag) {
-                ctx.request.headers["If-none-match"] = sourceElement._htmx.etag
+            if (sourceElement._htmx?.etag && !this.__isBoosted(sourceElement)) {
+                ctx.request.headers["If-None-Match"] = sourceElement._htmx.etag
             }
             return ctx;
         }


### PR DESCRIPTION
## Problem

Using `hx-boost` with `innerMorph` or `outerMorph` causes a broken navigation state. The URL updates but the page content stays the same.

```html
<body hx-boost:inherited="true" hx-swap:inherited="innerMorph">
  <a href="/page-a">Page A</a>
  <a href="/page-b">Page B</a>
</body>
```

Steps to reproduce:
1. Click **Page A**. htmx fetches it and stores the ETag on the `<a>` element.
2. Click **Page B**.
3. Click **Page A** again. htmx sends `If-None-Match`. Server returns `304 Not Modified`.
4. `__handleStatusCodes` sets `swap: none`. But `__handleHistoryUpdate` already pushed `/page-a` to history.
5. URL shows `/page-a`. Content still shows Page B. ❌

This does not affect `innerHTML`/`outerHTML` because those replace elements on every swap, discarding any stored ETags. Morph keeps `<a>` elements alive across navigations, so `_htmx.etag` persists and gets sent on the next visit.

htmx stores ETags but not the response body, so on a 304 there is nothing to swap with regardless.

## Fix

Skip `If-None-Match` for boosted requests.

Also fixes capitalization: `If-none-match` -> `If-None-Match`.