### PR TITLE
fix hx-location to handle replace

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -4696,8 +4696,10 @@ var htmx = (function() {
     const requestPath = responseInfo.pathInfo.finalRequestPath
     const responsePath = responseInfo.pathInfo.responsePath
 
-    const pushUrl = responseInfo.etc.push || getClosestAttributeValue(elt, 'hx-push-url')
-    const replaceUrl = responseInfo.etc.replace || getClosestAttributeValue(elt, 'hx-replace-url')
+    let pushUrl = responseInfo.etc.push || getClosestAttributeValue(elt, 'hx-push-url')
+    let replaceUrl = responseInfo.etc.replace || getClosestAttributeValue(elt, 'hx-replace-url')
+    if (pushUrl === 'false') pushUrl = null
+    if (replaceUrl === 'false') replaceUrl = null
     const elementIsBoosted = getInternalData(elt).boosted
 
     let saveType = null
@@ -4715,11 +4717,6 @@ var htmx = (function() {
     }
 
     if (path) {
-    // false indicates no push, return empty object
-      if (path === 'false') {
-        return {}
-      }
-
       // true indicates we want to follow wherever the server ended up sending us
       if (path === 'true') {
         path = responsePath || requestPath // if there is no response path, go with the original request path
@@ -4825,7 +4822,7 @@ var htmx = (function() {
         redirectPath = redirectSwapSpec.path
         delete redirectSwapSpec.path
       }
-      redirectSwapSpec.push = redirectSwapSpec.push || 'true'
+      redirectSwapSpec.push = redirectSwapSpec.push ?? 'true'
       ajaxHelper('get', redirectPath, redirectSwapSpec)
       return
     }

--- a/www/static/test/core/headers.js
+++ b/www/static/test/core/headers.js
@@ -442,6 +442,38 @@ describe('Core htmx AJAX headers', function() {
     }, 30)
   })
 
+  it('should replace Url on HX-Location if push is false and replace is set', function(done) {
+    sessionStorage.setItem('htmx-current-path-for-history', '/old')
+    this.server.respondWith('GET', '/test', [200, { 'HX-Location': '{"push":false, "replace":"true", "path":"/test2", "target":"#work-area"}' }, ''])
+    this.server.respondWith('GET', '/test2', [200, {}, '<div>Yay! Welcome</div>'])
+    var div = make('<div id="testdiv" hx-trigger="click" hx-get="/test"></div>')
+    div.click()
+    this.server.respond()
+    this.server.respond()
+    setTimeout(function() {
+      getWorkArea().innerHTML.should.equal('<div>Yay! Welcome</div>')
+      var path = sessionStorage.getItem('htmx-current-path-for-history')
+      path.should.equal('/test2')
+      done()
+    }, 30)
+  })
+
+  it('should replace Url on HX-Location if push is string false and replace is set', function(done) {
+    sessionStorage.setItem('htmx-current-path-for-history', '/old')
+    this.server.respondWith('GET', '/test', [200, { 'HX-Location': '{"push":"false", "replace":"true", "path":"/test2", "target":"#work-area"}' }, ''])
+    this.server.respondWith('GET', '/test2', [200, {}, '<div>Yay! Welcome</div>'])
+    var div = make('<div id="testdiv" hx-trigger="click" hx-get="/test"></div>')
+    div.click()
+    this.server.respond()
+    this.server.respond()
+    setTimeout(function() {
+      getWorkArea().innerHTML.should.equal('<div>Yay! Welcome</div>')
+      var path = sessionStorage.getItem('htmx-current-path-for-history')
+      path.should.equal('/test2')
+      done()
+    }, 30)
+  })
+
   it('should push different Url on HX-Location if push Url is string', function(done) {
     sessionStorage.removeItem('htmx-current-path-for-history')
     var HTMX_HISTORY_CACHE_NAME = 'htmx-history-cache'


### PR DESCRIPTION
## Description
With HX-Location you can disable the default push = 'true' it does with false but there is currently no way to enable the replace option I added documentation for earlier.  While you can set push to 'false' this is still truthy and this blocks it picking up replace option.  You can try using the boolean false but this just gets overwritten by 'true' right now.  

So to fix this just need to use ?? instead of || so boolean false will prevent the 'true'.  And also improve handling of 'false' by setting it to null so it won't block replace applying.

Corresponding issue:

## Testing
Added a couple of tests for setting push to false and 'false' and setting replace.

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
