### PR TITLE
Real outerHTML swap on body; use it for history restore

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1027,13 +1027,14 @@ var htmx = (() => {
             response = response.replace(/<head(\s[^>]*)?>[\s\S]*?<\/head>/i, m => (title = this.__parseHTML(m).title, ''));
             let startTag = response.match(/<([a-z][^\/>\x20\t\r\n\f]*)/i)?.[1]?.toLowerCase();
 
-            let doc, fragment;
+            let doc, fragment, body;
             if (startTag === 'html' || startTag === 'body') {
                 doc = this.__parseHTML(response);
                 fragment = document.createDocumentFragment();
                 while (doc.body.childNodes.length > 0) {
                     fragment.append(doc.body.childNodes[0]);
                 }
+                body = doc.body;
             } else {
                 doc = this.__parseHTML(`<template>${response}</template>`);
                 fragment = doc.querySelector('template').content;
@@ -1051,7 +1052,8 @@ var htmx = (() => {
 
             return {
                 fragment,
-                title
+                title,
+                body
             };
         }
 
@@ -1209,8 +1211,9 @@ var htmx = (() => {
 
         async swap(ctx) {
             this.__handleHistoryUpdate(ctx);
-            let {fragment, title} = this.__makeFragment(ctx.text);
-            ctx.title = title;
+            let parsed = this.__makeFragment(ctx.text);
+            ctx.title = parsed.title;
+            let { fragment } = parsed;
             let tasks = [];
 
             // Process OOB and partials
@@ -1219,7 +1222,7 @@ var htmx = (() => {
             tasks.push(...oobTasks, ...partialTasks);
 
             // Process main swap first
-            let mainSwap = this.__processMainSwap(ctx, fragment, partialTasks);
+            let mainSwap = this.__processMainSwap(ctx, parsed, partialTasks);
             if (mainSwap) {
                 tasks.unshift(mainSwap);
             }
@@ -1255,7 +1258,8 @@ var htmx = (() => {
             this.__handleAnchorScroll(ctx);
         }
 
-        __processMainSwap(ctx, fragment, partialTasks) {
+        __processMainSwap(ctx, parsed, partialTasks) {
+            let { fragment, body } = parsed;
             // Create main task if needed
             let swapSpec = this.__parseSwapSpec(ctx.swap || this.config.defaultSwap);
             // skip creating main swap if extracting partials resulted in empty response except for delete style
@@ -1268,20 +1272,20 @@ var htmx = (() => {
                 if (this.__isBoosted(ctx.sourceElement)) {
                     swapSpec.show ||= 'top';
                 }
-                let mainSwap = {
+                return {
                     type: 'main',
                     fragment,
+                    body,
                     target: this.__resolveTarget(ctx.sourceElement || document.body, swapSpec.target || ctx.target),
                     swapSpec,
                     sourceElement: ctx.sourceElement,
                     transition: ctx.transition && swapSpec.transition !== false
                 };
-                return mainSwap;
             }
         }
 
         async __insertContent(task, cssTransition = true) {
-            let {target, swapSpec, fragment} = task;
+            let {target, swapSpec, fragment, body} = task;
             if (typeof target === 'string') {
                 target = document.querySelector(target);
             }
@@ -1327,11 +1331,15 @@ var htmx = (() => {
             let pantry = this.__handlePreservedElements(fragment);
             let newContent = [...fragment.childNodes]
             try {
-                if (swapStyle === 'innerHTML' || (swapStyle === 'outerHTML' && target === document.body)) {
+                let outerBodySwap = swapStyle === 'outerHTML' && target === document.body;
+                if (swapStyle === 'innerHTML' || outerBodySwap) {
                     for (const child of target.children) {
                         this.__cleanup(child)
                     }
                     target.replaceChildren(...fragment.childNodes);
+                    if (outerBodySwap && body) {
+                        this.__copyAttributes(document.body, body)
+                    }
                 } else if (swapStyle === 'textContent') {
                     for (const child of target.querySelectorAll('[data-htmx-powered]')) {
                         this.__cleanup(child)

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1599,11 +1599,10 @@ var htmx = (() => {
                     location.reload();
                 } else {
                     this.#historyAbort = new AbortController();
-                    let isPartialTarget = historyElt !== document.body;
                     this.ajax('GET', path, {
                         target: historyElt,
-                        swap: `innerHTML${isPartialTarget ? ' strip:true' : ''}`,
-                        select: isPartialTarget ? this.__prefixSelector('[hx-history-elt]') : undefined,
+                        swap: 'outerHTML',
+                        select: historyElt !== document.body ? this.__prefixSelector('[hx-history-elt]') : undefined,
                         request: {
                             headers: {'HX-History-Restore-Request': 'true'},
                             signal: this.#historyAbort.signal

--- a/test/tests/end2end/basic-history.js
+++ b/test/tests/end2end/basic-history.js
@@ -162,3 +162,43 @@ describe('hx-push-url and hx-replace-url attributes', function() {
         }
     });
 });
+
+describe('hx-history-elt scopes history restore', function() {
+
+    beforeEach(() => { setupTest(this.currentTest); });
+    afterEach(() => { cleanupTest(); });
+
+    it('restoring history with hx-history-elt swaps only that element and leaves siblings intact', async function() {
+        playground().innerHTML = `
+            <div id="sentinel">untouched</div>
+            <main hx-history-elt><p id="orig">old</p></main>
+            <div id="sentinel-after">also untouched</div>
+        `;
+        htmx.process(playground());
+
+        let response = `<html><head><title>x</title></head><body>
+            <header>HEADER LEAK</header>
+            <main hx-history-elt><p id="new">new</p></main>
+            <footer>FOOTER LEAK</footer>
+        </body></html>`;
+        mockResponse('GET', '/restore-test', response);
+
+        htmx.__restoreHistory('/restore-test');
+        await forRequest();
+
+        let sentinel = document.getElementById('sentinel');
+        let sentinelAfter = document.getElementById('sentinel-after');
+        sentinel.should.not.equal(null);
+        sentinel.textContent.should.equal('untouched');
+        sentinelAfter.should.not.equal(null);
+        sentinelAfter.textContent.should.equal('also untouched');
+
+        let elt = playground().querySelector('[hx-history-elt]');
+        elt.should.not.equal(null);
+        elt.querySelector('#new').should.not.equal(null);
+        (elt.querySelector('#orig') === null).should.equal(true);
+
+        document.body.textContent.should.not.include('HEADER LEAK');
+        document.body.textContent.should.not.include('FOOTER LEAK');
+    });
+});

--- a/test/tests/end2end/basic-history.js
+++ b/test/tests/end2end/basic-history.js
@@ -163,6 +163,38 @@ describe('hx-push-url and hx-replace-url attributes', function() {
     });
 });
 
+describe('outerHTML swap into document.body', function() {
+    let savedAttrs;
+    let savedChildren;
+
+    beforeEach(() => {
+        setupTest(this.currentTest);
+        savedAttrs = [...document.body.attributes].map(a => ({ name: a.name, value: a.value }));
+        savedChildren = [...document.body.childNodes];
+    });
+
+    afterEach(() => {
+        for (let a of [...document.body.attributes]) document.body.removeAttribute(a.name);
+        for (let a of savedAttrs) document.body.setAttribute(a.name, a.value);
+        document.body.replaceChildren(...savedChildren);
+        cleanupTest();
+    });
+
+    it('syncs body attributes from response and replaces children', async function() {
+        document.body.setAttribute('data-original', 'yes');
+        await htmx.swap({
+            target: document.body,
+            swap: 'outerHTML',
+            text: '<html><body class="injected" data-test-x="1"><div id="bodyswap-marker"></div></body></html>',
+            sourceElement: document.body
+        });
+        document.body.classList.contains('injected').should.equal(true);
+        document.body.getAttribute('data-test-x').should.equal('1');
+        (document.body.getAttribute('data-original') === null).should.equal(true);
+        document.getElementById('bodyswap-marker').should.not.equal(null);
+    });
+});
+
 describe('hx-history-elt scopes history restore', function() {
 
     beforeEach(() => { setupTest(this.currentTest); });

--- a/test/tests/unit/__makeFragment.js
+++ b/test/tests/unit/__makeFragment.js
@@ -81,4 +81,17 @@ describe('__makeFragment unit tests', function() {
         fragment.children[1].tagName.should.equal('TBODY');
     })
 
+    it('captures body element with attributes from full-page response', function () {
+        let {body} = htmx.__makeFragment('<html><body class="dark" data-theme="x"><div>content</div></body></html>');
+        body.should.not.equal(undefined);
+        body.tagName.should.equal('BODY');
+        body.getAttribute('class').should.equal('dark');
+        body.getAttribute('data-theme').should.equal('x');
+    })
+
+    it('returns undefined body for partial responses', function () {
+        let {body} = htmx.__makeFragment('<div>partial</div>');
+        assert.isUndefined(body);
+    })
+
 });


### PR DESCRIPTION
## Summary
- `__makeFragment` now preserves `<body>` (with attributes) for full-page responses, alongside the existing fragment.
- `outerHTML` swap into `document.body` does a real outer swap: body attributes sync from the response via `__copyAttributes`, children are replaced. Previously this was coerced to `innerHTML` semantics, dropping body attrs.
- `__restoreHistory` now uses `outerHTML` for both the `[hx-history-elt]` partial and the body fallback. Drops the `strip:true` workaround, unifies on a single swap style, and `<body>` class/data-attrs now persist across history restore.

Follow-up to #3773.

## Test plan
- [x] `__makeFragment` unit tests: body element captured (with attributes) for full-page responses; undefined for partial responses.
- [x] Integration test: `htmx.swap` `outerHTML` into `document.body` syncs class + data-attrs and removes attrs not in the response (body state saved/restored around the test).
- [x] Integration test: history restore with `[hx-history-elt]` swaps only the marked element, leaves siblings intact, and does not leak response content outside `[hx-history-elt]` into the live document.
- [x] Full suite: 1144 passed, 0 failed, 5 skipped.