### PR TITLE
handle disabling hx-location push better so you can use replace easier.

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -603,7 +603,7 @@ var htmx = (() => {
                     path = opts.path;
                     delete opts.path;
                 }
-                opts.push = opts.push || 'true';
+                opts.push ??= 'true';
                 this.ajax('GET', path, opts);
                 return true // TODO this seems legit
             }


### PR DESCRIPTION
## Description
* If you need to use hx-location with the optional replace option then you also need to set push to false to remove the default push=true that hx-location applies.  But right now it checks if push is set to something falsey before setting push to 'true' and this means the only way to block push and allow replace option to work is to use javascript format and set push to "false" so it is a truthy string.  you can't use boolean false or the non JSON parseConfig format which always uses boolean false here.  To fix this we can simplify the code with ??= 'true' so it will set push to true only when it is null or undefined.

Corresponding issue:

## Testing
no automatic testing for hx-location yet as it breaks the automated tests

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
