### PR TITLE
alpine history restore state without errors

### DIFF
--- a/src/ext/hx-alpine-compat.js
+++ b/src/ext/hx-alpine-compat.js
@@ -90,7 +90,11 @@
             document.querySelectorAll('[data-alpine-state]').forEach(el => {
                 let saved = JSON.parse(el.getAttribute('data-alpine-state'));
                 el.removeAttribute('data-alpine-state');
-                if (el._x_dataStack) Object.assign(el._x_dataStack[0], saved);
+                if (el._x_dataStack) {
+                    for (let key in saved) {
+                        try { el._x_dataStack[0][key] = saved[key]; } catch {}
+                    }
+                }
             });
         },
 

--- a/test/tests/ext/hx-alpine-compat-history.js
+++ b/test/tests/ext/hx-alpine-compat-history.js
@@ -204,6 +204,26 @@
         assert.equal(teleportTarget.querySelectorAll('.tp-content').length, 1);
     });
 
+    it('does not throw when restoring state with getter and method properties', async function () {
+        let elt = await saveAndRestoreAlpine(root => {
+            root.innerHTML =
+                '<div x-data="{' +
+                '  selectedCategory: \'all\',' +
+                '  searchTerm: \'htmx\',' +
+                '  cartItems: 3,' +
+                '  products: [],' +
+                '  get filteredProducts() { return this.products; },' +
+                '  addToCart(p) { this.cartItems++; }' +
+                '}">' +
+                '  <span id="cart" x-text="cartItems"></span>' +
+                '  <span id="cat" x-text="selectedCategory"></span>' +
+                '</div>';
+        });
+        // Plain data restored, no exception thrown
+        assert.equal(elt.querySelector('#cart').textContent, '3');
+        assert.equal(elt.querySelector('#cat').textContent, 'all');
+    });
+
     it('teleport target is empty after destroyTree runs before snapshot', async function () {
         let cachedPath = location.pathname + location.search;
         createProcessedHTML(`

--- a/www/src/content/docs/06-extensions/14-alpine-compat.md
+++ b/www/src/content/docs/06-extensions/14-alpine-compat.md
@@ -1,10 +1,10 @@
 ---
 title: "Alpine.js Compatibility"
 description: "Compatibility layer for using htmx with Alpine.js"
-keywords: ["alpine", "alpinejs", "compatibility", "integration"]
+keywords: ["alpine", "alpinejs", "compatibility", "integration", "history"]
 ---
 
-The `alpine-compat` extension provides compatibility between htmx and [Alpine.js](https://alpinejs.dev/), ensuring that Alpine components work correctly when htmx swaps new content into the DOM.
+The `alpine-compat` extension provides a compatibility layer between htmx and [Alpine.js](https://alpinejs.dev/), ensuring Alpine components are correctly initialized and preserved across htmx-driven DOM updates.
 
 ## Installing
 
@@ -14,6 +14,26 @@ The `alpine-compat` extension provides compatibility between htmx and [Alpine.js
 <script defer src="/path/to/alpine.js"></script>
 ```
 
-## Usage
+Alpine must load **after** the extension script. The `defer` attribute ensures this.
 
-Once loaded, the extension automatically initializes Alpine.js components in content that htmx swaps into the page. Without this extension, Alpine components in dynamically swapped content would not be initialized.
+## What it does
+
+### Alpine initialization on swap
+
+htmx's settle phase introduces a brief pause after swapping content to allow CSS transitions to run. Alpine's mutation observer fires during this window and sees the intermediate DOM state, causing components to initialize against incomplete or transitioning content. The extension defers Alpine's mutation observer before the swap and flushes it only after the settle phase completes, so Alpine always initializes against the final stable DOM.
+
+### Morph-aware state preservation
+
+When using `innerMorph` or `outerMorph` swap styles, htmx reconciles the existing DOM with new content rather than replacing it. The extension hooks into `htmx:before:morph:node` to carry Alpine's reactive data stack from the old node to the new one before morphing, preventing Alpine state from being lost during reconciliation. This replaces the need for Alpine's native morph extension.
+
+### Alpine ID binding compatibility
+
+Alpine can bind reactive values to an element's `id` attribute via `:id` or `x-bind:id`. This causes the morph algorithm to see mismatched IDs and treat matching elements as different nodes. The extension overrides the soft-match check to ignore ID mismatches when both nodes have Alpine-reactive ID bindings, keeping the morph stable.
+
+## Combining with `history-cache`
+
+When used alongside the [`history-cache`](/docs/extensions/history-cache) extension, `alpine-compat` also handles saving and restoring Alpine component state across history navigation.
+
+### How it works
+
+Before a page is saved to the history cache, the extension serializes each Alpine component's reactive data to a `data-alpine-state` attribute, then tears down the Alpine tree so the snapshot is clean HTML. On restore, it re-applies the saved values back into the live Alpine data stack after Alpine has re-initialized the restored content.


### PR DESCRIPTION
## Description
When apline compat extension restores state from history cache it assigns old state data to the new state data but some non pure data types can throw errors.  we can safely ignore these to allow real data to be set only.

Corresponding issue:

## Testing
Added a test to cover alpine state that is not just data.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
