### PR TITLE
docs: clarify HX-Retarget interaction with hx-swap="none" (#3446)

### DIFF
--- a/www/content/docs.md
+++ b/www/content/docs.md
@@ -1038,7 +1038,7 @@ htmx supports some htmx-specific response headers:
 * `HX-Refresh` - if set to "true" the client-side will do a full refresh of the page
 * [`HX-Replace-Url`](@/headers/hx-replace-url.md) - replaces the current URL in the location bar
 * `HX-Reswap` - allows you to specify how the response will be swapped. See [hx-swap](@/attributes/hx-swap.md) for possible values
-* `HX-Retarget` - a CSS selector that updates the target of the content update to a different element on the page
+* `HX-Retarget` - a CSS selector that updates the target of the content update to a different element on the page. Note that this only changes *where* the swap happens; the swap style is still determined by the source element's [`hx-swap`](@/attributes/hx-swap.md) (or `HX-Reswap`). If the source uses `hx-swap="none"`, you also need to send `HX-Reswap` to make the swap actually occur at the new target.
 * `HX-Reselect` - a CSS selector that allows you to choose which part of the response is used to be swapped in. Overrides an existing [`hx-select`](@/attributes/hx-select.md) on the triggering element
 * [`HX-Trigger`](@/headers/hx-trigger.md) - allows you to trigger client-side events
 * [`HX-Trigger-After-Settle`](@/headers/hx-trigger.md) - allows you to trigger client-side events after the settle step

--- a/www/content/reference.md
+++ b/www/content/reference.md
@@ -116,7 +116,7 @@ All other attributes available in htmx.
 | `HX-Refresh`                                         | if set to "true" the client-side will do a full refresh of the page
 | [`HX-Replace-Url`](@/headers/hx-replace-url.md)      | replaces the current URL in the location bar
 | `HX-Reswap`                                          | allows you to specify how the response will be swapped. See [hx-swap](@/attributes/hx-swap.md) for possible values
-| `HX-Retarget`                                        | a CSS selector that updates the target of the content update to a different element on the page
+| `HX-Retarget`                                        | a CSS selector that updates the target of the content update to a different element on the page (only changes *where* the swap happens; combine with `HX-Reswap` if the source has `hx-swap="none"`)
 | `HX-Reselect`                                        | a CSS selector that allows you to choose which part of the response is used to be swapped in. Overrides an existing [`hx-select`](@/attributes/hx-select.md) on the triggering element
 | [`HX-Trigger`](@/headers/hx-trigger.md)              | allows you to trigger client-side events
 | [`HX-Trigger-After-Settle`](@/headers/hx-trigger.md) | allows you to trigger client-side events after the settle step


### PR DESCRIPTION
Fixes #3446.

## Background

The issue reporter set `hx-swap="none"` on a form, then expected an `HX-Retarget` response header to cause a swap to happen at the new target. Tracing the code (`src/htmx.js:4848–4929`):

1. `responseHandling.swap` is `true` for the 2xx response, so the swap block is entered.
2. `HX-Retarget` updates `responseInfo.target` to the new selector.
3. `getSwapSpecification(elt, swapOverride)` reads `hx-swap="none"` from the source element.
4. `swapWithStyle('none', ...)` returns immediately — no DOM change at the new target.

This is intentional and consistent: `HX-Retarget` is a "where" header, not a "whether" header. The `none` swap style applies at the new target just as it would have at the original. The reporter even noted in their suggestion: *"If this is the expected behavior, I would update the docs to include that setting hx-swap='none' will prevent the use of a swap via HX-Retarget."*

## The fix

This PR is exactly that doc update. Two single-line edits in the response-headers tables:

- `www/content/docs.md` — adds a clarifying sentence to the `HX-Retarget` entry, pointing users at `HX-Reswap` for the "swap was 'none', but I want to swap at the new target" case.
- `www/content/reference.md` — same clarification, parenthetical form to match the table style.

Docs-only, no code change. Targeting `master` per CONTRIBUTING.md.

## What I'm *not* changing, and why

The behavior itself isn't a bug. Making `HX-Retarget` implicitly override `hx-swap="none"` would be a backwards-incompatible change to a header whose contract is well understood by the wider htmx ecosystem (extensions, frameworks, server libraries). Any user who genuinely wants the source's swap style overridden already has the right tool: `HX-Reswap`.

## Checklist

* [X] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
