### PR TITLE
Clarify use of filters for polling triggers

### DIFF
--- a/www/content/attributes/hx-trigger.md
+++ b/www/content/attributes/hx-trigger.md
@@ -137,10 +137,11 @@ By using the syntax `every <timing declaration>` you can have an element poll pe
 This example will issue a `GET` to the `/latest_updates` URL every second and swap the results into
 the innerHTML of this div.
 
-If you want to add a filter to polling, it should be added *after* the poll declaration:
+If you want to add a filter to polling, it should be added *after* the poll declaration. The filter must be a
+JavaScript expression. This example will only poll when the tab is being viewed:
 
 ```html
-<div hx-get="/latest_updates" hx-trigger="every 1s [someConditional]">
+<div hx-get="/latest_updates" hx-trigger="every 1s [!document.hidden]">
   Nothing Yet!
 </div>
 ```


### PR DESCRIPTION
## Description
I found the documentation for filters on polling triggers with `hx-trigger="every 1s [...]"` less useful than it could be. I initially did not understand, that a filter could be any JavaScript expression. I have clarified this and changed the example to a common scenario: The polling is paused when a tab is in the background.

## Testing
I have created some test HTML with this body:
```
<body
	hx-get="file:///tmp/index.html"
	hx-trigger="every 5s [!document.hidden]">
```

I could see in the developer console, that requests were triggered, when the tab was being viewed, but not when I was looking at another tab.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* ~I ran the test suite locally (`npm run test`) and verified that it succeeded~
  * Is this necessary for documentation changes?