### PR TITLE
simplify outerHTML target fallback

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1329,11 +1329,10 @@ var htmx = (() => {
                     target.textContent = fragment.textContent;
                 } else if (swapStyle === 'outerHTML') {
                     if (parentNode) {
-                        let sibling = target.previousSibling;
                         this.__insertNodes(parentNode, target, fragment);
                         this.__cleanup(target)
                         parentNode.removeChild(target);
-                        target = sibling?.nextSibling || parentNode.firstChild || parentNode
+                        target = newContent[0] || parentNode
                     }
                 } else if (swapStyle === 'innerMorph') {
                     this.__morph(target, fragment, true);


### PR DESCRIPTION
## Description
I think we can simplify the fallback code for when outerHTML removes the target to just newContent[0].  I was worried this could be a text element which could break things so was thinking of doing a filter to return first Element in newContent but turns out if it is a text node it just works fine and triggers events fine and class changes on target are guarded already so just no-op .

The only thing we lose with this simplification is possibly scroll To will possibly go to the parent node when you use outerHTML to blank the target with "".  But I can't see a realistic situation where you would want to delete with outerHTML swap and also want to scroll to this exact point.

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
