### PR TITLE
fix: moved playwright from dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,8 +69,6 @@
     "brotli-cli": "^2.1.1",
     "terser": "^5.46.0",
     "ws": "^8.19.0"
-  },
-  "dependencies": {
     "playwright": "^1.58.2"
-  }
+  },
 }


### PR DESCRIPTION
[Issue #3745](https://github.com/bigskysoftware/htmx/issues/3745)

## Description
moved playwright from dependencies to devDependencies

Corresponding issue:

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
