### PR TITLE
Add back hx-history-elt and improve history cache extension

### DIFF
--- a/src/ext/hx-history-cache.js
+++ b/src/ext/hx-history-cache.js
@@ -1,5 +1,6 @@
 (() => {
     let api;
+    let _currentId = null;
 
     const INDEX_KEY = 'htmx-history-index';
 
@@ -7,9 +8,9 @@
         return htmx.config.historyCache;
     }
 
-    function prefixSelector(attr, value) {
-        let result = [`[${attr}${value != null ? `="${value}"` : ''}]`];
-        if (htmx.config.prefix) result.push(`[${attr.replace('hx-', htmx.config.prefix)}${value != null ? `="${value}"` : ''}]`);
+    function prefixSelector(s) {
+        let result = [s];
+        if (htmx.config.prefix) result.push(s.replaceAll('hx-', htmx.config.prefix));
         return result.join(',');
     }
 
@@ -26,7 +27,7 @@
     }
 
     function getHistoryTarget() {
-        return htmx.find(prefixSelector('hx-history-elt')) || document.body;
+        return htmx.find(prefixSelector('[hx-history-elt]')) || document.body;
     }
 
     const ATTR_VALUE   = 'data-htmx-history-value';
@@ -85,7 +86,19 @@
         return clone.innerHTML;
     }
 
-    // --- sessionStorage index (LRU list of htmxIds) ---
+    // --- Stamp the current history entry with an htmxId and track it ---
+
+    function stampCurrentEntry() {
+        let state = history.state || { htmx: true };
+        let id = state.htmxId;
+        if (!id) {
+            id = genId();
+            history.replaceState({ ...state, htmxId: id }, '', location.href);
+        }
+        _currentId = id;
+    }
+
+    // --- sessionStorage (LRU index of htmxIds) ---
 
     function readIndex() {
         try { return JSON.parse(sessionStorage.getItem(INDEX_KEY)) || []; } catch { return []; }
@@ -95,15 +108,13 @@
         sessionStorage.setItem(INDEX_KEY, JSON.stringify(index));
     }
 
-    function saveToSessionStorage(htmxId, content, head) {
-        if (cfg().size <= 0) return false;
+    function saveToStorage(htmxId, entry) {
+        if (!canUseStorage() || cfg().size <= 0) return false;
         let index = readIndex().filter(id => id !== htmxId);
-        // evict oldest until we're under the limit (leaving room for our new entry)
         while (index.length >= cfg().size) {
             sessionStorage.removeItem('htmx-history-' + index.shift());
         }
-        // try to write, evicting more if sessionStorage is full
-        let data = JSON.stringify({ content, head });
+        let data = JSON.stringify(entry);
         while (true) {
             try {
                 sessionStorage.setItem('htmx-history-' + htmxId, data);
@@ -117,14 +128,17 @@
         }
     }
 
-    function getFromSessionStorage(htmxId) {
+    function getFromStorage(htmxId) {
         try { return JSON.parse(sessionStorage.getItem('htmx-history-' + htmxId)); } catch { return null; }
     }
 
-    // --- two-tier save/get ---
+    // --- save / get ---
 
-    function saveCurrentPage() {
-        if (htmx.find(prefixSelector('hx-history', 'false'))) return;
+
+    function saveCurrentPage(targetId) {
+        targetId = targetId || _currentId;
+        if (!targetId) return;
+        if (htmx.find(prefixSelector('[hx-history="false"]'))) return;
 
         let target = getHistoryTarget();
         annotateState(target);
@@ -137,59 +151,21 @@
         let content = cleanContent(target);
         head = detail.head;
 
-        // Reuse existing htmxId if this entry already fell back to sessionStorage
-        let existingId = history.state?.htmxId;
-
-        if (existingId) {
-            // Already using sessionStorage for this entry — update it there
-            history.replaceState({ ...history.state, scroll, title }, '', location.href);
-            if (canUseStorage()) saveToSessionStorage(existingId, content, head);
-        } else {
-            // Tier 1: try storing content directly in history.state
-            try {
-                history.replaceState({
-                    ...history.state,
-                    htmxContent: { content, head },
-                    scroll,
-                    title
-                }, '', location.href);
-            } catch (e) {
-                // Tier 2: overflow — mint an htmxId, store content in sessionStorage
-                let htmxId = genId();
-                history.replaceState({
-                    ...history.state,
-                    htmxId,
-                    htmxContent: undefined,
-                    scroll,
-                    title
-                }, '', location.href);
-                if (canUseStorage()) saveToSessionStorage(htmxId, content, head);
-            }
-        }
-
+        saveToStorage(targetId, { content, head, scroll, title });
         api.triggerHtmxEvent(document, 'htmx:history:cache:after:save', { content, head, scroll, title });
     }
 
     function getCachedContent() {
-        let state = history.state;
-        if (!state) return null;
-
-        // Tier 1: content directly in history.state
-        if (state.htmxContent) return state.htmxContent;
-
-        // Tier 2: htmxId points to sessionStorage
-        if (state.htmxId && canUseStorage()) return getFromSessionStorage(state.htmxId);
-
-        return null;
+        let id = history.state?.htmxId;
+        if (!id) return null;
+        return canUseStorage() ? getFromStorage(id) : null;
     }
 
     async function restoreFromCache(item) {
-        // Let head extension merge stylesheets/blocking scripts before body swap
         let detail = { head: item.head, ready: null };
         api.triggerHtmxEvent(document, 'htmx:history:cache:before:restore', detail);
         if (detail.ready) await detail.ready;
 
-        // Swap body — pass deferred scripts on ctx so htmx_after_swap picks them up
         let ctx = {
             sourceElement: document.body,
             target: getHistoryTarget(),
@@ -200,10 +176,9 @@
         };
         await htmx.swap(ctx);
 
-        let state = history.state;
-        document.title = state?.title || document.title;
+        document.title = item.title || document.title;
         requestAnimationFrame(() => {
-            window.scrollTo(0, state?.scroll || 0);
+            window.scrollTo(0, item.scroll || 0);
             restoreAnnotations(getHistoryTarget());
             api.triggerHtmxEvent(document, 'htmx:history:cache:after:restore', { item });
         });
@@ -217,15 +192,38 @@
             htmx.config.historyCache.refreshOnMiss ??= false;
             htmx.config.historyCache.disable       ??= false;
             htmx.config.historyCache.swapStyle     ??= 'innerHTML';
+            stampCurrentEntry();
         },
 
+        // Before core pushes/replaces, save the outgoing page
         htmx_before_history_update: (elt, detail) => {
             if (cfg().disable) return;
+            if (!_currentId) stampCurrentEntry();
             saveCurrentPage();
+        },
+
+        // After core pushes/replaces, stamp the new entry and track it
+        htmx_after_history_update: () => {
+            if (cfg().disable) return;
+            stampCurrentEntry();
         },
 
         htmx_before_history_restore: (elt, detail) => {
             if (cfg().disable) return;
+
+            let outgoingId = _currentId;
+            let destinationId = history.state?.htmxId;
+
+            if (outgoingId && outgoingId !== destinationId) {
+                saveCurrentPage(outgoingId);
+            }
+
+            if (!destinationId) {
+                stampCurrentEntry();
+            } else {
+                _currentId = destinationId;
+            }
+
             let item = getCachedContent();
             if (!item) {
                 let missDetail = { path: detail.path, refreshOnMiss: cfg().refreshOnMiss };

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1327,7 +1327,7 @@ var htmx = (() => {
             let pantry = this.__handlePreservedElements(fragment);
             let newContent = [...fragment.childNodes]
             try {
-                if (swapStyle === 'innerHTML') {
+                if (swapStyle === 'innerHTML' || (swapStyle === 'outerHTML' && target === document.body)) {
                     for (const child of target.children) {
                         this.__cleanup(child)
                     }
@@ -1585,14 +1585,17 @@ var htmx = (() => {
 
         __restoreHistory(path) {
             path = path || location.pathname + location.search;
+            let historyElt = document.querySelector(this.__prefixSelector('[hx-history-elt]')) || document.body;
             if (this.__trigger(document, "htmx:before:history:restore", {path, cacheMiss: true})) {
                 if (this.config.history === "reload") {
                     location.reload();
                 } else {
                     this.#historyAbort = new AbortController();
+                    let isPartialTarget = historyElt !== document.body;
                     this.ajax('GET', path, {
-                        target: 'body',
-                        swap: 'innerHTML',
+                        target: historyElt,
+                        swap: `innerHTML${isPartialTarget ? ' strip:true' : ''}`,
+                        select: isPartialTarget ? this.__prefixSelector('[hx-history-elt]') : undefined,
                         request: {
                             headers: {'HX-History-Restore-Request': 'true'},
                             signal: this.#historyAbort.signal

--- a/src/skills/htmx-upgrade-from-htmx2.md
+++ b/src/skills/htmx-upgrade-from-htmx2.md
@@ -46,7 +46,6 @@ hx-disabled-elt  →  hx-disable    (htmx 2's "disable elements during request")
 | `hx-inherit="..."`    | Remove (use `:inherited` modifier on individual attributes) |
 | `hx-request='...'`    | `hx-config='...'` (same JSON format)                        |
 | `hx-history="false"`  | Remove (history no longer uses localStorage)                |
-| `hx-history-elt`      | Remove (history uses target element)                        |
 
 ## Step 3: Update Attribute Inheritance
 

--- a/test/tests/ext/hx-alpine-compat-history.js
+++ b/test/tests/ext/hx-alpine-compat-history.js
@@ -69,16 +69,13 @@
         htmx.process(historyElt);
         await htmx.timeout(50);
 
-        let savedState;
-        document.addEventListener('htmx:history:cache:after:save', () => {
-            savedState = { ...history.state };
-        }, { once: true });
-
         mockResponse('GET', '/page2', '<p>page 2</p>');
         playground().querySelector('button').click();
         await forRequest();
 
-        history.replaceState(savedState, '', cachedPath);
+        let index = JSON.parse(sessionStorage.getItem('htmx-history-index') || '[]');
+        let htmxId = index[index.length - 1];
+        history.replaceState({ htmx: true, htmxId }, '', cachedPath);
         await new Promise(resolve => {
             document.addEventListener('htmx:history:cache:after:restore', resolve, { once: true });
             htmx.__restoreHistory(cachedPath);
@@ -98,21 +95,17 @@
         htmx.process(historyElt);
         await htmx.timeout(50);
 
-        // Simulate user incrementing the counter
         let component = historyElt.querySelector('[x-data]');
         Alpine.$data(component).count = 42;
         await htmx.timeout(10);
-
-        let savedState;
-        document.addEventListener('htmx:history:cache:after:save', () => {
-            savedState = { ...history.state };
-        }, { once: true });
 
         mockResponse('GET', '/page2', '<p>page 2</p>');
         playground().querySelector('button').click();
         await forRequest();
 
-        history.replaceState(savedState, '', cachedPath);
+        let index = JSON.parse(sessionStorage.getItem('htmx-history-index') || '[]');
+        let htmxId = index[index.length - 1];
+        history.replaceState({ htmx: true, htmxId }, '', cachedPath);
         await new Promise(resolve => {
             document.addEventListener('htmx:history:cache:after:restore', resolve, { once: true });
             htmx.__restoreHistory(cachedPath);
@@ -136,16 +129,13 @@
         Alpine.$data(historyElt.querySelector('[x-data]')).name = 'changed';
         await htmx.timeout(10);
 
-        let savedState;
-        document.addEventListener('htmx:history:cache:after:save', () => {
-            savedState = { ...history.state };
-        }, { once: true });
-
         mockResponse('GET', '/page2', '<p>page 2</p>');
         playground().querySelector('button').click();
         await forRequest();
 
-        history.replaceState(savedState, '', cachedPath);
+        let index = JSON.parse(sessionStorage.getItem('htmx-history-index') || '[]');
+        let htmxId = index[index.length - 1];
+        history.replaceState({ htmx: true, htmxId }, '', cachedPath);
         await new Promise(resolve => {
             document.addEventListener('htmx:history:cache:after:restore', resolve, { once: true });
             htmx.__restoreHistory(cachedPath);
@@ -184,16 +174,13 @@
         htmx.process(historyElt);
         await htmx.timeout(50);
 
-        let savedState;
-        document.addEventListener('htmx:history:cache:after:save', () => {
-            savedState = { ...history.state };
-        }, { once: true });
-
         mockResponse('GET', '/page2', '<p>page 2</p>');
         playground().querySelector('button').click();
         await forRequest();
 
-        history.replaceState(savedState, '', cachedPath);
+        let index = JSON.parse(sessionStorage.getItem('htmx-history-index') || '[]');
+        let htmxId = index[index.length - 1];
+        history.replaceState({ htmx: true, htmxId }, '', cachedPath);
         await new Promise(resolve => {
             document.addEventListener('htmx:history:cache:after:restore', resolve, { once: true });
             htmx.__restoreHistory(cachedPath);

--- a/test/tests/ext/hx-history-cache.js
+++ b/test/tests/ext/hx-history-cache.js
@@ -253,17 +253,13 @@ describe('hx-history-cache extension', function () {
         `);
         historyElt = playground().querySelector('[hx-history-elt]');
 
-        let savedState;
-        document.addEventListener('htmx:history:cache:after:save', () => {
-            savedState = { ...history.state };
-        }, { once: true });
-
         mockResponse('GET', '/page2', '<p>page 2</p>');
         playground().querySelector('button').click();
         await forRequest();
 
-        // Restore the state the extension saved htmxContent into, then call restoreHistory directly
-        history.replaceState(savedState, '', cachedPath);
+        let index = JSON.parse(sessionStorage.getItem('htmx-history-index') || '[]');
+        let htmxId = index[index.length - 1];
+        history.replaceState({ htmx: true, htmxId }, '', cachedPath);
         historyElt.innerHTML = '<p>current page</p>';
 
         let serverFetched = false;
@@ -286,16 +282,13 @@ describe('hx-history-cache extension', function () {
         `);
         historyElt = playground().querySelector('[hx-history-elt]');
 
-        let savedState;
-        document.addEventListener('htmx:history:cache:after:save', () => {
-            savedState = { ...history.state };
-        }, { once: true });
-
         mockResponse('GET', '/page2', '<p>page 2</p>');
         playground().querySelector('button').click();
         await forRequest();
 
-        history.replaceState(savedState, '', cachedPath);
+        let index = JSON.parse(sessionStorage.getItem('htmx-history-index') || '[]');
+        let htmxId = index[index.length - 1];
+        history.replaceState({ htmx: true, htmxId }, '', cachedPath);
         document.addEventListener('htmx:history:cache:hit', e => e.preventDefault(), { once: true });
         document.addEventListener('htmx:before:swap', e => e.preventDefault(), { once: true });
 
@@ -316,16 +309,13 @@ describe('hx-history-cache extension', function () {
         `);
         historyElt = playground().querySelector('[hx-history-elt]');
 
-        let savedState;
-        document.addEventListener('htmx:history:cache:after:save', () => {
-            savedState = { ...history.state };
-        }, { once: true });
-
         mockResponse('GET', '/page2', '<p>page 2</p>');
         playground().querySelector('button').click();
         await forRequest();
 
-        history.replaceState(savedState, '', cachedPath);
+        let index = JSON.parse(sessionStorage.getItem('htmx-history-index') || '[]');
+        let htmxId = index[index.length - 1];
+        history.replaceState({ htmx: true, htmxId }, '', cachedPath);
         historyElt.innerHTML = '<p>current page</p>';
 
         document.addEventListener('htmx:history:cache:hit', e => {
@@ -349,17 +339,14 @@ describe('hx-history-cache extension', function () {
         `);
         historyElt = playground().querySelector('[hx-history-elt]');
 
-        let savedState;
-        document.addEventListener('htmx:history:cache:after:save', () => {
-            savedState = { ...history.state };
-        }, { once: true });
-
         mockResponse('GET', '/page2', '<p>page 2</p>');
         playground().querySelector('button').click();
         await forRequest();
 
+        let index = JSON.parse(sessionStorage.getItem('htmx-history-index') || '[]');
+        let htmxId = index[index.length - 1];
         document.title = 'Changed Title';
-        history.replaceState(savedState, '', cachedPath);
+        history.replaceState({ htmx: true, htmxId }, '', cachedPath);
 
         await new Promise(resolve => {
             document.addEventListener('htmx:history:cache:after:restore', resolve, { once: true });
@@ -411,11 +398,6 @@ describe('hx-history-cache extension', function () {
         };
 
         try {
-            let savedState;
-            document.addEventListener('htmx:history:cache:after:save', () => {
-                savedState = { ...history.state };
-            }, { once: true });
-
             createProcessedHTML(`
                 <div hx-history-elt><p>tier 2 content</p></div>
                 <button hx-get="/page2" hx-push-url="/page2">go</button>
@@ -426,14 +408,15 @@ describe('hx-history-cache extension', function () {
             playground().querySelector('button').click();
             await forRequest();
 
-            assert.isString(savedState.htmxId);
-            assert.notExists(savedState.htmxContent);
-            assert.equal(readCache().length, 1);
+            let index = JSON.parse(sessionStorage.getItem('htmx-history-index') || '[]');
+            assert.equal(index.length, 1);
 
-            // Verify restore also works from sessionStorage
+            let htmxId = index[0];
+            assert.isString(htmxId);
+
             let cachedPath = location.pathname + location.search;
             history.replaceState = original;
-            history.replaceState(savedState, '', cachedPath);
+            history.replaceState({ htmx: true, htmxId }, '', cachedPath);
             historyElt.innerHTML = '<p>current page</p>';
 
             await new Promise(resolve => {
@@ -456,16 +439,13 @@ describe('hx-history-cache extension', function () {
         `);
         historyElt = playground().querySelector('[hx-history-elt]');
 
-        let savedState;
-        document.addEventListener('htmx:history:cache:after:save', () => {
-            savedState = { ...history.state };
-        }, { once: true });
-
         mockResponse('GET', '/page2', '<p>page 2</p>');
         playground().querySelector('button').click();
         await forRequest();
 
-        history.replaceState(savedState, '', cachedPath);
+        let index = JSON.parse(sessionStorage.getItem('htmx-history-index') || '[]');
+        let htmxId = index[index.length - 1];
+        history.replaceState({ htmx: true, htmxId }, '', cachedPath);
 
         await new Promise(resolve => {
             document.addEventListener('htmx:history:cache:after:restore', resolve, { once: true });
@@ -488,16 +468,13 @@ describe('hx-history-cache extension', function () {
         historyElt = playground().querySelector('[hx-history-elt]');
         setupFn(historyElt);
 
-        let savedState;
-        document.addEventListener('htmx:history:cache:after:save', () => {
-            savedState = { ...history.state };
-        }, { once: true });
-
         mockResponse('GET', '/page2', '<p>page 2</p>');
         playground().querySelector('button').click();
         await forRequest();
 
-        history.replaceState(savedState, '', cachedPath);
+        let index = JSON.parse(sessionStorage.getItem('htmx-history-index') || '[]');
+        let htmxId = index[index.length - 1];
+        history.replaceState({ htmx: true, htmxId }, '', cachedPath);
         await new Promise(resolve => {
             document.addEventListener('htmx:history:cache:after:restore', resolve, { once: true });
             htmx.__restoreHistory(cachedPath);

--- a/www/src/content/docs/01-get-started/02-migration.md
+++ b/www/src/content/docs/01-get-started/02-migration.md
@@ -113,7 +113,8 @@ Fix: add [`hx-include`](/reference/attributes/hx-include)`="closest form"` where
 ### No history cache
 
 History no longer caches pages in [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage).
-When navigating back, htmx re-fetches the page and swaps it into `<body>`.
+When navigating back, htmx re-fetches the page and swaps it into `<body>`, or into the `[hx-history-elt]` element if
+one is present — the same behavior as htmx 2.
 
 Use [`htmx.config.history`](/reference/config/htmx-config-history) `= "reload"` for a full page reload instead. Use
 `htmx.config.history = false` to disable.
@@ -182,7 +183,6 @@ Rename in this order to avoid conflicts:
 | `hx-inherit`     | Not needed (inheritance is explicit)                                                              |
 | `hx-request`     | [`hx-config`](/reference/attributes/hx-config)                                                    |
 | `hx-history`     | Removed (no [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)) |
-| `hx-history-elt` | Removed                                                                                           |
 
 ### Renamed events
 

--- a/www/src/content/reference/01-attributes/33-hx-history-elt.md
+++ b/www/src/content/reference/01-attributes/33-hx-history-elt.md
@@ -1,0 +1,56 @@
+---
+title: "hx-history-elt"
+description: "Mark the element to swap on history restore"
+---
+
+The `hx-history-elt` attribute marks the element that htmx should swap when restoring a page from
+history (back/forward navigation). Only this element is replaced — the rest of the page is left
+untouched.
+
+When a history restore request is made, htmx sends a `GET` request with the
+[`HX-History-Restore-Request`](/reference/headers/HX-History-Restore-Request) header. The server
+should return a full page response; htmx selects the `hx-history-elt` element from it and swaps it
+into the matching element in the current page.
+
+## Syntax
+
+```html
+<main hx-history-elt>
+    <!-- only this element is replaced on back/forward navigation -->
+</main>
+```
+
+## Example
+
+```html
+<body>
+    <nav><!-- never replaced --></nav>
+
+    <main hx-history-elt>
+        <h1>Page 1</h1>
+        <button hx-get="/page2" hx-target="[hx-history-elt]" hx-push-url="/page2">
+            Go to Page 2
+        </button>
+    </main>
+</body>
+```
+
+The server should detect `HX-History-Restore-Request` and return a full page containing a matching
+`hx-history-elt` element:
+
+```
+if request.headers["HX-History-Restore-Request"]:
+    return render_full_page()   # includes <main hx-history-elt>...</main>
+else:
+    return render_fragment()    # just the inner content
+```
+
+## Notes
+
+* Only one `hx-history-elt` element should exist in the page at a time
+* If no `hx-history-elt` is present, htmx falls back to swapping `<body>`
+* The server response must include a `hx-history-elt` element for the select to work; if it is
+  missing, htmx falls back to a full body swap
+* In htmx 2, history was cached in localStorage. In htmx 4, caching has moved to the
+  [`hx-history-cache`](/docs/extensions/history-cache) extension — `hx-history-elt` works with
+  both the core re-fetch behavior and the extension's cache restore


### PR DESCRIPTION
## Description
While we don't have core history cache support anymore it is still useful to support the hx-history-elt feature for users that want to not replace the whole page when navigating back/forwards and it should be easy to just use select and target for the history elt to add this feature back.

Also There were some cases where the history cache extension was not saving to cache when popstate was fired and to fix this I had to re-do the storage to sessionStorage code to make this work properly

Corresponding issue:

## Testing
Updated tests to account for the cache extension changes.  Auto testing hx-history-elt is not easy in our testing suite so I had to test this by hand.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
