### PR TITLE
Streamline history event names

### DIFF
--- a/src/editors/jetbrains/htmx.web-types.json
+++ b/src/editors/jetbrains/htmx.web-types.json
@@ -313,14 +313,14 @@
           "doc-url": "https://htmx.org/events/#htmx:after:process"
         },
         {
-          "name": "after:push:into:history",
+          "name": "after:history:push",
           "description": "This event is triggered after a URL has been pushed into history.\n\n##### Details\n\n* `detail.path` - the path that was pushed into history",
-          "doc-url": "https://htmx.org/events/#htmx:after:push:into:history"
+          "doc-url": "https://htmx.org/events/#htmx:after:history:push"
         },
         {
-          "name": "after:replace:into:history",
+          "name": "after:history:replace",
           "description": "This event is triggered after a URL has been replaced in history.\n\n##### Details\n\n* `detail.path` - the path that was replaced in history",
-          "doc-url": "https://htmx.org/events/#htmx:after:replace:into:history"
+          "doc-url": "https://htmx.org/events/#htmx:after:history:replace"
         },
         {
           "name": "after:request",
@@ -383,9 +383,9 @@
           "doc-url": "https://htmx.org/events/#htmx:before:response"
         },
         {
-          "name": "before:restore:history",
+          "name": "before:history:restore",
           "description": "This event is triggered before history is restored.\n\n##### Details\n\n* `detail.path` - the path being restored",
-          "doc-url": "https://htmx.org/events/#htmx:before:restore:history"
+          "doc-url": "https://htmx.org/events/#htmx:before:history:restore"
         },
         {
           "name": "before:settle",

--- a/src/ext/htmx-2-compat.js
+++ b/src/ext/htmx-2-compat.js
@@ -75,13 +75,13 @@
         htmx_config_request: function (elt, detail) {
             maybeRetriggerEvent(elt, "htmx:configRequest", detail);
         },
-        htmx_before_restore_history: function (elt, detail) {
+        htmx_before_history_restore: function (elt, detail) {
             maybeRetriggerEvent(elt, "htmx:historyRestore", detail);
         },
-        htmx_after_push_into_history: function (elt, detail) {
+        htmx_after_history_push: function (elt, detail) {
             maybeRetriggerEvent(elt, "htmx:pushedIntoHistory", detail);
         },
-        htmx_after_replace_into_history: function (elt, detail) {
+        htmx_after_history_replace: function (elt, detail) {
             maybeRetriggerEvent(elt, "htmx:replacedInHistory", detail);
         },
         htmx_error: function (elt, detail) {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1564,18 +1564,18 @@ var htmx = (() => {
         __pushUrlIntoHistory(path) {
             if (!this.config.history) return;
             history.pushState({htmx: true}, '', path);
-            this.__trigger(document, "htmx:after:push:into:history", {path});
+            this.__trigger(document, "htmx:after:history:push", {path});
         }
 
         __replaceUrlInHistory(path) {
             if (!this.config.history) return;
             history.replaceState({htmx: true}, '', path);
-            this.__trigger(document, "htmx:after:replace:into:history", {path});
+            this.__trigger(document, "htmx:after:history:replace", {path});
         }
 
         __restoreHistory(path) {
             path = path || location.pathname + location.search;
-            if (this.__trigger(document, "htmx:before:restore:history", {path, cacheMiss: true})) {
+            if (this.__trigger(document, "htmx:before:history:restore", {path, cacheMiss: true})) {
                 if (this.config.history === "reload") {
                     location.reload();
                 } else {

--- a/src/skills/htmx-extension-authoring.md
+++ b/src/skills/htmx-extension-authoring.md
@@ -108,9 +108,9 @@ Hook names use underscores (not colons). All hooks receive `(elt, detail)` unles
 |------|-------|
 | `htmx_before_history_update` | `htmx:before:history:update` |
 | `htmx_after_history_update` | `htmx:after:history:update` |
-| `htmx_after_push_into_history` | `htmx:after:push:into:history` |
-| `htmx_after_replace_into_history` | `htmx:after:replace:into:history` |
-| `htmx_before_restore_history` | `htmx:before:restore:history` |
+| `htmx_after_history_push` | `htmx:after:history:push` |
+| `htmx_after_history_replace` | `htmx:after:history:replace` |
+| `htmx_before_history_restore` | `htmx:before:history:restore` |
 
 ### View Transitions
 

--- a/src/skills/htmx-guidance.md
+++ b/src/skills/htmx-guidance.md
@@ -225,8 +225,8 @@ htmx 4 naming convention: `htmx:phase:action`
 **History:**
 
 - `htmx:before:history:update` / `htmx:after:history:update`
-- `htmx:after:push:into:history` / `htmx:after:replace:into:history`
-- `htmx:before:restore:history`
+- `htmx:after:history:push` / `htmx:after:history:replace`
+- `htmx:before:history:restore`
 
 **View Transitions:**
 

--- a/src/skills/htmx-upgrade-from-htmx2.md
+++ b/src/skills/htmx-upgrade-from-htmx2.md
@@ -141,10 +141,10 @@ htmx 2 uses camelCase event names. htmx 4 uses colon-separated names.
 | `htmx:beforeCleanupElement` | `htmx:before:cleanup`             |
 | `htmx:beforeHistorySave`    | `htmx:before:history:update`      |
 | `htmx:beforeHistoryUpdate`  | `htmx:before:history:update`      |
-| `htmx:historyCacheMiss`     | `htmx:before:restore:history`     |
-| `htmx:historyRestore`       | `htmx:before:restore:history`     |
-| `htmx:pushedIntoHistory`    | `htmx:after:push:into:history`    |
-| `htmx:replacedInHistory`    | `htmx:after:replace:into:history` |
+| `htmx:historyCacheMiss`     | `htmx:before:history:restore`     |
+| `htmx:historyRestore`       | `htmx:before:history:restore`     |
+| `htmx:pushedIntoHistory`    | `htmx:after:history:push`         |
+| `htmx:replacedInHistory`    | `htmx:after:history:replace`      |
 | `htmx:beforeTransition`     | `htmx:before:viewTransition`      |
 | `htmx:oobBeforeSwap`        | `htmx:before:swap`                |
 | `htmx:oobAfterSwap`         | `htmx:after:swap`                 |

--- a/test/tests/end2end/basic-history.js
+++ b/test/tests/end2end/basic-history.js
@@ -24,7 +24,7 @@ describe('hx-push-url and hx-replace-url attributes', function() {
             eventPath = event.detail.path;
         };
         
-        document.addEventListener('htmx:after:push:into:history', handler);
+        document.addEventListener('htmx:after:history:push', handler);
         
         try {
             let btn = createProcessedHTML('<button hx-get="/test" hx-push-url="true">Click me</button>');
@@ -35,7 +35,7 @@ describe('hx-push-url and hx-replace-url attributes', function() {
             historyEventFired.should.equal(true);
             eventPath.should.equal('/test');
         } finally {
-            document.removeEventListener('htmx:after:push:into:history', handler);
+            document.removeEventListener('htmx:after:history:push', handler);
         }
     });
     
@@ -51,7 +51,7 @@ describe('hx-push-url and hx-replace-url attributes', function() {
             eventPath = event.detail.path;
         };
         
-        document.addEventListener('htmx:after:replace:into:history', handler);
+        document.addEventListener('htmx:after:history:replace', handler);
         
         try {
             let btn = createProcessedHTML('<button hx-get="/test" hx-replace-url="true">Click me</button>');
@@ -62,7 +62,7 @@ describe('hx-push-url and hx-replace-url attributes', function() {
             historyEventFired.should.equal(true);
             eventPath.should.equal('/test');
         } finally {
-            document.removeEventListener('htmx:after:replace:into:history', handler);
+            document.removeEventListener('htmx:after:history:replace', handler);
         }
     });
     
@@ -78,7 +78,7 @@ describe('hx-push-url and hx-replace-url attributes', function() {
             eventPath = event.detail.path;
         };
         
-        document.addEventListener('htmx:after:push:into:history', handler);
+        document.addEventListener('htmx:after:history:push', handler);
         
         try {
             let btn = createProcessedHTML('<button hx-get="/test" hx-push-url="/custom">Click me</button>');
@@ -89,7 +89,7 @@ describe('hx-push-url and hx-replace-url attributes', function() {
             historyEventFired.should.equal(true);
             eventPath.should.equal('/custom');
         } finally {
-            document.removeEventListener('htmx:after:push:into:history', handler);
+            document.removeEventListener('htmx:after:history:push', handler);
         }
     });
     
@@ -103,7 +103,7 @@ describe('hx-push-url and hx-replace-url attributes', function() {
             historyEventFired = true;
         };
         
-        document.addEventListener('htmx:after:push:into:history', handler);
+        document.addEventListener('htmx:after:history:push', handler);
         
         try {
             let btn = createProcessedHTML('<button hx-get="/test" hx-push-url="false">Click me</button>');
@@ -113,7 +113,7 @@ describe('hx-push-url and hx-replace-url attributes', function() {
             playground().textContent.should.equal('Test Response');
             historyEventFired.should.equal(false);
         } finally {
-            document.removeEventListener('htmx:after:push:into:history', handler);
+            document.removeEventListener('htmx:after:history:push', handler);
         }
     });
     

--- a/test/tests/unit/bootstrap.js
+++ b/test/tests/unit/bootstrap.js
@@ -205,7 +205,8 @@ describe('bootstrap unit tests', function() {
         ].sort();
 
         const expectedPublicProperties = [
-            'config'
+            'config',
+            'version',
         ].sort();
 
         // Get own properties (like config, eventSource)


### PR DESCRIPTION
## Summary

- `htmx:after:push:into:history` → `htmx:after:history:push`
- `htmx:after:replace:into:history` → `htmx:after:history:replace`
- `htmx:before:restore:history` → `htmx:before:history:restore`

All history events now follow the consistent `htmx:{phase}:history:{action}` pattern, matching the existing `htmx:before:history:update` / `htmx:after:history:update`.

## Changes

- Core (`src/htmx.js`): 3 event emissions renamed
- htmx-2-compat extension: hook names updated (still re-fires old htmx 2 event names)
- Editor metadata (JetBrains web-types): event names + doc URLs
- Skills: extension-authoring, guidance, upgrade-from-htmx2
- Tests: basic-history end2end tests
- Fix pre-existing API surface test (`version` property)

## Test plan

- [x] 1044/1044 tests passing
- [x] History push/replace/restore tests updated and green