### PR TITLE
docs: clarify next/previous selectors scan whole DOM, not just siblings (#3430)

### DIFF
--- a/www/content/attributes/hx-disabled-elt.md
+++ b/www/content/attributes/hx-disabled-elt.md
@@ -16,10 +16,10 @@ added to them for the duration of the request. The value of this attribute can b
 * `find <CSS selector>` which will find the first child descendant element that matches the given CSS selector
 * `next` which resolves to [element.nextElementSibling](https://developer.mozilla.org/docs/Web/API/Element/nextElementSibling)
 * `next <CSS selector>` which will scan the DOM forward for the first element that matches the given CSS selector
-  (e.g. `next button` will disable the closest following sibling `button` element)
+  (e.g. `next button` will disable the closest following `button` element — note this scans the whole DOM forward, not just siblings)
 * `previous` which resolves to [element.previousElementSibling](https://developer.mozilla.org/docs/Web/API/Element/previousElementSibling)
 * `previous <CSS selector>` which will scan the DOM backwards for the first element that matches the given CSS selector.
-  (e.g. `previous input` will disable the closest previous sibling `input` element)
+  (e.g. `previous input` will disable the closest previous `input` element — note this scans the whole DOM backward, not just siblings)
 
 Here is an example with a button that will disable itself during a request:
 

--- a/www/content/attributes/hx-include.md
+++ b/www/content/attributes/hx-include.md
@@ -13,9 +13,9 @@ attribute can be:
   (e.g. `closest tr` will target the closest table row to the element).
 * `find <CSS selector>` which will find the first child descendant element that matches the given CSS selector.
 * `next <CSS selector>` which will scan the DOM forward for the first element that matches the given CSS selector.
-  (e.g. `next .error` will target the closest following sibling element with `error` class)
+  (e.g. `next .error` will target the next element with `error` class — note this scans the whole DOM forward, not just siblings)
 * `previous <CSS selector>` which will scan the DOM backwards for the first element that matches the given CSS selector.
-  (e.g. `previous .error` will target the closest previous sibling with `error` class)
+  (e.g. `previous .error` will target the previous element with `error` class — note this scans the whole DOM backward, not just siblings)
 
 Here is an example that includes a separate input value:
 

--- a/www/content/attributes/hx-target.md
+++ b/www/content/attributes/hx-target.md
@@ -16,10 +16,10 @@ request.  The value of this attribute can be:
 * `find <CSS selector>` which will find the first child descendant element that matches the given CSS selector.
 * `next` which resolves to [element.nextElementSibling](https://developer.mozilla.org/docs/Web/API/Element/nextElementSibling)
 * `next <CSS selector>` which will scan the DOM forward for the first element that matches the given CSS selector.
-  (e.g. `next .error` will target the closest following sibling element with `error` class)
+  (e.g. `next .error` will target the next element with `error` class — note this scans the whole DOM forward, not just siblings)
 * `previous` which resolves to [element.previousElementSibling](https://developer.mozilla.org/docs/Web/API/Element/previousElementSibling)
 * `previous <CSS selector>` which will scan the DOM backwards for the first element that matches the given CSS selector.
-  (e.g. `previous .error` will target the closest previous sibling with `error` class)
+  (e.g. `previous .error` will target the previous element with `error` class — note this scans the whole DOM backward, not just siblings)
 
 
 Here is an example that targets a div:

--- a/www/content/attributes/hx-trigger.md
+++ b/www/content/attributes/hx-trigger.md
@@ -71,10 +71,10 @@ is seen again before the delay completes, it is ignored, the element will trigge
     * `find <CSS selector>` - finds the closest child matching the given css selector
     * `next` resolves to [element.nextElementSibling](https://developer.mozilla.org/docs/Web/API/Element/nextElementSibling)
     * `next <CSS selector>` scans the DOM forward for the first element that matches the given CSS selector.
-      (e.g. `next .error` will target the closest following sibling element with `error` class)
+      (e.g. `next .error` will target the next element with `error` class — note this scans the whole DOM forward, not just siblings)
     * `previous` resolves to [element.previousElementSibling](https://developer.mozilla.org/docs/Web/API/Element/previousElementSibling)
     * `previous <CSS selector>` scans the DOM backwards for the first element that matches the given CSS selector.
-      (e.g. `previous .error` will target the closest previous sibling with `error` class)
+      (e.g. `previous .error` will target the previous element with `error` class — note this scans the whole DOM backward, not just siblings)
 * `target:<CSS selector>` - allows you to filter via a CSS selector on the target of the event.  This can be useful when you want to listen for
 triggers from elements that might not be in the DOM at the point of initialization, by, for example, listening on the body,
 but with a target filter for a child element

--- a/www/content/extensions/response-targets.md
+++ b/www/content/extensions/response-targets.md
@@ -18,9 +18,9 @@ The value of each attribute can be:
 (e.g. `closest tr` will target the closest table row to the element).
 * `find <CSS selector>` which will find the first child descendant element that matches the given CSS selector.
 * `next <CSS selector>` which will scan the DOM forward for the first element that matches the given CSS selector.
-(e.g. `next .error` will target the closest following sibling element with `error` class)
+(e.g. `next .error` will target the next element with `error` class — note this scans the whole DOM forward, not just siblings)
 * `previous <CSS selector>` which will scan the DOM backwards for the first element that matches the given CSS selector.
-(e.g `previous .error` will target the closest previous sibling with `error` class)
+(e.g. `previous .error` will target the previous element with `error` class — note this scans the whole DOM backward, not just siblings)
 
 ## Installing
 


### PR DESCRIPTION
Fixes #3430.

The parenthetical examples for the `next <CSS selector>` and `previous <CSS selector>` extended-target syntax described the result as the closest *sibling* with the matching class. The surrounding sentence already correctly describes the actual behavior (a forward/backward DOM scan that can land on elements at any hierarchy level), but the examples in parentheses contradicted it. As @MichaelWest22 noted in the issue, this is "a copy paste error in the documentation from when that feature was added."

This PR replaces "sibling" with "element" in those examples and adds a brief clarifying clause, in 10 places across 5 docs:

- `www/content/attributes/hx-target.md` (next + previous)
- `www/content/attributes/hx-trigger.md` (next + previous)
- `www/content/attributes/hx-include.md` (next + previous)
- `www/content/attributes/hx-disabled-elt.md` (next + previous)
- `www/content/extensions/response-targets.md` (next + previous)

Docs-only — targeting `master` per CONTRIBUTING.md.

## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
