### PR TITLE
alpine-compat ext defer mutation count needs to handle htmx.swap usage

### DIFF
--- a/src/ext/hx-alpine-compat.js
+++ b/src/ext/hx-alpine-compat.js
@@ -9,6 +9,13 @@
     let api;
     let deferCount = 0;
 
+    function maybeFlush() {
+        if (deferCount > 0) deferCount--;
+        if (deferCount === 0 && window.Alpine?.flushAndStopDeferringMutations) {
+            window.Alpine.flushAndStopDeferringMutations();
+        }
+    }
+
     htmx.registerExtension('alpine-compat', {
         init: (internalAPI) => {
             api = internalAPI;
@@ -71,13 +78,13 @@
             }
         },
 
+        htmx_after_swap: (elt, detail) => {
+            detail.ctx._alpineFlushed = true;
+            maybeFlush();
+        },
+
         htmx_finally_request: (elt, detail) => {
-            if (deferCount > 0) {
-                deferCount--;
-            }
-            if (deferCount === 0 && window.Alpine?.flushAndStopDeferringMutations) {
-                window.Alpine.flushAndStopDeferringMutations();
-            }
+            if (!detail.ctx._alpineFlushed) maybeFlush();
         }
     });
 })();


### PR DESCRIPTION
## Description
the defer mutations count would go up when htmx.swap api is called and then not go down as expected and enable mutation processing again because it only listens on finally event that does not fire in htmx.swap.  so added code to flush on both events

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
