### PR TITLE
docs: clarify afterRequest successful/failed reflect responseHandling rule (#3440)

### DIFF
--- a/www/content/events.md
+++ b/www/content/events.md
@@ -48,10 +48,14 @@ can be paired with [`htmx:beforeRequest`](#htmx:beforeRequest) to wrap behavior 
 * `detail.xhr` - the `XMLHttpRequest`
 * `detail.target` - the target of the request
 * `detail.requestConfig` - the configuration of the AJAX request
-* `detail.successful` - true if the response has a 20x status code or is marked `detail.isError = false` in the
-  `htmx:beforeSwap` event, else false
-* `detail.failed` - true if the response does not have a 20x status code or is marked `detail.isError = true` in the
-  `htmx:beforeSwap` event, else false
+* `detail.successful` - true if the response is not marked as an error by the matched
+  [`htmx.config.responseHandling`](@/docs.md#response-handling) rule (by default, a 20x status code) or is marked
+  `detail.isError = false` in the `htmx:beforeSwap` event, else false. Note that if you customize
+  `responseHandling` to allow non-2xx codes to swap (e.g. `{"code":"...", "swap": true}` without `error: true`),
+  those responses will also be marked `successful` here.
+* `detail.failed` - true if the response is marked as an error by the matched
+  [`htmx.config.responseHandling`](@/docs.md#response-handling) rule (by default, a non-20x status code) or is marked
+  `detail.isError = true` in the `htmx:beforeSwap` event, else false
 
 ### Event - `htmx:afterSettle` {#htmx:afterSettle}
 


### PR DESCRIPTION
Fixes #3440.

The `htmx:afterRequest` event docs described `detail.successful` and `detail.failed` purely as "true if 20x status code", but the actual code (at `src/htmx.js:4849, 4893–4894`) derives them from the matched `htmx.config.responseHandling` rule's `error` flag:

```js
const shouldSwap = responseHandling.swap
let isError = !!responseHandling.error
// ... beforeSwap can override isError ...
responseInfo.failed = isError
responseInfo.successful = !isError
```

When users customize `responseHandling` to allow non-2xx responses to swap — for example with `{"code":"...", "swap": true}` and no `error: true` — those responses are *also* marked `successful` in `htmx:afterRequest`. The issue reporter was surprised by this. As @MichaelWest22 confirmed in the issue, the behavior is intentional ("If you override the default of what is defined as successful to swap then you would expect this to flow though"); the docs were just incomplete.

This PR rewords the descriptions of both `detail.successful` and `detail.failed` to:

1. Reference `htmx.config.responseHandling` as the source of truth.
2. Keep the "20x = successful" framing as a parenthetical "by default" note so existing readers' mental model is preserved.
3. Add an explicit note about the custom `responseHandling` case so future users with the same setup don't hit the same surprise.

Docs-only — targeting `master` per CONTRIBUTING.md. No code change.

## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
