### PR TITLE
Add auto detection and header based triggering to hx-download extension

### DIFF
--- a/src/ext/hx-download.js
+++ b/src/ext/hx-download.js
@@ -1,9 +1,15 @@
 //==========================================================
 // hx-download.js
 //
-// An extension that adds a 'download' swap style which
-// triggers a file download instead of a DOM swap, with
-// streaming progress events for progress bars.
+// An extension that triggers a file download instead of a
+// DOM swap, with streaming progress events for progress bars.
+//
+// Activates when:
+//   - hx-swap="download" is set on the element
+//   - server responds with Content-Disposition: attachment
+//   - server responds with HX-Download: <url> (fetches that
+//     url as the download, useful when the backend cannot
+//     stream the file directly as the htmx response)
 //
 // Usage:
 //   <button hx-get="/file.pdf" hx-swap="download"
@@ -15,51 +21,51 @@
 //   htmx:download:complete {filename, size}
 //==========================================================
 (() => {
+    let api;
+
     htmx.registerExtension('download', {
-        htmx_before_request: (elt, {ctx}) => {
-            if (ctx.swap !== 'download') return;
-            let originalFetch = ctx.fetch;
-            ctx.fetch = async (url, options) => {
-                let response = await originalFetch(url, options);
-                let total = +response.headers.get('Content-Length') || null;
-                htmx.trigger(ctx.sourceElement, 'htmx:download:start', {total});
-
-                let reader = response.body.getReader();
-                let chunks = [], loaded = 0;
-                while (true) {
-                    let {done, value} = await reader.read();
-                    if (done) break;
-                    chunks.push(value);
-                    loaded += value.length;
-                    htmx.trigger(ctx.sourceElement, 'htmx:download:progress', {
-                        loaded, total,
-                        percent: total ? Math.round(loaded / total * 100) : null
-                    });
-                }
-
-                ctx.download = {
-                    blob: new Blob(chunks, {
-                        type: response.headers.get('Content-Type') || 'application/octet-stream'
-                    }),
-                    filename: parseFilename(response.headers, url)
-                };
-                return new Response('', {status: response.status, headers: response.headers});
-            };
+        init: (internalAPI) => {
+            api = internalAPI;
         },
-
-        htmx_before_swap: (elt, {ctx}) => {
-            if (!ctx.download) return;
-            let {blob, filename} = ctx.download;
-            let url = URL.createObjectURL(blob);
-            let a = document.createElement('a');
-            a.href = url;
-            a.download = filename;
-            a.click();
-            URL.revokeObjectURL(url);
-            htmx.trigger(ctx.sourceElement, 'htmx:download:complete', {filename, size: blob.size});
+        htmx_before_response: (elt, {ctx}) => {
+            let downloadUrl = ctx.response.headers.get('HX-Download');
+            if (downloadUrl) {
+                (async () => streamDownload(ctx.sourceElement, await fetch(downloadUrl), downloadUrl))();
+                return;
+            }
+            let cd = ctx.response.headers.get('Content-Disposition');
+            if (ctx.swap !== 'download' && !cd?.includes('attachment')) return;
+            streamDownload(ctx.sourceElement, ctx.response.raw, ctx.request.action);
             return false;
         }
     });
+
+    function streamDownload(sourceElement, response, url) {
+        (async () => {
+            let total = +response.headers.get('Content-Length') || null;
+            api.triggerHtmxEvent(sourceElement, 'htmx:download:start', {total});
+            let reader = response.body.getReader();
+            let chunks = [], loaded = 0;
+            while (true) {
+                let {done, value} = await reader.read();
+                if (done) break;
+                chunks.push(value);
+                loaded += value.length;
+                api.triggerHtmxEvent(sourceElement, 'htmx:download:progress', {
+                    loaded, total,
+                    percent: total ? Math.round(loaded / total * 100) : null
+                });
+            }
+            let blob = new Blob(chunks, {
+                type: response.headers.get('Content-Type') || 'application/octet-stream'
+            });
+            let filename = parseFilename(response.headers, url);
+            let blobUrl = URL.createObjectURL(blob);
+            Object.assign(document.createElement('a'), {href: blobUrl, download: filename}).click();
+            URL.revokeObjectURL(blobUrl);
+            api.triggerHtmxEvent(sourceElement, 'htmx:download:complete', {filename, size: blob.size});
+        })();
+    }
 
     function parseFilename(headers, url) {
         let cd = headers.get('Content-Disposition');

--- a/test/manual/download-example.js
+++ b/test/manual/download-example.js
@@ -8,50 +8,78 @@ const routes = {
 <html>
 <head>
     <title>hx-download demo</title>
+    <meta name="htmx-config" content='{"extensions":"download"}'>
     <script src="/htmx.js"></script>
     <script src="/ext/hx-download.js"></script>
     <style>
-        body { font-family: system-ui; max-width: 600px; margin: 40px auto; padding: 0 20px; }
-        button { padding: 8px 16px; cursor: pointer; font-size: 14px; }
-        progress { width: 100%; height: 24px; margin: 12px 0; }
-        #status { color: #666; font-size: 14px; min-height: 20px; }
+        body { font-family: system-ui; max-width: 700px; margin: 40px auto; padding: 0 20px; }
+        h2 { margin-top: 2em; border-bottom: 1px solid #ccc; padding-bottom: 4px; }
+        button { padding: 8px 16px; cursor: pointer; font-size: 14px; margin-right: 8px; }
+        progress { width: 100%; height: 20px; margin: 8px 0; }
+        .status { color: #555; font-size: 13px; min-height: 18px; margin-bottom: 8px; }
+        #swap-result { border: 1px solid #ccc; padding: 8px; min-height: 2em; margin-top: 8px; color: #333; }
+        .htmx-indicator { display: none; }
+        .htmx-request .htmx-indicator, .htmx-request.htmx-indicator { display: inline; }
     </style>
 </head>
-<body>
-    <h2>hx-swap="download" demo</h2>
-
-    <button hx-get="/small-file" hx-swap="download" hx-ext="download">
-        Small file (instant)
-    </button>
-
-    <button hx-get="/large-file" hx-swap="download" hx-ext="download">
-        Large file (slow, with progress)
-    </button>
+<body hx-ext="download">
+    <h1>hx-download demo</h1>
 
     <progress id="prog" value="0" max="100"></progress>
-    <div id="status"></div>
+    <div class="status" id="status">—</div>
 
     <script>
-        let status = document.getElementById("status");
-        let prog = document.getElementById("prog");
-
-        document.body.addEventListener("htmx:download:start", e => {
+        let prog = document.getElementById('prog');
+        let status = document.getElementById('status');
+        document.body.addEventListener('htmx:download:start', e => {
             prog.value = 0;
-            let total = e.detail.total;
-            status.textContent = total
-                ? "Downloading " + (total / 1024).toFixed(0) + " KB..."
-                : "Downloading...";
+            status.textContent = 'start — total: ' + (e.detail.total ?? 'unknown');
         });
-
-        document.body.addEventListener("htmx:download:progress", e => {
+        document.body.addEventListener('htmx:download:progress', e => {
             if (e.detail.percent != null) prog.value = e.detail.percent;
+            status.textContent = 'progress — ' + e.detail.loaded + ' bytes'
+                + (e.detail.percent != null ? ' (' + e.detail.percent + '%)' : ' (no Content-Length)');
         });
-
-        document.body.addEventListener("htmx:download:complete", e => {
+        document.body.addEventListener('htmx:download:complete', e => {
             prog.value = 100;
-            status.textContent = "Saved " + e.detail.filename + " (" + (e.detail.size / 1024).toFixed(0) + " KB)";
+            status.textContent = 'complete — ' + e.detail.filename + ' (' + e.detail.size + ' bytes)';
         });
     </script>
+
+    <h2>1. hx-swap="download" (explicit)</h2>
+    <p>Expected: downloads <code>hello.txt</code></p>
+    <button hx-get="/small-file" hx-swap="download">Small file (instant)</button>
+
+    <h2>2. Large file with progress</h2>
+    <p>Expected: progress bar fills over ~3s, downloads <code>large.bin</code></p>
+    <button hx-get="/large-file" hx-swap="download">Large file (slow, with progress)</button>
+
+    <h2>3. Content-Disposition: attachment auto-detect</h2>
+    <p>Expected: downloads <code>auto.txt</code> with no <code>hx-swap</code> needed on the element</p>
+    <button hx-get="/auto-detect" hx-target="#swap-result">Download (auto-detect)</button>
+
+    <h2>4. HX-Download header — download + swap</h2>
+    <p>Expected: downloads <code>redirected.txt</code> AND swaps HTML into the box below</p>
+    <button hx-get="/hx-download-header" hx-target="#swap-result">Download + swap (HX-Download)</button>
+    <div id="swap-result">swap target (should update on test 4)</div>
+
+    <h2>5. UTF-8 filename (filename*=UTF-8''...)</h2>
+    <p>Expected: downloads <code>café report.txt</code></p>
+    <button hx-get="/utf8-filename" hx-swap="download">UTF-8 filename</button>
+
+    <h2>6. No Content-Length header</h2>
+    <p>Expected: downloads <code>unknown-size.txt</code>, progress shows bytes but no percent</p>
+    <button hx-get="/no-content-length" hx-swap="download">No Content-Length</button>
+
+    <h2>7. Indicators cleared after download</h2>
+    <p>Expected: spinner visible during download, hidden after — button re-enabled</p>
+    <button id="ind-btn"
+            hx-get="/large-file"
+            hx-swap="download"
+            hx-indicator="#spinner"
+            hx-disabled-elt="#ind-btn">
+        Download with indicator <span id="spinner" class="htmx-indicator">⏳ loading...</span>
+    </button>
 </body>
 </html>`);
     },
@@ -66,7 +94,7 @@ const routes = {
         res.end(await fs.readFile('src/ext/hx-download.js'));
     },
 
-    // Small file — downloads instantly
+    // 1. Small file — downloads instantly via hx-swap="download"
     '/small-file': (req, res) => {
         let body = 'Hello from hx-download!\n';
         res.writeHead(200, {
@@ -77,29 +105,81 @@ const routes = {
         res.end(body);
     },
 
-    // Large file — streams slowly so you can see the progress bar
+    // 2. Large file — streams slowly so progress bar is visible
     '/large-file': (req, res) => {
-        let chunkSize = 16 * 1024;  // 16 KB chunks
-        let totalChunks = 32;       // 512 KB total
+        let chunkSize = 16 * 1024;
+        let totalChunks = 32;
         let total = chunkSize * totalChunks;
-
         res.writeHead(200, {
             'Content-Type': 'application/octet-stream',
             'Content-Length': total,
-            'Content-Disposition': 'attachment; filename="test-data.bin"'
+            'Content-Disposition': 'attachment; filename="large.bin"'
         });
-
         let sent = 0;
         let interval = setInterval(() => {
-            let chunk = Buffer.alloc(chunkSize, 0x42);  // fill with 'B'
-            res.write(chunk);
+            res.write(Buffer.alloc(chunkSize, 0x42));
             sent += chunkSize;
-            if (sent >= total) {
-                clearInterval(interval);
-                res.end();
-            }
+            if (sent >= total) { clearInterval(interval); res.end(); }
         }, 100);
+        req.on('close', () => clearInterval(interval));
+    },
 
+    // 3. Auto-detect via Content-Disposition: attachment, no hx-swap needed
+    '/auto-detect': (req, res) => {
+        let body = 'auto-detected download\n';
+        res.writeHead(200, {
+            'Content-Type': 'text/plain',
+            'Content-Length': Buffer.byteLength(body),
+            'Content-Disposition': 'attachment; filename="auto.txt"'
+        });
+        res.end(body);
+    },
+
+    // 4a. HX-Download header — also returns HTML for the swap
+    '/hx-download-header': (req, res) => {
+        let body = '<em>swap also happened!</em>';
+        res.writeHead(200, {
+            'Content-Type': 'text/html',
+            'Content-Length': Buffer.byteLength(body),
+            'HX-Download': '/hx-download-target'
+        });
+        res.end(body);
+    },
+
+    // 4b. The actual file fetched by the extension via HX-Download
+    '/hx-download-target': (req, res) => {
+        let body = 'redirected download content\n';
+        res.writeHead(200, {
+            'Content-Type': 'text/plain',
+            'Content-Length': Buffer.byteLength(body),
+            'Content-Disposition': 'attachment; filename="redirected.txt"'
+        });
+        res.end(body);
+    },
+
+    // 5. UTF-8 encoded filename via filename*=UTF-8''
+    '/utf8-filename': (req, res) => {
+        let body = 'unicode filename test\n';
+        res.writeHead(200, {
+            'Content-Type': 'text/plain',
+            'Content-Length': Buffer.byteLength(body),
+            'Content-Disposition': "attachment; filename*=UTF-8''caf%C3%A9%20report.txt"
+        });
+        res.end(body);
+    },
+
+    // 6. No Content-Length — percent should be null in progress events
+    '/no-content-length': (req, res) => {
+        let chunks = ['no ', 'content-', 'length\n'].map(s => Buffer.from(s));
+        res.writeHead(200, {
+            'Content-Type': 'text/plain',
+            'Content-Disposition': 'attachment; filename="unknown-size.txt"'
+        });
+        let i = 0;
+        let interval = setInterval(() => {
+            res.write(chunks[i++]);
+            if (i >= chunks.length) { clearInterval(interval); res.end(); }
+        }, 200);
         req.on('close', () => clearInterval(interval));
     }
 };

--- a/www/src/content/docs/06-extensions/09-download.md
+++ b/www/src/content/docs/06-extensions/09-download.md
@@ -4,7 +4,13 @@ description: "Save responses as file downloads with streaming progress."
 keywords: ["download", "file", "save", "progress", "streaming"]
 ---
 
-The `download` extension adds a `download` swap style that saves the response as a file instead of swapping it into the DOM. It streams the response body and fires progress events.
+The `download` extension saves a response as a file download instead of swapping it into the DOM. It streams the response body and fires progress events.
+
+It activates in three ways:
+
+- `hx-swap="download"` on the element
+- The server responds with `Content-Disposition: attachment` (auto-detected, no attribute needed)
+- The server responds with `HX-Download: <url>` (extension fetches that URL as the download, while the original response is still swapped normally)
 
 ## Installing
 
@@ -15,7 +21,9 @@ The `download` extension adds a `download` swap style that saves the response as
 
 ## Usage
 
-Use `hx-swap="download"` on any element that should trigger a file download:
+### Explicit swap style
+
+Use `hx-swap="download"` to always treat the response as a download:
 
 ```html
 <button hx-get="/files/report.pdf" hx-swap="download">
@@ -23,7 +31,40 @@ Use `hx-swap="download"` on any element that should trigger a file download:
 </button>
 ```
 
-The filename is extracted from the `Content-Disposition` header, falling back to the URL's last path segment.
+### Auto-detect via Content-Disposition
+
+If the server returns `Content-Disposition: attachment`, the extension triggers a download automatically — no `hx-swap` needed:
+
+```html
+<button hx-get="/files/report.pdf" hx-target="#result">
+    Download Report
+</button>
+```
+
+```http
+Content-Disposition: attachment; filename="report.pdf"
+```
+
+### HX-Download header
+
+When the backend cannot stream the file directly as the htmx response (e.g. it needs to redirect to a separate download endpoint), return an `HX-Download` header pointing to the file URL. The extension will fetch that URL as the download while htmx processes the original response body as a normal swap:
+
+```html
+<button hx-get="/prepare-download" hx-target="#status">
+    Download Report
+</button>
+```
+
+```http
+HX-Download: /files/report.pdf
+Content-Type: text/html
+
+<span>Your download has started...</span>
+```
+
+The `<span>` is swapped into `#status` and the file at `/files/report.pdf` is downloaded simultaneously.
+
+This approach also avoids the indicator/disabled-element cleanup problem that occurs with `HX-Redirect` pointing to a download URL — indicators are cleared correctly after the original request completes.
 
 ### Progress Bar
 
@@ -42,18 +83,19 @@ document.body.addEventListener("htmx:download:progress", e => {
 </script>
 ```
 
-The server must send a `Content-Length` header for percentage-based progress. Without it, `percent` will be `null`.
+The server must send a `Content-Length` header for percentage-based progress. Without it, `percent` will be `null` and only `loaded` (bytes received) is available.
 
 ## Events
 
 | Event | Detail | Description |
 |---|---|---|
-| `htmx:download:start` | `{total}` | Response headers received, streaming begins |
-| `htmx:download:progress` | `{loaded, total, percent}` | Fired for each chunk received |
-| `htmx:download:complete` | `{filename, size}` | File download triggered |
+| `htmx:download:start` | `{total}` | Response headers received, streaming begins. `total` is `null` if no `Content-Length` |
+| `htmx:download:progress` | `{loaded, total, percent}` | Fired for each chunk received. `percent` is `null` if no `Content-Length` |
+| `htmx:download:complete` | `{filename, size}` | File download triggered in the browser |
 
 ## Notes
 
-- Only the response body is downloaded: no DOM swap occurs.
-- Cancellation works automatically via htmx's built-in request abort handling.
 - Binary files (PDFs, images, archives) are handled correctly.
+- The filename is extracted from the `Content-Disposition` header (`filename` or `filename*=UTF-8''...`), falling back to the URL's last path segment.
+- Cancellation works automatically via htmx's built-in request abort handling.
+- For `HX-Download`, indicators and disabled elements are cleared correctly after the original request completes — the secondary fetch runs independently.


### PR DESCRIPTION
## Description
I think we can simplify and extend the download extension.  because we now have the event htmx:before:response we can intercept all requests before they get text read and this avoids us having to patch fetch.  And this also gives us the super power of just reading `Content-Disposition` and if it is returned from any response to any htmx request we can auto upgrade to download streaming mode which makes the process completely seamless.  Server can just return a file for download and it just works with no hx-swap=download opt in.  

It is also common for users to use HX-Redirect headers in htmx to point to download files as a way for a htmx response to trigger an existing download url but this causes problems as request indicators are never cleared when you use this pattern.  So to solve this use case we can easily add a HX-Download response header that when returned with any response will trigger a full download to the supplied URL.

Corresponding issue:

## Testing
Updated the manual test server to fully test the new features.

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
