### PR TITLE
fix: support textContent swap style for hx-swap-oob (#3563)

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1818,6 +1818,9 @@ var htmx = (function() {
       case 'delete':
         swapDelete(target)
         return
+      case 'textContent':
+        target.textContent = fragment.textContent
+        return
       default:
         var extensions = getExtensions(elt)
         for (let i = 0; i < extensions.length; i++) {

--- a/test/attributes/hx-swap-oob.js
+++ b/test/attributes/hx-swap-oob.js
@@ -128,6 +128,28 @@ describe('hx-swap-oob attribute', function() {
     byId('d1').innerHTML.should.equal('Swapped5')
   })
 
+  it('handles textContent response properly', function() {
+    this.server.respondWith('GET', '/test', "Clicked<div id='d1' hx-swap-oob='textContent'><h1>Swapped</h1></div>")
+    var div = make('<div hx-get="/test">click me</div>')
+    make('<div id="d1"><span>old</span></div>')
+    div.click()
+    this.server.respond()
+    div.innerHTML.should.equal('Clicked')
+    byId('d1').innerHTML.should.equal('Swapped')
+    byId('d1').textContent.should.equal('Swapped')
+  })
+
+  it('handles textContent oob swap with selector', function() {
+    this.server.respondWith('GET', '/test', "<div>Clicked</div><div hx-swap-oob='textContent:#d1'><em>new</em></div>")
+    var div = make('<div hx-get="/test">click me</div>')
+    make('<div id="d1"><strong>old</strong></div>')
+    div.click()
+    this.server.respond()
+    div.innerHTML.should.equal('<div>Clicked</div>')
+    byId('d1').innerHTML.should.equal('new')
+    byId('d1').textContent.should.equal('new')
+  })
+
   it('oob swaps can be nested in content with config {"allowNestedOobSwaps": true}', function() {
     htmx.config.allowNestedOobSwaps = true
     this.server.respondWith('GET', '/test', "<div>Clicked<div id='d1' foo='bar' hx-swap-oob='innerHTML'>Swapped6</div></div>")


### PR DESCRIPTION
Fixes #3563.

## The bug

`swapWithStyle()` (`src/htmx.js:1799`) has cases for every OOB swap style — `none`, `outerHTML`, `afterbegin`, `beforebegin`, `beforeend`, `afterend`, `delete` — but no case for `textContent`. Falling into the `default` branch eventually recurses with `htmx.config.defaultSwapStyle` (normally `innerHTML`), so an `hx-swap-oob="textContent"` swap silently behaves like an `innerHTML` swap.

This contradicts the documented `textContent` contract — [hx-swap docs](https://htmx.org/attributes/hx-swap/) say:

> `textContent` — Replace the text content of the target element, without parsing the response as HTML.

The primary-swap path already handles this correctly at `src/htmx.js:1907` (`target.textContent = content`, before any HTML parsing). The OOB path was the outlier.

## The fix

Add a `case 'textContent'` to `swapWithStyle` mirroring the primary-swap behavior:

```js
case 'textContent':
  target.textContent = fragment.textContent
  return
```

For non-inline OOB swaps, `oobSwap()` sets `fragment` to the parsed OOB element clone (line 1492), so `fragment.textContent` is the concatenated text of all descendants — matching the OOB doc rule that "the encapsulating tag pair will be stripped for all strategies other than `outerHTML`".

3 lines in `src/htmx.js`.

## Tests

Two new cases in `test/attributes/hx-swap-oob.js`:

1. `handles textContent response properly` — verifies `<h1>Swapped</h1>` inside an OOB element becomes literal text `Swapped` in the target, not a parsed `<h1>` element.
2. `handles textContent oob swap with selector` — verifies the `textContent:#selector` form works the same way.

Both fail before the fix (the `<h1>` is parsed and inserted as an element), pass after.

Full suite: 848 passed, 0 failed, 3 skipped, 99.9% coverage. ESLint clean.

## Live before/after demo

https://manwithacat.github.io/htmx/demos/hx-swap-oob-textContent/

Side-by-side iframes load the same base commit (`d53932d4`) with and without this 3-line patch, using a mock `XMLHttpRequest` so htmx runs its real lifecycle without needing a server. The buggy panel renders the OOB response's `<h1>` as a real DOM element; the fixed panel renders it as literal text.

## Notes for reviewers

- I did not add `cleanUpElement()` calls for removed children before assigning `target.textContent`. The primary-swap textContent path at `src/htmx.js:1908` doesn't either, and adding cleanup only on the OOB side would be inconsistent. Happy to follow up with a separate PR that adds it to both paths if that's wanted.
- No docs change needed — `hx-swap.md` already lists `textContent` and `hx-swap-oob.md` already says any valid `hx-swap` value works. The docs were correct; the code was the outlier.

## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [X] I ran the test suite locally (`npm run test`) and verified that it succeeded
