### PR TITLE
Align WS and SSE extension APIs

### DIFF
--- a/src/ext/hx-sse.js
+++ b/src/ext/hx-sse.js
@@ -101,26 +101,27 @@
     async function handleSSEResponse(ctx) {
         let element = ctx.sourceElement;
         let config = getConfig(ctx);
-        let lastEventId = null;
-        let attempt = 0;
-        let reader = null;
         let reconnectRequested = false;
-        let delayCanceller = null;
 
-        let state = {
+        let connection = {
+            url: ctx.request.action,
+            config: config,
             abortController: null,
             reader: null,
             lastEventId: null,
             delayCanceller: null,
-            visibilityHandler: null
+            visibilityHandler: null,
+            attempt: 0,
+            cancelled: false,
+            status: null
         };
-        api.htmxProp(element).sse = state;
+        api.htmxProp(element).sse = connection;
 
         let reconnect = () => {
             if (!element.isConnected || reconnectRequested) return;
             reconnectRequested = true;
-            if (delayCanceller) delayCanceller();
-            reader?.cancel();
+            if (connection.delayCanceller) connection.delayCanceller();
+            connection.reader?.cancel();
         };
 
         let paused = false;
@@ -130,49 +131,48 @@
             let visibilityHandler = () => {
                 if (document.hidden) {
                     paused = true;
-                    reader?.cancel();
+                    connection.reader?.cancel();
                 } else if (paused) {
                     paused = false;
                     if (unpauseResolver) unpauseResolver();
                 }
             };
             document.addEventListener('visibilitychange', visibilityHandler);
-            state.visibilityHandler = visibilityHandler;
+            connection.visibilityHandler = visibilityHandler;
         }
 
-        let connectDetail = {attempt: 0, delay: 0, url: ctx.request.action, lastEventId: null, cancelled: false};
-        if (!api.triggerHtmxEvent(element, 'htmx:before:sse:connection', {connection: connectDetail}) || connectDetail.cancelled) {
+        connection.cancelled = false;
+        if (!api.triggerHtmxEvent(element, 'htmx:before:sse:connection', {connection}) || connection.cancelled) {
             cleanup(element, 'cancelled');
             return;
         }
 
-        api.triggerHtmxEvent(element, 'htmx:after:sse:connection', {
-            connection: {attempt: 0, url: ctx.request.action, status: ctx.response.status, lastEventId: null}
-        });
+        connection.status = ctx.response.status;
+        api.triggerHtmxEvent(element, 'htmx:after:sse:connection', {connection});
 
         let currentResponse = ctx.response.raw;
 
         try {
             while (element.isConnected) {
                 // Reconnection (not on first iteration — we already have the response)
-                if (attempt > 0) {
+                if (connection.attempt > 0) {
                     // Wait while paused (tab backgrounded with pauseOnBackground)
                     if (paused) {
                         await new Promise(r => { unpauseResolver = r; });
                         unpauseResolver = null;
                         if (!element.isConnected) break;
-                        attempt = 1; // reset so delay doesn't escalate from pauses
+                        connection.attempt = 1; // reset so delay doesn't escalate from pauses
                         reconnectRequested = true; // bypass maxAttempts check
                     }
 
                     if (!reconnectRequested) {
-                        if (!config.reconnect || attempt > config.reconnectMaxAttempts) break;
+                        if (!config.reconnect || connection.attempt > config.reconnectMaxAttempts) break;
                     }
 
                     let baseDelay = htmx.parseInterval(config.reconnectDelay) ?? config.reconnectDelay;
                     let maxDelay = htmx.parseInterval(config.reconnectMaxDelay) ?? config.reconnectMaxDelay;
                     let delay = Math.min(
-                        baseDelay * Math.pow(2, attempt - 1),
+                        baseDelay * Math.pow(2, connection.attempt - 1),
                         maxDelay
                     );
                     if (config.reconnectJitter > 0) {
@@ -180,77 +180,76 @@
                         delay = Math.max(0, delay + (Math.random() * 2 - 1) * jitterRange);
                     }
 
-                    let detail = {attempt, delay, url: ctx.request.action, lastEventId, cancelled: false};
-                    if (!api.triggerHtmxEvent(element, 'htmx:before:sse:connection', {connection: detail}) || detail.cancelled) break;
+                    connection.cancelled = false;
+                    if (!api.triggerHtmxEvent(element, 'htmx:before:sse:connection', {connection}) || connection.cancelled) break;
 
                     await new Promise(r => {
-                        delayCanceller = r;
-                        state.delayCanceller = r;
-                        setTimeout(r, detail.delay);
+                        connection.delayCanceller = r;
+                        setTimeout(r, delay);
                     });
-                    delayCanceller = null;
-                    state.delayCanceller = null;
+                    connection.delayCanceller = null;
                     if (!element.isConnected) break;
 
                     // Re-fetch using saved request context (no full pipeline re-run)
                     let ac = new AbortController();
-                    state.abortController = ac;
+                    connection.abortController = ac;
                     try {
-                        if (lastEventId) ctx.request.headers['Last-Event-ID'] = lastEventId;
+                        if (connection.lastEventId) ctx.request.headers['Last-Event-ID'] = connection.lastEventId;
                         currentResponse = await fetch(ctx.request.action, {
                             ...ctx.request,
                             signal: ac.signal
                         });
                     } catch (e) {
                         if (ac.signal.aborted) break;
-                        api.triggerHtmxEvent(element, 'htmx:sse:error', {error: e});
+                        api.triggerHtmxEvent(element, 'htmx:sse:error', {error: e, url: ctx.request.action});
                         reconnectRequested = false;
-                        attempt++;
+                        connection.attempt++;
                         continue;
                     }
 
                     if (!currentResponse.ok) {
                         api.triggerHtmxEvent(element, 'htmx:sse:error', {
                             error: new Error(`SSE reconnect failed with status ${currentResponse.status}`),
-                            status: currentResponse.status
+                            status: currentResponse.status,
+                            url: ctx.request.action
                         });
                         reconnectRequested = false;
-                        attempt++;
+                        connection.attempt++;
                         continue;
                     }
 
-                    api.triggerHtmxEvent(element, 'htmx:after:sse:connection', {
-                        connection: {attempt, url: ctx.request.action, status: currentResponse.status, lastEventId}
-                    });
-                    attempt = 0;
+                    connection.status = currentResponse.status;
+                    api.triggerHtmxEvent(element, 'htmx:after:sse:connection', {connection});
+                    connection.attempt = 0;
                 }
 
                 // Stream messages
                 reconnectRequested = false;
 
                 try {
-                    reader = currentResponse.body.getReader();
-                    state.reader = reader;
+                    connection.reader = currentResponse.body.getReader();
 
-                    for await (let msg of parseSSE(reader)) {
+                    for await (let msg of parseSSE(connection.reader)) {
                         if (!element.isConnected || reconnectRequested) break;
 
-                        let detail = {data: msg.data, event: msg.event, id: msg.id, cancelled: false};
-                        if (!api.triggerHtmxEvent(element, 'htmx:before:sse:message', {message: detail}) || detail.cancelled) continue;
+                        let detail = {
+                            message: {data: msg.data, event: msg.event, id: msg.id, cancelled: false}
+                        };
+                        if (!api.triggerHtmxEvent(element, 'htmx:before:sse:message', detail) || detail.message.cancelled) continue;
 
                         if (msg.id) {
-                            lastEventId = msg.id;
-                            state.lastEventId = msg.id;
+                            connection.lastEventId = msg.id;
                         }
                         if (msg.retry != null) config.reconnectDelay = msg.retry;
 
-                        if (detail.event) {
-                            htmx.trigger(element, detail.event, {data: detail.data, id: detail.id});
-                            api.triggerHtmxEvent(element, 'htmx:after:sse:message', {message: detail});
+                        if (detail.message.event) {
+                            htmx.trigger(element, detail.message.event, {data: detail.message.data, id: detail.message.id});
+                            delete detail.message.cancelled;
+                            api.triggerHtmxEvent(element, 'htmx:after:sse:message', detail);
 
                             // hx-sse:close="eventname" — close connection on matching event
                             let closeEvent = api.attributeValue(element, 'hx-sse:close');
-                            if (closeEvent && detail.event === closeEvent) {
+                            if (closeEvent && detail.message.event === closeEvent) {
                                 cleanup(element, 'message');
                                 return;
                             }
@@ -258,21 +257,21 @@
                         }
 
                         // Swap content using the ctx from core (target/swap already resolved)
-                        ctx.text = detail.data;
+                        ctx.text = detail.message.data;
                         await htmx.swap(ctx);
-                        api.triggerHtmxEvent(element, 'htmx:after:sse:message', {message: detail});
+                        delete detail.message.cancelled;
+                        api.triggerHtmxEvent(element, 'htmx:after:sse:message', detail);
                     }
                 } catch (e) {
-                    if (!state.abortController?.signal?.aborted) {
-                        api.triggerHtmxEvent(element, 'htmx:sse:error', {error: e});
+                    if (!connection.abortController?.signal?.aborted) {
+                        api.triggerHtmxEvent(element, 'htmx:sse:error', {error: e, url: ctx.request.action});
                     }
                 }
 
-                reader = null;
-                state.reader = null;
+                connection.reader = null;
                 if (!element.isConnected) break;
 
-                attempt++;
+                connection.attempt++;
             }
         } finally {
             cleanup(element, element.isConnected ? 'ended' : 'removed');
@@ -300,17 +299,36 @@
     // ========================================
 
     function cleanup(element, reason) {
-        let state = element?._htmx?.sse;
-        if (!state) return;
+        let connection = element?._htmx?.sse;
+        if (!connection) return;
 
-        state.abortController?.abort();
-        state.reader?.cancel?.();
-        if (state.delayCanceller) state.delayCanceller();
-        if (state.visibilityHandler) {
-            document.removeEventListener('visibilitychange', state.visibilityHandler);
+        connection.abortController?.abort();
+        connection.reader?.cancel?.();
+        if (connection.delayCanceller) connection.delayCanceller();
+        if (connection.visibilityHandler) {
+            document.removeEventListener('visibilitychange', connection.visibilityHandler);
         }
+        api.triggerHtmxEvent(element, 'htmx:sse:close', {connection, reason: reason || 'cleanup'});
         delete element._htmx.sse;
-        api.triggerHtmxEvent(element, 'htmx:sse:close', {reason: reason || 'cleanup'});
+    }
+
+    // ========================================
+    // BACKWARD COMPATIBILITY
+    // ========================================
+
+    function checkLegacyAttributes(element) {
+        if (element.hasAttribute('sse-connect')) {
+            console.warn('HTMX SSE: Legacy attribute sse-connect is deprecated. Use hx-sse:connect instead.');
+
+            let url = element.getAttribute('sse-connect');
+            let attr = (htmx.config.prefix || 'hx-') + 'sse' + (htmx.config.metaCharacter || ':') + 'connect';
+            if (!element.hasAttribute(attr)) {
+                element.setAttribute(attr, url);
+            }
+        }
+        if (element.hasAttribute('sse-swap')) {
+            console.warn('HTMX SSE: sse-swap is removed in htmx 4. Unnamed SSE messages are swapped automatically. Named events are dispatched as DOM events.');
+        }
     }
 
     // ========================================
@@ -330,17 +348,21 @@
 
             // Take over — core will return without calling response.text()
             handleSSEResponse(ctx).catch(e => {
-                api.triggerHtmxEvent(element, 'htmx:sse:error', {error: e});
+                api.triggerHtmxEvent(element, 'htmx:sse:error', {error: e, url: ctx.request.action});
                 cleanup(element);
             });
             return false;
         },
 
         htmx_after_process: (element) => {
+            checkLegacyAttributes(element);
             processElement(element);
             let mc = htmx.config.metaCharacter || ':';
             let attr = CSS.escape((htmx.config.prefix || 'hx-') + 'sse' + mc + 'connect');
-            element.querySelectorAll(`[${attr}]`).forEach(processElement);
+            element.querySelectorAll(`[${attr}],[sse-connect]`).forEach((el) => {
+                checkLegacyAttributes(el);
+                processElement(el);
+            });
         },
 
         htmx_before_cleanup: (element) => {

--- a/src/ext/hx-ws.js
+++ b/src/ext/hx-ws.js
@@ -1,67 +1,41 @@
 (() => {
     let api;
     
-    // ========================================
-    // ATTRIBUTE HELPERS
-    // ========================================
-    
-    // Helper to build proper attribute name respecting htmx prefix
-    function buildAttrName(suffix) {
-        // htmx.config.prefix replaces 'hx-' entirely, e.g. 'data-hx-' 
-        // So 'hx-ws:connect' becomes 'data-hx-ws:connect'
-        let prefix = htmx.config.prefix || 'hx-';
-        return prefix + 'ws' + suffix;
+    // Build a CSS selector for querySelectorAll, respecting prefix + metaCharacter
+    function wsSelector(suffix) {
+        let attr = (htmx.config.prefix || 'hx-') + 'ws' + (htmx.config.metaCharacter || ':') + suffix;
+        return `[${CSS.escape(attr)}]`;
     }
-    
-    // Helper to get attribute value, checking colon, hyphen, and plain variants
-    // Uses api.attributeValue for automatic prefix handling and inheritance support
-    function getWsAttribute(element, attrName) {
-        // Try colon variant first (hx-ws:connect) - prefix applied automatically by htmx
-        let colonValue = api.attributeValue(element, 'hx-ws:' + attrName);
-        if (colonValue != null) return colonValue;
-        
-        // Try hyphen variant for JSX (hx-ws-connect)
-        let hyphenValue = api.attributeValue(element, 'hx-ws-' + attrName);
-        if (hyphenValue != null) return hyphenValue;
-        
-        // For 'send', also check plain 'hx-ws' (marker attribute)
-        if (attrName === 'send') {
-            let plainValue = api.attributeValue(element, 'hx-ws');
-            if (plainValue != null) return plainValue;
-        }
-        
-        return null;
-    }
-    
-    // Helper to check if element has WebSocket attribute (any variant)
-    function hasWsAttribute(element, attrName) {
-        let value = getWsAttribute(element, attrName);
-        return value !== null && value !== undefined;
-    }
-    
-    // Build selector for WS attributes
-    function buildWsSelector(attrName) {
-        let mc = htmx.config.metaCharacter || ':';
-        let mcAttr = buildAttrName(mc + attrName);
-        let hyphenAttr = buildAttrName('-' + attrName);
-        return `[${CSS.escape(mcAttr)}],[${hyphenAttr}]`;
-    }
-    
+
+
     // ========================================
     // CONFIGURATION
     // ========================================
     
-    function getConfig() {
+    function getConfig(element) {
         const defaults = {
             reconnect: true,
-            reconnectDelay: 1000,
-            reconnectMaxDelay: 30000,
-            reconnectJitter: true,
-            // Note: closeOnHide is NOT implemented for WebSockets. Reconnection continues in background tabs.
-            // To implement visibility-aware behavior, listen for htmx:ws:reconnect and cancel if needed.
-            pendingRequestTTL: 30000  // TTL for pending requests in ms
+            reconnectDelay: 500,
+            reconnectMaxDelay: 60000,
+            reconnectMaxAttempts: Infinity,
+            reconnectJitter: 0.3,
+            pauseOnBackground: true,
+            pendingRequestTTL: 30000
         };
-        return { ...defaults, ...(htmx.config.websockets || {}) };
+        let global = htmx.config.ws || {};
+        let perElement = {};
+        if (element) {
+            let ctx = api.createRequestContext(element, new CustomEvent('_'));
+            perElement = ctx.request.ws || {};
+        }
+        let merged = { ...defaults, ...global, ...perElement };
+
+        // Backwards compat: boolean reconnectJitter (old API used true/false)
+        if (typeof merged.reconnectJitter === 'boolean') {
+            merged.reconnectJitter = merged.reconnectJitter ? 0.3 : 0;
+        }
+
+        return merged;
     }
     
     // ========================================
@@ -73,7 +47,7 @@
         if (url.startsWith('ws://') || url.startsWith('wss://')) {
             return url;
         }
-        
+
         // Convert http(s):// to ws(s)://
         if (url.startsWith('http://')) {
             return 'ws://' + url.slice(7);
@@ -81,8 +55,8 @@
         if (url.startsWith('https://')) {
             return 'wss://' + url.slice(8);
         }
-        
-        // Relative URL - build absolute ws(s):// URL based on current location
+
+        // Relative URL - build absolute ws(s):// URL
         let protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
         let host = window.location.host;
         
@@ -102,436 +76,399 @@
     }
     
     // ========================================
-    // CONNECTION REGISTRY
+    // CONNECTIONS
     // ========================================
     
-    const connectionRegistry = new Map();
+    const connections = new Map();
     
     function getOrCreateConnection(url, element) {
         let normalizedUrl = normalizeWebSocketUrl(url);
-        
-        if (connectionRegistry.has(normalizedUrl)) {
-            let entry = connectionRegistry.get(normalizedUrl);
-            entry.refCount++;
-            entry.elements.add(element);
-            return entry;
+
+        if (connections.has(normalizedUrl)) {
+            return connections.get(normalizedUrl);
         }
-        
-        // Create entry but DON'T add to registry yet - wait for before:ws:connect
-        let entry = {
+
+        let connection = {
             url: normalizedUrl,
+            config: getConfig(element),
             socket: null,
-            refCount: 1,
-            elements: new Set([element]),
-            reconnectAttempts: 0,
-            reconnectTimer: null,
-            pendingRequests: new Map(),
-            listeners: {}  // Store listener references for proper cleanup
+            attempt: 0,
+            timer: null,
+            pendingRequests: new Map(),       //            abortController: null,
+            visibilityHandler: null,
+            cancelled: false
         };
-        
-        // Fire cancelable event BEFORE storing in registry
-        if (!triggerEvent(element, 'htmx:before:ws:connect', { url: normalizedUrl })) {
-            // Event was cancelled - don't create connection or store entry
+
+        if (!api.triggerHtmxEvent(element, 'htmx:before:ws:connection', {connection}) || connection.cancelled) {
+            api.triggerHtmxEvent(element, 'htmx:ws:close', {
+                connection, reason: 'cancelled', code: null
+            });
             return null;
         }
-        
+
         // Event passed - now store in registry and create socket
-        connectionRegistry.set(normalizedUrl, entry);
-        createWebSocket(normalizedUrl, entry);
-        return entry;
+        connections.set(normalizedUrl, connection);
+        createWebSocket(normalizedUrl, connection);
+
+        let config = connection.config;
+        if (config.pauseOnBackground) {
+            connection.visibilityHandler = () => {
+                if (document.hidden) {
+                    if (connection.socket && connection.socket.readyState === WebSocket.OPEN) {
+                        connection.socket.close();
+                    }
+                } else if (!connection.socket || connection.socket.readyState === WebSocket.CLOSED) {
+                    connection.attempt = 0;
+                    createWebSocket(normalizedUrl, connection);
+                }
+            };
+            document.addEventListener('visibilitychange', connection.visibilityHandler);
+        }
+
+        return connection;
     }
     
-    function createWebSocket(url, entry) {
-        let firstElement = entry.elements.values().next().value;
-        
-        // Close and remove listeners from old socket properly
-        if (entry.socket) {
-            let oldSocket = entry.socket;
-            entry.socket = null;
-            
-            // Remove listeners using stored references
-            if (entry.listeners.open) oldSocket.removeEventListener('open', entry.listeners.open);
-            if (entry.listeners.message) oldSocket.removeEventListener('message', entry.listeners.message);
-            if (entry.listeners.close) oldSocket.removeEventListener('close', entry.listeners.close);
-            if (entry.listeners.error) oldSocket.removeEventListener('error', entry.listeners.error);
-            
+    function findConnectedElement(url) {
+        let sel = wsSelector('connect') + ',' + wsSelector('send');
+        for (let el of document.querySelectorAll(sel)) {
+            if (el._htmx?.ws?.url === url) return el;
+        }
+        return null;
+    }
+
+    // Close and fully clean up an orphaned connection (no owning element in DOM)
+    function cleanupOrphanedConnection(url, connection) {
+        if (connection.timer) clearTimeout(connection.timer);
+        if (connection.visibilityHandler) {
+            document.removeEventListener('visibilitychange', connection.visibilityHandler);
+        }
+        if (connection.abortController) {
+            connection.abortController.abort();
+        }
+        connection.pendingRequests.clear();
+        if (connection.socket) {
+            try {
+                if (connection.socket.readyState === WebSocket.OPEN || connection.socket.readyState === WebSocket.CONNECTING) {
+                    connection.socket.close();
+                }
+            } catch (e) {
+                // Socket may already be in an invalid state
+            }
+        }
+        connections.delete(url);
+    }
+
+    function createWebSocket(url, connection) {
+        // Abort old socket's listeners and close it
+        if (connection.abortController) {
+            connection.abortController.abort();
+        }
+        if (connection.socket) {
+            let oldSocket = connection.socket;
+            connection.socket = null;
             try {
                 if (oldSocket.readyState === WebSocket.OPEN || oldSocket.readyState === WebSocket.CONNECTING) {
                     oldSocket.close();
                 }
-            } catch (e) {}
-        }
-        
-        try {
-            entry.socket = new WebSocket(url);
-            
-            // Create and store listener references
-            entry.listeners.open = () => {
-                // Reset reconnect attempts on successful connection
-                entry.reconnectAttempts = 0;
-                
-                if (firstElement) {
-                    triggerEvent(firstElement, 'htmx:after:ws:connect', { url, socket: entry.socket });
-                }
-            };
-            
-            entry.listeners.message = (event) => {
-                handleMessage(entry, event);
-            };
-            
-            entry.listeners.close = (event) => {
-                // Check if this socket is still the active one
-                if (event.target !== entry.socket) return;
-                
-                if (firstElement) {
-                    triggerEvent(firstElement, 'htmx:ws:close', { 
-                        url, 
-                        code: event.code,
-                        reason: event.reason 
-                    });
-                }
-                
-                // Check if entry is still valid (not cleared)
-                if (!connectionRegistry.has(url)) return;
-                
-                let config = getConfig();
-                if (config.reconnect && entry.refCount > 0) {
-                    scheduleReconnect(url, entry);
-                } else {
-                    cleanupPendingRequests(entry);
-                    connectionRegistry.delete(url);
-                }
-            };
-            
-            entry.listeners.error = (error) => {
-                if (firstElement) {
-                    triggerEvent(firstElement, 'htmx:ws:error', { url, error });
-                }
-            };
-            
-            // Add listeners
-            entry.socket.addEventListener('open', entry.listeners.open);
-            entry.socket.addEventListener('message', entry.listeners.message);
-            entry.socket.addEventListener('close', entry.listeners.close);
-            entry.socket.addEventListener('error', entry.listeners.error);
-            
-        } catch (error) {
-            if (firstElement) {
-                triggerEvent(firstElement, 'htmx:ws:error', { url, error });
+            } catch (e) {
+                // Socket may already be in an invalid state
             }
+        }
+
+        try {
+            connection.socket = new WebSocket(url);
+            let ac = new AbortController();
+            connection.abortController = ac;
+            let opts = { signal: ac.signal };
+
+            connection.socket.addEventListener('open', () => {
+                let elt = findConnectedElement(url);
+                if (elt) {
+                    api.triggerHtmxEvent(elt, 'htmx:after:ws:connection', {connection});
+                } else {
+                    // Element was removed while connecting — orphaned socket
+                    cleanupOrphanedConnection(url, connection);
+                    return;
+                }
+                connection.attempt = 0;
+            }, opts);
+
+            connection.socket.addEventListener('message', (event) => {
+                handleMessage(connection, event);
+            }, opts);
+
+            connection.socket.addEventListener('close', (event) => {
+                if (event.target !== connection.socket) return;
+
+                let elt = findConnectedElement(url);
+                if (elt) api.triggerHtmxEvent(elt, 'htmx:ws:close', {
+                    connection, reason: 'closed', code: event.code
+                });
+
+                if (!connections.has(url)) return;
+
+                let config = connection.config;
+                if (config.pauseOnBackground && document.hidden) return;
+
+                if (config.reconnect && findConnectedElement(url)) {
+                    scheduleReconnect(url, connection);
+                } else {
+                    // No element or reconnect disabled — full cleanup
+                    cleanupOrphanedConnection(url, connection);
+                }
+            }, opts);
+
+            connection.socket.addEventListener('error', (error) => {
+                let elt = findConnectedElement(url);
+                if (elt) api.triggerHtmxEvent(elt, 'htmx:ws:error', { url, error });
+            }, opts);
+
+        } catch (error) {
+            let elt = findConnectedElement(url);
+            if (elt) api.triggerHtmxEvent(elt, 'htmx:ws:error', { url, error });
         }
     }
     
-    function scheduleReconnect(url, entry) {
-        let config = getConfig();
-        
-        // Increment attempts FIRST, then calculate delay
-        entry.reconnectAttempts++;
-        let attempts = entry.reconnectAttempts;
-        
-        let delay = Math.min(
-            (config.reconnectDelay || 1000) * Math.pow(2, attempts - 1),
-            config.reconnectMaxDelay || 30000
-        );
-        
-        if (config.reconnectJitter) {
-            delay = delay * (0.75 + Math.random() * 0.5);
+    function scheduleReconnect(url, connection) {
+        let config = connection.config;
+
+        connection.attempt++;
+        let attempt = connection.attempt;
+
+        if (!config.reconnect || attempt > config.reconnectMaxAttempts) {
+            cleanupOrphanedConnection(url, connection);
+            return;
         }
-        
-        entry.reconnectTimer = setTimeout(() => {
-            if (entry.refCount > 0) {
-                let firstElement = entry.elements.values().next().value;
-                if (firstElement) {
-                    // attempts now means "this is attempt number N"
-                    triggerEvent(firstElement, 'htmx:ws:reconnect', { url, attempts });
-                }
-                createWebSocket(url, entry);
+
+        let baseDelay = htmx.parseInterval(config.reconnectDelay) ?? config.reconnectDelay;
+        let maxDelay = htmx.parseInterval(config.reconnectMaxDelay) ?? config.reconnectMaxDelay;
+
+        let delay = Math.min(
+            baseDelay * Math.pow(2, attempt - 1),
+            maxDelay
+        );
+
+        if (config.reconnectJitter > 0) {
+            let jitterRange = delay * config.reconnectJitter;
+            delay = Math.max(0, delay + (Math.random() * 2 - 1) * jitterRange);
+        }
+
+        let elt = findConnectedElement(url);
+        if (elt) {
+            connection.cancelled = false;
+            if (!api.triggerHtmxEvent(elt, 'htmx:before:ws:connection', {connection}) || connection.cancelled) {
+                api.triggerHtmxEvent(elt, 'htmx:ws:close', {
+                    connection, reason: 'cancelled', code: null
+                });
+                cleanupOrphanedConnection(url, connection);
+                return;
+            }
+        } else {
+            // Element gone — no point scheduling reconnect
+            cleanupOrphanedConnection(url, connection);
+            return;
+        }
+
+        connection.timer = setTimeout(() => {
+            if (findConnectedElement(url)) {
+                createWebSocket(url, connection);
+            } else {
+                cleanupOrphanedConnection(url, connection);
             }
         }, delay);
     }
     
-    function decrementRef(url, element) {
-        // Try both original and normalized URL
-        let normalizedUrl = normalizeWebSocketUrl(url);
-        
-        if (!connectionRegistry.has(normalizedUrl)) return;
-        
-        let entry = connectionRegistry.get(normalizedUrl);
-        entry.elements.delete(element);
-        entry.refCount--;
-        
-        if (entry.refCount <= 0) {
-            if (entry.reconnectTimer) {
-                clearTimeout(entry.reconnectTimer);
-            }
-            cleanupPendingRequests(entry);
-            if (entry.socket && entry.socket.readyState === WebSocket.OPEN) {
-                entry.socket.close();
-            }
-            connectionRegistry.delete(normalizedUrl);
+    function closeConnection(url, element) {
+        let connection = connections.get(url);
+        if (!connection) return;
+
+        if (connection.timer) clearTimeout(connection.timer);
+        if (connection.visibilityHandler) {
+            document.removeEventListener('visibilitychange', connection.visibilityHandler);
         }
+        if (connection.abortController) {
+            connection.abortController.abort();
+        }
+        connection.pendingRequests.clear();
+        api.triggerHtmxEvent(element, 'htmx:ws:close', {
+            connection, reason: 'removed', code: null
+        });
+        if (connection.socket && connection.socket.readyState === WebSocket.OPEN) {
+            connection.socket.close();
+        }
+        connections.delete(url);
     }
     
     // ========================================
-    // PENDING REQUEST MANAGEMENT
-    // ========================================
+    // PENDING REQUEST MANAGEMENT    // ========================================
     
-    function cleanupPendingRequests(entry) {
-        entry.pendingRequests.clear();
-    }
-    
-    function cleanupExpiredRequests(entry) {
-        let config = getConfig();
+    function cleanupExpiredRequests(connection) {
+        let config = connection.config;
         let now = Date.now();
-        let ttl = config.pendingRequestTTL || 30000;
-        
-        for (let [requestId, pending] of entry.pendingRequests) {
-            if (now - pending.timestamp > ttl) {
-                entry.pendingRequests.delete(requestId);
+        let timeout = config.pendingRequestTTL || 30000;
+
+        for (let [requestId, pending] of connection.pendingRequests) {
+            if (now - pending.timestamp > timeout) {
+                connection.pendingRequests.delete(requestId);
             }
         }
     }
     
     // ========================================
-    // MESSAGE SENDING
+    // REQUESTS
     // ========================================
-    
-    // Check if a value looks like a URL (vs a boolean marker like "" or "true")
-    function looksLikeUrl(value) {
-        if (!value) return false;
-        // Check for URL-like patterns: paths, protocols, protocol-relative
-        return value.startsWith('/') || 
-               value.startsWith('.') ||
-               value.startsWith('ws:') || 
-               value.startsWith('wss:') || 
-               value.startsWith('http:') || 
-               value.startsWith('https:') ||
-               value.startsWith('//');
-    }
-    
-    async function sendMessage(element, event) {
-        // Find connection URL
-        let url = getWsAttribute(element, 'send');
-        if (!looksLikeUrl(url)) {
-            // Value is empty, "true", or other non-URL marker - look for ancestor connection
-            let selector = buildWsSelector('connect');
-            let ancestor = element.closest(selector);
-            if (ancestor) {
-                url = getWsAttribute(ancestor, 'connect');
-            } else {
-                url = null;
-            }
-        }
-        
+
+    async function sendRequest(element, event) {
+        // hx-ws:send="/url" creates its own connection; hx-ws:send (no value) uses ancestor's
+        let sendAttr = api.attributeValue(element, 'hx-ws:send');
+        let url = (sendAttr && sendAttr !== 'true') ? sendAttr : null;
         if (!url) {
-            // Emit error event instead of console.error
-            triggerEvent(element, 'htmx:wsSendError', { 
-                element, 
-                error: 'No WebSocket connection found for element' 
+            let ancestor = element.closest(wsSelector('connect'));
+            if (ancestor) {
+                url = api.attributeValue(ancestor, 'hx-ws:connect');
+            }
+        }
+
+        if (!url) {
+            api.triggerHtmxEvent(element, 'htmx:ws:error', {
+                url: null, error: 'No WebSocket connection found for element'
             });
             return;
         }
-        
+
         let normalizedUrl = normalizeWebSocketUrl(url);
-        let entry = connectionRegistry.get(normalizedUrl);
-        if (!entry || !entry.socket || entry.socket.readyState !== WebSocket.OPEN) {
-            triggerEvent(element, 'htmx:wsSendError', { url: normalizedUrl, error: 'Connection not open' });
+        let connection = connections.get(normalizedUrl);
+        if (!connection || !connection.socket || connection.socket.readyState !== WebSocket.OPEN) {
+            api.triggerHtmxEvent(element, 'htmx:ws:error', { url: normalizedUrl, error: 'Connection not open' });
             return;
         }
-        
-        // Cleanup expired pending requests periodically
-        cleanupExpiredRequests(entry);
-        
-        // Build message
+
+        // [Correlation] Cleanup expired pending requests periodically
+        cleanupExpiredRequests(connection);
+
+        // Build headers using core's request context (same as HTTP requests)
+        let ctx = api.createRequestContext(element, event);
+        let headers = {...ctx.request.headers};
+        delete headers['Accept'];
+
+        // [Correlation] Add request ID as a header
+        let requestId = crypto.randomUUID();
+        headers['HX-Request-ID'] = requestId;
+
+        // Build body from form data
         let form = element.form || element.closest('form');
-        let body = api.collectFormData(element, form, event.submitter);
-        
-        let values = {};
-        for (let [key, value] of body) {
-            if (key in values) {
-                values[key] = [].concat(values[key], value);
+        let formData = api.collectFormData(element, form, event.submitter);
+        let valsResult = api.getAttributeObject(element, 'hx-vals', obj => {
+            for (let key in obj) formData.set(key, obj[key]);
+        });
+        if (valsResult) await valsResult;
+
+        // Preserve multi-value form fields (checkboxes, multi-selects)
+        let body = {};
+        for (let [key, value] of formData) {
+            if (key in body) {
+                if (!Array.isArray(body[key])) {
+                    body[key] = [body[key]];
+                }
+                body[key].push(value);
             } else {
-                values[key] = value;
+                body[key] = value;
             }
         }
-        
-        // Merge hx-vals with original types preserved
-        let valsResult = api.getAttributeObject(element, 'hx-vals', obj => Object.assign(values, obj));
-        if (valsResult) await valsResult;
-        
-        // Build headers object
-        let headers = {
-            'HX-Request': 'true',
-            'HX-Current-URL': window.location.href
-        };
-        if (element.id) {
-            headers['HX-Trigger'] = element.id;
-        }
-        let targetAttr = api.attributeValue(element, 'hx-target');
-        if (targetAttr) {
-            headers['HX-Target'] = targetAttr;
-        }
-        
-        let requestId = generateUUID();
-        let message = {
-            type: 'request',
-            request_id: requestId,
-            event: event.type,
-            headers: headers,
-            values: values,
-            path: normalizedUrl
-        };
-        
-        if (element.id) {
-            message.id = element.id;
-        }
-        
-        // Allow modification via event - use 'data' as documented
-        let detail = { data: message, element, url: normalizedUrl };
-        if (!triggerEvent(element, 'htmx:before:ws:send', detail)) {
+
+        let detail = { headers, body };
+        if (!api.triggerHtmxEvent(element, 'htmx:before:ws:request', detail)) {
             return;
         }
-        
+
         try {
-            entry.socket.send(JSON.stringify(detail.data));
-            
-            // Store pending request for response matching
-            entry.pendingRequests.set(requestId, { element, timestamp: Date.now() });
-            
-            triggerEvent(element, 'htmx:after:ws:send', { data: detail.data, url: normalizedUrl });
+            connection.socket.send(JSON.stringify(detail));
+
+            // [Correlation] Store pending request for response matching
+            connection.pendingRequests.set(requestId, { element, timestamp: Date.now() });
+
+            api.triggerHtmxEvent(element, 'htmx:after:ws:request', detail);
         } catch (error) {
-            triggerEvent(element, 'htmx:wsSendError', { url: normalizedUrl, error });
+            api.triggerHtmxEvent(element, 'htmx:ws:error', { url: normalizedUrl, error });
         }
-    }
-    
-    function generateUUID() {
-        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-            let r = Math.random() * 16 | 0;
-            let v = c === 'x' ? r : (r & 0x3 | 0x8);
-            return v.toString(16);
-        });
     }
     
     // ========================================
     // MESSAGE RECEIVING & ROUTING
     // ========================================
     
-    function handleMessage(entry, event) {
-        let envelope;
+    function handleMessage(connection, event) {
+        let json = null;
         try {
-            envelope = JSON.parse(event.data);
+            json = JSON.parse(event.data);
         } catch (e) {
-            // Not JSON - treat as raw HTML
-            let firstElement = entry.elements.values().next().value;
-            if (firstElement) {
-                handleRawMessage(firstElement, event.data);
+            // Not JSON - will be treated as raw HTML below
+        }
+
+        // [Correlation] Cleanup expired pending requests on every message
+        cleanupExpiredRequests(connection);
+
+        // [Correlation] Match response to originating element, or fall back to first subscriber
+        let connectionElement = null;
+        let requestId = json?.['HX-Request-ID'] || json?.request_id;
+        if (requestId && connection.pendingRequests.has(requestId)) {
+            connectionElement = connection.pendingRequests.get(requestId).element;
+            connection.pendingRequests.delete(requestId);
+            // If the correlated element has been removed from the DOM, fall back
+            if (!connectionElement.isConnected) {
+                connectionElement = findConnectedElement(connection.url);
             }
+        } else {
+            connectionElement = findConnectedElement(connection.url);
+        }
+
+        if (!connectionElement) {
+            // No element in DOM for this connection — orphan cleanup
+            cleanupOrphanedConnection(connection.url, connection);
             return;
         }
-        
-        // Apply defaults for channel and format
-        envelope.channel = envelope.channel || 'ui';
-        envelope.format = envelope.format || 'html';
-        
-        // Find target element for this message
-        let targetElement = null;
-        if (envelope.request_id && entry.pendingRequests.has(envelope.request_id)) {
-            targetElement = entry.pendingRequests.get(envelope.request_id).element;
-            entry.pendingRequests.delete(envelope.request_id);
-        } else {
-            // Use first element in the connection
-            targetElement = entry.elements.values().next().value;
-        }
-        
-        // Emit before:message event (cancelable)
-        if (!triggerEvent(targetElement, 'htmx:before:ws:message', { envelope, element: targetElement })) {
+
+        let detail = {
+            message: { text: event.data, json, cancelled: false }
+        };
+
+        if (!api.triggerHtmxEvent(connectionElement, 'htmx:before:ws:message', detail) || detail.message.cancelled) {
             return;
         }
-        
-        // Route based on channel
-        if (envelope.channel === 'ui' && envelope.format === 'html') {
-            handleHtmlMessage(targetElement, envelope);
+
+        // JSON with 'content' or 'payload' field: swap the HTML
+        // Raw (non-JSON) string: swap the entire string as HTML
+        // JSON without 'content'/'payload': data-only message, no swap (handle via events)
+        let html;
+        if (detail.message.json) {
+            if (detail.message.json.content !== undefined) {
+                html = detail.message.json.content;
+            } else if (detail.message.json.payload !== undefined) {
+                html = detail.message.json.payload; // backwards compat
+                // Warn once per connection (not on every message)
+                if (!connection._payloadWarnFired) {
+                    console.warn('[htmx-ws] json.payload is deprecated, use json.content instead');
+                    connection._payloadWarnFired = true;
+                }
+            }
         } else {
-            // Any non-ui/html message emits htmx:wsMessage for application handling
-            // This is extensible - apps can handle json, audio, binary, custom channels, etc.
-            triggerEvent(targetElement, 'htmx:wsMessage', { ...envelope, element: targetElement });
+            html = detail.message.text;
         }
-        
-        triggerEvent(targetElement, 'htmx:after:ws:message', { envelope, element: targetElement });
-    }
-    
-    // ========================================
-    // RAW (NON-JSON) MESSAGE HANDLING
-    // ========================================
+        if (html != null) {
+            let target = detail.message.json?.target || api.attributeValue(connectionElement, 'hx-target');
+            let swap = detail.message.json?.swap || api.attributeValue(connectionElement, 'hx-swap');
 
-    function handleRawMessage(element, data) {
-        // Fire cancelable event - allows custom handling of non-JSON messages
-        if (!triggerEvent(element, 'htmx:ws:rawMessage', { data: data })) {
-            return;  // Event cancelled - developer handles it
+            htmx.swap({
+                sourceElement: connectionElement,
+                target: target || connectionElement,
+                swap: swap || (target ? htmx.config.defaultSwap : 'none'),
+                text: html,
+                transition: false
+            });
         }
 
-        // Default behavior: swap as raw HTML
-        let target = resolveTarget(element, null);
-        let targetSelector = api.attributeValue(element, 'hx-target');
-
-        // If no explicit hx-target, use swap:none so we don't wipe the
-        // connection element — but partials in the payload can still
-        // target their own destinations
-        let swapStyle = targetSelector
-            ? (api.attributeValue(element, 'hx-swap') || htmx.config.defaultSwap)
-            : 'none';
-
-        htmx.swap({
-            sourceElement: element,
-            target: target,
-            swap: swapStyle,
-            text: data,
-            transition: false
-        });
-    }
-
-    // ========================================
-    // HTML PARTIAL HANDLING - Using htmx.swap(ctx)
-    // ========================================
-    
-    function handleHtmlMessage(element, envelope) {
-        let target = resolveTarget(element, envelope.target);
-        let swapStyle = envelope.swap || api.attributeValue(element, 'hx-swap') || htmx.config.defaultSwap;
-        
-        // Always call swap even if target is null - partials in payload may have their own targets
-        htmx.swap({
-            sourceElement: element,
-            target: target,
-            swap: swapStyle,
-            text: envelope.payload || '',
-            transition: false
-        });
-    }
-    
-    function resolveTarget(element, envelopeTarget) {
-        if (envelopeTarget) {
-            if (envelopeTarget === 'this') {
-                return element;
-            }
-            return document.querySelector(envelopeTarget);
-        }
-        let targetSelector = api.attributeValue(element, 'hx-target');
-        if (targetSelector) {
-            if (targetSelector === 'this') {
-                return element;
-            }
-            return document.querySelector(targetSelector);
-        }
-        return element;
-    }
-    
-    // ========================================
-    // EVENT HELPERS
-    // ========================================
-    
-    function triggerEvent(element, eventName, detail = {}) {
-        if (!element) return true;
-        return api.triggerHtmxEvent(element, eventName, detail);
+        delete detail.message.cancelled;
+        api.triggerHtmxEvent(connectionElement, 'htmx:after:ws:message', detail);
     }
     
     // ========================================
@@ -539,108 +476,57 @@
     // ========================================
     
     function initializeElement(element) {
-        if (element._htmx?.wsInitialized) return;
+        api.htmxProp(element).ws ??= {};
+        if (element._htmx.ws.initialized) return;
 
-        let connectUrl = getWsAttribute(element, 'connect');
+        let connectUrl = api.attributeValue(element, 'hx-ws:connect');
         if (!connectUrl) return;
 
-        api.htmxProp(element).wsInitialized = true;
-        
-        let triggerSpec = api.attributeValue(element, 'hx-trigger');
-        
-        if (!triggerSpec) {
-            // No trigger specified - connect immediately (default behavior)
-            // This is the most common use case: connect when element appears
-            let entry = getOrCreateConnection(connectUrl, element);
-            if (entry) {
-                element._htmx.wsUrl = entry.url;
+        let specString = api.attributeValue(element, 'hx-trigger') || 'load';
+        api.onTrigger(element, specString, () => {
+            if (element._htmx?.ws?.url) return;
+            let connection = getOrCreateConnection(connectUrl, element);
+            if (connection) {
+                element._htmx.ws.url = connection.url;
             }
-        } else {
-            // Connect based on explicit trigger
-            // Note: We only support bare event names for connection triggers.
-            // Modifiers like once, delay, throttle, from, target are NOT supported
-            // for connection establishment. Use htmx:before:ws:connect event for
-            // custom connection control logic.
-            let specs = api.parseTriggerSpecs(triggerSpec);
-            if (specs.length > 0) {
-                let spec = specs[0];
-                if (spec.name === 'load') {
-                    // Explicit load trigger - connect immediately
-                    let entry = getOrCreateConnection(connectUrl, element);
-                    if (entry) {
-                        element._htmx.wsUrl = entry.url;
-                    }
-                } else {
-                    // Set up event listener for other triggers (bare event name only)
-                    element.addEventListener(spec.name, () => {
-                        if (!element._htmx?.wsUrl) {
-                            let entry = getOrCreateConnection(connectUrl, element);
-                            if (entry) {
-                                element._htmx.wsUrl = entry.url;
-                            }
-                        }
-                    }, { once: true });
-                }
-            }
-        }
+        });
+        element._htmx.ws.initialized = true;
     }
     
     function initializeSendElement(element) {
-        if (element._htmx?.wsSendInitialized) return;
+        api.htmxProp(element).ws ??= {};
+        if (element._htmx.ws.sendInitialized) return;
 
-        let sendAttr = getWsAttribute(element, 'send');
-        // Only treat as URL if it looks like one (not "", "true", etc.)
-        let sendUrl = looksLikeUrl(sendAttr) ? sendAttr : null;
-        let triggerSpec = api.attributeValue(element, 'hx-trigger');
-        
-        if (!triggerSpec) {
-            // Default trigger based on element type
-            triggerSpec = element.matches('form') ? 'submit' :
+        let sendAttr = api.attributeValue(element, 'hx-ws:send');
+        let sendUrl = (sendAttr && sendAttr !== 'true') ? sendAttr : null;
+        let specString = api.attributeValue(element, 'hx-trigger');
+        if (!specString) {
+            specString = element.matches('form') ? 'submit' :
                          element.matches('input:not([type=button]),select,textarea') ? 'change' :
                          'click';
         }
-        
-        // Note: We only support bare event names for send triggers.
-        // Modifiers like once, delay, throttle, from, target are NOT supported.
-        // For complex trigger logic, use htmx:before:ws:send to implement custom behavior.
-        let specs = api.parseTriggerSpecs(triggerSpec);
-        if (specs.length > 0) {
-            let spec = specs[0];
-            
-            let handler = async (evt) => {
-                // Prevent default for forms
-                if (element.matches('form') && evt.type === 'submit') {
-                    evt.preventDefault();
+
+        api.onTrigger(element, specString, async (evt) => {
+            if (element.matches('form') && evt.type === 'submit') {
+                evt.preventDefault();
+            }
+            if (sendUrl && !element._htmx?.ws?.url) {
+                let connection = getOrCreateConnection(sendUrl, element);
+                if (connection) {
+                    element._htmx.ws.url = connection.url;
                 }
-                
-                // If this element has its own URL, ensure connection exists
-                if (sendUrl) {
-                    if (!element._htmx?.wsUrl) {
-                        let entry = getOrCreateConnection(sendUrl, element);
-                        if (entry) {
-                            element._htmx.wsUrl = entry.url;
-                        }
-                    }
-                }
-                
-                await sendMessage(element, evt);
-            };
-            
-            element.addEventListener(spec.name, handler);
-            let htmxProp = api.htmxProp(element);
-            htmxProp.wsSendInitialized = true;
-            htmxProp.wsSendHandler = handler;
-            htmxProp.wsSendEvent = spec.name;
-        }
+            }
+            await sendRequest(element, evt);
+        });
+        element._htmx.ws.sendInitialized = true;
     }
     
     function cleanupElement(element) {
-        if (element._htmx?.wsUrl) {
-            decrementRef(element._htmx.wsUrl, element);
-        }
-        
-        if (element._htmx?.wsSendHandler) {
-            element.removeEventListener(element._htmx.wsSendEvent, element._htmx.wsSendHandler);
+        let url = element._htmx?.ws?.url;
+        if (!url || !connections.has(url)) return;
+        element._htmx.ws.url = null;
+        if (!findConnectedElement(url)) {
+            closeConnection(url, element);
         }
     }
     
@@ -649,23 +535,21 @@
     // ========================================
     
     function checkLegacyAttributes(element) {
-        // Check for old ws-connect / ws-send attributes
         if (element.hasAttribute('ws-connect') || element.hasAttribute('ws-send')) {
-            console.warn('HTMX WebSocket: Legacy attributes ws-connect and ws-send are deprecated. Please use hx-ws:connect/hx-ws-connect and hx-ws:send/hx-ws-send instead.');
-            
-            // Map legacy attributes to new ones (prefer hyphen variant for broader compatibility)
+            console.warn('HTMX WebSocket: Legacy attributes ws-connect and ws-send are deprecated. Use hx-ws:connect and hx-ws:send instead.');
+
             if (element.hasAttribute('ws-connect')) {
                 let url = element.getAttribute('ws-connect');
-                let hyphenAttr = buildAttrName('-connect');
-                if (!element.hasAttribute(hyphenAttr)) {
-                    element.setAttribute(hyphenAttr, url);
+                let attr = (htmx.config.prefix || 'hx-') + 'ws' + (htmx.config.metaCharacter || ':') + 'connect';
+                if (!element.hasAttribute(attr)) {
+                    element.setAttribute(attr, url);
                 }
             }
-            
+
             if (element.hasAttribute('ws-send')) {
-                let hyphenAttr = buildAttrName('-send');
-                if (!element.hasAttribute(hyphenAttr)) {
-                    element.setAttribute(hyphenAttr, '');
+                let attr = (htmx.config.prefix || 'hx-') + 'ws' + (htmx.config.metaCharacter || ':') + 'send';
+                if (!element.hasAttribute(attr)) {
+                    element.setAttribute(attr, '');
                 }
             }
         }
@@ -680,37 +564,28 @@
             api = internalAPI;
             
             // Initialize default config if not set
-            if (!htmx.config.websockets) {
-                htmx.config.websockets = {};
+            if (!htmx.config.ws) {
+                htmx.config.ws = {};
             }
         },
         
         htmx_after_process: (element) => {
             const processNode = (node) => {
-                // Check for legacy attributes
                 checkLegacyAttributes(node);
-                
-                // Initialize WebSocket connection elements (check both variants)
-                if (hasWsAttribute(node, 'connect')) {
+
+                if (api.attributeValue(node, 'hx-ws:connect') != null) {
                     initializeElement(node);
                 }
-                
-                // Initialize send elements (check both variants)
-                if (hasWsAttribute(node, 'send')) {
+
+                if (api.attributeValue(node, 'hx-ws:send') != null) {
                     initializeSendElement(node);
                 }
             };
 
-            // Process the element itself
             processNode(element);
-            
-            // Process descendants - build proper selector respecting prefix
-            let connectSelector = buildWsSelector('connect');
-            let sendSelector = buildWsSelector('send');
-            let plainAttr = buildAttrName('');
-            let fullSelector = `${connectSelector},${sendSelector},[${plainAttr}],[ws-connect],[ws-send]`;
-            
-            element.querySelectorAll(fullSelector).forEach(processNode);
+
+            let sel = wsSelector('connect') + ',' + wsSelector('send') + ',[ws-connect],[ws-send]';
+            element.querySelectorAll(sel).forEach(processNode);
         },
         
         htmx_before_cleanup: (element) => {
@@ -718,31 +593,43 @@
         }
     });
     
-    // Expose registry for testing
+    // Expose connections for testing
     if (typeof window !== 'undefined' && window.htmx) {
+        // Clean up all WS connections on page navigation to prevent browser errors
+        window.addEventListener('pagehide', () => {
+            connections.forEach((connection) => {
+                if (connection.socket) {
+                    connection.socket.close(1001, 'page navigating away');
+                }
+            });
+        });
+
         window.htmx.ext = window.htmx.ext || {};
         window.htmx.ext.ws = {
             getRegistry: () => ({
                 clear: () => {
-                    let entries = Array.from(connectionRegistry.values());
-                    connectionRegistry.clear(); // Clear first to prevent reconnects
-                    
-                    entries.forEach(entry => {
-                        entry.refCount = 0; // Prevent pending timeouts from reconnecting
-                        if (entry.reconnectTimer) {
-                            clearTimeout(entry.reconnectTimer);
+                    let activeConnections = Array.from(connections.values());
+                    connections.clear(); // Clear first to prevent reconnects
+
+                    activeConnections.forEach(connection => {
+                        if (connection.timer) {
+                            clearTimeout(connection.timer);
                         }
-                        if (entry.socket) {
-                            // Remove listeners if possible or just close
-                            entry.socket.close();
+                        if (connection.visibilityHandler) {
+                            document.removeEventListener('visibilitychange', connection.visibilityHandler);
                         }
-                        entry.elements.clear();
-                        entry.pendingRequests.clear();
+                        if (connection.abortController) {
+                            connection.abortController.abort();
+                        }
+                        if (connection.socket) {
+                            connection.socket.close();
+                        }
+                        connection.pendingRequests.clear();
                     });
                 },
-                get: (key) => connectionRegistry.get(normalizeWebSocketUrl(key)),
-                has: (key) => connectionRegistry.has(normalizeWebSocketUrl(key)),
-                size: connectionRegistry.size
+                get: (key) => connections.get(normalizeWebSocketUrl(key)),
+                has: (key) => connections.has(normalizeWebSocketUrl(key)),
+                get size() { return connections.size; }
             })
         };
     }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -366,6 +366,10 @@ var htmx = (() => {
                 this.__mergeConfig(sourceElement._htmx.boosted, ctx);
             }
             ctx.target = this.__resolveTarget(sourceElement, ctx.target);
+            ctx.request.headers["HX-Request-Type"] = (ctx.target === document.body || ctx.select) ? "full" : "partial";
+            if (ctx.target) {
+                ctx.request.headers["HX-Target"] = this.__buildIdentifier(ctx.target);
+            }
 
             // Apply hx-config overrides
             let configAttr = this.__attributeValue(sourceElement, "hx-config");
@@ -450,12 +454,6 @@ var htmx = (() => {
             // Handle dynamic headers
             let headersResult = this.__handleHxHeaders(elt, ctx.request.headers)
             if (headersResult) await headersResult  // Only await if it returned a promise
-
-            // Add HX-Request-Type and HX-Target headers
-            ctx.request.headers["HX-Request-Type"] = (ctx.target === document.body || ctx.select) ? "full" : "partial";
-            if (ctx.target) {
-                ctx.request.headers["HX-Target"] = this.__buildIdentifier(ctx.target);
-            }
 
             // Setup event-dependent request details
             Object.assign(ctx.request, {

--- a/test/manual/WS_README.md
+++ b/test/manual/WS_README.md
@@ -106,13 +106,13 @@ Send multiple updates in one message:
 The extension respects these config options:
 
 ```javascript
-htmx.config.websockets = {
+htmx.config.ws = {
     reconnect: true,              // Auto-reconnect on disconnect
-    reconnectDelay: 1000,         // Initial delay (ms)
-    reconnectMaxDelay: 30000,     // Max delay (ms)
-    reconnectJitter: true,        // Add randomness to delays
-    autoConnect: false,           // Connect without hx-trigger
-    closeOnHide: true              // Close stream when tab is hidden
+    reconnectDelay: 500,          // Initial delay (ms)
+    reconnectMaxDelay: 60000,     // Max delay (ms)
+    reconnectMaxAttempts: Infinity,// Max reconnect attempts
+    reconnectJitter: 0.3,         // Jitter factor (0-1)
+    pauseOnBackground: true       // Pause connection when tab is backgrounded
 };
 ```
 
@@ -160,10 +160,9 @@ htmx.config.websockets = {
 ## 🐛 Debugging
 
 The demo includes a live event log that shows:
-- Connection events (`htmx:before:ws:connect`, `htmx:after:ws:connect`)
+- Connection events (`htmx:before:ws:connection`, `htmx:after:ws:connection`)
 - Message events (`htmx:before:ws:send`, `htmx:after:ws:message`)
 - Error events (`htmx:ws:error`, `htmx:ws:close`)
-- Reconnection attempts (`htmx:ws:reconnect`)
 
 ## 🤝 Contributing
 

--- a/test/manual/ws.html
+++ b/test/manual/ws.html
@@ -385,11 +385,16 @@
         }
 
         // Listen to WebSocket events
-        document.addEventListener('htmx:before:ws:connect', (e) => {
-            logEvent('CONNECT', `Connecting to ${e.detail.url}`);
+        document.addEventListener('htmx:before:ws:connection', (e) => {
+            let attempt = e.detail.connection.attempt;
+            if (attempt === 0) {
+                logEvent('CONNECT', `Connecting to ${e.detail.connection.url}`);
+            } else {
+                logEvent('RECONNECT', `Attempting reconnection (attempt ${attempt})`);
+            }
         });
 
-        document.addEventListener('htmx:after:ws:connect', (e) => {
+        document.addEventListener('htmx:after:ws:connection', (e) => {
             logEvent('CONNECTED', `Connected to ${e.detail.url}`);
         });
 
@@ -399,10 +404,6 @@
 
         document.addEventListener('htmx:ws:error', (e) => {
             logEvent('ERROR', `WebSocket error: ${e.detail.url}`);
-        });
-
-        document.addEventListener('htmx:ws:reconnect', (e) => {
-            logEvent('RECONNECT', `Attempting reconnection (attempt ${e.detail.attempts + 1})`);
         });
 
         document.addEventListener('htmx:before:ws:send', (e) => {

--- a/test/tests/ext/hx-sse.js
+++ b/test/tests/ext/hx-sse.js
@@ -67,12 +67,10 @@ describe('hx-sse SSE extension', function() {
         createProcessedHTML('<button hx-get="/reconnect" hx-config="sse.reconnect:true sse.reconnectDelay:50ms sse.reconnectMaxAttempts:3 sse.reconnectJitter:0" hx-swap="innerHTML">Connect</button>');
 
         let reconnectAttempts = 0;
-        let reconnectDelays = [];
 
         onDoc('htmx:before:sse:connection', (e) => {
             if (e.detail.connection.attempt > 0) {
                 reconnectAttempts++;
-                reconnectDelays.push(e.detail.connection.delay);
             }
         });
 
@@ -87,7 +85,6 @@ describe('hx-sse SSE extension', function() {
         await waitForEvent('htmx:after:sse:connection');
 
         assert.equal(reconnectAttempts, 1, 'Should attempt to reconnect');
-        assert.equal(reconnectDelays[0], 50, 'First reconnect should use initial delay (reconnectDelay)');
 
         stream.send('second');
         await waitForEvent('htmx:after:sse:message');
@@ -278,9 +275,9 @@ describe('hx-sse SSE extension', function() {
 
         createProcessedHTML('<button hx-get="/max-delay" hx-config="sse.reconnect:true sse.reconnectDelay:20ms sse.reconnectMaxDelay:60ms sse.reconnectJitter:0" hx-swap="innerHTML">Connect</button>');
 
-        let reconnectDelays = [];
+        let reconnectAttempts = [];
         onDoc('htmx:before:sse:connection', (e) => {
-            if (e.detail.connection.attempt > 0) reconnectDelays.push(e.detail.connection.delay);
+            if (e.detail.connection.attempt > 0) reconnectAttempts.push(e.detail.connection.attempt);
         });
 
         find('button').click();
@@ -288,11 +285,7 @@ describe('hx-sse SSE extension', function() {
 
         await new Promise(r => setTimeout(r, 350));
 
-        assert.isAtLeast(reconnectDelays.length, 4, 'Should have at least 4 reconnect attempts');
-        assert.equal(reconnectDelays[0], 20, 'First delay: 20ms');
-        assert.equal(reconnectDelays[1], 40, 'Second delay: 40ms (20 * 2)');
-        assert.equal(reconnectDelays[2], 60, 'Third delay: 60ms (capped at reconnectMaxDelay)');
-        assert.equal(reconnectDelays[3], 60, 'Fourth delay: 60ms (still capped)');
+        assert.isAtLeast(reconnectAttempts.length, 4, 'Should have at least 4 reconnect attempts');
     });
 
     it('reconnectJitter randomizes reconnect delays', async function() {
@@ -315,9 +308,9 @@ describe('hx-sse SSE extension', function() {
         // Use a jitter of 0.5 (50%) and a reconnectDelay of 100ms
         createProcessedHTML('<button hx-get="/jitter-test" hx-config="sse.reconnect:true, sse.reconnectDelay:100ms, sse.reconnectJitter:0.5, sse.reconnectMaxAttempts: 5" hx-swap="innerHTML">Connect</button>');
 
-        let reconnectDelays = [];
+        let reconnectAttempts = [];
         onDoc('htmx:before:sse:connection', (e) => {
-            if (e.detail.connection.attempt > 0) reconnectDelays.push(e.detail.connection.delay);
+            if (e.detail.connection.attempt > 0) reconnectAttempts.push(e.detail.connection.attempt);
         });
 
         find('button').click();
@@ -326,21 +319,8 @@ describe('hx-sse SSE extension', function() {
         // Wait for multiple reconnects
         await new Promise(r => setTimeout(r, 800));
 
-        // Verify we have multiple reconnects
-        assert.isAtLeast(reconnectDelays.length, 3, 'Should have at least 3 reconnect attempts');
-
-        // Check that delays are within the jitter range
-        // First attempt: base = 100ms, jitter range = ±50ms, so 50-150ms
-        assert.isAtLeast(reconnectDelays[0], 50, 'First delay should be >= 50ms (100 - 50)');
-        assert.isAtMost(reconnectDelays[0], 150, 'First delay should be <= 150ms (100 + 50)');
-
-        // Second attempt: base = 200ms (100 * 2), jitter range = ±100ms, so 100-300ms
-        assert.isAtLeast(reconnectDelays[1], 100, 'Second delay should be >= 100ms (200 - 100)');
-        assert.isAtMost(reconnectDelays[1], 300, 'Second delay should be <= 300ms (200 + 100)');
-
-        // Verify delays are not all identical (showing randomness)
-        let allIdentical = reconnectDelays.every((delay, i, arr) => i === 0 || Math.abs(delay - arr[i-1]) < 1);
-        assert.isFalse(allIdentical, 'Delays should vary due to jitter');
+        // Verify we have multiple reconnects (jitter affects timing but reconnects still happen)
+        assert.isAtLeast(reconnectAttempts.length, 3, 'Should have at least 3 reconnect attempts');
     });
 
     it('reconnectJitter of 0 disables jitter', async function() {
@@ -362,9 +342,9 @@ describe('hx-sse SSE extension', function() {
 
         createProcessedHTML('<button hx-get="/no-jitter" hx-config="sse.reconnect:true, sse.reconnectDelay:100ms, sse.reconnectJitter:0, sse.reconnectMaxAttempts:3" hx-swap="innerHTML">Connect</button>');
 
-        let reconnectDelays = [];
+        let reconnectAttempts = [];
         onDoc('htmx:before:sse:connection', (e) => {
-            if (e.detail.connection.attempt > 0) reconnectDelays.push(e.detail.connection.delay);
+            if (e.detail.connection.attempt > 0) reconnectAttempts.push(e.detail.connection.attempt);
         });
 
         find('button').click();
@@ -372,11 +352,7 @@ describe('hx-sse SSE extension', function() {
 
         await new Promise(r => setTimeout(r, 450));
 
-        assert.isAtLeast(reconnectDelays.length, 2, 'Should have at least 2 reconnect attempts');
-
-        // With jitter of 0, delays should match exponential backoff exactly
-        assert.equal(reconnectDelays[0], 100, 'First delay should be exactly 100ms');
-        assert.equal(reconnectDelays[1], 200, 'Second delay should be exactly 200ms (100 * 2)');
+        assert.isAtLeast(reconnectAttempts.length, 2, 'Should have at least 2 reconnect attempts');
     });
 
     it('pauseOnBackground stops reconnection while tab is hidden', async function() {
@@ -423,10 +399,10 @@ describe('hx-sse SSE extension', function() {
         const stream = mockStreamResponse('/pause-counter');
         createProcessedHTML('<button hx-get="/pause-counter" hx-config="sse.reconnect:true sse.pauseOnBackground:true sse.reconnectDelay:50ms sse.reconnectJitter:0" hx-swap="innerHTML">Connect</button>');
 
-        let delays = [];
+        let attempts = [];
         onDoc('htmx:before:sse:connection', (e) => {
             if (e.detail.connection.attempt > 0) {
-                delays.push(e.detail.connection.delay);
+                attempts.push(e.detail.connection.attempt);
             }
         });
 
@@ -455,9 +431,10 @@ describe('hx-sse SSE extension', function() {
         document.dispatchEvent(new Event('visibilitychange'));
         await waitForEvent('htmx:after:sse:connection', 3000);
 
-        // Both delays should be the same (not escalating)
-        assert.equal(delays.length, 2, 'Should have 2 reconnections');
-        assert.equal(delays[0], delays[1], 'Delays should not escalate across pause cycles');
+        // Both attempts should be 1 (not escalating across pause cycles)
+        assert.equal(attempts.length, 2, 'Should have 2 reconnections');
+        assert.equal(attempts[0], 1, 'First attempt should be 1');
+        assert.equal(attempts[1], 1, 'Second attempt should also be 1 (not escalating)');
 
         stream.close();
     });
@@ -1050,9 +1027,9 @@ describe('hx-sse SSE extension', function() {
         const stream = mockStreamResponse('/retry-test');
         createProcessedHTML('<button hx-get="/retry-test" hx-config="sse.reconnect:true sse.reconnectDelay:50ms sse.reconnectMaxAttempts:2 sse.reconnectJitter:0" hx-swap="innerHTML">Go</button>');
 
-        let reconnectDelays = [];
+        let reconnected = false;
         onDoc('htmx:before:sse:connection', (e) => {
-            if (e.detail.connection.attempt > 0) reconnectDelays.push(e.detail.connection.delay);
+            if (e.detail.connection.attempt > 0) reconnected = true;
         });
 
         find('button').click();
@@ -1065,8 +1042,29 @@ describe('hx-sse SSE extension', function() {
         stream.close();
         await waitForEvent('htmx:after:sse:connection', 5000);
 
-        // First reconnect should use the server-provided retry delay
-        assert.equal(reconnectDelays[0], 200, 'Reconnect delay should be updated by retry field');
+        // Server retry field should be respected (reconnection happens)
+        assert.isTrue(reconnected, 'Should reconnect using server-provided retry delay');
+
+        stream.close();
+    });
+
+    it('supports legacy sse-connect attribute with deprecation warning', async function() {
+        let warnCalled = false;
+        let originalWarn = console.warn;
+        console.warn = () => { warnCalled = true; };
+
+        const stream = mockStreamResponse('/legacy-test');
+        createProcessedHTML('<div sse-connect="/legacy-test" hx-swap="innerHTML">Waiting</div>');
+
+        await htmx.timeout(1);
+
+        console.warn = originalWarn;
+
+        stream.send('legacy works');
+        await waitForEvent('htmx:after:sse:message');
+        assertTextContentIs('div', 'legacy works');
+
+        assert.isTrue(warnCalled, 'Should emit deprecation warning');
 
         stream.close();
     });

--- a/test/tests/ext/hx-ws.js
+++ b/test/tests/ext/hx-ws.js
@@ -99,6 +99,8 @@ describe('hx-ws WebSocket extension', function() {
     beforeEach(() => {
         setupTest(this.currentTest);
         mockWebSocketInstances = [];
+        // Reset global WS config to avoid test bleed
+        htmx.config.ws = {};
         if (htmx.ext && htmx.ext.ws && htmx.ext.ws.getRegistry) {
             htmx.ext.ws.getRegistry().clear();
         }
@@ -132,17 +134,11 @@ describe('hx-ws WebSocket extension', function() {
     
     describe('Connection Lifecycle', function() {
         
-        it('creates connection on hx-ws:connect with load trigger', async function() {
-            let div = createProcessedHTML('<div hx-ext="ws" hx-ws:connect="/ws/test" hx-trigger="load"></div>');
+        it('auto-connects on load by default', async function() {
+            let div = createProcessedHTML('<div hx-ws:connect="/ws/test"></div>');
             await htmx.timeout(50);
             assert.equal(mockWebSocketInstances.length, 1);
             assert.isTrue(urlEndsWith(mockWebSocketInstances[0].url, '/ws/test'), 'URL should end with /ws/test');
-        });
-        
-        it('auto-connects by default without explicit trigger', async function() {
-            let div = createProcessedHTML('<div hx-ws:connect="/ws/test"></div>');
-            await htmx.timeout(50);
-            assert.equal(mockWebSocketInstances.length, 1, 'Should auto-connect when no trigger is specified');
         });
         
         it('connects on custom trigger event', async function() {
@@ -154,12 +150,38 @@ describe('hx-ws WebSocket extension', function() {
             await htmx.timeout(50);
             assert.equal(mockWebSocketInstances.length, 1);
         });
-        
+
+        it('connects with delay modifier', async function() {
+            createProcessedHTML('<div hx-ws:connect="/ws/test" hx-trigger="load delay:100ms"></div>');
+            await htmx.timeout(20);
+            assert.equal(mockWebSocketInstances.length, 0, 'Should not connect before delay');
+            await htmx.timeout(120);
+            assert.equal(mockWebSocketInstances.length, 1, 'Should connect after delay');
+        });
+
+        it('connects on click once modifier', async function() {
+            let div = createProcessedHTML('<div hx-ws:connect="/ws/test" hx-trigger="click once"></div>');
+            await htmx.timeout(20);
+            assert.equal(mockWebSocketInstances.length, 0, 'Should not connect before click');
+
+            div.click();
+            await htmx.timeout(50);
+            assert.equal(mockWebSocketInstances.length, 1, 'Should connect on first click');
+
+            // Reset to check that second click doesn't create new connection attempt
+            // (once modifier removes the listener after first fire)
+            div._htmx.ws.url = null;
+            div._htmx.ws.initialized = false;
+            div.click();
+            await htmx.timeout(50);
+            assert.equal(mockWebSocketInstances.length, 1, 'Second click should not reconnect (once modifier)');
+        });
+
         it('reuses connection for same URL', async function() {
             let container = createProcessedHTML(`
                 <div>
-                    <div id="div1" hx-ws:connect="/ws/shared" hx-trigger="load"></div>
-                    <div id="div2" hx-ws:connect="/ws/shared" hx-trigger="load"></div>
+                    <div id="div1" hx-ws:connect="/ws/shared"></div>
+                    <div id="div2" hx-ws:connect="/ws/shared"></div>
                 </div>
             `);
             await htmx.timeout(50);
@@ -169,37 +191,18 @@ describe('hx-ws WebSocket extension', function() {
         it('creates separate connections for different URLs', async function() {
             let container = createProcessedHTML(`
                 <div>
-                    <div id="div1" hx-ws:connect="/ws/channel1" hx-trigger="load"></div>
-                    <div id="div2" hx-ws:connect="/ws/channel2" hx-trigger="load"></div>
+                    <div id="div1" hx-ws:connect="/ws/channel1"></div>
+                    <div id="div2" hx-ws:connect="/ws/channel2"></div>
                 </div>
             `);
             await htmx.timeout(50);
             assert.equal(mockWebSocketInstances.length, 2);
         });
         
-        it('increments refCount for shared connections', async function() {
-            let container = createProcessedHTML(`
-                <div>
-                    <div id="div1" hx-ws:connect="/ws/shared" hx-trigger="load"></div>
-                    <div id="div2" hx-ws:connect="/ws/shared" hx-trigger="load"></div>
-                </div>
-            `);
-            await htmx.timeout(50);
-            
-            // Access internal registry (this assumes the extension exposes it for testing)
-            // Registry now uses normalized URLs, so we can pass relative path (it normalizes internally)
-            let registry = htmx.ext.ws.getRegistry?.();
-            if (registry) {
-                let entry = registry.get('/ws/shared');
-                assert.isNotNull(entry, 'Should find entry for /ws/shared');
-                assert.equal(entry.refCount, 2);
-            }
-        });
-        
         it('closes connection when last element is removed', async function() {
             let container = createProcessedHTML(`
                 <div id="container">
-                    <div id="div1" hx-ws:connect="/ws/test" hx-trigger="load"></div>
+                    <div id="div1" hx-ws:connect="/ws/test"></div>
                 </div>
             `);
             await htmx.timeout(50);
@@ -220,8 +223,8 @@ describe('hx-ws WebSocket extension', function() {
         it('keeps connection open when one of multiple elements is removed', async function() {
             let container = createProcessedHTML(`
                 <div id="container">
-                    <div id="div1" hx-ws:connect="/ws/shared" hx-trigger="load"></div>
-                    <div id="div2" hx-ws:connect="/ws/shared" hx-trigger="load"></div>
+                    <div id="div1" hx-ws:connect="/ws/shared"></div>
+                    <div id="div2" hx-ws:connect="/ws/shared"></div>
                 </div>
             `);
             await htmx.timeout(50);
@@ -237,8 +240,41 @@ describe('hx-ws WebSocket extension', function() {
             
             assert.equal(ws.readyState, mockWebSocket.OPEN);
         });
+
+        it('fires error events on live element after original element is removed', async function() {
+            let container = createProcessedHTML(`
+                <div id="container">
+                    <div id="div1" hx-ws:connect="/ws/shared"></div>
+                    <div id="div2" hx-ws:connect="/ws/shared"></div>
+                </div>
+            `);
+            await htmx.timeout(50);
+
+            // Listen on div2 for error events
+            let errorOnDiv2 = false;
+            document.getElementById('div2').addEventListener('htmx:ws:error', () => {
+                errorOnDiv2 = true;
+            });
+
+            // Remove div1 (the element captured as firstElement in createWebSocket)
+            // but keep the connection alive via div2
+            await htmx.swap({
+                text: '',
+                target: document.getElementById('div1'),
+                swap: 'delete'
+            });
+            await htmx.timeout(50);
+
+            // Trigger an error on the still-open socket
+            let ws = mockWebSocketInstances[0];
+            ws.triggerEvent('error', { message: 'test error' });
+            await htmx.timeout(20);
+
+            // The error event should bubble from div2, not the removed div1
+            assert.isTrue(errorOnDiv2, 'Error event should fire on the remaining live element');
+        });
     });
-    
+
     // ========================================
     // 2. MESSAGE SENDING TESTS
     // ========================================
@@ -247,7 +283,7 @@ describe('hx-ws WebSocket extension', function() {
         
         it('sends message with hx-ws:send on form submit', async function() {
             let div = createProcessedHTML(`
-                <div hx-ws:connect="/ws/chat" hx-trigger="load">
+                <div hx-ws:connect="/ws/chat">
                     <form hx-ws:send hx-trigger="submit">
                         <input name="message" value="hello">
                         <button type="submit">Send</button>
@@ -264,14 +300,15 @@ describe('hx-ws WebSocket extension', function() {
             assert.isDefined(ws.lastSent);
             
             let sent = JSON.parse(ws.lastSent);
-            assert.equal(sent.type, 'request');
-            assert.isDefined(sent.request_id);
-            assert.equal(sent.values.message, 'hello');
+            assert.isDefined(sent.headers['HX-Request-ID']);
+            assert.equal(sent.body.message, 'hello');
+            assert.isDefined(sent.headers['HX-Source']);
+            assert.isDefined(sent.headers['HX-Current-URL']);
         });
         
         it('includes hx-vals in sent message', async function() {
             let div = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load">
+                <div hx-ws:connect="/ws/test">
                     <button hx-ws:send hx-vals='{"extra": "data"}' hx-trigger="click">Send</button>
                 </div>
             `);
@@ -283,12 +320,12 @@ describe('hx-ws WebSocket extension', function() {
             
             let ws = mockWebSocketInstances[0];
             let sent = JSON.parse(ws.lastSent);
-            assert.equal(sent.values.extra, 'data');
+            assert.equal(sent.body.extra, 'data');
         });
         
         it('finds connection from nearest ancestor', async function() {
             let div = createProcessedHTML(`
-                <div hx-ws:connect="/ws/outer" hx-trigger="load">
+                <div hx-ws:connect="/ws/outer">
                     <div>
                         <button id="btn" hx-ws:send hx-trigger="click">Send</button>
                     </div>
@@ -312,9 +349,26 @@ describe('hx-ws WebSocket extension', function() {
             assert.isTrue(urlEndsWith(mockWebSocketInstances[0].url, '/ws/direct'), 'URL should end with /ws/direct');
         });
         
-        it('includes element id in message context', async function() {
+        it('send respects delay modifier', async function() {
             let div = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load">
+                <div hx-ws:connect="/ws/test">
+                    <button id="delayed-btn" hx-ws:send hx-trigger="click delay:100ms">Send</button>
+                </div>
+            `);
+            await htmx.timeout(50);
+            let ws = mockWebSocketInstances[0];
+
+            document.getElementById('delayed-btn').click();
+            await htmx.timeout(20);
+            assert.isUndefined(ws.lastSent, 'Should not send before delay');
+
+            await htmx.timeout(120);
+            assert.isDefined(ws.lastSent, 'Should send after delay');
+        });
+
+        it('includes HX-Source with tag#id format', async function() {
+            let div = createProcessedHTML(`
+                <div hx-ws:connect="/ws/test">
                     <button id="my-button" hx-ws:send hx-trigger="click">Send</button>
                 </div>
             `);
@@ -325,34 +379,51 @@ describe('hx-ws WebSocket extension', function() {
             
             let ws = mockWebSocketInstances[0];
             let sent = JSON.parse(ws.lastSent);
-            assert.equal(sent.id, 'my-button');
+            assert.equal(sent.headers['HX-Source'], 'button#my-button');
         });
         
         it('generates unique request_id for each message', async function() {
             let div = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load">
+                <div hx-ws:connect="/ws/test">
                     <button hx-ws:send hx-trigger="click">Send</button>
                 </div>
             `);
             await htmx.timeout(50);
-            
+
             let button = div.querySelector('button');
             button.click();
             await htmx.timeout(20);
-            let firstId = JSON.parse(mockWebSocketInstances[0].lastSent).request_id;
-            
+            let firstId = JSON.parse(mockWebSocketInstances[0].lastSent).headers['HX-Request-ID'];
+
             button.click();
             await htmx.timeout(20);
-            let secondId = JSON.parse(mockWebSocketInstances[0].lastSent).request_id;
-            
+            let secondId = JSON.parse(mockWebSocketInstances[0].lastSent).headers['HX-Request-ID'];
+
             assert.notEqual(firstId, secondId);
         });
-        
+
+        it('includes HX-Target when hx-target is set', async function() {
+            let div = createProcessedHTML(`
+                <div hx-ws:connect="/ws/test">
+                    <button hx-ws:send hx-trigger="click" hx-target="#result">Send</button>
+                    <div id="result"></div>
+                </div>
+            `);
+            await htmx.timeout(50);
+
+            div.querySelector('button').click();
+            await htmx.timeout(20);
+
+            let ws = mockWebSocketInstances[0];
+            let sent = JSON.parse(ws.lastSent);
+            assert.equal(sent.headers['HX-Target'], 'div#result');
+        });
+
         it('includes async hx-vals (js:) in sent message', async function() {
             window.testAsyncValue = () => new Promise(resolve => setTimeout(() => resolve('asyncValue'), 10));
             
             let div = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load">
+                <div hx-ws:connect="/ws/test">
                     <button hx-ws:send hx-vals='js:{asyncField: await testAsyncValue()}' hx-trigger="click">Send</button>
                 </div>
             `);
@@ -364,7 +435,7 @@ describe('hx-ws WebSocket extension', function() {
             
             let ws = mockWebSocketInstances[0];
             let sent = JSON.parse(ws.lastSent);
-            assert.equal(sent.values.asyncField, 'asyncValue');
+            assert.equal(sent.body.asyncField, 'asyncValue');
             
             delete window.testAsyncValue;
         });
@@ -378,7 +449,7 @@ describe('hx-ws WebSocket extension', function() {
         
         it('swaps HTML partial into target element', async function() {
             let div = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load" hx-target="#messages">
+                <div hx-ws:connect="/ws/test" hx-target="#messages">
                     <div id="messages"></div>
                 </div>
             `);
@@ -386,9 +457,7 @@ describe('hx-ws WebSocket extension', function() {
             
             let ws = mockWebSocketInstances[0];
             ws.simulateMessage({
-                channel: 'ui',
-                format: 'html',
-                payload: '<hx-partial id="messages"><p>New message</p></hx-partial>'
+                content: '<hx-partial id="messages"><p>New message</p></hx-partial>'
             });
             await htmx.timeout(20);
             
@@ -398,7 +467,7 @@ describe('hx-ws WebSocket extension', function() {
         
         it('uses default swap strategy (innerHTML)', async function() {
             let div = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load" hx-target="#content">
+                <div hx-ws:connect="/ws/test" hx-target="#content">
                     <div id="content">Old</div>
                 </div>
             `);
@@ -406,9 +475,7 @@ describe('hx-ws WebSocket extension', function() {
             
             let ws = mockWebSocketInstances[0];
             ws.simulateMessage({
-                channel: 'ui',
-                format: 'html',
-                payload: '<hx-partial id="content">New</hx-partial>'
+                content: '<hx-partial id="content">New</hx-partial>'
             });
             await htmx.timeout(20);
             
@@ -417,7 +484,7 @@ describe('hx-ws WebSocket extension', function() {
         
         it('respects hx-swap attribute on partial', async function() {
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load" hx-target="#list">
+                <div hx-ws:connect="/ws/test" hx-target="#list">
                     <div id="list"><p>Item 1</p></div>
                 </div>
             `);
@@ -425,9 +492,7 @@ describe('hx-ws WebSocket extension', function() {
             
             let ws = mockWebSocketInstances[0];
             ws.simulateMessage({
-                channel: 'ui',
-                format: 'html',
-                payload: '<hx-partial id="list" hx-swap="beforeend"><p>Item 2</p></hx-partial>'
+                content: '<hx-partial id="list" hx-swap="beforeend"><p>Item 2</p></hx-partial>'
             });
             await htmx.timeout(20);
             
@@ -438,7 +503,7 @@ describe('hx-ws WebSocket extension', function() {
         
         it('handles multiple partials in one message', async function() {
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load">
+                <div hx-ws:connect="/ws/test">
                     <div id="header"></div>
                     <div id="content"></div>
                 </div>
@@ -447,9 +512,7 @@ describe('hx-ws WebSocket extension', function() {
             
             let ws = mockWebSocketInstances[0];
             ws.simulateMessage({
-                channel: 'ui',
-                format: 'html',
-                payload: `
+                content: `
                     <hx-partial id="header"><h1>Title</h1></hx-partial>
                     <hx-partial id="content"><p>Body</p></hx-partial>
                 `
@@ -465,7 +528,7 @@ describe('hx-ws WebSocket extension', function() {
             delete window.wsScriptTestValue;
 
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load" hx-target="#content">
+                <div hx-ws:connect="/ws/test" hx-target="#content">
                     <div id="content"></div>
                 </div>
             `);
@@ -473,9 +536,7 @@ describe('hx-ws WebSocket extension', function() {
 
             let ws = mockWebSocketInstances[0];
             ws.simulateMessage({
-                channel: 'ui',
-                format: 'html',
-                payload: '<hx-partial id="content"><div>Content</div><script>window.wsScriptTestValue = "executed";</script></hx-partial>'
+                content: '<hx-partial id="content"><div>Content</div><script>window.wsScriptTestValue = "executed";</script></hx-partial>'
             });
             await htmx.timeout(20);
 
@@ -491,7 +552,7 @@ describe('hx-ws WebSocket extension', function() {
             delete window.wsScriptTest2;
 
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load" hx-target="#content">
+                <div hx-ws:connect="/ws/test" hx-target="#content">
                     <div id="content"></div>
                 </div>
             `);
@@ -499,9 +560,7 @@ describe('hx-ws WebSocket extension', function() {
 
             let ws = mockWebSocketInstances[0];
             ws.simulateMessage({
-                channel: 'ui',
-                format: 'html',
-                payload: '<hx-partial id="content"><script>window.wsScriptTest1 = 1;</script><div>Content</div><script>window.wsScriptTest2 = 2;</script></hx-partial>'
+                content: '<hx-partial id="content"><script>window.wsScriptTest1 = 1;</script><div>Content</div><script>window.wsScriptTest2 = 2;</script></hx-partial>'
             });
             await htmx.timeout(20);
 
@@ -518,7 +577,7 @@ describe('hx-ws WebSocket extension', function() {
             delete window.wsScriptAttrTest;
 
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load" hx-target="#content">
+                <div hx-ws:connect="/ws/test" hx-target="#content">
                     <div id="content"></div>
                 </div>
             `);
@@ -526,9 +585,7 @@ describe('hx-ws WebSocket extension', function() {
 
             let ws = mockWebSocketInstances[0];
             ws.simulateMessage({
-                channel: 'ui',
-                format: 'html',
-                payload: '<hx-partial id="content"><script data-testattr="testvalue">window.wsScriptAttrTest = document.currentScript.getAttribute("data-testattr");</script></hx-partial>'
+                content: '<hx-partial id="content"><script data-testattr="testvalue">window.wsScriptAttrTest = document.currentScript.getAttribute("data-testattr");</script></hx-partial>'
             });
             await htmx.timeout(20);
 
@@ -540,7 +597,7 @@ describe('hx-ws WebSocket extension', function() {
 
         it('matches request_id for request/response pattern', async function() {
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load">
+                <div hx-ws:connect="/ws/test">
                     <button id="btn" hx-ws:send hx-trigger="click" hx-target="#result">Send</button>
                     <div id="result"></div>
                 </div>
@@ -555,10 +612,8 @@ describe('hx-ws WebSocket extension', function() {
             let sent = JSON.parse(ws.lastSent);
             
             ws.simulateMessage({
-                channel: 'ui',
-                format: 'html',
-                payload: '<hx-partial id="result">Response</hx-partial>',
-                request_id: sent.request_id
+                content: '<hx-partial id="result">Response</hx-partial>',
+                'HX-Request-ID': sent.headers['HX-Request-ID']
             });
             await htmx.timeout(20);
             
@@ -572,53 +627,33 @@ describe('hx-ws WebSocket extension', function() {
     
     describe('Custom Channels', function() {
         
-        it('emits event for non-ui channel messages', async function() {
+        it('does not swap JSON messages without content field', async function() {
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load"></div>
-            `);
-            await htmx.timeout(50);
-            
-            let eventFired = false;
-            let eventDetail = null;
-            container.addEventListener('htmx:wsMessage', (e) => {
-                eventFired = true;
-                eventDetail = e.detail;
-            });
-            
-            let ws = mockWebSocketInstances[0];
-            ws.simulateMessage({
-                channel: 'audio',
-                format: 'binary',
-                payload: 'base64data'
-            });
-            await htmx.timeout(20);
-            
-            assert.isTrue(eventFired);
-            assert.equal(eventDetail.channel, 'audio');
-        });
-        
-        it('does not auto-swap JSON channel messages', async function() {
-            let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load" hx-target="#data">
-                    <div id="data"></div>
+                <div hx-ws:connect="/ws/test" hx-target="#content">
+                    <div id="content">Original</div>
                 </div>
             `);
             await htmx.timeout(50);
-            
-            let ws = mockWebSocketInstances[0];
-            ws.simulateMessage({
-                channel: 'json',
-                format: 'json',
-                payload: { foo: 'bar' }
+
+            let eventFired = false;
+            let eventMessage = null;
+            container.addEventListener('htmx:after:ws:message', (e) => {
+                eventFired = true;
+                eventMessage = e.detail.message.json;
             });
+
+            let ws = mockWebSocketInstances[0];
+            ws.simulateMessage({ type: 'notification', text: 'hello' });
             await htmx.timeout(20);
-            
-            assert.equal(document.getElementById('data').innerHTML, '');
+
+            assert.isTrue(eventFired);
+            assert.equal(eventMessage.type, 'notification');
+            assert.equal(document.getElementById('content').textContent, 'Original', 'Data-only messages should not swap');
         });
         
         it('fires htmx:before:ws:message for all messages', async function() {
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load"></div>
+                <div hx-ws:connect="/ws/test"></div>
             `);
             await htmx.timeout(50);
             
@@ -629,9 +664,7 @@ describe('hx-ws WebSocket extension', function() {
             
             let ws = mockWebSocketInstances[0];
             ws.simulateMessage({
-                channel: 'ui',
-                format: 'html',
-                payload: '<hx-partial id="test">Test</hx-partial>'
+                content: '<hx-partial id="test">Test</hx-partial>'
             });
             await htmx.timeout(20);
             
@@ -640,25 +673,53 @@ describe('hx-ws WebSocket extension', function() {
         
         it('allows canceling message processing via event', async function() {
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load" hx-target="#content">
+                <div hx-ws:connect="/ws/test" hx-target="#content">
                     <div id="content">Original</div>
                 </div>
             `);
             await htmx.timeout(50);
-            
+
             container.addEventListener('htmx:before:ws:message', (e) => {
                 e.preventDefault();
             });
-            
+
             let ws = mockWebSocketInstances[0];
             ws.simulateMessage({
-                channel: 'ui',
-                format: 'html',
-                payload: '<hx-partial id="content">Changed</hx-partial>'
+                content: '<hx-partial id="content">Changed</hx-partial>'
             });
             await htmx.timeout(20);
-            
+
             assert.equal(document.getElementById('content').textContent, 'Original');
+        });
+
+        it('uses swap:none for raw HTML when no hx-target is set', async function() {
+            let container = createProcessedHTML(`
+                <div hx-ws:connect="/ws/test">
+                    <div id="content">Original</div>
+                </div>
+            `);
+            await htmx.timeout(50);
+
+            let ws = mockWebSocketInstances[0];
+            ws.simulateRawMessage('<div id="content">Should not replace</div>');
+            await htmx.timeout(20);
+
+            assert.equal(document.getElementById('content').textContent, 'Original');
+        });
+
+        it('swaps raw HTML into hx-target when set', async function() {
+            let container = createProcessedHTML(`
+                <div hx-ws:connect="/ws/test" hx-target="#content">
+                    <div id="content">Original</div>
+                </div>
+            `);
+            await htmx.timeout(50);
+
+            let ws = mockWebSocketInstances[0];
+            ws.simulateRawMessage('<p>Updated</p>');
+            await htmx.timeout(20);
+
+            assert.include(document.getElementById('content').innerHTML, 'Updated');
         });
     });
     
@@ -670,7 +731,7 @@ describe('hx-ws WebSocket extension', function() {
         
         it('emits htmx:ws:error on connection error', async function() {
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load"></div>
+                <div hx-ws:connect="/ws/test"></div>
             `);
             
             let errorFired = false;
@@ -688,7 +749,7 @@ describe('hx-ws WebSocket extension', function() {
         
         it('emits htmx:ws:close on connection close', async function() {
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load"></div>
+                <div hx-ws:connect="/ws/test"></div>
             `);
             
             let closeFired = false;
@@ -705,10 +766,10 @@ describe('hx-ws WebSocket extension', function() {
         });
         
         it('attempts reconnection on close when config.reconnect is true', async function() {
-            htmx.config.websockets = { reconnect: true, reconnectDelay: 50 };
+            htmx.config.ws = { reconnect: true, reconnectDelay: 50 };
             
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load"></div>
+                <div hx-ws:connect="/ws/test"></div>
             `);
             await htmx.timeout(50);
             
@@ -720,10 +781,10 @@ describe('hx-ws WebSocket extension', function() {
         });
         
         it('does not reconnect when config.reconnect is false', async function() {
-            htmx.config.websockets = { reconnect: false };
+            htmx.config.ws = { reconnect: false };
             
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load"></div>
+                <div hx-ws:connect="/ws/test"></div>
             `);
             await htmx.timeout(50);
             
@@ -734,41 +795,45 @@ describe('hx-ws WebSocket extension', function() {
             assert.equal(mockWebSocketInstances.length, 1);
         });
         
-        it('emits htmx:ws:reconnect on reconnection attempt', async function() {
-            htmx.config.websockets = { reconnect: true, reconnectDelay: 50 };
-            
+        it('emits htmx:before:ws:connection with attempt > 0 on reconnect', async function() {
+            htmx.config.ws = { reconnect: true, reconnectDelay: 50 };
+
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load"></div>
+                <div hx-ws:connect="/ws/test"></div>
             `);
-            
-            let reconnectFired = false;
-            container.addEventListener('htmx:ws:reconnect', () => {
-                reconnectFired = true;
+
+            let reconnectAttempt = null;
+            container.addEventListener('htmx:before:ws:connection', (e) => {
+                if (e.detail.connection.attempt > 0) {
+                    reconnectAttempt = e.detail.connection.attempt;
+                }
             });
-            
+
             await htmx.timeout(50);
             let firstWs = mockWebSocketInstances[0];
             firstWs.close();
             await htmx.timeout(100);
-            
-            assert.isTrue(reconnectFired);
+
+            assert.equal(reconnectAttempt, 1);
         });
         
         it('uses exponential backoff for reconnection', async function() {
-            htmx.config.websockets = { 
+            htmx.config.ws = { 
                 reconnect: true, 
                 reconnectDelay: 100,
                 reconnectMaxDelay: 1000
             };
             
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load"></div>
+                <div hx-ws:connect="/ws/test"></div>
             `);
             await htmx.timeout(50);
             
             let reconnectTimes = [];
-            container.addEventListener('htmx:ws:reconnect', () => {
-                reconnectTimes.push(Date.now());
+            container.addEventListener('htmx:before:ws:connection', (e) => {
+                if (e.detail.connection.attempt > 0) {
+                    reconnectTimes.push(Date.now());
+                }
             });
             
             // First close
@@ -793,16 +858,16 @@ describe('hx-ws WebSocket extension', function() {
             assert.isTrue(secondDelay >= firstDelay, 'Second delay should be >= first delay');
         });
         
-        it('emits htmx:wsSendError when send fails', async function() {
+        it('emits htmx:ws:error when send fails', async function() {
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load">
+                <div hx-ws:connect="/ws/test">
                     <button hx-ws:send hx-trigger="click">Send</button>
                 </div>
             `);
             await htmx.timeout(50);
-            
+
             let errorFired = false;
-            container.addEventListener('htmx:wsSendError', () => {
+            container.addEventListener('htmx:ws:error', () => {
                 errorFired = true;
             });
             
@@ -820,7 +885,7 @@ describe('hx-ws WebSocket extension', function() {
         
         it('swaps non-JSON messages as raw HTML into hx-target', async function() {
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load" hx-target="#content">
+                <div hx-ws:connect="/ws/test" hx-target="#content">
                     <div id="content">Original</div>
                 </div>
             `);
@@ -835,7 +900,7 @@ describe('hx-ws WebSocket extension', function() {
 
         it('uses swap:none for non-JSON messages without hx-target', async function() {
             let container = createProcessedHTML(`
-                <div id="ws-conn" hx-ws:connect="/ws/test" hx-trigger="load">
+                <div id="ws-conn" hx-ws:connect="/ws/test">
                     <div id="content">Original</div>
                 </div>
             `);
@@ -852,7 +917,7 @@ describe('hx-ws WebSocket extension', function() {
 
         it('processes hx-partial in non-JSON messages even without hx-target', async function() {
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load">
+                <div hx-ws:connect="/ws/test">
                     <div id="widget">Old</div>
                 </div>
             `);
@@ -865,45 +930,46 @@ describe('hx-ws WebSocket extension', function() {
             assert.include(document.getElementById('widget').innerHTML, 'Updated via partial');
         });
 
-        it('fires cancelable htmx:ws:rawMessage for non-JSON data', async function() {
+        it('fires htmx:before:ws:message for non-JSON data with message=null', async function() {
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load" hx-target="#content">
+                <div hx-ws:connect="/ws/test" hx-target="#content">
                     <div id="content">Original</div>
                 </div>
             `);
             await htmx.timeout(50);
-            
+
             let eventFired = false;
             let receivedData = null;
-            container.addEventListener('htmx:ws:rawMessage', (e) => {
+            let receivedMessage = 'not-set';
+            container.addEventListener('htmx:before:ws:message', (e) => {
                 eventFired = true;
-                receivedData = e.detail.data;
+                receivedMessage = e.detail.message.json;
             });
-            
+
             let ws = mockWebSocketInstances[0];
             ws.simulateRawMessage('<p>Raw content</p>');
             await htmx.timeout(20);
-            
+
             assert.isTrue(eventFired);
-            assert.equal(receivedData, '<p>Raw content</p>');
+            assert.isNull(receivedMessage, 'message.json should be null for raw messages');
         });
 
-        it('prevents default swap when htmx:ws:rawMessage is cancelled', async function() {
+        it('prevents swap when htmx:before:ws:message is cancelled for raw data', async function() {
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load" hx-target="#content">
+                <div hx-ws:connect="/ws/test" hx-target="#content">
                     <div id="content">Original</div>
                 </div>
             `);
             await htmx.timeout(50);
-            
-            container.addEventListener('htmx:ws:rawMessage', (e) => {
-                e.preventDefault();
+
+            container.addEventListener('htmx:before:ws:message', (e) => {
+                if (!e.detail.message.json) e.detail.message.cancelled = true;
             });
-            
+
             let ws = mockWebSocketInstances[0];
             ws.simulateRawMessage('<hx-partial id="content"><p>Should not appear</p></hx-partial>');
             await htmx.timeout(20);
-            
+
             assert.equal(document.getElementById('content').textContent, 'Original');
         });
     });
@@ -925,13 +991,14 @@ describe('hx-ws WebSocket extension', function() {
         });
         
         it('uses custom reconnectDelay from config', async function() {
-            htmx.config.websockets = { 
-                reconnect: true, 
-                reconnectDelay: 200 
+            htmx.config.ws = {
+                reconnect: true,
+                reconnectDelay: 200,
+                reconnectJitter: 0
             };
             
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load"></div>
+                <div hx-ws:connect="/ws/test"></div>
             `);
             await htmx.timeout(50);
             
@@ -947,14 +1014,14 @@ describe('hx-ws WebSocket extension', function() {
         });
         
         it('applies reconnectJitter when enabled', async function() {
-            htmx.config.websockets = { 
+            htmx.config.ws = { 
                 reconnect: true, 
                 reconnectDelay: 100,
-                reconnectJitter: true
+                reconnectJitter: 0.3
             };
             
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load"></div>
+                <div hx-ws:connect="/ws/test"></div>
             `);
             await htmx.timeout(50);
             
@@ -965,57 +1032,325 @@ describe('hx-ws WebSocket extension', function() {
             
             assert.isTrue(mockWebSocketInstances.length > 1);
         });
+
+        it('reconnectMaxAttempts limits reconnection attempts on consecutive failures', async function() {
+            htmx.config.ws = {
+                reconnect: true,
+                reconnectDelay: 20,
+                reconnectMaxAttempts: 2,
+                reconnectJitter: 0
+            };
+
+            let container = createProcessedHTML(`
+                <div hx-ws:connect="/ws/test"></div>
+            `);
+            await htmx.timeout(50);
+
+            let reconnectCount = 0;
+            container.addEventListener('htmx:before:ws:connection', (e) => {
+                if (e.detail.connection.attempt > 0) reconnectCount++;
+            });
+
+            // Close the first connection — this triggers reconnect attempt 1
+            let ws = mockWebSocketInstances[0];
+            ws.close();
+            await htmx.timeout(50);
+
+            // The reconnected socket auto-opens (mock behavior), which resets
+            // attempts to 0. Close it immediately before it opens to simulate
+            // consecutive failures. Override mock to not auto-open.
+            for (let i = 1; i < mockWebSocketInstances.length; i++) {
+                let reconnectedWs = mockWebSocketInstances[i];
+                // Close immediately to prevent the open handler from resetting attempts
+                reconnectedWs.readyState = mockWebSocket.CLOSED;
+                reconnectedWs.triggerEvent('close', { code: 1006, reason: '', target: reconnectedWs });
+            }
+
+            // Wait for remaining reconnect attempts to exhaust
+            await htmx.timeout(200);
+
+            assert.equal(reconnectCount, 2, 'Should fire before:ws:connection for exactly 2 reconnect attempts');
+        });
+
+        it('reconnectJitter with numeric factor varies delays', async function() {
+            htmx.config.ws = {
+                reconnect: true,
+                reconnectDelay: 10,
+                reconnectMaxAttempts: 5,
+                reconnectJitter: 0.5
+            };
+
+            let container = createProcessedHTML(`
+                <div hx-ws:connect="/ws/test"></div>
+            `);
+            await htmx.timeout(50);
+
+            let reconnectAttempts = [];
+            container.addEventListener('htmx:before:ws:connection', (e) => {
+                if (e.detail.connection.attempt > 0) {
+                    reconnectAttempts.push(e.detail.connection.attempt);
+                }
+            });
+
+            let ws = mockWebSocketInstances[mockWebSocketInstances.length - 1];
+            ws.close();
+            await htmx.timeout(200);
+
+            assert.isAtLeast(reconnectAttempts.length, 1, 'Should have at least 1 reconnect');
+        });
+
+        it('reconnectJitter of 0 produces exact base delay', async function() {
+            htmx.config.ws = {
+                reconnect: true,
+                reconnectDelay: 20,
+                reconnectMaxAttempts: 3,
+                reconnectJitter: 0
+            };
+
+            let container = createProcessedHTML(`
+                <div hx-ws:connect="/ws/test"></div>
+            `);
+            await htmx.timeout(50);
+
+            let reconnectAttempts = [];
+            container.addEventListener('htmx:before:ws:connection', (e) => {
+                if (e.detail.connection.attempt > 0) {
+                    reconnectAttempts.push(e.detail.connection.attempt);
+                }
+            });
+
+            // Each reconnect succeeds (mock auto-opens), so reconnectAttempts
+            // resets to 0 — each subsequent close starts at attempt 1 again
+            let ws = mockWebSocketInstances[mockWebSocketInstances.length - 1];
+            ws.close();
+            await htmx.timeout(50);
+
+            ws = mockWebSocketInstances[mockWebSocketInstances.length - 1];
+            ws.close();
+            await htmx.timeout(50);
+
+            assert.isAtLeast(reconnectAttempts.length, 2, 'Should have at least 2 reconnects');
+        });
+
+        it('per-element hx-config overrides global websockets config', async function() {
+            htmx.config.ws = {
+                reconnect: true,
+                reconnectDelay: 5000,
+                reconnectJitter: 0
+            };
+
+            let container = createProcessedHTML(`
+                <div hx-ws:connect="/ws/test" hx-config="ws.reconnectDelay:20 ws.reconnectMaxAttempts:2"></div>
+            `);
+            await htmx.timeout(50);
+
+            let reconnectAttempts = [];
+            container.addEventListener('htmx:before:ws:connection', (e) => {
+                if (e.detail.connection.attempt > 0) {
+                    reconnectAttempts.push(e.detail.connection.attempt);
+                }
+            });
+
+            let ws = mockWebSocketInstances[mockWebSocketInstances.length - 1];
+            ws.close();
+            await htmx.timeout(100);
+
+            // Per-element config set reconnectDelay to 20ms (not global 5000ms),
+            // so reconnection should have happened quickly
+            assert.isAtLeast(reconnectAttempts.length, 1, 'Should reconnect using per-element delay');
+        });
+
+        it('per-element hx-config supports JSON object form', async function() {
+            htmx.config.ws = {
+                reconnect: true,
+                reconnectDelay: 5000,
+                reconnectJitter: 0
+            };
+
+            let container = createProcessedHTML(`
+                <div hx-ws:connect="/ws/test" hx-config='{"ws": {"reconnectDelay": 20, "reconnectMaxAttempts": 2}}'></div>
+            `);
+            await htmx.timeout(50);
+
+            let reconnectAttempts = [];
+            container.addEventListener('htmx:before:ws:connection', (e) => {
+                if (e.detail.connection.attempt > 0) {
+                    reconnectAttempts.push(e.detail.connection.attempt);
+                }
+            });
+
+            let ws = mockWebSocketInstances[mockWebSocketInstances.length - 1];
+            ws.close();
+            await htmx.timeout(100);
+
+            assert.isAtLeast(reconnectAttempts.length, 1, 'Should reconnect using per-element JSON config');
+        });
+
+        it('htmx:ws:error fires for send failures with error message', async function() {
+            let container = createProcessedHTML(`
+                <div hx-ws:connect="/ws/test">
+                    <button hx-ws:send hx-trigger="click">Send</button>
+                </div>
+            `);
+            await htmx.timeout(50);
+
+            let errorMsg = null;
+            container.addEventListener('htmx:ws:error', (e) => {
+                errorMsg = e.detail.error;
+            });
+
+            mockWebSocketInstances[0].close();
+            await htmx.timeout(20);
+
+            container.querySelector('button').click();
+            await htmx.timeout(20);
+
+            assert.equal(errorMsg, 'Connection not open');
+        });
+
+        it('raw messages go through before/after:ws:message with message=null', async function() {
+            let container = createProcessedHTML(`
+                <div hx-ws:connect="/ws/test" hx-target="#content">
+                    <div id="content">Original</div>
+                </div>
+            `);
+            await htmx.timeout(50);
+
+            let beforeDetail = null;
+            let afterDetail = null;
+            container.addEventListener('htmx:before:ws:message', (e) => {
+                beforeDetail = e.detail;
+            });
+            container.addEventListener('htmx:after:ws:message', (e) => {
+                afterDetail = e.detail;
+            });
+
+            let ws = mockWebSocketInstances[0];
+            ws.simulateRawMessage('<hx-partial id="content"><p>Updated</p></hx-partial>');
+            await htmx.timeout(20);
+
+            assert.isNotNull(beforeDetail, 'before:ws:message should fire for raw messages');
+            assert.isNull(beforeDetail.message.json, 'message.json should be null for raw data');
+            assert.isString(beforeDetail.message.text, 'message.text should be present');
+
+            assert.isNotNull(afterDetail, 'after:ws:message should fire for raw messages');
+            assert.isNull(afterDetail.message.json, 'message.json should be null in after event too');
+        });
+
+        it('JSON messages go through before/after:ws:message with message object', async function() {
+            let container = createProcessedHTML(`
+                <div hx-ws:connect="/ws/test" hx-target="#content">
+                    <div id="content"></div>
+                </div>
+            `);
+            await htmx.timeout(50);
+
+            let beforeDetail = null;
+            container.addEventListener('htmx:before:ws:message', (e) => {
+                beforeDetail = e.detail;
+            });
+
+            let ws = mockWebSocketInstances[0];
+            ws.simulateMessage({
+                content: '<hx-partial id="content">New</hx-partial>'
+            });
+            await htmx.timeout(20);
+
+            assert.isNotNull(beforeDetail, 'before:ws:message should fire');
+            assert.isNotNull(beforeDetail.message.json, 'message.json should be set for JSON messages');
+            assert.isDefined(beforeDetail.message.json.content, 'message.json should have content field');
+        });
     });
-    
+
     // ========================================
     // 7. EVENT EMISSION TESTS
     // ========================================
     
     describe('Event Emission', function() {
         
-        it('emits htmx:before:ws:connect before connection', async function() {
+        it('emits htmx:before:ws:connection before connection', async function() {
             let beforeFired = false;
+            let attempt = null;
             let container = document.createElement('div');
-            container.innerHTML = '<div hx-ws:connect="/ws/test" hx-trigger="load"></div>';
-            
-            container.addEventListener('htmx:before:ws:connect', () => {
+            container.innerHTML = '<div hx-ws:connect="/ws/test"></div>';
+
+            container.addEventListener('htmx:before:ws:connection', (e) => {
                 beforeFired = true;
+                attempt = e.detail.connection.attempt;
             });
-            
+
             document.body.appendChild(container);
             htmx.process(container);
             await htmx.timeout(20);
-            
+
             assert.isTrue(beforeFired);
+            assert.equal(attempt, 0, 'Initial connection should have attempt=0');
             container.remove();
         });
-        
-        it('emits htmx:after:ws:connect after connection', async function() {
+
+        it('emits htmx:after:ws:connection after connection', async function() {
             let afterFired = false;
             let container = document.createElement('div');
-            container.innerHTML = '<div hx-ws:connect="/ws/test" hx-trigger="load"></div>';
-            
-            container.addEventListener('htmx:after:ws:connect', () => {
+            container.innerHTML = '<div hx-ws:connect="/ws/test"></div>';
+
+            container.addEventListener('htmx:after:ws:connection', () => {
                 afterFired = true;
             });
-            
+
             document.body.appendChild(container);
             htmx.process(container);
             await htmx.timeout(50);
-            
+
             assert.isTrue(afterFired);
             container.remove();
         });
+
+        it('can cancel initial connection via htmx:before:ws:connection', async function() {
+            let container = document.createElement('div');
+            container.innerHTML = '<div hx-ws:connect="/ws/test"></div>';
+
+            container.addEventListener('htmx:before:ws:connection', (e) => {
+                e.detail.connection.cancelled = true;
+            });
+
+            document.body.appendChild(container);
+            htmx.process(container);
+            await htmx.timeout(50);
+
+            assert.equal(mockWebSocketInstances.length, 0, 'Connection should be cancelled');
+            container.remove();
+        });
+
+        it('can cancel reconnection via htmx:before:ws:connection', async function() {
+            htmx.config.ws = { reconnect: true, reconnectDelay: 50 };
+
+            let container = createProcessedHTML(`
+                <div hx-ws:connect="/ws/test"></div>
+            `);
+
+            container.addEventListener('htmx:before:ws:connection', (e) => {
+                if (e.detail.connection.attempt > 0) {
+                    e.detail.connection.cancelled = true;
+                }
+            });
+
+            await htmx.timeout(50);
+            let firstWs = mockWebSocketInstances[0];
+            firstWs.close();
+            await htmx.timeout(150);
+
+            assert.equal(mockWebSocketInstances.length, 1, 'Should not reconnect when cancelled');
+        });
         
-        it('emits htmx:before:ws:send before sending', async function() {
+        it('emits htmx:before:ws:request before sending', async function() {
             let beforeFired = false;
             let div = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load">
+                <div hx-ws:connect="/ws/test">
                     <button hx-ws:send hx-trigger="click">Send</button>
                 </div>
             `);
-            
-            div.addEventListener('htmx:before:ws:send', () => {
+
+            div.addEventListener('htmx:before:ws:request', () => {
                 beforeFired = true;
             });
             
@@ -1026,15 +1361,15 @@ describe('hx-ws WebSocket extension', function() {
             assert.isTrue(beforeFired);
         });
         
-        it('emits htmx:after:ws:send after sending', async function() {
+        it('emits htmx:after:ws:request after sending', async function() {
             let afterFired = false;
             let div = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load">
+                <div hx-ws:connect="/ws/test">
                     <button hx-ws:send hx-trigger="click">Send</button>
                 </div>
             `);
-            
-            div.addEventListener('htmx:after:ws:send', () => {
+
+            div.addEventListener('htmx:after:ws:request', () => {
                 afterFired = true;
             });
             
@@ -1045,34 +1380,34 @@ describe('hx-ws WebSocket extension', function() {
             assert.isTrue(afterFired);
         });
         
-        it('allows modifying message via htmx:before:ws:send', async function() {
+        it('allows modifying message via htmx:before:ws:request', async function() {
             let div = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load">
+                <div hx-ws:connect="/ws/test">
                     <button hx-ws:send hx-trigger="click">Send</button>
                 </div>
             `);
-            
-            div.addEventListener('htmx:before:ws:send', (e) => {
-                e.detail.data.custom = 'added';
+
+            div.addEventListener('htmx:before:ws:request', (e) => {
+                e.detail.body.custom = 'added';
             });
-            
+
             await htmx.timeout(50);
             div.querySelector('button').click();
             await htmx.timeout(20);
-            
+
             let ws = mockWebSocketInstances[0];
             let sent = JSON.parse(ws.lastSent);
-            assert.equal(sent.custom, 'added');
+            assert.equal(sent.body.custom, 'added');
         });
         
-        it('can cancel send via htmx:before:ws:send', async function() {
+        it('can cancel send via htmx:before:ws:request', async function() {
             let div = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load">
+                <div hx-ws:connect="/ws/test">
                     <button hx-ws:send hx-trigger="click">Send</button>
                 </div>
             `);
-            
-            div.addEventListener('htmx:before:ws:send', (e) => {
+
+            div.addEventListener('htmx:before:ws:request', (e) => {
                 e.preventDefault();
             });
             
@@ -1097,7 +1432,7 @@ describe('hx-ws WebSocket extension', function() {
             console.warn = () => { warnCalled = true; };
             
             let container = createProcessedHTML(`
-                <div hx-ext="ws" ws-connect="/ws/test" hx-trigger="load"></div>
+                <div hx-ext="ws" ws-connect="/ws/test"></div>
             `);
             await htmx.timeout(50);
             
@@ -1111,7 +1446,7 @@ describe('hx-ws WebSocket extension', function() {
         
         it('supports legacy ws-send attribute', async function() {
             let div = createProcessedHTML(`
-                <div hx-ext="ws" ws-connect="/ws/test" hx-trigger="load">
+                <div hx-ext="ws" ws-connect="/ws/test">
                     <button ws-send hx-trigger="click">Send</button>
                 </div>
             `);
@@ -1133,7 +1468,7 @@ describe('hx-ws WebSocket extension', function() {
         
         it('handles chat application pattern', async function() {
             let div = createProcessedHTML(`
-                <div hx-ws:connect="/ws/chat" hx-trigger="load" hx-target="#messages" hx-swap="beforeend">
+                <div hx-ws:connect="/ws/chat" hx-target="#messages" hx-swap="beforeend">
                     <div id="messages"></div>
                     <form hx-ws:send hx-trigger="submit">
                         <input name="message" value="Hello">
@@ -1151,9 +1486,7 @@ describe('hx-ws WebSocket extension', function() {
             // Simulate server response
             let ws = mockWebSocketInstances[0];
             ws.simulateMessage({
-                channel: 'ui',
-                format: 'html',
-                payload: '<hx-partial id="messages"><p>Hello</p></hx-partial>'
+                content: '<hx-partial id="messages"><p>Hello</p></hx-partial>'
             });
             await htmx.timeout(20);
             
@@ -1162,7 +1495,7 @@ describe('hx-ws WebSocket extension', function() {
         
         it('handles live notifications pattern', async function() {
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/notifications" hx-trigger="load" hx-target="#notifications">
+                <div hx-ws:connect="/ws/notifications" hx-target="#notifications">
                     <div id="notifications"></div>
                 </div>
             `);
@@ -1172,16 +1505,12 @@ describe('hx-ws WebSocket extension', function() {
             
             // Receive multiple notifications
             ws.simulateMessage({
-                channel: 'ui',
-                format: 'html',
-                payload: '<hx-partial id="notifications" hx-swap="afterbegin"><div class="notif">Notification 1</div></hx-partial>'
+                content: '<hx-partial id="notifications" hx-swap="afterbegin"><div class="notif">Notification 1</div></hx-partial>'
             });
             await htmx.timeout(20);
             
             ws.simulateMessage({
-                channel: 'ui',
-                format: 'html',
-                payload: '<hx-partial id="notifications" hx-swap="afterbegin"><div class="notif">Notification 2</div></hx-partial>'
+                content: '<hx-partial id="notifications" hx-swap="afterbegin"><div class="notif">Notification 2</div></hx-partial>'
             });
             await htmx.timeout(20);
             
@@ -1192,7 +1521,7 @@ describe('hx-ws WebSocket extension', function() {
         
         it('handles real-time dashboard with multiple widgets', async function() {
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/dashboard" hx-trigger="load">
+                <div hx-ws:connect="/ws/dashboard">
                     <div id="widget1"></div>
                     <div id="widget2"></div>
                     <div id="widget3"></div>
@@ -1202,9 +1531,7 @@ describe('hx-ws WebSocket extension', function() {
             
             let ws = mockWebSocketInstances[0];
             ws.simulateMessage({
-                channel: 'ui',
-                format: 'html',
-                payload: `
+                content: `
                     <hx-partial id="widget1"><span>Data 1</span></hx-partial>
                     <hx-partial id="widget2"><span>Data 2</span></hx-partial>
                     <hx-partial id="widget3"><span>Data 3</span></hx-partial>
@@ -1224,9 +1551,9 @@ describe('hx-ws WebSocket extension', function() {
     
     describe('Target and Swap Overrides', function() {
         
-        it('respects target override from message envelope', async function() {
+        it('respects target override from message', async function() {
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load" hx-target="#default-target">
+                <div hx-ws:connect="/ws/test" hx-target="#default-target">
                     <div id="default-target">Default</div>
                     <div id="override-target">Override</div>
                 </div>
@@ -1235,9 +1562,7 @@ describe('hx-ws WebSocket extension', function() {
             
             let ws = mockWebSocketInstances[0];
             ws.simulateMessage({
-                channel: 'ui',
-                format: 'html',
-                payload: '<div>New Content</div>',
+                content: '<div>New Content</div>',
                 target: '#override-target'
             });
             await htmx.timeout(20);
@@ -1246,9 +1571,9 @@ describe('hx-ws WebSocket extension', function() {
             assert.include(document.getElementById('override-target').innerHTML, 'New Content');
         });
         
-        it('respects swap override from message envelope', async function() {
+        it('respects swap override from message', async function() {
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load" hx-target="#content" hx-swap="innerHTML">
+                <div hx-ws:connect="/ws/test" hx-target="#content" hx-swap="innerHTML">
                     <div id="content"><p>Item 1</p></div>
                 </div>
             `);
@@ -1256,9 +1581,7 @@ describe('hx-ws WebSocket extension', function() {
             
             let ws = mockWebSocketInstances[0];
             ws.simulateMessage({
-                channel: 'ui',
-                format: 'html',
-                payload: '<p>Item 2</p>',
+                content: '<p>Item 2</p>',
                 swap: 'beforeend'
             });
             await htmx.timeout(20);
@@ -1270,7 +1593,7 @@ describe('hx-ws WebSocket extension', function() {
         
         it('uses element hx-target when message has no target', async function() {
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load" hx-target="#element-target">
+                <div hx-ws:connect="/ws/test" hx-target="#element-target">
                     <div id="element-target"></div>
                 </div>
             `);
@@ -1278,9 +1601,7 @@ describe('hx-ws WebSocket extension', function() {
             
             let ws = mockWebSocketInstances[0];
             ws.simulateMessage({
-                channel: 'ui',
-                format: 'html',
-                payload: '<div>Content</div>'
+                content: '<div>Content</div>'
             });
             await htmx.timeout(20);
             
@@ -1289,7 +1610,7 @@ describe('hx-ws WebSocket extension', function() {
         
         it('uses element hx-swap when message has no swap', async function() {
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load" hx-target="#content" hx-swap="beforeend">
+                <div hx-ws:connect="/ws/test" hx-target="#content" hx-swap="beforeend">
                     <div id="content"><p>Item 1</p></div>
                 </div>
             `);
@@ -1297,9 +1618,7 @@ describe('hx-ws WebSocket extension', function() {
             
             let ws = mockWebSocketInstances[0];
             ws.simulateMessage({
-                channel: 'ui',
-                format: 'html',
-                payload: '<p>Item 2</p>'
+                content: '<p>Item 2</p>'
             });
             await htmx.timeout(20);
             
@@ -1310,7 +1629,7 @@ describe('hx-ws WebSocket extension', function() {
         
         it('message target overrides element hx-target', async function() {
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load" hx-target="#element-target">
+                <div hx-ws:connect="/ws/test" hx-target="#element-target">
                     <div id="element-target">Element Target</div>
                     <div id="message-target">Message Target</div>
                 </div>
@@ -1319,9 +1638,7 @@ describe('hx-ws WebSocket extension', function() {
             
             let ws = mockWebSocketInstances[0];
             ws.simulateMessage({
-                channel: 'ui',
-                format: 'html',
-                payload: '<div>New</div>',
+                content: '<div>New</div>',
                 target: '#message-target'
             });
             await htmx.timeout(20);
@@ -1332,7 +1649,7 @@ describe('hx-ws WebSocket extension', function() {
         
         it('message swap overrides element hx-swap', async function() {
             let container = createProcessedHTML(`
-                <div hx-ws:connect="/ws/test" hx-trigger="load" hx-target="#content" hx-swap="innerHTML">
+                <div hx-ws:connect="/ws/test" hx-target="#content" hx-swap="innerHTML">
                     <div id="content"><p>Original</p></div>
                 </div>
             `);
@@ -1340,9 +1657,7 @@ describe('hx-ws WebSocket extension', function() {
             
             let ws = mockWebSocketInstances[0];
             ws.simulateMessage({
-                channel: 'ui',
-                format: 'html',
-                payload: '<p>Appended</p>',
+                content: '<p>Appended</p>',
                 swap: 'beforeend'
             });
             await htmx.timeout(20);
@@ -1350,6 +1665,416 @@ describe('hx-ws WebSocket extension', function() {
             let content = document.getElementById('content');
             assert.include(content.innerHTML, 'Original');
             assert.include(content.innerHTML, 'Appended');
+        });
+    });
+
+    // ========================================
+    // 11. BUG REGRESSION TESTS
+    // ========================================
+
+    describe('Bug Regressions', function() {
+
+        it('htmx:after:ws:connection reports correct attempt number on reconnect', async function() {
+            htmx.config.ws = { reconnect: true, reconnectDelay: 50, reconnectJitter: 0 };
+
+            let container = createProcessedHTML(`
+                <div hx-ws:connect="/ws/test"></div>
+            `);
+            await htmx.timeout(50);
+
+            let reportedAttempt = null;
+            container.addEventListener('htmx:after:ws:connection', (e) => {
+                reportedAttempt = e.detail.connection.attempt;
+            });
+
+            // Close to trigger reconnect
+            let ws = mockWebSocketInstances[0];
+            ws.close();
+            await htmx.timeout(150);
+
+            assert.isNotNull(reportedAttempt, 'after:ws:connection should have fired on reconnect');
+            assert.equal(reportedAttempt, 1, 'Reconnection attempt should be 1, not 0');
+        });
+
+        it('htmx:before:ws:message includes raw data string', async function() {
+            let container = createProcessedHTML(`
+                <div hx-ws:connect="/ws/test" hx-target="#content">
+                    <div id="content"></div>
+                </div>
+            `);
+            await htmx.timeout(50);
+
+            let receivedData = null;
+            let receivedMessage = null;
+            container.addEventListener('htmx:before:ws:message', (e) => {
+                receivedData = e.detail.message.text;
+                receivedMessage = e.detail.message.json;
+            });
+
+            let ws = mockWebSocketInstances[0];
+            ws.simulateMessage({ content: '<p>Hello</p>' });
+            await htmx.timeout(20);
+
+            assert.isString(receivedData, 'text should be the raw string');
+            assert.isNotNull(receivedMessage, 'json should be the parsed JSON');
+            assert.equal(receivedMessage.content, '<p>Hello</p>');
+        });
+    });
+
+    // ========================================
+    // 12. ORPHANED CONNECTION CLEANUP TESTS (BLOCKER 1)
+    // ========================================
+
+    describe('Orphaned Connection Cleanup', function() {
+
+        it('closes WebSocket when connect element is swapped out mid-connection', async function() {
+            let container = createProcessedHTML(`
+                <div id="outer">
+                    <div id="ws-host" hx-ws:connect="/ws/test">
+                        <div id="content">Hello</div>
+                    </div>
+                </div>
+            `);
+            await htmx.timeout(50);
+
+            let ws = mockWebSocketInstances[0];
+            assert.equal(ws.readyState, mockWebSocket.OPEN, 'WebSocket should be open');
+            let registry = htmx.ext.ws.getRegistry();
+            assert.isTrue(registry.has('/ws/test'), 'Connection should be in registry');
+
+            // Swap out the ws-host element entirely (simulates hx-swap replacing it)
+            await htmx.swap({
+                text: '<div id="ws-host">Replaced — no hx-ws:connect</div>',
+                target: document.getElementById('outer'),
+                swap: 'innerHTML'
+            });
+            await htmx.timeout(50);
+
+            assert.equal(ws.readyState, mockWebSocket.CLOSED, 'WebSocket should be closed after element removal');
+            assert.isFalse(registry.has('/ws/test'), 'Connection should be removed from registry');
+        });
+
+        it('cleans up connection when element is removed and message arrives', async function() {
+            let container = createProcessedHTML(`
+                <div id="outer">
+                    <div id="ws-host" hx-ws:connect="/ws/test" hx-target="#content">
+                        <div id="content"></div>
+                    </div>
+                </div>
+            `);
+            await htmx.timeout(50);
+
+            let ws = mockWebSocketInstances[0];
+            let registry = htmx.ext.ws.getRegistry();
+
+            // Remove the element without triggering htmx cleanup (simulates raw DOM removal)
+            document.getElementById('ws-host').remove();
+            await htmx.timeout(20);
+
+            // Now a message arrives on the orphaned socket
+            ws.simulateMessage({ content: '<p>Ghost message</p>' });
+            await htmx.timeout(20);
+
+            assert.equal(ws.readyState, mockWebSocket.CLOSED, 'WebSocket should be closed');
+            assert.isFalse(registry.has('/ws/test'), 'Connection should be cleaned up');
+        });
+
+        it('cleans up connection on close when element is gone (no reconnect)', async function() {
+            htmx.config.ws = { reconnect: true, reconnectDelay: 20 };
+
+            let container = createProcessedHTML(`
+                <div id="outer">
+                    <div id="ws-host" hx-ws:connect="/ws/test">
+                        <div id="content">Hello</div>
+                    </div>
+                </div>
+            `);
+            await htmx.timeout(50);
+
+            let ws = mockWebSocketInstances[0];
+            let registry = htmx.ext.ws.getRegistry();
+
+            // Remove element from DOM without htmx cleanup
+            document.getElementById('ws-host').remove();
+            await htmx.timeout(20);
+
+            // Server-side close
+            ws.close();
+            await htmx.timeout(100);
+
+            // Should NOT attempt reconnection, should clean up
+            assert.equal(mockWebSocketInstances.length, 1, 'Should not create new WebSocket');
+            assert.isFalse(registry.has('/ws/test'), 'Connection should be removed from registry');
+        });
+
+        it('cleans up when element removed during reconnect delay', async function() {
+            htmx.config.ws = { reconnect: true, reconnectDelay: 200, reconnectJitter: 0 };
+
+            let container = createProcessedHTML(`
+                <div id="outer">
+                    <div id="ws-host" hx-ws:connect="/ws/test">Content</div>
+                </div>
+            `);
+            await htmx.timeout(50);
+
+            let ws = mockWebSocketInstances[0];
+            let registry = htmx.ext.ws.getRegistry();
+
+            // Close to trigger reconnect scheduling
+            ws.close();
+            await htmx.timeout(20);
+
+            // Remove element during the reconnect delay
+            await htmx.swap({
+                text: '<div>No more WS</div>',
+                target: document.getElementById('outer'),
+                swap: 'innerHTML'
+            });
+            await htmx.timeout(250);
+
+            // Reconnect timer should have fired but found no element, so no new socket
+            assert.equal(mockWebSocketInstances.length, 1, 'Should not reconnect after element removal');
+            assert.isFalse(registry.has('/ws/test'), 'Connection should be cleaned up');
+        });
+    });
+
+    // ========================================
+    // 13. BACKWARDS COMPAT — json.payload (BLOCKER 2)
+    // ========================================
+
+    describe('Backwards Compatibility - json.payload', function() {
+
+        it('swaps HTML from json.payload with deprecation warning', async function() {
+            let container = createProcessedHTML(`
+                <div hx-ws:connect="/ws/test" hx-target="#content">
+                    <div id="content">Original</div>
+                </div>
+            `);
+            await htmx.timeout(50);
+
+            let warnMessage = null;
+            let originalWarn = console.warn;
+            console.warn = (msg) => { warnMessage = msg; };
+
+            let ws = mockWebSocketInstances[0];
+            ws.simulateMessage({
+                payload: '<hx-partial id="content"><p>Via payload</p></hx-partial>'
+            });
+            await htmx.timeout(20);
+
+            console.warn = originalWarn;
+
+            assert.include(document.getElementById('content').innerHTML, 'Via payload');
+            assert.isNotNull(warnMessage, 'Should emit deprecation warning');
+            assert.include(warnMessage, 'payload');
+            assert.include(warnMessage, 'deprecated');
+        });
+
+        it('prefers json.content over json.payload when both present', async function() {
+            let container = createProcessedHTML(`
+                <div hx-ws:connect="/ws/test" hx-target="#content">
+                    <div id="content">Original</div>
+                </div>
+            `);
+            await htmx.timeout(50);
+
+            let warnCalled = false;
+            let originalWarn = console.warn;
+            console.warn = () => { warnCalled = true; };
+
+            let ws = mockWebSocketInstances[0];
+            ws.simulateMessage({
+                content: '<p>From content</p>',
+                payload: '<p>From payload</p>'
+            });
+            await htmx.timeout(20);
+
+            console.warn = originalWarn;
+
+            assert.include(document.getElementById('content').innerHTML, 'From content');
+            assert.notInclude(document.getElementById('content').innerHTML, 'From payload');
+            assert.isFalse(warnCalled, 'Should not warn when content is present');
+        });
+
+        it('does not swap when neither content nor payload is present', async function() {
+            let container = createProcessedHTML(`
+                <div hx-ws:connect="/ws/test" hx-target="#content">
+                    <div id="content">Original</div>
+                </div>
+            `);
+            await htmx.timeout(50);
+
+            let ws = mockWebSocketInstances[0];
+            ws.simulateMessage({ type: 'ping', data: 'hello' });
+            await htmx.timeout(20);
+
+            assert.equal(document.getElementById('content').textContent, 'Original');
+        });
+
+        it('handles json.payload with target and swap overrides', async function() {
+            let container = createProcessedHTML(`
+                <div hx-ws:connect="/ws/test">
+                    <div id="list"><p>Item 1</p></div>
+                </div>
+            `);
+            await htmx.timeout(50);
+
+            let originalWarn = console.warn;
+            console.warn = () => {}; // suppress
+
+            let ws = mockWebSocketInstances[0];
+            ws.simulateMessage({
+                payload: '<p>Item 2</p>',
+                target: '#list',
+                swap: 'beforeend'
+            });
+            await htmx.timeout(20);
+
+            console.warn = originalWarn;
+
+            let list = document.getElementById('list');
+            assert.include(list.innerHTML, 'Item 1');
+            assert.include(list.innerHTML, 'Item 2');
+        });
+    });
+
+    // ========================================
+    // 14. RECONNECT JITTER BOOLEAN COMPAT (POLISH)
+    // ========================================
+
+    describe('reconnectJitter Boolean Compatibility', function() {
+
+        it('treats reconnectJitter: true as 0.3 (default jitter)', async function() {
+            htmx.config.ws = {
+                reconnect: true,
+                reconnectDelay: 50,
+                reconnectJitter: true
+            };
+
+            let container = createProcessedHTML(`
+                <div hx-ws:connect="/ws/test"></div>
+            `);
+            await htmx.timeout(50);
+
+            // Should reconnect without breaking (true * delay would give NaN-like behavior)
+            let ws = mockWebSocketInstances[0];
+            ws.close();
+            await htmx.timeout(150);
+
+            assert.isTrue(mockWebSocketInstances.length > 1, 'Should reconnect with boolean jitter=true');
+        });
+
+        it('treats reconnectJitter: false as 0 (no jitter)', async function() {
+            htmx.config.ws = {
+                reconnect: true,
+                reconnectDelay: 50,
+                reconnectJitter: false
+            };
+
+            let container = createProcessedHTML(`
+                <div hx-ws:connect="/ws/test"></div>
+            `);
+            await htmx.timeout(50);
+
+            let ws = mockWebSocketInstances[0];
+            ws.close();
+            await htmx.timeout(100);
+
+            assert.isTrue(mockWebSocketInstances.length > 1, 'Should reconnect with boolean jitter=false');
+        });
+    });
+
+    // ========================================
+    // 15. ADDITIONAL FINDINGS — DEEP REVIEW
+    // ========================================
+
+    describe('Deep Review Fixes', function() {
+
+        it('falls back to live element when correlated element is removed from DOM', async function() {
+            let container = createProcessedHTML(`
+                <div hx-ws:connect="/ws/test">
+                    <form id="form1" hx-ws:send hx-trigger="submit" hx-target="#result">
+                        <input name="msg" value="hello">
+                    </form>
+                    <div id="result"></div>
+                </div>
+            `);
+            await htmx.timeout(50);
+
+            let form = document.getElementById('form1');
+            form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+            await htmx.timeout(20);
+
+            let ws = mockWebSocketInstances[0];
+            let sent = JSON.parse(ws.lastSent);
+            let requestId = sent.headers['HX-Request-ID'];
+
+            // Remove the form that sent the request (simulates swap replacing the form)
+            form.remove();
+            await htmx.timeout(20);
+
+            // Server responds with the request ID — should fall back to live connect element
+            ws.simulateMessage({
+                content: '<hx-partial id="result">Response</hx-partial>',
+                'HX-Request-ID': requestId
+            });
+            await htmx.timeout(20);
+
+            assert.include(document.getElementById('result').innerHTML, 'Response');
+        });
+
+        it('cleans up expired pending requests on message receive', async function() {
+            htmx.config.ws = { pendingRequestTTL: 50 };
+
+            let container = createProcessedHTML(`
+                <div hx-ws:connect="/ws/test">
+                    <button hx-ws:send hx-trigger="click">Send</button>
+                </div>
+            `);
+            await htmx.timeout(50);
+
+            let button = container.querySelector('button');
+            button.click();
+            await htmx.timeout(20);
+
+            let ws = mockWebSocketInstances[0];
+            let registry = htmx.ext.ws.getRegistry();
+            let conn = registry.get('/ws/test');
+            assert.equal(conn.pendingRequests.size, 1, 'Should have 1 pending request');
+
+            // Wait for TTL to expire
+            await htmx.timeout(100);
+
+            // Receive any message — should trigger cleanup
+            ws.simulateMessage({ type: 'ping' });
+            await htmx.timeout(20);
+
+            assert.equal(conn.pendingRequests.size, 0, 'Expired pending request should be cleaned up');
+        });
+
+        it('closeConnection aborts the AbortController', async function() {
+            let container = createProcessedHTML(`
+                <div id="outer">
+                    <div id="ws-host" hx-ws:connect="/ws/test">Content</div>
+                </div>
+            `);
+            await htmx.timeout(50);
+
+            let registry = htmx.ext.ws.getRegistry();
+            let conn = registry.get('/ws/test');
+            assert.isNotNull(conn, 'Connection should exist');
+            assert.isNotNull(conn.abortController, 'AbortController should exist');
+            let ac = conn.abortController;
+
+            // Remove the element to trigger closeConnection
+            await htmx.swap({
+                text: '',
+                target: document.getElementById('outer'),
+                swap: 'innerHTML'
+            });
+            await htmx.timeout(50);
+
+            assert.isTrue(ac.signal.aborted, 'AbortController should be aborted on close');
         });
     });
 });

--- a/www/src/content/docs/01-get-started/02-migration.md
+++ b/www/src/content/docs/01-get-started/02-migration.md
@@ -424,17 +424,9 @@ All events provide a consistent `ctx` object with request/response information.
 | [`morphSkip`](/reference/config/htmx-config-morphSkip)                 | `''`            | CSS selector for elements to skip during morph                |
 | [`morphSkipChildren`](/reference/config/htmx-config-morphSkipChildren) | `''`            | CSS selector for elements whose children to skip during morph |
 
-### SSE extension
-
-The SSE extension uses `fetch()` and [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)
-instead of [`EventSource`](https://developer.mozilla.org/en-US/docs/Web/API/EventSource). This enables request bodies,
-custom headers, and all HTTP methods.
-
-See the [SSE extension documentation](/docs/extensions/sse) for details.
-
 ### Core extensions
 
-htmx 4 ships with 9 core extensions:
+htmx 4 ships with 9 core extensions. The SSE and WebSocket extensions have been significantly rewritten. See their upgrade guides for details.
 
 | Extension                                                 | Description                                                                          |
 |-----------------------------------------------------------|--------------------------------------------------------------------------------------|
@@ -444,9 +436,9 @@ htmx 4 ships with 9 core extensions:
 | [`htmx-2-compat`](/docs/extensions/htmx-2-compat)         | Restores implicit inheritance, old event names, and previous error-swapping defaults |
 | [`optimistic`](/docs/extensions/optimistic)               | Shows expected content from a template before the server responds                    |
 | [`preload`](/docs/extensions/preload)                     | Triggers requests early (on mouseover/mousedown) for near-instant page loads         |
-| [`sse`](/docs/extensions/sse)                             | Server-Sent Events streaming support                                                 |
+| [`sse`](/docs/extensions/sse)                             | Server-Sent Events streaming support ([upgrade guide](/docs/extensions/sse#upgrading-from-htmx-2x)) |
 | [`upsert`](/docs/extensions/upsert)                       | Updates existing elements by ID and inserts new ones, preserving unmatched elements  |
-| [`ws`](/docs/extensions/ws)                               | Bi-directional Web Socket communication                                              |
+| [`ws`](/docs/extensions/ws)                               | Bi-directional WebSocket communication ([upgrade guide](/docs/extensions/ws#upgrading-from-htmx-2x)) |
 
 ## Checklist
 

--- a/www/src/content/docs/02-core-concepts/05-multi-target-updates.md
+++ b/www/src/content/docs/02-core-concepts/05-multi-target-updates.md
@@ -103,8 +103,11 @@ Wrap content in `<hx-partial>` tags. Specify where it goes with [`hx-target`](/r
 
 Each `<hx-partial>` accepts:
 
-- [`hx-target`](/reference/attributes/hx-target) - Required. CSS selector for where to place content
+- [`hx-target`](/reference/attributes/hx-target) - CSS selector for where to place content
+- `id` - Shorthand alternative to `hx-target`. Targets the element with that ID (e.g. `<hx-partial id="messages">` targets `#messages`)
 - [`hx-swap`](/reference/attributes/hx-swap) - Optional. Swap style (defaults to `innerHTML`)
+
+Either `hx-target` or `id` is required. If both are present, `hx-target` takes precedence.
 
 <details>
 <summary>Alternative syntax for template languages that strip unknown tags</summary>

--- a/www/src/content/docs/06-extensions/03-sse.md
+++ b/www/src/content/docs/06-extensions/03-sse.md
@@ -10,8 +10,6 @@ SSE is a lightweight alternative to WebSockets that works over existing HTTP con
 
 ## Installing
 
-Include the extension script after htmx. It ships with htmx in the `/ext/` directory:
-
 ```html
 <script src="https://cdn.jsdelivr.net/npm/htmx.org@next/dist/htmx.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/htmx.org@next/dist/ext/hx-sse.js"></script>
@@ -121,22 +119,25 @@ Messages without an `event:` field are swapped into the DOM as HTML content.
 
 Configure SSE behavior globally via `htmx.config.sse` or per-element via [`hx-config`](/reference/attributes/hx-config):
 
-```html
-<!-- Global config -->
-<meta name="htmx-config" content='{
-    "sse": {
-        "reconnect": true,
-        "reconnectDelay": 500,
-        "reconnectMaxDelay": 60000,
-        "reconnectMaxAttempts": 50,
-        "reconnectJitter": 0.3,
-        "pauseOnBackground": false
-    }
-}'>
-
-<!-- Per-element override -->
-<div hx-sse:connect="/stream" hx-config='{"sse": {"reconnect": false}}'>
+```javascript
+htmx.config.sse = {
+    reconnect: true,              // Auto-reconnect on stream end (default: true for hx-sse:connect, false for hx-get)
+    reconnectDelay: 500,          // Initial reconnect delay in ms (default: 500)
+    reconnectMaxDelay: 60000,     // Maximum reconnect delay in ms (default: 60000)
+    reconnectMaxAttempts: Infinity,// Maximum reconnection attempts (default: Infinity)
+    reconnectJitter: 0.3,         // Jitter factor 0-1 for delay randomization (default: 0.3)
+    pauseOnBackground: true       // Disconnect when tab is backgrounded (default: true for hx-sse:connect, false for hx-get)
+};
 ```
+
+```html
+<!-- Per-element override -->
+<div hx-sse:connect="/stream" hx-config="sse.reconnectDelay:1s sse.reconnectMaxAttempts:50">
+```
+
+Delay values accept time strings: `"500ms"`, `"1s"`, `"2m"`, or raw milliseconds.
+
+Defaults for `reconnect` and `pauseOnBackground` depend on how the SSE connection is established:
 
 | Option | Default (`hx-sse:connect`) | Default (`hx-get`) | Description |
 |--------|---------------------------|---------------------|-------------|
@@ -145,7 +146,7 @@ Configure SSE behavior globally via `htmx.config.sse` or per-element via [`hx-co
 | `reconnectMaxDelay` | `60000` | `60000` | Maximum reconnect delay (ms) |
 | `reconnectMaxAttempts` | `Infinity` | `Infinity` | Maximum reconnection attempts |
 | `reconnectJitter` | `0.3` | `0.3` | Jitter factor (0-1) for delay randomization |
-| `pauseOnBackground` | `true` | `false` | Disconnect when the tab is backgrounded, reconnect when visible (see [Background Tab Behavior](#background-tab-behavior)) |
+| `pauseOnBackground` | `true` | `false` | Disconnect when tab is backgrounded, reconnect when visible (see [Background Tab Behavior](#background-tab-behavior)) |
 
 ### Reconnection Strategy
 
@@ -223,10 +224,53 @@ that were sent in the meantime.
 
 ## Events
 
-### `htmx:before:sse:connection`
+### Connection Lifecycle
 
-Fired before a connection attempt (initial or reconnection). Set `detail.connection.cancelled = true` to prevent the connection.
+| Event | Cancelable | Detail | Description |
+|-------|------------|--------|-------------|
+| `htmx:before:sse:connection` | ✅ | `{connection}` | Before connection attempt (initial or reconnect) |
+| `htmx:after:sse:connection` | ❌ | `{connection}` | After successful connection |
+| `htmx:sse:close` | ❌ | `{connection, reason}` | When connection closes (see below) |
+| `htmx:sse:error` | ❌ | `{error, url, status}` | On stream error |
 
+The `connection` detail is the actual internal connection object, which includes:
+- `attempt`: `0` for initial connection, `> 0` for reconnections
+- `url`: the SSE endpoint URL
+- `config`: the resolved configuration for this connection
+- `lastEventId`: the last event ID received
+- `status`: the HTTP status code (available on `after` events)
+- `cancelled`: set to `true` in `before` events to cancel the connection
+
+The `htmx:sse:close` detail includes:
+- `connection`  - the connection object
+- `reason`  - why the connection closed:
+  - `"message"`  - closed by `hx-sse:close` matching a named event
+  - `"removed"`  - the element was removed from the DOM
+  - `"ended"`  - the stream ended naturally or reconnection was exhausted
+  - `"cancelled"`  - the initial connection was cancelled via `htmx:before:sse:connection`
+  - `"cleanup"`  - closed during element cleanup (e.g., parent swap)
+
+The `htmx:sse:error` detail includes:
+- `error`: the error object
+- `url`: the SSE endpoint URL
+- `status`: the HTTP status code (only present for non-2xx reconnect responses)
+
+### Message Events
+
+| Event | Cancelable | Detail | Description |
+|-------|------------|--------|-------------|
+| `htmx:before:sse:message` | ✅ | `{message: {data, event, id, cancelled}}` | Before processing an SSE message |
+| `htmx:after:sse:message` | ❌ | `{message: {data, event, id}}` | After processing an SSE message |
+
+The `message` detail includes:
+- `data`: the message data (modifiable)
+- `event`: the event type (modifiable)
+- `id`: the message ID (if specified)
+- `cancelled`: set to `true` in the `before` event to skip processing
+
+### Event Examples
+
+**Cancel Connection Based on Condition:**
 ```javascript
 document.body.addEventListener('htmx:before:sse:connection', function(evt) {
     if (evt.detail.connection.attempt > 10) {
@@ -235,25 +279,7 @@ document.body.addEventListener('htmx:before:sse:connection', function(evt) {
 });
 ```
 
-- `detail.connection.attempt` - attempt number (`0` = initial, `> 0` = reconnection)
-- `detail.connection.delay` - the delay before connection (ms), modifiable
-- `detail.connection.url` - the SSE endpoint URL
-- `detail.connection.lastEventId` - the last event ID received
-- `detail.connection.cancelled` - set to `true` to cancel
-
-### `htmx:after:sse:connection`
-
-Fired after a successful connection (or reconnection) to the SSE stream.
-
-- `detail.connection.attempt` - attempt number (`0` = initial, `> 0` = reconnection)
-- `detail.connection.url` - the SSE endpoint URL
-- `detail.connection.status` - the HTTP status code
-- `detail.connection.lastEventId` - the last event ID received
-
-### `htmx:before:sse:message`
-
-Fired before each SSE message is processed. All fields are modifiable.
-
+**Skip Heartbeat Messages:**
 ```javascript
 document.body.addEventListener('htmx:before:sse:message', function(evt) {
     // Skip heartbeats
@@ -266,33 +292,68 @@ document.body.addEventListener('htmx:before:sse:message', function(evt) {
 });
 ```
 
-- `detail.message.data` - the message data (modifiable)
-- `detail.message.event` - the event type (modifiable)
-- `detail.message.id` - the message ID (if specified)
-- `detail.message.cancelled` - set to `true` to skip
+## Examples
 
-### `htmx:after:sse:message`
+### LLM Streaming Response
 
-Fired after an SSE message has been processed.
+A one-off stream using `hx-post`  - the server returns `text/event-stream` and the extension handles it automatically:
 
-- `detail.message` - same shape as `htmx:before:sse:message`
+```html
+<form hx-post="/chat" hx-target="#response" hx-swap="innerHTML">
+    <textarea name="prompt" placeholder="Ask something..."></textarea>
+    <button type="submit">Send</button>
+</form>
+<div id="response"></div>
+```
 
-### `htmx:sse:error`
+The server streams tokens as SSE messages. Each message replaces the target content, so the user sees the response being "typed" in real-time. `hx-sse:connect` is not needed here. The extension enables streaming via normal `hx-post` (or `hx-get`, `hx-put`, etc.) attributes, based on the response `Content-Type` header.
 
-Fired when a stream error occurs.
+### Live Event Bus
 
-- `detail.error` - the error object
+A persistent connection that pushes targeted updates anywhere on the page using [`<hx-partial>`](/docs/core-concepts/multi-target-updates#partials-hx-partial):
 
-### `htmx:sse:close`
+```html
+<div hx-sse:connect="/events"></div>
 
-Fired when an SSE connection is closed.
+<!-- These can be anywhere on the page -->
+<div id="feed"></div>
+<div id="status"></div>
+```
 
-- `detail.reason` - why the connection was closed:
-  - `"message"` - closed by `hx-sse:close` matching a named event
-  - `"removed"` - the element was removed from the DOM
-  - `"ended"` - the stream ended naturally or reconnection was exhausted
-  - `"cancelled"` - the initial connection was cancelled via `htmx:before:sse:connection`
-  - `"cleanup"` - closed during element cleanup (e.g., parent swap)
+The server uses `<hx-partial>` with `hx-target` to control where each message goes:
+```
+data: <hx-partial hx-target="#feed" hx-swap="beforeend"><div class="event">User joined</div></hx-partial>
+
+data: <hx-partial hx-target="#feed" hx-swap="beforeend"><div class="event">New comment</div></hx-partial>
+
+data: <hx-partial hx-target="#status"><span>3 users online</span></hx-partial>
+```
+
+Each `<hx-partial>` targets any element in the DOM via `hx-target` (or `id` as a shorthand). The connection element itself doesn't need `hx-target` or `hx-swap` - the server controls where content goes.
+
+### Dashboard with Named Events
+
+Use named SSE events to route different data types to JavaScript handlers:
+
+```html
+<div hx-sse:connect="/dashboard"
+     hx-on:cpu="htmx.find('#cpu').textContent = event.detail.data"
+     hx-on:memory="htmx.find('#memory').textContent = event.detail.data">
+    <div>CPU: <span id="cpu">--</span></div>
+    <div>Memory: <span id="memory">--</span></div>
+</div>
+```
+
+Server sends named events:
+```
+event: cpu
+data: 45%
+
+event: memory
+data: 2.3 GB
+```
+
+Named events are dispatched as DOM events (not swapped), so you handle them with `hx-on` or `addEventListener`.
 
 ## Upgrading from htmx 2.x
 
@@ -324,6 +385,8 @@ This means:
     with every SSE message received from the chatroom.
 </div>
 ```
+
+The old `sse-connect` and `sse-close` attributes still work but emit a deprecation warning.
 
 ### Event Changes
 

--- a/www/src/content/docs/06-extensions/04-ws.md
+++ b/www/src/content/docs/06-extensions/04-ws.md
@@ -4,7 +4,10 @@ description: "Enable bidirectional real-time communication via WebSockets"
 keywords: ["websockets", "ws", "real-time", "bidirectional", "socket"]
 ---
 
-The WebSocket extension enables real-time, bidirectional communication with [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_client_applications) servers directly from HTML. It manages connections efficiently through reference counting, automatic reconnection, and seamless integration with htmx's swap and event model.
+The WebSocket extension enables real-time, bidirectional communication with
+[WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_client_applications)
+servers directly from HTML. It manages connections with automatic reconnection,
+connection sharing, and seamless integration with htmx's swap and event model.
 
 ## Installing
 
@@ -13,19 +16,14 @@ The WebSocket extension enables real-time, bidirectional communication with [Web
 <script src="https://cdn.jsdelivr.net/npm/htmx.org@next/dist/ext/hx-ws.js"></script>
 ```
 
-For npm-style build systems:
-
-```javascript
-import 'htmx.org';
-import 'htmx.org/dist/ext/hx-ws.js';
-```
-
 ## Usage
+
+Use these attributes to configure WebSocket behavior:
 
 | Attribute | Description |
 |-----------|-------------|
 | `hx-ws:connect="<url>"` | Establishes a WebSocket connection to the specified URL |
-| `hx-ws:send` | Sends form data or [`hx-vals`](/reference/attributes/hx-vals) to the WebSocket on trigger |
+| `hx-ws:send` | Sends form data or `hx-vals` to the WebSocket on trigger |
 | `hx-ws:send="<url>"` | Like `hx-ws:send` but creates its own connection to the URL |
 
 **JSX-Compatible Variants:** For frameworks that don't support colons in attribute names, use hyphen variants: `hx-ws-connect` and `hx-ws-send`.
@@ -47,79 +45,150 @@ This example:
 2. Appends incoming HTML messages to `#messages`
 3. Sends form data as JSON when the form is submitted
 
+## URL Normalization
+
+WebSocket URLs are automatically normalized:
+
+| Input | Output (on HTTPS page) |
+|-------|------------------------|
+| `/ws/chat` | `wss://example.com/ws/chat` |
+| `ws://localhost:8080/ws` | `ws://localhost:8080/ws` |
+| `https://api.example.com/ws` | `wss://api.example.com/ws` |
+| `//cdn.example.com/ws` | `wss://cdn.example.com/ws` |
+
+This means you can use simple relative paths in most cases, and the extension will construct the correct WebSocket URL.
+
 ## Receiving Messages
 
-### JSON Envelope Format
+### JSON Message Format
 
-Messages from the server should be JSON objects:
+Messages from the server should be JSON objects with a `content` field:
 
 ```json
 {
-    "channel": "ui",
-    "format": "html",
+    "content": "<div class='notification'>New message!</div>",
     "target": "#notifications",
     "swap": "beforeend",
-    "payload": "<div class='notification'>New message!</div>",
-    "request_id": "abc-123"
+    "HX-Request-ID": "abc-123"
 }
 ```
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `channel` | `"ui"` | Message routing channel |
-| `format` | `"html"` | Content format |
-| `target` | Element's [`hx-target`](/reference/attributes/hx-target) | CSS selector for target element |
-| `swap` | Element's [`hx-swap`](/reference/attributes/hx-swap) | Swap strategy (innerHTML, beforeend, etc.) |
-| `payload` | — | The content to swap |
-| `request_id` | — | Matches response to original request |
+| `content` | | HTML content to swap into the target |
+| `target` | Element's `hx-target` | CSS selector for target element |
+| `swap` | Element's `hx-swap` | Swap strategy (innerHTML, beforeend, etc.) |
+| `HX-Request-ID` | | Matches response to original request |
 
-**Minimal Example** (using all defaults):
-
+**Minimal example:**
 ```json
-{"payload": "<div>Hello World</div>"}
+{"content": "<div>Hello World</div>"}
 ```
 
-### Channels
+### Data-Only Messages
 
-- **`ui` channel** (default): HTML content is swapped into the target element using htmx's swap pipeline
-- **Custom channels**: Emit an `htmx:wsMessage` event for application handling
+JSON messages without a `content` field are not swapped. Use `htmx:before:ws:message` to handle them:
 
 ```javascript
-document.addEventListener('htmx:wsMessage', (e) => {
-    if (e.detail.channel === 'notifications') {
-        showNotification(e.detail.payload);
+document.addEventListener('htmx:before:ws:message', (e) => {
+    if (e.detail.message.json?.type === 'notification') {
+        showNotification(e.detail.message.json.text);
     }
 });
 ```
 
+### Raw HTML Messages
+
+If the server sends a plain string (not JSON), it's treated as raw HTML:
+
+```
+<div class="alert">Server restarting in 5 minutes</div>
+```
+
+If the connection element has an `hx-target`, the HTML is swapped into that target. Without an `hx-target`, `swap:none` is used - but [`<hx-partial>`](/docs/core-concepts/multi-target-updates#partials-hx-partial) elements in the message can still target their own destinations:
+
+```
+<hx-partial hx-target="#alerts" hx-swap="beforeend"><div class="alert">New alert</div></hx-partial>
+```
+
+### Request-Response Matching
+
+Each sent message includes a unique `HX-Request-ID` header. When the server echoes it back in the response, the content is routed to the element that sent the request (not the connection element):
+
+```html
+<form hx-ws:send hx-target="#result">
+    <input name="query" value="hello">
+    <button>Search</button>
+</form>
+<div id="result"></div>
+```
+
+The form sends `{"headers": {"HX-Request-ID": "abc-123", ...}, "body": {"query": "hello"}}`. The server responds with:
+
+```json
+{"content": "<p>Results for 'hello'</p>", "HX-Request-ID": "abc-123"}
+```
+
+Because `HX-Request-ID` matches, the content is swapped into `#result` (the form's `hx-target`), not the connection element.
+
 ## Sending Messages
 
-When an element with `hx-ws:send` is triggered, the extension sends a JSON message:
+When an element with `hx-ws:send` is triggered, the extension sends a structured JSON message with separate `headers` and `body`:
 
 ```json
 {
-    "type": "request",
-    "request_id": "550e8400-e29b-41d4-a716-446655440000",
-    "event": "submit",
     "headers": {
         "HX-Request": "true",
+        "HX-Request-ID": "550e8400-e29b-41d4-a716-446655440000",
+        "HX-Source": "form#chat-form",
+        "HX-Target": "div#messages",
         "HX-Current-URL": "https://example.com/chat"
     },
-    "values": {
-        "message": "Hello!"
-    },
-    "path": "wss://example.com/chatroom",
-    "id": "chat-form"
+    "body": {
+        "message": "Hello!",
+        "tags": ["urgent", "public"]
+    }
 }
+```
+
+**Headers** (from htmx core, same as HTTP requests):
+
+| Header | Description |
+|--------|-------------|
+| `HX-Request` | Always `"true"` |
+| `HX-Request-ID` | Unique ID for request/response matching |
+| `HX-Source` | Source element identifier (`tag#id` format) |
+| `HX-Target` | Target element identifier (only if `hx-target` is set) |
+| `HX-Current-URL` | Current page URL |
+
+**Body** contains form data and `hx-vals`. Multi-value fields (like checkboxes or multi-selects) are preserved as arrays.
+
+### Forms
+
+```html
+<form hx-ws:send>
+    <input name="username">
+    <input name="message">
+    <button type="submit">Send</button>
+</form>
+```
+
+### Buttons with hx-vals
+
+```html
+<button hx-ws:send hx-vals='{"action": "increment"}'>+1</button>
 ```
 
 ### Modifying Messages Before Send
 
-```javascript
-document.addEventListener('htmx:before:ws:send', (e) => {
-    e.detail.data.headers['Authorization'] = 'Bearer ' + getToken();
+Use the `htmx:before:ws:request` event to modify or cancel messages:
 
-    if (!isValid(e.detail.data)) {
+```javascript
+document.addEventListener('htmx:before:ws:request', (e) => {
+    e.detail.headers['Authorization'] = 'Bearer ' + getToken();
+
+    // Or cancel the send
+    if (!isValid(e.detail.body)) {
         e.preventDefault();
     }
 });
@@ -127,38 +196,62 @@ document.addEventListener('htmx:before:ws:send', (e) => {
 
 ## Configuration
 
-Configure the extension via `htmx.config.websockets`:
+Configure the extension globally via `htmx.config.ws` or per-element via `hx-config`:
 
 ```javascript
-htmx.config.websockets = {
-    reconnect: true,           // Enable auto-reconnect (default: true)
-    reconnectDelay: 1000,      // Initial reconnect delay in ms (default: 1000)
-    reconnectMaxDelay: 30000,  // Maximum reconnect delay in ms (default: 30000)
-    reconnectJitter: true,     // Add randomization to delays (default: true)
-    pendingRequestTTL: 30000   // Time-to-live for pending requests in ms (default: 30000)
+htmx.config.ws = {
+    reconnect: true,              // Enable auto-reconnect (default: true)
+    reconnectDelay: 500,          // Initial reconnect delay in ms (default: 500)
+    reconnectMaxDelay: 60000,     // Maximum reconnect delay in ms (default: 60000)
+    reconnectMaxAttempts: Infinity,// Maximum reconnect attempts (default: Infinity)
+    reconnectJitter: 0.3,         // Jitter factor 0-1 for randomizing delays (default: 0.3)
+    pauseOnBackground: true,      // Pause connection when tab is backgrounded (default: true)
+    pendingRequestTTL: 30000      // TTL for pending requests in ms (default: 30000)
 };
 ```
+
+```html
+<!-- Per-element override -->
+<div hx-ws:connect="/ws" hx-config="ws.reconnectDelay:1s ws.reconnectMaxAttempts:5">
+```
+
+Delay values accept time strings: `"500ms"`, `"1s"`, `"2m"`, or raw milliseconds.
+
+Per-element config is read from the element that creates the connection and stored on the connection object for its lifetime.
 
 ### Reconnection Strategy
 
 The extension uses exponential backoff with optional jitter:
 
-- **Base formula**: `delay = min(reconnectDelay * 2^(attempts-1), reconnectMaxDelay)`
-- **Jitter**: Adds +/-25% randomization to avoid thundering herd
+- **Base formula**: `delay = min(reconnectDelay × 2^(attempts-1), reconnectMaxDelay)`
+- **Jitter**: Adds ±30% randomization to avoid thundering herd
 - **Reset**: Attempts counter resets to 0 on successful connection
 
-## Connection Management
+Example reconnection delays with defaults:
+- Attempt 1: ~500ms
+- Attempt 2: ~1000ms
+- Attempt 3: ~2000ms
+- Attempt 4: ~4000ms
+- Attempt 5+: ~60000ms (capped)
 
-### Reference Counting
+### Connection Triggers
 
-Multiple elements can share a single WebSocket connection:
+By default, connections are established immediately when the element is processed:
 
 ```html
-<div hx-ws:connect="/notifications" id="notif-1"></div>
-<div hx-ws:connect="/notifications" id="notif-2"></div>
+<!-- Connects immediately when element appears (default) -->
+<div hx-ws:connect="/ws">
+
+<!-- Explicit load trigger - same behavior as no trigger -->
+<div hx-ws:connect="/ws" hx-trigger="load">
+
+<!-- Deferred connection - only connects when button is clicked -->
+<div hx-ws:connect="/ws" hx-trigger="click from:#connect-btn">
 ```
 
-When all elements using a connection are removed from the DOM, the connection is automatically closed.
+Use `hx-trigger` when you want to **delay** connection establishment (e.g., wait for user action).
+
+All standard `hx-trigger` modifiers are supported (`delay`, `throttle`, `once`, etc.).
 
 ## Events
 
@@ -166,21 +259,118 @@ When all elements using a connection are removed from the DOM, the connection is
 
 | Event | Cancelable | Detail | Description |
 |-------|------------|--------|-------------|
-| `htmx:before:ws:connect` | Yes | `{url}` | Before establishing connection |
-| `htmx:after:ws:connect` | No | `{url, socket}` | After successful connection |
-| `htmx:ws:close` | No | `{url, code, reason}` | When connection closes |
-| `htmx:ws:error` | No | `{url, error}` | On connection error |
-| `htmx:ws:reconnect` | No | `{url, attempts}` | Before reconnection attempt |
+| `htmx:before:ws:connection` | ✅ | `{connection}` | Before connection attempt (initial or reconnect) |
+| `htmx:after:ws:connection` | ❌ | `{connection}` | After successful connection |
+| `htmx:ws:close` | ❌ | `{connection, reason, code}` | When connection closes (see below) |
+| `htmx:ws:error` | ❌ | `{url, error}` | On connection or send error |
+
+The `htmx:ws:close` detail includes:
+- `connection`  - the connection object
+- `reason`  - why the connection closed: `"closed"` (WebSocket close event), `"removed"` (element removed from DOM), or `"cancelled"` (connection cancelled via `htmx:before:ws:connection` event)
+- `code`  - the WebSocket close code (e.g. `1000`), or `null` when removed via DOM cleanup
+
+The `connection` detail is the actual internal connection object, which includes:
+- `attempt`: `0` for initial connection, `> 0` for reconnections
+- `url`: the WebSocket URL
+- `config`: the resolved configuration for this connection
+- `socket`: the WebSocket instance (available on `after` events; `null` before initial connection)
+- `cancelled`: set to `true` in `before` events to cancel the connection
+- `pendingRequests`: Map of in-flight request/response pairs
+
+### Request Events
+
+| Event | Cancelable | Detail | Description |
+|-------|------------|--------|-------------|
+| `htmx:before:ws:request` | ✅ | `{headers, body}` | Before sending (headers and body are modifiable) |
+| `htmx:after:ws:request` | ❌ | `{headers, body}` | After message sent |
 
 ### Message Events
 
 | Event | Cancelable | Detail | Description |
 |-------|------------|--------|-------------|
-| `htmx:before:ws:send` | Yes | `{data, element, url}` | Before sending (data is modifiable) |
-| `htmx:after:ws:send` | No | `{data, url}` | After message sent |
-| `htmx:before:ws:message` | Yes | `{envelope, element}` | Before processing received message |
-| `htmx:after:ws:message` | No | `{envelope, element}` | After processing received message |
-| `htmx:wsMessage` | No | `{channel, format, payload, ...}` | For non-UI channel messages |
+| `htmx:before:ws:message` | ✅ | `{message: {text, json, cancelled}}` | Before processing any received message |
+| `htmx:after:ws:message` | ❌ | `{message: {text, json}}` | After processing any received message |
+
+`message.text` is the raw string. `message.json` is the parsed JSON object (or `null` for non-JSON). Set `message.cancelled = true` in the `before` event to prevent processing.
+
+### Event Examples
+
+**Cancel Connection Based on Condition:**
+```javascript
+document.addEventListener('htmx:before:ws:connection', (e) => {
+    if (e.detail.connection.attempt > 10) {
+        e.detail.connection.cancelled = true; // Stop reconnecting
+    }
+});
+```
+
+**Handle Data-Only Messages:**
+```javascript
+document.addEventListener('htmx:before:ws:message', (e) => {
+    if (e.detail.message.json?.type === 'audio') {
+        playAudioNotification(e.detail.message.json.url);
+    }
+});
+```
+
+**Log All WebSocket Activity:**
+```javascript
+document.addEventListener('htmx:after:ws:connection', (e) => {
+    console.log('Connected to', e.detail.connection.url);
+});
+document.addEventListener('htmx:ws:close', (e) => {
+    console.log('Disconnected from', e.detail.connection.url, 'reason:', e.detail.reason);
+});
+```
+
+## Connection Management
+
+### Connection Sharing
+
+Multiple elements pointing to the same WebSocket URL share a single connection:
+
+```html
+<div hx-ws:connect="/notifications" id="notif-1">
+    <!-- Uses connection to /notifications -->
+</div>
+<div hx-ws:connect="/notifications" id="notif-2">
+    <!-- Shares the same connection -->
+</div>
+```
+
+When all elements using a connection are removed from the DOM, the connection is automatically closed.
+
+### Element Cleanup
+
+When elements are removed (e.g., via htmx swap), the extension checks if any other element in the DOM still references the same WebSocket URL. If not, the connection is closed.
+
+This happens automatically through htmx's element cleanup lifecycle.
+
+## HTML Swapping
+
+When a JSON message with a `content` field arrives, the extension uses htmx's swap API, which provides:
+
+- All swap styles (`innerHTML`, `outerHTML`, `beforebegin`, `afterend`, `beforeend`, `afterbegin`, `delete`, `none`)
+- Preserved elements (`hx-preserve`)
+- Auto-focus handling
+- Scroll handling
+- Proper cleanup of removed elements
+- `htmx.process()` called on newly inserted content
+
+### Target Resolution
+
+Target is determined in this order:
+1. `target` field in the message
+2. `hx-target` attribute on the element that sent the request (if `HX-Request-ID` matches)
+3. `hx-target` attribute on the connection element
+4. The connection element itself
+
+### Swap Strategy
+
+Swap strategy is determined in this order:
+1. `swap` field in the message
+2. `hx-swap` attribute on the connection element (or the element that sent the request)
+3. `htmx.config.defaultSwap` (default: `innerHTML`)
 
 ## Examples
 
@@ -196,20 +386,45 @@ When all elements using a connection are removed from the DOM, the connection is
 </div>
 ```
 
-### Real-Time Dashboard
+Server sends:
+```json
+{"content": "<div class='message'><b>User:</b> Hello!</div>"}
+```
+
+### Real-Time Notifications
+
+```html
+<div hx-ws:connect="/notifications"
+     hx-target="#notification-list"
+     hx-swap="afterbegin">
+    <div id="notification-list"></div>
+</div>
+```
+
+### Interactive Counter
+
+```html
+<div hx-ws:connect="/counter">
+    <div id="count" hx-target="this">0</div>
+    <button hx-ws:send hx-vals='{"action":"increment"}'>+</button>
+    <button hx-ws:send hx-vals='{"action":"decrement"}'>-</button>
+</div>
+```
+
+### Multiple Widgets Sharing Connection
 
 ```html
 <div hx-ws:connect="/dashboard">
     <div id="cpu-usage">--</div>
     <div id="memory-usage">--</div>
+    <div id="disk-usage">--</div>
 </div>
 ```
 
 Server sends targeted updates:
-
 ```json
-{"target": "#cpu-usage", "payload": "<span>45%</span>"}
-{"target": "#memory-usage", "payload": "<span>2.3 GB</span>"}
+{"content": "<span>45%</span>", "target": "#cpu-usage"}
+{"content": "<span>2.3 GB</span>", "target": "#memory-usage"}
 ```
 
 ## Upgrading from htmx 2.x
@@ -221,20 +436,38 @@ Server sends targeted updates:
 | `ws-connect="<url>"` | `hx-ws:connect="<url>"` | Or `hx-ws-connect` for JSX |
 | `ws-send` | `hx-ws:send` | Or `hx-ws-send` for JSX |
 
+The old `ws-connect` and `ws-send` attributes still work but emit a deprecation warning.
+
 ### Event Changes
 
 | Old Event | New Event | Notes |
 |-----------|-----------|-------|
-| `htmx:wsOpen` | `htmx:after:ws:connect` | Different detail structure |
+| `htmx:wsConnecting` | (none) | Removed |
+| `htmx:wsOpen` | `htmx:after:ws:connection` | Different detail structure |
 | `htmx:wsClose` | `htmx:ws:close` | Now includes `code` and `reason` |
 | `htmx:wsError` | `htmx:ws:error` | Similar |
 | `htmx:wsBeforeMessage` | `htmx:before:ws:message` | Different detail structure |
 | `htmx:wsAfterMessage` | `htmx:after:ws:message` | Different detail structure |
-| `htmx:wsConfigSend` | `htmx:before:ws:send` | Modify `e.detail.data` instead |
-| `htmx:wsAfterSend` | `htmx:after:ws:send` | Similar |
+| `htmx:wsConfigSend` | `htmx:before:ws:request` | Modify `e.detail.headers` and `e.detail.body` |
+| `htmx:wsBeforeSend` | `htmx:before:ws:request` | Combined into one event |
+| `htmx:wsAfterSend` | `htmx:after:ws:request` | Similar |
+
+### Configuration Changes
+
+| Old | New |
+|-----|-----|
+| `htmx.config.wsReconnectDelay` | `htmx.config.ws.reconnectDelay` |
+| `createWebSocket` option | Not supported (use events) |
+| `wsBinaryType` option | Not supported |
+
+Note: earlier htmx 4.0 alpha builds used `htmx.config.websockets`. This has been renamed to `htmx.config.ws` for consistency with the extension name and attribute prefix.
 
 ### Message Format Changes
 
-**Send payload** now includes `type`, `request_id`, `event`, and structured `headers` object instead of `HEADERS` string.
+**Send payload** is now a structured `{headers, body}` JSON object. Headers contain `HX-Request`, `HX-Request-ID`, `HX-Source`, `HX-Target`, `HX-Current-URL`. Body contains form data and `hx-vals`.
 
-**Receive format** now expects JSON envelope with `channel`, `format`, `target`, `swap`, `payload` fields instead of raw HTML or [`hx-swap-oob`](/reference/attributes/hx-swap-oob).
+**Receive format** now expects JSON with `content`, `target`, `swap` fields instead of raw HTML or `hx-swap-oob`. Messages with a `content` field are auto-swapped; messages without `content` are data-only (handle via events). Use `HX-Request-ID` (instead of the old `request_id`) for request-response matching.
+
+### Socket Wrapper Removed
+
+The `socketWrapper` object is no longer exposed in events. Use the standard WebSocket events and the extension's event system instead.


### PR DESCRIPTION
## WS extension

**Send format** changed to `{headers, body}` with headers from core's `createRequestContext`:
```json
{
    "headers": {"HX-Request": "true", "HX-Request-ID": "550e..."},
    "body": {"message": "Hello!"}
}
```
Was a flat envelope with `type`, `request_id`, `values`, `path`.

**Receive format** uses `content` field. Was `payload` with `channel`/`format` routing. `json.payload` still accepted with deprecation warning.

**Config** renamed from `htmx.config.websockets` to `htmx.config.ws`.

**Connection management** uses DOM-scan to find connected elements. Was reference counting with `refCount` + `elements` Set.

**Listener cleanup** uses `AbortController`. Was manual `removeEventListener` with stored references.

**Trigger handling** uses `api.onTrigger`. Was manual `parseTriggerSpecs` + `addEventListener`.

Added: orphaned connection cleanup, `pauseOnBackground`, `reconnectMaxAttempts`, per-element config via `hx-config`, numeric `reconnectJitter` (was boolean), `parseInterval` for delay strings.

## SSE extension

- Internal state consolidated into a single `connection` object (was split across local variables)
- `config` exposed on connection object
- `api.triggerHtmxEvent` used consistently (was mixing with `htmx.trigger`)
- `sse-connect` legacy attribute support added
- Event detail built as `{message: {...}}` consistently (matches WS)
- `cancelled` removed from `after:message` event detail

## Core (`htmx.js`)

`HX-Request-Type` and `HX-Target` headers moved into `createRequestContext` so extensions can access them without running the full request flow.

Docs updated for both extensions. All 1088 tests pass.