### PR TITLE
Bug fix for pantry moveBefore and morph scripts issue

### DIFF
--- a/src/ext/hx-alpine-compat.js
+++ b/src/ext/hx-alpine-compat.js
@@ -23,14 +23,11 @@
             // Override isSoftMatch to handle Alpine reactive IDs
             let originalIsSoftMatch = api.isSoftMatch;
             api.isSoftMatch = function(oldNode, newNode) {
-                if (!(oldNode instanceof Element) || oldNode.tagName !== newNode.tagName) {
-                    return false;
-                }
                 // If both have Alpine reactive ID bindings, ignore ID mismatch
                 if (oldNode._x_bindings?.id && newNode.matches?.('[\\:id], [x-bind\\:id]')) {
-                    return true;
+                    return oldNode instanceof Element && oldNode.tagName === newNode.tagName;
                 }
-                return !oldNode.id || oldNode.id === newNode.id;
+                return originalIsSoftMatch(oldNode, newNode);
             };
         },
         

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -977,16 +977,12 @@ var htmx = (() => {
         __handlePreservedElements(fragment) {
             let pantry = document.createElement('div');
             pantry.style.display = 'none';
-            document.body.appendChild(pantry);
+            document.body.insertAdjacentElement('afterend', pantry);
             let newPreservedElts = fragment.querySelectorAll?.(`[${this.__prefix('hx-preserve')}]`) || [];
             for (let preservedElt of newPreservedElts) {
                 let currentElt = document.getElementById(preservedElt.id);
                 if (currentElt) {
-                    if (pantry.moveBefore) {
-                        pantry.moveBefore(currentElt, null);
-                    } else {
-                        pantry.appendChild(currentElt);
-                    }
+                    this.__moveBefore(pantry, currentElt, null);
                 }
             }
             return pantry
@@ -996,11 +992,7 @@ var htmx = (() => {
             for (let preservedElt of [...pantry.children]) {
                 let newElt = document.getElementById(preservedElt.id);
                 if (newElt) {
-                    if (newElt.parentNode.moveBefore) {
-                        newElt.parentNode.moveBefore(preservedElt, newElt);
-                    } else {
-                        newElt.replaceWith(preservedElt);
-                    }
+                    this.__moveBefore(newElt.parentNode, preservedElt, newElt);
                     this.__cleanup(newElt)
                     newElt.remove()
                 }
@@ -1287,7 +1279,7 @@ var htmx = (() => {
                 fragment.append(...(task.fragment.firstElementChild.content || task.fragment.firstElementChild).childNodes);
             }
 
-            target.classList.add("htmx-swapping")
+            this.__addClass(target, "htmx-swapping")
             if (cssTransition && task.swapSpec?.swap) {
                 await this.timeout(task.swapSpec?.swap)
             }
@@ -1370,7 +1362,7 @@ var htmx = (() => {
                     }
                 }
             } finally {
-                target.classList.remove("htmx-swapping")
+                this.__removeClass(target, "htmx-swapping")
             }
             this.__restorePreservedElements(pantry);
             if (focusInfo && !focusInfo.elt.matches(':focus')) {
@@ -1384,23 +1376,23 @@ var htmx = (() => {
             this.__trigger(target, "htmx:before:settle", {task, newContent, settleTasks})
 
             for (const elt of newContent) {
-                elt.classList?.add?.("htmx-added")
+                this.__addClass(elt, "htmx-added")
             }
 
             if (cssTransition && settleTasks.length > 0) {
-                target.classList.add("htmx-settling")
+                this.__addClass(target, "htmx-settling")
                 await this.timeout(settleDelay);
                 // invoke settle tasks
                 for (let settleTask of settleTasks) {
                     settleTask()
                 }
-                target.classList.remove("htmx-settling")
+                this.__removeClass(target, "htmx-settling")
             }
 
             this.__trigger(target, "htmx:after:settle", {task, newContent, settleTasks})
 
             for (const elt of newContent) {
-                elt.classList?.remove?.("htmx-added")
+                this.__removeClass(elt, "htmx-added")
                 this.process(elt);
                 this.__handleAutoFocus(elt);
             }
@@ -1462,9 +1454,9 @@ var htmx = (() => {
 
         takeClass(element, className, container = element.parentElement) {
             for (let elt of this.__findAllExt(this.__normalizeElement(container), "." + className)) {
-                elt.classList.remove(className);
+                this.__removeClass(elt, className);
             }
-            element.classList.add(className);
+            this.__addClass(element, className);
         }
 
         on(eventOrElt, eventOrCallback, callback) {
@@ -1672,7 +1664,7 @@ var htmx = (() => {
             for (const indicator of indicatorElements) {
                 indicator._htmxReqCount ||= 0
                 indicator._htmxReqCount++
-                indicator.classList.add(this.config.requestClass)
+                this.__addClass(indicator, this.config.requestClass)
             }
             return indicatorElements
         }
@@ -1682,7 +1674,7 @@ var htmx = (() => {
                 if (indicator._htmxReqCount) {
                     indicator._htmxReqCount--;
                     if (indicator._htmxReqCount <= 0) {
-                        indicator.classList.remove(this.config.requestClass);
+                        this.__removeClass(indicator, this.config.requestClass);
                         delete indicator._htmxReqCount
                     }
                 }
@@ -2045,6 +2037,8 @@ var htmx = (() => {
             if (!(oldNode instanceof Element) || oldNode.tagName !== newNode.tagName) {
                 return false;
             }
+            // Script tags must be identical to match - never patch a script with different content
+            if (oldNode.tagName === 'SCRIPT' && !oldNode.isEqualNode(newNode)) return false;
             // If both have Alpine reactive ID bindings, ignore ID mismatch
             if (oldNode._x_bindings?.id && newNode.matches?.('[\\:id], [x-bind\\:id]')) {
                 return true;
@@ -2218,6 +2212,15 @@ var htmx = (() => {
                 }
             }
             return restoreTasks;
+        }
+
+        __addClass(elt, cls) {
+            elt?.classList?.add?.(cls);
+        }
+
+        __removeClass(elt, cls) {
+            elt?.classList?.remove?.(cls);
+            if (elt?.classList?.length === 0) elt.removeAttribute('class');
         }
 
         __normalizeElement(cssOrElement) {

--- a/test/tests/attributes/hx-get.js
+++ b/test/tests/attributes/hx-get.js
@@ -59,7 +59,7 @@ describe('hx-get attribute', function() {
         let form = createProcessedHTML('<form hx-trigger="click" hx-get="/test?foo=bar#foo" hx-swap="outerHTML"><input name="i1" value="value"/><button id="b1">Click Me!</button></form>');
         form.click()
         await forRequest();
-        playground().innerHTML.should.equal('<div id="foo" class="">Clicked</div>')
+        playground().innerHTML.should.equal('<div id="foo">Clicked</div>')
         lastFetch().url.should.equal('/test?foo=bar&i1=value')
         // TODO: Add assertion for scroll behavior to #foo
     })

--- a/test/tests/attributes/hx-select.js
+++ b/test/tests/attributes/hx-select.js
@@ -13,7 +13,7 @@ describe('hx-select', function() {
         let div = createProcessedHTML('<div hx-get="/test" hx-select="#content" hx-swap="innerHTML">Old</div>');
         div.click()
         await forRequest()
-        assert.equal(div.innerHTML, '<div id="content" class="">Selected</div>')
+        assert.equal(div.innerHTML, '<div id="content">Selected</div>')
     })
 
     it('selects nested content from response', async function () {
@@ -21,7 +21,7 @@ describe('hx-select', function() {
         let div = createProcessedHTML('<div hx-get="/test" hx-select="#main" hx-swap="innerHTML">Old</div>');
         div.click()
         await forRequest()
-        assert.equal(div.innerHTML, '<main id="main" class="">Main content</main>')
+        assert.equal(div.innerHTML, '<main id="main">Main content</main>')
     })
 
     it('does not affect OOB swaps', async function () {
@@ -29,7 +29,7 @@ describe('hx-select', function() {
         let div = createProcessedHTML('<div hx-get="/test" hx-select="#content" hx-swap="innerHTML">Old</div><div id="oob">Old OOB</div>');
         div.click()
         await forRequest()
-        assert.equal(div.innerHTML, '<div id="content" class="">Selected</div>')
+        assert.equal(div.innerHTML, '<div id="content">Selected</div>')
         assert.equal(document.getElementById('oob').innerHTML, 'OOB content')
     })
 

--- a/test/tests/unit/ajax.js
+++ b/test/tests/unit/ajax.js
@@ -296,7 +296,7 @@ describe('ajax() unit Tests', function() {
             target: '#target',
             swap: 'innerHTML'
         });
-        assert.equal(div.innerHTML, '<span class="">inner</span>');
+        assert.equal(div.innerHTML, '<span>inner</span>');
     });
 
     it('ajax with swap beforeend', async function() {
@@ -307,6 +307,6 @@ describe('ajax() unit Tests', function() {
             swap: 'beforeend'
         });
         assert.include(div.innerHTML, '<p>old</p>');
-        assert.include(div.innerHTML, '<span class="">new</span>');
+        assert.include(div.innerHTML, '<span>new</span>');
     });
 });

--- a/test/tests/unit/morph.js
+++ b/test/tests/unit/morph.js
@@ -246,6 +246,30 @@ describe('Morph Swap Styles Tests', function() {
             assert.equal(div.querySelector('#\\31'), hr);
         });
 
+        it('does not re-execute identical script tags during morph', async function() {
+            window._scriptMorphCount = 0;
+            createProcessedHTML('<div id="target"></div>');
+            await htmx.swap({target: '#target', text: '<script>window._scriptMorphCount++<\/script><div id="content">original</div>', swap: 'innerHTML'});
+            assert.equal(window._scriptMorphCount, 1, 'Script should run once after initial swap');
+
+            await htmx.swap({target: '#target', text: '<script>window._scriptMorphCount++<\/script><div id="content">updated</div>', swap: 'innerMorph'});
+
+            assert.equal(window._scriptMorphCount, 1, 'Identical script should not re-execute after morph');
+            delete window._scriptMorphCount;
+        });
+
+        it('executes changed script tags once when replaced during morph', async function() {
+            window._scriptMorphCount = 0;
+            createProcessedHTML('<div id="target"></div>');
+            await htmx.swap({target: '#target', text: '<script>window._scriptMorphCount++<\/script>', swap: 'innerHTML'});
+            assert.equal(window._scriptMorphCount, 1, 'Original script should run once after initial swap');
+
+            await htmx.swap({target: '#target', text: '<script>window._scriptMorphCount += 10<\/script>', swap: 'innerMorph'});
+
+            assert.equal(window._scriptMorphCount, 11, 'Changed script should execute exactly once after morph');
+            delete window._scriptMorphCount;
+        });
+
         it('does not treat empty id="" as a persistent id', async function() {
             // When both old and new content have <h1 id="">, the empty string should NOT
             // be treated as a persistent ID that needs to be preserved/matched.


### PR DESCRIPTION
## Description
Found a couple of bugs.  pantry used by hx-preserve is placed at the bottom of body so innerHTML replacment of body itself will remove the pantry from the DOM and then moveBefore throws an Hierarchy Error because it blocks such disconnected to connected moves.  To address this I moved to use insertAdjacentElement to place pantry after the body which is what htmx2 did and also moved the manual moveBefore calls to use the safer internal __moveBefore with a try catch fallback.  Now pantry works as expected when i manually test

Second issue I found is morph is softMatching script tags and mutating their text content which does nothing as they will not re-evaluate in this kind of change.  We need identical scripts to match well and do nothing so they don't re-execute and different scripts to not match and re-insert and remove the old one on morph.  Updated softmatch with this guard and added tests.

Also found an issue where class="" was getting added to all the htmx touched nodes after htmx temp classes are added and removed and this is breaking morph node change detection so added a proper remove class handler function

Corresponding issue:

## Testing
Can unit test the morph issue but pantry one replaces body so unit testing not easy

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
