### PR TITLE
restore hx-on:: shorthand from htmx 2

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1639,11 +1639,15 @@ var htmx = (() => {
             this.__trigger(document, "htmx:after:history:update", historyDetail);
         }
 
+        // hx-on:<event> binds to <event> directly
+        // hx-on::<event> is shorthand for hx-on:htmx:<event> (htmx events)
         __handleHxOnAttributes(node) {
             let searchString = this.__maybeAdjustMetaCharacter(this.__prefix("hx-on:"));
             for (let attr of node.getAttributeNames()) {
                 if (attr.startsWith(searchString)) {
                     let evtName = attr.substring(searchString.length)
+                    let mc = this.config.metaCharacter || ':';
+                    if (evtName.startsWith(mc)) evtName = 'htmx' + evtName
                     let code = node.getAttribute(attr);
                     let handler = async (evt) => {
                         try {

--- a/test/tests/attributes/hx-on.js
+++ b/test/tests/attributes/hx-on.js
@@ -82,5 +82,17 @@ describe('hx-on attribute', function() {
         delete window.foo
     })
 
+    it('hx-on:: shorthand expands to htmx: event', function() {
+        var btn = createProcessedHTML("<button hx-on::my-event='window.foo = true'>Foo</button>")
+        htmx.trigger(btn, "htmx:my-event")
+        window.foo.should.equal(true)
+        delete window.foo
+    })
+
+    it('hx-on:: shorthand does not fire on non-htmx event', function() {
+        var btn = createProcessedHTML("<button hx-on::my-event='window.foo = true'>Foo</button>")
+        htmx.trigger(btn, "my-event")
+        assert.equal(window.foo, undefined)
+    })
 
 })

--- a/www/src/content/docs/01-get-started/02-migration.md
+++ b/www/src/content/docs/01-get-started/02-migration.md
@@ -200,25 +200,6 @@ All error events are consolidated to [`htmx:error`](/reference/events/htmx-error
 | `htmx:targetError`          | [`htmx:error`](/reference/events/htmx-error)                                      |
 | `htmx:timeout`              | [`htmx:error`](/reference/events/htmx-error)                                      |
 
-### `hx-on::` shorthand
-
-The double-colon shorthand for htmx events no longer works. Because event names changed from camelCase to
-colon-separated (e.g. `htmx:afterRequest` → `htmx:after:request`), the `hx-on::` prefix can no longer map to the correct
-event name.
-
-Use the full event name instead:
-
-```html
-<!-- htmx 2 -->
-<form hx-on::after-request="this.reset()">
-
-    <!-- htmx 4 -->
-    <form hx-on:htmx:after:request="this.reset()">
-```
-
-This applies to all `hx-on::` event handlers. Find and replace `hx-on::` with `hx-on:htmx:` and update the event name to
-the new colon-separated format (see table above).
-
 ### Removed events
 
 Validation events are removed. Use native browser form validation:
@@ -483,7 +464,7 @@ htmx 4 ships with 9 core extensions:
 2. Rename `hx-disable` to [`hx-ignore`](/reference/attributes/hx-ignore), then `hx-disabled-elt` to [
    `hx-disable`](/reference/attributes/hx-disable)
 3. Replace removed attributes with alternatives
-4. Find/replace event names in JavaScript and `hx-on::` attributes
+4. Find/replace event names in JavaScript and `hx-on` attributes
 5. Replace removed API methods with native JS
 6. Update extensions
 7. Rename changed config keys


### PR DESCRIPTION
## Summary
- Restores the `hx-on::` shorthand for htmx events that existed in htmx 2
- `hx-on::after:request` expands to `hx-on:htmx:after:request`
- One line of logic + two tests

## Test plan
- [x] Existing hx-on tests pass (1056 passed, 0 failed)
- [x] New test: `hx-on::` shorthand expands to `htmx:` event
- [x] New test: `hx-on::` shorthand does not fire on non-htmx event