### PR TITLE
Restore scroll position on back/forward with history:"reload"

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -68,6 +68,7 @@ var htmx = (() => {
         #hxOnQuery
         #transitionQueue
         #historyAbort
+        #scrollIdx
         #processingTransition
 
         constructor() {
@@ -1553,8 +1554,44 @@ var htmx = (() => {
             if (!history.state) {
                 history.replaceState({htmx: true}, '', location.href);
             }
+            let scrollTimer;
+            if (this.config.history === "reload") {
+                history.scrollRestoration = 'manual';
+                // assign a unique index to this history entry for scroll tracking
+                if (history.state._htmxIdx == null) {
+                    let idx = parseInt(sessionStorage.getItem('htmx:idx') || '0');
+                    history.replaceState({...history.state, _htmxIdx: idx}, '', location.href);
+                    sessionStorage.setItem('htmx:idx', idx + 1);
+                }
+                this.#scrollIdx = history.state._htmxIdx;
+                let savedY = sessionStorage.getItem('htmx:scroll:' + this.#scrollIdx);
+                // start tracking scroll after restoration is complete
+                let startScrollTracking = () => {
+                    window.addEventListener('scroll', () => {
+                        clearTimeout(scrollTimer);
+                        scrollTimer = setTimeout(() => {
+                            sessionStorage.setItem('htmx:scroll:' + this.#scrollIdx, window.scrollY);
+                        }, 350);
+                    }, {passive: true});
+                };
+                if (savedY != null) {
+                    window.addEventListener('load', () => {
+                        requestAnimationFrame(() => {
+                            window.scrollTo(0, parseInt(savedY));
+                            requestAnimationFrame(startScrollTracking);
+                        });
+                    });
+                } else {
+                    startScrollTracking();
+                }
+            }
             window.addEventListener('popstate', (event) => {
                 if (event.state && event.state.htmx) {
+                    // save scroll for the entry we're leaving (using tracked index)
+                    if (this.config.history === "reload" && this.#scrollIdx != null) {
+                        clearTimeout(scrollTimer);
+                        sessionStorage.setItem('htmx:scroll:' + this.#scrollIdx, window.scrollY);
+                    }
                     this.#historyAbort?.abort();
                     this.__restoreHistory();
                 }
@@ -1563,7 +1600,17 @@ var htmx = (() => {
 
         __pushUrlIntoHistory(path) {
             if (!this.config.history) return;
-            history.pushState({htmx: true}, '', path);
+            if (this.config.history === "reload") {
+                // save scroll for the current entry before pushing
+                sessionStorage.setItem('htmx:scroll:' + this.#scrollIdx, window.scrollY);
+                // assign a new index for the new entry
+                let idx = parseInt(sessionStorage.getItem('htmx:idx') || '0');
+                sessionStorage.setItem('htmx:idx', idx + 1);
+                this.#scrollIdx = idx;
+                history.pushState({htmx: true, _htmxIdx: idx}, '', path);
+            } else {
+                history.pushState({htmx: true}, '', path);
+            }
             this.__trigger(document, "htmx:after:history:push", {path});
         }
 


### PR DESCRIPTION
## Problem

`history:"reload"` loses scroll position on back/forward navigation.

```
1. User scrolls to Y=500 on /page-a
2. Clicks a boosted link to /page-b
3. Presses back
4. /page-a reloads at Y=0
```

## Solution

Track scroll positions in `sessionStorage`, keyed by a unique index per history entry. Same pattern used by SvelteKit, React Router, and TanStack Router.

```
1. User scrolls to Y=500 on /page-a
2. Clicks a boosted link: scrollY saved to sessionStorage
3. Presses back
4. /page-a reloads, reads scrollY from sessionStorage, scrolls to 500
```

Scroll is saved via a debounced (350ms) scroll listener, on `pushState`, and on `popstate`. The 350ms debounce stays under Safari's `replaceState` rate limit. After reload, scroll is restored via `requestAnimationFrame` after the `load` event.

## How to test

```html
<body hx-boost:inherited="true">
<meta name="htmx-config" content='{"history":"reload"}'>
```

1. Scroll down on a page, click a boosted link
2. Press back : scroll should restore
3. Press forward, then back again: scroll should persist across cycles