### PR TITLE
Add hx-nonce security extension with nonce, safe eval and trusted types support

### DIFF
--- a/src/ext/hx-nonce.js
+++ b/src/ext/hx-nonce.js
@@ -1,0 +1,191 @@
+//==========================================================
+// hx-nonce.js
+//
+// Security extension that gates htmx attribute processing
+// behind CSP nonces, protecting against HTML injection
+// attacks on sites that already use CSP script nonces.
+//
+// How it works:
+//   - Reads the page-load nonce from the first script[nonce]
+//     element (browsers expose this via .nonce property, not
+//     the attribute, to prevent CSS exfiltration attacks).
+//     config.nonce is intentionally NOT supported — the nonce
+//     must come from an actual script tag to prevent JS-based
+//     forgery before the extension initialises.
+//   - Before each element is initialized, cancels init if the
+//     element's hx-nonce doesn't match the page nonce — covers
+//     hx-get/post/etc and hx-boost via htmx:before:init
+//   - Before each hx-on: node is bound, cancels if hx-nonce
+//     doesn't match — covers hx-on: via htmx:before:on:init
+//   - Before each swap, reads the partial response's own CSP
+//     nonce, validates fragment elements against it, then
+//     rewrites valid ones to the page nonce so they survive
+//     subsequent process() calls
+//   - At request time, blocks boosted form submissions where
+//     an unnnonced submitter overrode formAction
+//
+// Always-on: enforcement is unconditional once the extension
+// is loaded. If no page nonce is detected, all htmx processing
+// is blocked — a missing nonce means misconfiguration or active
+// attack (e.g. nonce stripped by injected content). Fail closed.
+//
+// Safe eval: set config.safeEval:true to also replace
+// htmx's eval with nonce-based script injection, enabling
+// htmx JS features (hx-on:, hx-vals js:, hx-confirm js:,
+// trigger filters) on pages with no unsafe-eval CSP.
+// Requires pageNonce to be present — silently skipped if not.
+//
+// Usage:
+//   <meta name="htmx-config" content='extensions:"hx-nonce"'>
+//   <meta name="htmx-config" content='extensions:"hx-nonce",safeEval:true'>
+//   <script src="hx-nonce.js"></script>
+//
+//   Server stamps hx-nonce on every hx- bearing element:
+//   <button hx-post="/save" hx-nonce="<csp-nonce>">Save</button>
+//==========================================================
+(() => {
+
+    let pageNonce = null;
+    let internalApi = null;
+
+    // Get nonce value from element using api.attributeValue for prefix support
+    function getNonce(elt) {
+        return internalApi?.attributeValue(elt, 'hx-nonce');
+    }
+
+    // Check nonce on element — strips and blocks if invalid, used by both init hooks
+    function checkNonce(elt) {
+        if (!pageNonce) return false;
+        if (getNonce(elt) !== pageNonce) {
+            stripHxAttributes(elt);
+            return false;
+        }
+    }
+
+    // Extract nonce value from a CSP header string.
+    // Anchors to script-src or default-src to avoid matching nonces
+    // in other directives (e.g. img-src) which would extract the wrong value.
+    function extractNonceFromCSP(csp) {
+        return csp?.match(/(?:script-src|default-src)[^;]*'nonce-([^']+)'/i)?.[1] ?? null;
+    }
+
+    // Escape a string for use in a RegExp
+    function escapeRegex(str) {
+        return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
+
+    // Rewrite all occurrences of responseNonce to pageNonce in raw HTML text,
+    // covering both hx-nonce="..." / hx-nonce='...' and script nonce="..." / nonce='...'.
+    // Uses a backreference to ensure open/close quotes match.
+    // Only rewrites exact nonce value matches — won't touch other attribute values.
+    function rewriteNoncesInText(text, responseNonce) {
+        let escaped = escapeRegex(responseNonce);
+        return text.replace(
+            new RegExp(`(nonce=)(["'])${escaped}\\2`, 'gi'),
+            (_, attr, quote) => `${attr}${quote}${pageNonce}${quote}`
+        );
+    }
+
+    // Strip all hx- attributes from an element and fire a
+    // security event so the app can log/audit the violation.
+    function stripHxAttributes(elt) {
+        for (let attr of [...elt.attributes]) {
+            if (attr.name.startsWith('hx-') || (htmx.config.prefix && attr.name.startsWith(htmx.config.prefix))) {
+                elt.removeAttribute(attr.name);
+            }
+        }
+        htmx.trigger(elt, 'htmx:security:strip', { reason: 'nonce-mismatch' });
+    }
+
+    htmx.registerExtension('hx-nonce', {
+
+        init: (api) => {
+            internalApi = api;
+            // Read page nonce from first nonced script tag.
+            // Must use .nonce property — browsers blank the nonce
+            // attribute value to prevent CSS attribute selector
+            // exfiltration attacks, but .nonce remains readable via JS.
+            pageNonce = document.querySelector('script[nonce]')?.nonce || null;
+
+            if (!pageNonce) {
+                // No nonce found — fail closed. Loading hx-nonce signals
+                // intent to enforce. A missing nonce is misconfiguration
+                // or an active attack stripping the nonce from the page.
+                // Block all htmx by returning false from every hook.
+                console.error('hx-nonce: no page nonce found — blocking all htmx. Add a nonce to your script tags.');
+                return;
+            }
+
+            // Safe eval: replace Function/AsyncFunction constructors with
+            // nonce-based script injection so htmx JS features work without
+            // unsafe-eval CSP. Gated on config.safeEval since it requires
+            // the server to also set up per-response CSP nonces.
+            if (htmx.config.safeEval) {
+                let counter = 0;
+                function makeNoncedConstructor(isAsync) {
+                    return function(...keys) {
+                        let body = keys.pop();
+                        return {
+                            call: (thisArg, ...values) => {
+                                if (getNonce(thisArg) !== pageNonce) {
+                                    htmx.trigger(thisArg, 'htmx:security:violation', { reason: 'nonce-mismatch-at-eval' });
+                                    return;
+                                }
+                                let fn = `__htmx_eval_${++counter}`;
+                                let asyncPrefix = isAsync ? 'async ' : '';
+                                let script = document.createElement('script');
+                                script.nonce = pageNonce;
+                                script.textContent = `window.${fn} = ${asyncPrefix}function(${keys.join(',')}) { ${body} }`;
+                                document.head.appendChild(script);
+                                script.remove();
+                                let r = window[fn].call(thisArg, ...values);
+                                delete window[fn];
+                                return r;
+                            }
+                        };
+                    };
+                }
+                api.initEvalFunctions(makeNoncedConstructor(false), makeNoncedConstructor(true));
+            }
+        },
+
+        htmx_before_init: checkNonce,
+
+        htmx_before_on_init: checkNonce,
+
+        // Fires after ctx.text is set (htmx:after:request), before fragment
+        // parsing. Rewrite response nonces to pageNonce in the raw HTML so
+        // both hx-nonce attributes and script nonce attributes are promoted
+        // in one pass before the DOM is built.
+        htmx_after_request: (elt, detail) => {
+            if (!pageNonce) return false;
+            let csp = detail.ctx?.response?.headers?.get('Content-Security-Policy');
+            let responseNonce = extractNonceFromCSP(csp);
+            if (responseNonce && responseNonce !== pageNonce) {
+                detail.ctx.text = rewriteNoncesInText(detail.ctx.text, responseNonce);
+            }
+        },
+
+        // Block boosted form submissions where an unnnonced
+        // submitter overrode formAction.
+        htmx_config_request: (elt, detail) => {
+            if (!pageNonce) return false;
+
+            let ctx = detail.ctx;
+            let submitter = ctx.sourceEvent?.submitter;
+
+            if (!elt._htmx?.boosted || !submitter?.getAttribute('formaction')) return;
+
+            if (getNonce(submitter) !== pageNonce) {
+                htmx.trigger(elt, 'htmx:security:violation', {
+                    reason: 'unnnonced-submitter',
+                    submitter,
+                    ctx
+                });
+                detail.cancelled = true;
+                return false;
+            }
+        }
+    });
+
+})();

--- a/src/ext/hx-nonce.js
+++ b/src/ext/hx-nonce.js
@@ -145,7 +145,7 @@
                 asyncFn = makeNoncedConstructor(true);
             }
 
-            api.initEvalFunctions(ttPolicy, syncFn, asyncFn);
+            api.initSecurity(ttPolicy, syncFn, asyncFn);
         },
 
         htmx_before_init: checkNonce,
@@ -170,8 +170,17 @@
         },
 
         // Blocks boosted form submissions where an unnnonced submitter overrides formaction.
+        // Also blocks js:/javascript: action URLs — entity encoding doesn't neutralise these
+        // so they may survive template rendering and execute unexpectedly.
         htmx_config_request: (elt, detail) => {
             if (!pageNonce) return false;
+            let action = detail.ctx?.request?.action;
+            if (action && /^(js|javascript):/i.test(action)) {
+                console.error(`hx-nonce: blocked js:/javascript: action URL on <${elt.tagName.toLowerCase()}${elt.id ? '#'+elt.id : ''}>.`);
+                htmx.trigger(elt, 'htmx:security:violation', { reason: 'javascript-url', action, ctx: detail.ctx });
+                detail.cancelled = true;
+                return false;
+            }
             let submitter = detail.ctx?.sourceEvent?.submitter;
             if (!elt._htmx?.boosted || !submitter?.getAttribute('formaction')) return;
             if (getNonce(submitter) !== pageNonce) {

--- a/src/ext/hx-nonce.js
+++ b/src/ext/hx-nonce.js
@@ -1,83 +1,66 @@
 //==========================================================
 // hx-nonce.js
 //
-// Security extension that gates htmx attribute processing
-// behind CSP nonces, protecting against HTML injection
-// attacks on sites that already use CSP script nonces.
+// Gates htmx processing behind CSP nonces to prevent HTML
+// injection attacks on sites that use script nonces.
 //
-// How it works:
-//   - Reads the page-load nonce from the first script[nonce]
-//     element (browsers expose this via .nonce property, not
-//     the attribute, to prevent CSS exfiltration attacks).
-//     config.nonce is intentionally NOT supported — the nonce
-//     must come from an actual script tag to prevent JS-based
-//     forgery before the extension initialises.
-//   - Before each element is initialized, cancels init if the
-//     element's hx-nonce doesn't match the page nonce — covers
-//     hx-get/post/etc and hx-boost via htmx:before:init
-//   - Before each hx-on: node is bound, cancels if hx-nonce
-//     doesn't match — covers hx-on: via htmx:before:on:init
-//   - Before each swap, reads the partial response's own CSP
-//     nonce, validates fragment elements against it, then
-//     rewrites valid ones to the page nonce so they survive
-//     subsequent process() calls
-//   - At request time, blocks boosted form submissions where
-//     an unnnonced submitter overrode formAction
+// Nonce source: script[nonce].nonce property on page load.
+// Fail closed if none found.
 //
-// Always-on: enforcement is unconditional once the extension
-// is loaded. If no page nonce is detected, all htmx processing
-// is blocked — a missing nonce means misconfiguration or active
-// attack (e.g. nonce stripped by injected content). Fail closed.
+// Trusted Types: creates 'htmx' TT policy (passthrough —
+// trust established by nonce gate). Add trusted-types htmx
+// to CSP to enforce that only htmx touches DOM sinks.
+// Fail closed if policy creation is blocked by CSP.
 //
-// Safe eval: set config.safeEval:true to also replace
-// htmx's eval with nonce-based script injection, enabling
-// htmx JS features (hx-on:, hx-vals js:, hx-confirm js:,
-// trigger filters) on pages with no unsafe-eval CSP.
-// Requires pageNonce to be present — silently skipped if not.
+// safeEval: set config.safeEval:true to replace htmx's
+// Function/AsyncFunction with nonce-based script injection,
+// enabling hx-on:/hx-vals js:/hx-confirm js: without
+// unsafe-eval CSP.
 //
 // Usage:
 //   <meta name="htmx-config" content='extensions:"hx-nonce"'>
 //   <meta name="htmx-config" content='extensions:"hx-nonce",safeEval:true'>
 //   <script src="hx-nonce.js"></script>
 //
-//   Server stamps hx-nonce on every hx- bearing element:
+//   Server stamps hx-nonce on every htmx element:
 //   <button hx-post="/save" hx-nonce="<csp-nonce>">Save</button>
 //==========================================================
 (() => {
 
     let pageNonce = null;
+    let ttPolicy = null;
     let internalApi = null;
 
-    // Get nonce value from element using api.attributeValue for prefix support
     function getNonce(elt) {
         return internalApi?.attributeValue(elt, 'hx-nonce');
     }
 
-    // Check nonce on element — strips and blocks if invalid, used by both init hooks
     function checkNonce(elt) {
         if (!pageNonce) return false;
-        if (getNonce(elt) !== pageNonce) {
-            stripHxAttributes(elt);
-            return false;
-        }
+        let eltNonce = getNonce(elt);
+        if (eltNonce === pageNonce) return;
+        if (stripHxAttributes(elt, eltNonce)) return false;
     }
 
-    // Extract nonce value from a CSP header string.
-    // Anchors to script-src or default-src to avoid matching nonces
-    // in other directives (e.g. img-src) which would extract the wrong value.
+    // Anchors to script-src/default-src to avoid matching nonces in other directives
     function extractNonceFromCSP(csp) {
         return csp?.match(/(?:script-src|default-src)[^;]*'nonce-([^']+)'/i)?.[1] ?? null;
     }
 
-    // Escape a string for use in a RegExp
+    // Fallback: parse raw response HTML and extract nonce from meta CSP tag in <head>.
+    // Only used for full-page responses with no CSP header.
+    function extractNonceFromMetaTag(text) {
+        let doc = Document.parseHTMLUnsafe(ttPolicy.createHTML(text));
+        let meta = doc.head?.querySelector('meta[http-equiv="Content-Security-Policy"]');
+        return extractNonceFromCSP(meta?.content);
+    }
+
     function escapeRegex(str) {
         return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     }
 
-    // Rewrite all occurrences of responseNonce to pageNonce in raw HTML text,
-    // covering both hx-nonce="..." / hx-nonce='...' and script nonce="..." / nonce='...'.
-    // Uses a backreference to ensure open/close quotes match.
-    // Only rewrites exact nonce value matches — won't touch other attribute values.
+    // Rewrites responseNonce → pageNonce in raw HTML before DOM parsing,
+    // covering hx-nonce and script nonce attributes in one pass.
     function rewriteNoncesInText(text, responseNonce) {
         let escaped = escapeRegex(responseNonce);
         return text.replace(
@@ -86,40 +69,51 @@
         );
     }
 
-    // Strip all hx- attributes from an element and fire a
-    // security event so the app can log/audit the violation.
-    function stripHxAttributes(elt) {
+    // Strips all hx- attributes, fires htmx:security:strip, returns true if anything stripped.
+    function stripHxAttributes(elt, eltNonce) {
+        let stripped = [];
         for (let attr of [...elt.attributes]) {
             if (attr.name.startsWith('hx-') || (htmx.config.prefix && attr.name.startsWith(htmx.config.prefix))) {
+                stripped.push(attr.name);
                 elt.removeAttribute(attr.name);
             }
         }
-        htmx.trigger(elt, 'htmx:security:strip', { reason: 'nonce-mismatch' });
+        if (!stripped.length) return false;
+        let tag = elt.tagName?.toLowerCase();
+        let id = elt.id ? `#${elt.id}` : '';
+        let reason = eltNonce == null ? 'missing-nonce' : 'nonce-mismatch';
+        console.error(`hx-nonce: blocked <${tag}${id}> — ${eltNonce == null ? 'no hx-nonce attribute' : 'nonce mismatch (possible injection)'}.`);
+        htmx.trigger(elt, 'htmx:security:strip', { reason, stripped });
+        return true;
     }
 
     htmx.registerExtension('hx-nonce', {
 
         init: (api) => {
             internalApi = api;
-            // Read page nonce from first nonced script tag.
-            // Must use .nonce property — browsers blank the nonce
-            // attribute value to prevent CSS attribute selector
-            // exfiltration attacks, but .nonce remains readable via JS.
+
+            // .nonce property stays readable after browsers blank the attribute
+            // to prevent CSS exfiltration attacks.
             pageNonce = document.querySelector('script[nonce]')?.nonce || null;
 
             if (!pageNonce) {
-                // No nonce found — fail closed. Loading hx-nonce signals
-                // intent to enforce. A missing nonce is misconfiguration
-                // or an active attack stripping the nonce from the page.
-                // Block all htmx by returning false from every hook.
                 console.error('hx-nonce: no page nonce found — blocking all htmx. Add a nonce to your script tags.');
                 return;
             }
 
-            // Safe eval: replace Function/AsyncFunction constructors with
-            // nonce-based script injection so htmx JS features work without
-            // unsafe-eval CSP. Gated on config.safeEval since it requires
-            // the server to also set up per-response CSP nonces.
+            // Passthrough TT policy — trust established by nonce gate.
+            // Fail closed if 'htmx' is not in the trusted-types whitelist.
+            try {
+                ttPolicy = typeof trustedTypes !== 'undefined'
+                    ? trustedTypes.createPolicy('htmx', { createHTML: s => s, createScript: s => s })
+                    : { createHTML: s => s, createScript: s => s };
+            } catch (e) {
+                console.error("hx-nonce: TrustedTypes policy 'htmx' blocked — add 'htmx' to trusted-types CSP directive. Blocking all htmx.");
+                pageNonce = null;
+                return;
+            }
+
+            let syncFn, asyncFn;
             if (htmx.config.safeEval) {
                 let counter = 0;
                 function makeNoncedConstructor(isAsync) {
@@ -128,14 +122,16 @@
                         return {
                             call: (thisArg, ...values) => {
                                 if (getNonce(thisArg) !== pageNonce) {
+                                    let tag = thisArg?.tagName?.toLowerCase();
+                                    let id = thisArg?.id ? `#${thisArg.id}` : '';
+                                    console.error(`hx-nonce: blocked eval on <${tag}${id}> — nonce mismatch.`);
                                     htmx.trigger(thisArg, 'htmx:security:violation', { reason: 'nonce-mismatch-at-eval' });
                                     return;
                                 }
                                 let fn = `__htmx_eval_${++counter}`;
-                                let asyncPrefix = isAsync ? 'async ' : '';
                                 let script = document.createElement('script');
                                 script.nonce = pageNonce;
-                                script.textContent = `window.${fn} = ${asyncPrefix}function(${keys.join(',')}) { ${body} }`;
+                                script.textContent = ttPolicy.createScript(`window.${fn} = ${isAsync ? 'async ' : ''}function(${keys.join(',')}) { ${body} }`);
                                 document.head.appendChild(script);
                                 script.remove();
                                 let r = window[fn].call(thisArg, ...values);
@@ -145,43 +141,43 @@
                         };
                     };
                 }
-                api.initEvalFunctions(makeNoncedConstructor(false), makeNoncedConstructor(true));
+                syncFn = makeNoncedConstructor(false);
+                asyncFn = makeNoncedConstructor(true);
             }
+
+            api.initEvalFunctions(ttPolicy, syncFn, asyncFn);
         },
 
         htmx_before_init: checkNonce,
 
         htmx_before_on_init: checkNonce,
 
-        // Fires after ctx.text is set (htmx:after:request), before fragment
-        // parsing. Rewrite response nonces to pageNonce in the raw HTML so
-        // both hx-nonce attributes and script nonce attributes are promoted
-        // in one pass before the DOM is built.
+        // Rewrites response nonces to pageNonce in raw HTML before fragment parsing.
+        // Same-origin only — promoting a cross-origin nonce would trust untrusted content.
         htmx_after_request: (elt, detail) => {
             if (!pageNonce) return false;
-            let csp = detail.ctx?.response?.headers?.get('Content-Security-Policy');
-            let responseNonce = extractNonceFromCSP(csp);
+            let ctx = detail.ctx;
+            let responseURL = ctx?.response?.raw?.url;
+            if (responseURL) {
+                try { if (new URL(responseURL).origin !== location.origin) return; }
+                catch (_) { return; }
+            }
+            let responseNonce = extractNonceFromCSP(ctx?.response?.headers?.get('Content-Security-Policy'))
+                             ?? extractNonceFromMetaTag(ctx?.text);
             if (responseNonce && responseNonce !== pageNonce) {
-                detail.ctx.text = rewriteNoncesInText(detail.ctx.text, responseNonce);
+                ctx.text = rewriteNoncesInText(ctx.text, responseNonce);
             }
         },
 
-        // Block boosted form submissions where an unnnonced
-        // submitter overrode formAction.
+        // Blocks boosted form submissions where an unnnonced submitter overrides formaction.
         htmx_config_request: (elt, detail) => {
             if (!pageNonce) return false;
-
-            let ctx = detail.ctx;
-            let submitter = ctx.sourceEvent?.submitter;
-
+            let submitter = detail.ctx?.sourceEvent?.submitter;
             if (!elt._htmx?.boosted || !submitter?.getAttribute('formaction')) return;
-
             if (getNonce(submitter) !== pageNonce) {
-                htmx.trigger(elt, 'htmx:security:violation', {
-                    reason: 'unnnonced-submitter',
-                    submitter,
-                    ctx
-                });
+                let id = submitter?.id ? `#${submitter.id}` : '';
+                console.error(`hx-nonce: blocked boosted form — unnnonced submitter${id} overrode formaction.`);
+                htmx.trigger(elt, 'htmx:security:violation', { reason: 'unnnonced-submitter', submitter, ctx: detail.ctx });
                 detail.cancelled = true;
                 return false;
             }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -88,7 +88,7 @@ var htmx = (() => {
                 insertContent: this.__insertContent.bind(this),
                 morph: this.__morph.bind(this),
                 isSoftMatch: this.__isSoftMatch.bind(this),
-                initEvalFunctions: (ttPolicy, syncFn, asyncFn) => {
+                initSecurity: (ttPolicy, syncFn, asyncFn) => {
                     this.#ttPolicy = ttPolicy;
                     if (syncFn) this.#Function = syncFn;
                     if (asyncFn) this.#AsyncFunction = asyncFn;

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -62,6 +62,8 @@ var htmx = (() => {
         __approvedExt = '';
         __registeredExt = new Set();
         #internalAPI;
+        #Function = Function;
+        #AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
         #actionSelector
         #boostSelector = "a,form";
         #verbs = ["get", "post", "put", "patch", "delete"];
@@ -85,6 +87,10 @@ var htmx = (() => {
                 insertContent: this.__insertContent.bind(this),
                 morph: this.__morph.bind(this),
                 isSoftMatch: this.__isSoftMatch.bind(this),
+                initEvalFunctions: (syncFn, asyncFn) => {
+                    this.#Function = syncFn;
+                    this.#AsyncFunction = asyncFn;
+                },
                 onTrigger: this.__onTrigger.bind(this),
                 htmxProp: this.__htmxProp.bind(this),
                 triggerHtmxEvent: this.__trigger.bind(this)
@@ -473,7 +479,7 @@ var htmx = (() => {
             let javascriptContent = this.__extractJavascriptContent(ctx.request.action);
             if (javascriptContent != null) {
                 let data = Object.fromEntries(ctx.request.body);
-                await this.__executeJavaScriptAsync(ctx.sourceElement, data, javascriptContent, false);
+                await this.__executeJavaScript(ctx.sourceElement, data, javascriptContent, false);
                 return
             } else if (usesQueryParams) {
                 let url = new URL(ctx.request.action, document.baseURI);
@@ -517,7 +523,7 @@ var htmx = (() => {
                         let detail = {ctx, issueRequest: () => resolve(true), dropRequest: () => resolve(false)};
                         if (this.__trigger(elt, "htmx:confirm", detail)) {
                             let js = this.__extractJavascriptContent(ctx.confirm);
-                            resolve(js ? this.__executeJavaScriptAsync(elt, {}, js, true) : window.confirm(ctx.confirm));
+                            resolve(js ? this.__executeJavaScript(elt, {}, js, true) : window.confirm(ctx.confirm));
                         }
                     });
                     if (!confirmed) return;
@@ -793,7 +799,8 @@ var htmx = (() => {
                     let original = spec.handler
                     spec.handler = (evt) => {
                         if (this.__shouldCancel(evt)) evt.preventDefault()
-                        if (this.__executeFilter(elt, evt, filter)) {
+                        let evtArgs = {}; for (let k in evt) evtArgs[k] = evt[k];
+                        if (this.__executeJavaScript(elt, evtArgs, filter, true, false)) {
                             original(evt)
                         }
                     }
@@ -878,27 +885,14 @@ var htmx = (() => {
             return bound;
         }
 
-        async __executeJavaScriptAsync(thisArg, obj, code, expression = true) {
+        __executeJavaScript(thisArg, obj, code, expression = true, isAsync = true) {
             let args = {}
             Object.assign(args, this.__apiMethods(thisArg))
             Object.assign(args, obj)
             let keys = Object.keys(args);
             let values = Object.values(args);
-            let AsyncFunction = Object.getPrototypeOf(async function () {
-            }).constructor;
-            let func = new AsyncFunction(...keys, expression ? `return (${code})` : code);
-            return await func.call(thisArg, ...values);
-        }
-
-        __executeFilter(thisArg, event, code) {
-            let args = {}
-            Object.assign(args, this.__apiMethods(thisArg))
-            for (let key in event) {
-                args[key] = event[key];
-            }
-            let keys = Object.keys(args);
-            let values = Object.values(args);
-            let func = new Function(...keys, `return (${code})`);
+            let FunctionConstructor = isAsync ? this.#AsyncFunction : this.#Function;
+            let func = new FunctionConstructor(...keys, expression ? `return (${code})` : code);
             return func.call(thisArg, ...values);
         }
 
@@ -915,7 +909,7 @@ var htmx = (() => {
             let node = null
             while (node = iter.iterateNext()) hxOnNodes.push(node)
             for (let hxOnNode of hxOnNodes) {
-                if (!this.__ignore(hxOnNode)) {
+                if (!this.__ignore(hxOnNode) && this.__trigger(hxOnNode, "htmx:before:on:init", {}, true)) {
                     this.__handleHxOnAttributes(hxOnNode)
                 }
             }
@@ -1665,7 +1659,7 @@ var htmx = (() => {
                     let code = node.getAttribute(attr);
                     let handler = async (evt) => {
                         try {
-                            await this.__executeJavaScriptAsync(node, {"event": evt}, code, false)
+                            await this.__executeJavaScript(node, {"event": evt}, code, false)
                         } catch (e) {
                             console.error(e);
                         }
@@ -1795,7 +1789,7 @@ var htmx = (() => {
                     javascriptContent = '{' + javascriptContent + '}';
                 }
                 // Return promise for async evaluation
-                return this.__executeJavaScriptAsync(elt, {}, javascriptContent, true).then(obj => {
+                return this.__executeJavaScript(elt, {}, javascriptContent, true).then(obj => {
                     callback(obj);
                 });
             } else {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -89,7 +89,7 @@ var htmx = (() => {
                 morph: this.__morph.bind(this),
                 isSoftMatch: this.__isSoftMatch.bind(this),
                 initSecurity: (ttPolicy, syncFn, asyncFn) => {
-                    this.#ttPolicy = ttPolicy;
+                    if (ttPolicy) this.#ttPolicy = ttPolicy;
                     if (syncFn) this.#Function = syncFn;
                     if (asyncFn) this.#AsyncFunction = asyncFn;
                 },

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -64,6 +64,7 @@ var htmx = (() => {
         #internalAPI;
         #Function = Function;
         #AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
+        #ttPolicy = { createHTML: s => s, createScript: s => s };
         #actionSelector
         #boostSelector = "a,form";
         #verbs = ["get", "post", "put", "patch", "delete"];
@@ -87,9 +88,10 @@ var htmx = (() => {
                 insertContent: this.__insertContent.bind(this),
                 morph: this.__morph.bind(this),
                 isSoftMatch: this.__isSoftMatch.bind(this),
-                initEvalFunctions: (syncFn, asyncFn) => {
-                    this.#Function = syncFn;
-                    this.#AsyncFunction = asyncFn;
+                initEvalFunctions: (ttPolicy, syncFn, asyncFn) => {
+                    this.#ttPolicy = ttPolicy;
+                    if (syncFn) this.#Function = syncFn;
+                    if (asyncFn) this.#AsyncFunction = asyncFn;
                 },
                 onTrigger: this.__onTrigger.bind(this),
                 htmxProp: this.__htmxProp.bind(this),
@@ -1011,7 +1013,8 @@ var htmx = (() => {
         }
 
         __parseHTML(resp) {
-            return Document.parseHTMLUnsafe?.(resp) || new DOMParser().parseFromString(resp, 'text/html');
+            let trusted = this.#ttPolicy.createHTML(resp);
+            return Document.parseHTMLUnsafe?.(trusted) || new DOMParser().parseFromString(trusted, 'text/html');
         }
 
         __makeFragment(text) {
@@ -1192,7 +1195,7 @@ var htmx = (() => {
                 if (this.config.inlineScriptNonce) {
                     newScript.nonce = this.config.inlineScriptNonce;
                 }
-                newScript.textContent = oldScript.textContent;
+                newScript.textContent = this.#ttPolicy.createScript(oldScript.textContent);
                 oldScript.replaceWith(newScript);
             }
         }

--- a/test/manual/hx-nonce/alpine.html
+++ b/test/manual/hx-nonce/alpine.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>hx-nonce + Alpine CSP test</title>
+  <meta name="htmx-config" content='extensions:"hx-nonce,hx-alpine-compat",safeEval:true'>
+  <!-- Alpine CSP build — no unsafe-eval required -->
+  <script defer nonce="__NONCE__" src="https://cdn.jsdelivr.net/npm/@alpinejs/csp@3.x.x/dist/cdn.min.js"></script>
+  <script nonce="__NONCE__" src="/htmx.js"></script>
+  <script nonce="__NONCE__" src="/ext/hx-nonce.js"></script>
+  <script nonce="__NONCE__" src="/ext/hx-alpine-compat.js"></script>
+  <style nonce="__NONCE__">
+    body { font-family: sans-serif; max-width: 700px; margin: 2rem auto; }
+    .modes { display: flex; gap: .5rem; flex-wrap: wrap; margin-bottom: 1.5rem; }
+    .modes a { padding: .3rem .7rem; border: 1px solid #999; border-radius: 4px; text-decoration: none; color: #333; }
+    .modes a.active { background: #333; color: #fff; }
+    section { border: 1px solid #ddd; border-radius: 6px; padding: 1rem; margin-bottom: 1rem; }
+    h2 { margin: 0 0 .5rem; font-size: 1rem; }
+    .result { min-height: 2rem; padding: .5rem; background: #f5f5f5; border-radius: 4px; }
+    .csp-info { font-size: .8rem; color: #666; margin-bottom: 1rem; }
+  </style>
+</head>
+<body>
+
+<h1>hx-nonce + Alpine CSP build test</h1>
+
+<div class="modes">
+  <a href="/alpine?csp=alpine-csp">alpine-csp</a>
+  <a href="/alpine?csp=alpine-csp-tt">alpine-csp-tt</a>
+  <a href="/">back to main tests</a>
+</div>
+
+<p class="csp-info">
+  Current mode: <strong id="mode-label"></strong><br>
+  Alpine CSP build — no <code>unsafe-eval</code> required. Check console for violations.
+</p>
+
+<!-- 1. Alpine reactivity — basic expressions without unsafe-eval -->
+<section>
+  <h2>1. Alpine reactivity (no unsafe-eval)</h2>
+  <p>Basic Alpine expressions using the CSP build. Should work without unsafe-eval.</p>
+  <div x-data="{ count: 0 }">
+    <button x-on:click="count++">Increment</button>
+    <button x-on:click="count = 0">Reset</button>
+    <span x-text="count"></span>
+    <span x-show="count > 5"> — count is greater than 5!</span>
+  </div>
+</section>
+
+<!-- 2. htmx + Alpine together -->
+<section>
+  <h2>2. htmx swap + Alpine reactive content</h2>
+  <p>htmx loads a partial, Alpine reacts to the new content.</p>
+  <button hx-get="/partial" hx-target="#alpine-result">Load partial</button>
+  <div id="alpine-result" class="result">— not loaded —</div>
+</section>
+
+<!-- 3. Alpine x-data with htmx hx-vals -->
+<section>
+  <h2>3. Alpine state read by htmx hx-vals js:</h2>
+  <p>htmx reads Alpine component state via hx-vals js:. Requires safeEval:true.</p>
+  <div x-data="{ userId: 42 }">
+    <button hx-post="/partial"
+            hx-vals="js:{userId: document.querySelector('[x-data]')._x_dataStack?.[0]?.userId}"
+            hx-target="#vals-result">POST with Alpine state</button>
+  </div>
+  <div id="vals-result" class="result">— not loaded —</div>
+</section>
+
+<!-- 4. Alpine CSP limitation — globals not supported -->
+<section>
+  <h2>4. Alpine CSP limitation — globals not supported</h2>
+  <p>The Alpine CSP build blocks global access entirely — <code>console</code>, <code>window</code>
+     etc. throw <em>"Undefined variable"</em> Alpine errors (check console). Extract logic to
+     <code>Alpine.data()</code> in a nonced <code>&lt;script&gt;</code> tag instead.</p>
+  <div x-data="{}">
+    <button x-on:click="console.log('clicked')">console.log (throws Alpine error)</button>
+    <button x-on:click="window.alert('hi')">window.alert (throws Alpine error)</button>
+  </div>
+</section>
+
+<!-- 5. Alpine CSP self-policed sinks -->
+<section>
+  <h2>5. Alpine CSP self-policed sinks</h2>
+  <p>The Alpine CSP build actively blocks its own dangerous sinks before they reach the DOM —
+     no TT violation needed. These throw Alpine's own errors, not browser TT errors.
+     This means <code>trusted-types htmx</code> alone is sufficient alongside the Alpine CSP build.</p>
+
+  <p><strong>x-html</strong> — Alpine CSP throws <em>"Using the x-html directive is prohibited"</em></p>
+  <div x-data="{ msg: '<b>bold</b>' }">
+    <span x-html="msg"></span>
+  </div>
+
+  <p><strong>x-init + insertAdjacentHTML</strong> — Alpine CSP throws <em>"Accessing insertAdjacentHTML is prohibited"</em></p>
+  <div x-data x-init="$el.insertAdjacentHTML('beforeend', '<span>injected</span>')">
+    (insertAdjacentHTML target)
+  </div>
+
+  <p><strong>x-if / x-for</strong> — Alpine CSP handles template cloning internally without hitting TT sinks</p>
+  <div x-data="{ show: true, items: ['a', 'b', 'c'] }">
+    <template x-if="show"><p>x-if rendered &#x2713;</p></template>
+    <ul><template x-for="item in items"><li x-text="item"></li></template></ul>
+  </div>
+
+  <p><strong>x-bind:innerHTML</strong> — Alpine CSP blocks this too</p>
+  <div x-data="{ html: '<em>bound</em>' }">
+    <div x-bind:innerHTML="html"></div>
+  </div>
+</section>
+
+<script nonce="__NONCE__">
+  const params = new URLSearchParams(location.search);
+  const mode = params.get('csp') || document.cookie.match(/csp-mode=([^;]+)/)?.[1] || 'alpine-csp';
+  document.getElementById('mode-label').textContent = mode;
+  document.querySelectorAll('.modes a').forEach(a => {
+    if (a.href.includes('csp=' + mode)) a.classList.add('active');
+  });
+
+  document.addEventListener('htmx:security:strip', e => {
+    console.warn('htmx:security:strip', e.target, e.detail);
+  });
+</script>
+
+</body>
+</html>

--- a/test/manual/hx-nonce/index.html
+++ b/test/manual/hx-nonce/index.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>hx-nonce CSP test</title>
+  <meta name="htmx-config" content='extensions:"hx-nonce",safeEval:true'>
+  <script nonce="__NONCE__" src="/htmx.js"></script>
+  <script nonce="__NONCE__" src="/ext/hx-nonce.js"></script>
+  <style nonce="__NONCE__">
+    body { font-family: sans-serif; max-width: 700px; margin: 2rem auto; }
+    .modes { display: flex; gap: .5rem; flex-wrap: wrap; margin-bottom: 1.5rem; }
+    .modes a { padding: .3rem .7rem; border: 1px solid #999; border-radius: 4px; text-decoration: none; color: #333; }
+    .modes a.active { background: #333; color: #fff; }
+    section { border: 1px solid #ddd; border-radius: 6px; padding: 1rem; margin-bottom: 1rem; }
+    h2 { margin: 0 0 .5rem; font-size: 1rem; }
+    #result, #eval-result, #unnonced-result { min-height: 2rem; padding: .5rem; background: #f5f5f5; border-radius: 4px; }
+    .csp-info { font-size: .8rem; color: #666; margin-bottom: 1rem; }
+  </style>
+</head>
+<body>
+
+<h1>hx-nonce + Trusted Types CSP test</h1>
+
+<div class="modes">
+  <a href="/?csp=permissive">permissive</a>
+  <a href="/?csp=nonce">nonce</a>
+  <a href="/?csp=nonce-no-eval">nonce-no-eval</a>
+  <a href="/?csp=nonce-no-eval-no-safeeval">nonce-no-eval-no-safeeval &#x26A0;</a>
+  <a href="/?csp=trusted-types">trusted-types</a>
+  <a href="/?csp=trusted-types-no-eval">trusted-types-no-eval</a>
+  <a href="/?csp=trusted-types-multi">trusted-types-multi</a>
+  <a href="/?csp=trusted-types-no-htmx">trusted-types-no-htmx &#x26A0;</a>
+</div>
+
+<p class="csp-info">
+  Current mode: <strong id="mode-label"></strong><br>
+  Check the browser console and Network tab for CSP violations.
+</p>
+
+<!-- 1. Basic AJAX swap -->
+<section>
+  <h2>1. Basic hx-get swap</h2>
+  <p>Tests that nonced elements can make requests and swap content.</p>
+  <button hx-get="/partial" hx-target="#result">Load partial</button>
+  <div id="result">— not loaded —</div>
+</section>
+
+<!-- 2. JS eval paths -->
+<section>
+  <h2>2. JS eval paths (all require safeEval under no-eval CSP)</h2>
+  <p>Each button exercises a different htmx JS eval entry point. Check console for output.</p>
+
+  <p><strong>hx-on:click</strong> — inline event handler</p>
+  <button hx-on:click="console.log('hx-on:click fired')" hx-nonce="__NONCE__">hx-on:click</button>
+
+  <p><strong>hx-trigger filter</strong> — click[expression] guard</p>
+  <button hx-get="/partial" hx-target="#eval-result"
+          hx-trigger="click[console.log('filter ran') || true]">hx-trigger filter</button>
+
+  <p><strong>hx-vals js:</strong> — JS object expression for request body</p>
+  <button hx-post="/partial" hx-target="#eval-result"
+          hx-vals="js:{ts: Date.now(), rand: Math.random()}">hx-vals js:</button>
+
+  <p><strong>hx-headers js:</strong> — JS object expression for request headers</p>
+  <button hx-get="/partial" hx-target="#eval-result"
+          hx-headers="js:{'X-Timestamp': String(Date.now())}">hx-headers js:</button>
+
+  <p><strong>hx-confirm js:</strong> — async confirm via JS expression</p>
+  <button hx-get="/partial" hx-target="#eval-result"
+          hx-confirm="js:confirm('hx-confirm js: — proceed?')">hx-confirm js:</button>
+
+  <p><strong>hx-get js:</strong> — JS expression executed instead of HTTP request (side-effect only, no swap)</p>
+  <button hx-get="js:console.log('hx-get js: executed') || undefined"
+          hx-target="#eval-result">hx-get js:</button>
+
+  <div id="eval-result">— eval results —</div>
+</section>
+
+<!-- 3. Script tag execution -->
+<section>
+  <h2>3. Script tag execution in swapped responses</h2>
+  <p>Tests whether scripts in partial responses execute based on their nonce.</p>
+
+  <p><strong>With nonce</strong> — script carries the response nonce, rewritten to page nonce by hx-nonce. Should execute under all modes.</p>
+  <button hx-get="/script-with-nonce" hx-target="#script-result">Swap in nonced script</button>
+
+  <p><strong>Without nonce</strong> — script has no nonce. Should execute in permissive, blocked by CSP in all nonce modes.</p>
+  <button hx-get="/script-without-nonce" hx-target="#script-result">Swap in unnnonced script</button>
+
+  <div id="script-result">— script results —</div>
+</section>
+
+<!-- 4. Blocked elements (should never fire a request) -->
+<section>
+  <h2>4. Blocked elements (should never fire a request)</h2>
+  <p>Both buttons should be stripped by hx-nonce and fire htmx:security:strip.</p>
+  <button hx-get="/partial" hx-target="#unnonced-result" hx-nonce="INVALID">
+    Wrong nonce (mismatch)
+  </button>
+  <button data-no-nonce hx-get="/partial" hx-target="#unnonced-result">
+    No nonce (missing)
+  </button>
+  <div id="unnonced-result">— should stay empty —</div>
+</section>
+
+<script nonce="__NONCE__">
+  // Mark active mode link
+  const params = new URLSearchParams(location.search);
+  const mode = params.get('csp') || document.cookie.match(/csp-mode=([^;]+)/)?.[1] || 'permissive';
+  document.getElementById('mode-label').textContent = mode;
+  document.querySelectorAll('.modes a').forEach(a => {
+    if (a.href.includes('csp=' + mode)) a.classList.add('active');
+  });
+
+  // Log security events
+  document.addEventListener('htmx:security:strip', e => {
+    console.warn('htmx:security:strip fired on', e.target, e.detail);
+  });
+  document.addEventListener('htmx:security:violation', e => {
+    console.error('htmx:security:violation fired', e.detail);
+  });
+</script>
+
+</body>
+</html>

--- a/test/manual/hx-nonce/nonce-server.js
+++ b/test/manual/hx-nonce/nonce-server.js
@@ -1,0 +1,196 @@
+/**
+ * hx-nonce + Trusted Types CSP test server
+ *
+ * Usage:
+ *   node test/manual/hx-nonce/nonce-server.js
+ *
+ * Modes (?csp= query param or csp-mode cookie):
+ *
+ *   permissive (default)       script-src 'unsafe-inline' 'unsafe-eval'
+ *   nonce                      script-src 'nonce-X' 'unsafe-eval'
+ *   nonce-no-eval              script-src 'nonce-X'
+ *   nonce-no-eval-no-safeeval  script-src 'nonce-X', safeEval disabled
+ *   trusted-types              nonce + require-trusted-types-for + trusted-types htmx
+ *   trusted-types-no-eval      trusted-types, no unsafe-eval
+ *   trusted-types-multi        trusted-types htmx my-app
+ *   trusted-types-no-htmx      trusted-types my-app only — htmx policy blocked
+ *   alpine-csp                 nonce, no unsafe-eval, Alpine CSP build from CDN
+ *   alpine-csp-tt              alpine-csp + Trusted Types
+ */
+
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const ROOT = __dirname;
+const HTMX_SRC       = path.join(__dirname, '..', '..', '..', 'src', 'htmx.js');
+const HX_NONCE_SRC   = path.join(__dirname, '..', '..', '..', 'src', 'ext', 'hx-nonce.js');
+const HX_ALPINE_SRC  = path.join(__dirname, '..', '..', '..', 'src', 'ext', 'hx-alpine-compat.js');
+
+function makeNonce() {
+    return crypto.randomBytes(16).toString('base64');
+}
+
+function makeCsp(mode, nonce) {
+    const tt = `require-trusted-types-for 'script'; trusted-types htmx`;
+    switch (mode) {
+        case 'nonce':
+            return `default-src 'self'; script-src 'self' 'nonce-${nonce}' 'unsafe-eval'; style-src 'self' 'nonce-${nonce}';`;
+        case 'nonce-no-eval':
+        case 'nonce-no-eval-no-safeeval':
+            return `default-src 'self'; script-src 'self' 'nonce-${nonce}'; style-src 'self' 'nonce-${nonce}';`;
+        case 'trusted-types':
+            return `default-src 'self'; script-src 'self' 'nonce-${nonce}' 'unsafe-eval'; style-src 'self' 'nonce-${nonce}'; ${tt};`;
+        case 'trusted-types-no-eval':
+            return `default-src 'self'; script-src 'self' 'nonce-${nonce}'; style-src 'self' 'nonce-${nonce}'; ${tt};`;
+        case 'trusted-types-multi':
+            return `default-src 'self'; script-src 'self' 'nonce-${nonce}' 'unsafe-eval'; style-src 'self' 'nonce-${nonce}'; require-trusted-types-for 'script'; trusted-types htmx my-app;`;
+        case 'trusted-types-no-htmx':
+            // 'htmx' not whitelisted — createPolicy('htmx') throws, all htmx blocked
+            return `default-src 'self'; script-src 'self' 'nonce-${nonce}' 'unsafe-eval'; style-src 'self' 'nonce-${nonce}'; require-trusted-types-for 'script'; trusted-types my-app;`;
+        case 'alpine-csp':
+            // Alpine CSP build handles expressions without Function() — no unsafe-eval needed.
+            // CDN allowed for Alpine CSP build.
+            return `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://cdn.jsdelivr.net; style-src 'self' 'nonce-${nonce}';`;
+        case 'alpine-csp-tt':
+            return `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://cdn.jsdelivr.net; style-src 'self' 'nonce-${nonce}'; ${tt};`;
+        default: // permissive
+            return `default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline';`;
+    }
+}
+
+// Replace __NONCE__ placeholder and stamp hx-nonce on hx- elements.
+// Elements with data-no-nonce are intentionally left without hx-nonce for testing.
+function stampNonce(html, nonce) {
+    return html
+        .replaceAll('__NONCE__', nonce)
+        .replace(/(<[^>]+\shx-(?:get|post|put|patch|delete|boost|on)[^>]*)(>)/gi,
+            (m, attrs, close) => (attrs.includes('hx-nonce') || attrs.includes('data-no-nonce')) ? m : `${attrs} hx-nonce="${nonce}"${close}`
+        );
+}
+
+function readFile(filePath) {
+    try { return fs.readFileSync(filePath, 'utf8'); } catch { return null; }
+}
+
+function partialHeaders(partialNonce) {
+    return { 'Content-Type': 'text/html', 'Content-Security-Policy': `script-src 'nonce-${partialNonce}';` };
+}
+
+http.createServer((req, res) => {
+    const url = new URL(req.url, 'http://localhost');
+    const pathname = url.pathname;
+
+    // Source files — no CSP needed
+    if (pathname === '/htmx.js') {
+        const content = readFile(HTMX_SRC);
+        if (!content) { res.writeHead(404); res.end('htmx.js not found'); return; }
+        res.writeHead(200, { 'Content-Type': 'application/javascript' });
+        res.end(content);
+        return;
+    }
+    if (pathname === '/ext/hx-nonce.js') {
+        const content = readFile(HX_NONCE_SRC);
+        if (!content) { res.writeHead(404); res.end('hx-nonce.js not found'); return; }
+        res.writeHead(200, { 'Content-Type': 'application/javascript' });
+        res.end(content);
+        return;
+    }
+    if (pathname === '/ext/hx-alpine-compat.js') {
+        const content = readFile(HX_ALPINE_SRC);
+        if (!content) { res.writeHead(404); res.end('hx-alpine-compat.js not found'); return; }
+        res.writeHead(200, { 'Content-Type': 'application/javascript' });
+        res.end(content);
+        return;
+    }
+
+    // Fresh nonce per request
+    const nonce = makeNonce();
+    const cookieMode = (req.headers.cookie || '').match(/csp-mode=([^;]+)/)?.[1];
+    const mode = url.searchParams.get('csp') || cookieMode || 'permissive';
+    const csp = makeCsp(mode, nonce);
+
+    const pageHeaders = {
+        'Content-Type': 'text/html',
+        'Content-Security-Policy': csp,
+        'Set-Cookie': `csp-mode=${mode}; Path=/`,
+        'X-CSP-Nonce': nonce,
+    };
+
+    // Script execution tests
+    if (pathname === '/script-with-nonce') {
+        const pn = makeNonce();
+        res.writeHead(200, partialHeaders(pn));
+        res.end(`<div hx-nonce="${pn}">
+  <p>Nonced script — should execute (check console).</p>
+  <script nonce="${pn}">console.log('script-with-nonce: executed \u2713');</script>
+</div>`);
+        return;
+    }
+
+    if (pathname === '/script-without-nonce') {
+        const pn = makeNonce();
+        res.writeHead(200, partialHeaders(pn));
+        res.end(`<div hx-nonce="${pn}">
+  <p>Unnnonced script — should be blocked by CSP (check console for violation, NOT execution).</p>
+  <script>console.log('script-without-nonce: executed \u2717 \u2014 CSP should have blocked this');</script>
+</div>`);
+        return;
+    }
+
+    if (pathname === '/partial') {
+        const pn = makeNonce();
+        res.writeHead(200, partialHeaders(pn));
+        res.end(`<div hx-nonce="${pn}">
+  <p>Partial loaded at ${new Date().toLocaleTimeString()}</p>
+  <button hx-get="/partial" hx-target="#result" hx-nonce="${pn}">Reload partial</button>
+</div>`);
+        return;
+    }
+
+    if (pathname === '/eval-partial') {
+        const pn = makeNonce();
+        res.writeHead(200, partialHeaders(pn));
+        res.end(`<div hx-nonce="${pn}" hx-on:htmx:after:swap="console.log('hx-on fired from eval-partial')">
+  <p>hx-on: loaded \u2014 check console for eval output</p>
+</div>`);
+        return;
+    }
+
+    if (pathname === '/alpine' || pathname === '/alpine.html') {
+        const template = readFile(path.join(ROOT, 'alpine.html'));
+        if (!template) { res.writeHead(404); res.end('alpine.html not found'); return; }
+        res.writeHead(200, pageHeaders);
+        res.end(stampNonce(template, nonce));
+        return;
+    }
+
+    if (pathname === '/' || pathname === '/index.html') {
+        const template = readFile(path.join(ROOT, 'index.html'));
+        if (!template) { res.writeHead(404); res.end('index.html not found'); return; }
+        let html = stampNonce(template, nonce);
+        if (mode === 'nonce-no-eval-no-safeeval') {
+            html = html.replace('extensions:"hx-nonce",safeEval:true', 'extensions:"hx-nonce"');
+        }
+        res.writeHead(200, pageHeaders);
+        res.end(html);
+        return;
+    }
+
+    res.writeHead(404);
+    res.end('Not found');
+
+}).listen(3002, () => {
+    console.log('hx-nonce CSP test server: http://localhost:3002\n');
+    console.log('  permissive                 http://localhost:3002/?csp=permissive');
+    console.log('  nonce                      http://localhost:3002/?csp=nonce');
+    console.log('  nonce-no-eval              http://localhost:3002/?csp=nonce-no-eval');
+    console.log('  nonce-no-eval-no-safeeval  http://localhost:3002/?csp=nonce-no-eval-no-safeeval');
+    console.log('  trusted-types              http://localhost:3002/?csp=trusted-types');
+    console.log('  trusted-types-no-eval      http://localhost:3002/?csp=trusted-types-no-eval');
+    console.log('  trusted-types-multi        http://localhost:3002/?csp=trusted-types-multi');
+    console.log('  trusted-types-no-htmx      http://localhost:3002/?csp=trusted-types-no-htmx');
+    console.log('  alpine-csp                 http://localhost:3002/alpine?csp=alpine-csp');
+    console.log('  alpine-csp-tt              http://localhost:3002/alpine?csp=alpine-csp-tt');
+});

--- a/www/src/content/docs/06-extensions/16-nonce.md
+++ b/www/src/content/docs/06-extensions/16-nonce.md
@@ -1,0 +1,113 @@
+---
+title: "Nonce Security"
+description: "CSP nonce enforcement and Trusted Types support for htmx"
+keywords: ["nonce", "csp", "security", "trusted types", "xss"]
+---
+
+The `hx-nonce` extension gates htmx attribute processing behind CSP nonces, protecting against HTML injection attacks on sites that already use script nonces.
+
+## Installing
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/htmx.org@next/dist/htmx.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/htmx.org@next/dist/ext/hx-nonce.js"></script>
+```
+
+## The hx-nonce Attribute
+
+The `hx-nonce` attribute is how the server signals to the extension that an htmx element was intentionally rendered by trusted server-side code. When htmx initialises an element, the extension checks that its `hx-nonce` matches the page nonce — if it doesn't match or is missing, all htmx attributes are stripped and the element is inert.
+
+Your templating engine should stamp `hx-nonce` on every element that carries htmx attributes:
+
+```html
+<!-- Django -->
+<button hx-post="/save" hx-nonce="{{ request.csp_nonce }}">Save</button>
+
+<!-- Rails ERB -->
+<button hx-post="/save" hx-nonce="<%= content_security_policy_nonce %>">Save</button>
+
+<!-- Laravel Blade -->
+<button hx-post="/save" hx-nonce="{{ csp_nonce() }}">Save</button>
+```
+
+**Important:** `hx-nonce` alone does not guarantee XSS protection. It proves the element was rendered by the server, but it says nothing about the safety of the attribute values on that element. Any htmx attribute that includes user-supplied data must still be properly escaped by your templating engine:
+
+```html
+<!-- UNSAFE — user data in hx-get without escaping -->
+<div hx-get="/search?q={{ user_input }}" hx-nonce="...">...</div>
+
+<!-- SAFE — escaped by the templating engine -->
+<div hx-get="/search?q={{ user_input | escape }}" hx-nonce="...">...</div>
+```
+
+All major templating engines should help you escape output by default — make sure you are not bypassing this with raw/unescaped output filters. If an attacker can inject unescaped content into an htmx attribute value on a nonced element, `hx-nonce` will not protect you.
+
+Set a `Content-Security-Policy` header with a per-request nonce and stamp `hx-nonce` on every htmx element:
+
+```http
+Content-Security-Policy: script-src 'self' 'nonce-<nonce>'
+```
+
+```html
+<script nonce="<nonce>" src="/htmx.js"></script>
+<script nonce="<nonce>" src="/hx-nonce.js"></script>
+
+<button hx-post="/save" hx-nonce="<nonce>">Save</button>
+```
+
+The extension reads the page nonce from the first `script[nonce]` element and blocks any htmx element whose `hx-nonce` doesn't match. If no page nonce is found, all htmx processing is blocked — fail closed.
+
+## Trusted Types
+
+Loading `hx-nonce` automatically creates a `'htmx'` Trusted Types policy. Add it to your CSP to enforce that only htmx can write HTML into DOM sinks:
+
+```http
+Content-Security-Policy: script-src 'self' 'nonce-<nonce>';
+                         require-trusted-types-for 'script';
+                         trusted-types htmx
+```
+
+No extra configuration needed. Falls back transparently on browsers without Trusted Types support. If `'htmx'` is not in your `trusted-types` whitelist, all htmx processing is blocked — fail closed.
+
+## Safe Eval
+
+htmx's JS expression features (`hx-on:`, `hx-vals js:`, `hx-confirm js:`, trigger filters) are entirely optional. If you don't use them, you can omit `unsafe-eval` from your CSP entirely with no further configuration.
+
+If you do use these features, set `safeEval:true` to replace htmx's `new Function()` eval with nonce-based script injection, enabling them without `unsafe-eval`:
+
+```http
+Content-Security-Policy: script-src 'self' 'nonce-<nonce>'
+```
+
+```html
+<meta name="htmx-config" content='extensions:"hx-nonce",safeEval:true'>
+```
+
+## Partial Responses
+
+Partial responses should include a `Content-Security-Policy` header with a fresh nonce. The extension rewrites the response nonce to the page nonce before fragment parsing so swapped-in elements pass subsequent nonce checks:
+
+```http
+Content-Security-Policy: script-src 'nonce-<response-nonce>'
+```
+
+## Inline Scripts in Swapped Content
+
+When htmx swaps in HTML containing `<script>` tags, it re-creates them to trigger execution. The `hx-nonce` extension ensures the response nonce is rewritten to the page nonce before parsing, so script nonces are correctly promoted and execute under a strict `script-src 'nonce-<nonce>'` policy.
+
+This is the ideal replacement for `htmx.config.inlineScriptNonce`. Do not use `inlineScriptNonce` when using this extension — it applies a single static nonce to all swapped scripts regardless of origin, which undermines the per-response nonce model this extension provides.
+
+## Security Events
+
+| Event | Fired when |
+|-------|-----------|
+| `htmx:security:strip` | Element stripped due to missing or mismatched nonce |
+| `htmx:security:violation` | Nonce mismatch at eval time or unnnonced boosted form submitter |
+
+```js
+document.addEventListener('htmx:security:strip', e => {
+    console.warn(e.target, e.detail.reason, e.detail.stripped);
+});
+```
+
+`detail.reason` is `'missing-nonce'` or `'nonce-mismatch'`.

--- a/www/src/content/docs/06-extensions/16-nonce.md
+++ b/www/src/content/docs/06-extensions/16-nonce.md
@@ -40,7 +40,9 @@ Your templating engine should stamp `hx-nonce` on every element that carries htm
 <div hx-get="/search?q={{ user_input | escape }}" hx-nonce="...">...</div>
 ```
 
-All major templating engines should help you escape output by default — make sure you are not bypassing this with raw/unescaped output filters. If an attacker can inject unescaped content into an htmx attribute value on a nonced element, `hx-nonce` will not protect you.
+All major templating engines escape HTML entities (`"`, `'`, `<`, `>`, `&`) by default — make sure you are not bypassing this with raw/unescaped output filters (`| raw`, `| safe`, `raw()` etc.), which would allow a `"` in user input to break out of the attribute and inject new attributes.
+
+URL-valued attributes (`hx-get`, `hx-post`, etc.) are also blocked by the extension if the value is a `js:` or `javascript:` URI — these schemes survive entity encoding and are not valid action URLs.
 
 Set a `Content-Security-Policy` header with a per-request nonce and stamp `hx-nonce` on every htmx element:
 
@@ -102,7 +104,7 @@ This is the ideal replacement for `htmx.config.inlineScriptNonce`. Do not use `i
 | Event | Fired when |
 |-------|-----------|
 | `htmx:security:strip` | Element stripped due to missing or mismatched nonce |
-| `htmx:security:violation` | Nonce mismatch at eval time or unnnonced boosted form submitter |
+| `htmx:security:violation` | Nonce mismatch at eval time, unnonced boosted form submitter, or `js:`/`javascript:` action URL |
 
 ```js
 document.addEventListener('htmx:security:strip', e => {
@@ -110,4 +112,4 @@ document.addEventListener('htmx:security:strip', e => {
 });
 ```
 
-`detail.reason` is `'missing-nonce'` or `'nonce-mismatch'`.
+`detail.reason` is `'missing-nonce'`, `'nonce-mismatch'`, or `'javascript-url'`.

--- a/www/src/content/docs/07-security/01-best-practices.md
+++ b/www/src/content/docs/07-security/01-best-practices.md
@@ -65,41 +65,52 @@ Browsers also provide tools for further securing your web application. The most 
 [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP). Using a CSP you can tell the
 browser to, for example, not issue requests to non-origin hosts, to not evaluate inline script tags, etc.
 
-Here is an example CSP in a `meta` tag:
+CSP can be set via an HTTP header or a `<meta>` tag. HTTP headers are preferred — `<meta>` tags
+do not enforce all directives and scripts that appear before the `<meta>` tag in the document are
+not covered by it:
 
-```html
-<meta http-equiv="Content-Security-Policy" content="default-src 'self';">
+```http
+Content-Security-Policy: default-src 'self'; script-src 'self' 'nonce-<nonce>'
 ```
 
 A full discussion of CSPs is beyond the scope of this document, but
 the [MDN Article](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) provides a good jumping-off point
 for exploring this topic.
 
+### hx-nonce Extension
+
+For sites using CSP script nonces, the [`hx-nonce` extension](/docs/extensions/nonce) provides deep integration:
+
+- Gates all htmx attribute processing behind a per-request nonce, blocking injected htmx attributes
+- Automatically creates a `'htmx'` [Trusted Types](https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API) policy so only htmx can write HTML into DOM sinks
+- Replaces `new Function()` eval with nonce-based script injection when `safeEval:true` is set, removing the need for `unsafe-eval`
+
+See the [hx-nonce extension docs](/docs/extensions/nonce) for full setup instructions.
+
 ### htmx & Eval
 
-htmx uses eval for some functionality:
+htmx uses `new Function()` for some optional features:
 
 * Event filters
 * The [`hx-on`](/reference/attributes/hx-on) attribute
-* Handling most attribute values that starts with `js:` or `javascript:`
+* Attribute values starting with `js:` or `javascript:`
 
-All of these features can be replaced with standard event listeners and thus are not crucial to using htmx.
+All of these are optional. If you don't use them you can omit `unsafe-eval` from your CSP entirely.
 
-Thus you can disable `eval()` via a CSP and continue to use htmx.
+If you do use these features, the [`hx-nonce` extension](/docs/extensions/nonce) with `safeEval:true` replaces
+`new Function()` with nonce-based script injection, enabling them without `unsafe-eval`.
 
 ### CSP & Inline Styles
 
-Annother area htmx can run into is with CSS transition and morphins swaps.  Both of these copy attributes (including `style`) between old and new elements during the settle
-phase. Under a strict `style-src` policy without `'unsafe-inline'`, these `setAttribute("style", ...)` calls will
-produce CSP violations.
+htmx injects its indicator CSS using [Constructable Stylesheets](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/CSSStyleSheet) (`document.adoptedStyleSheets`), which are not subject to `style-src` CSP restrictions.
 
-If you use a strict `style-src` CSP you should add `"style"` to [`morphIgnore`](/reference/config/htmx-config-morphIgnore):
+The one area to be aware of is morph swaps when used alongside JS frameworks like Alpine that set `style` attributes via JavaScript. During morph, htmx's `__copyAttributes` reads all attributes from the new element and copies them to the old one — including any `style` attributes set by the framework. Under a strict `style-src` policy without `'unsafe-inline'`, this `setAttribute("style", ...)` call will produce a CSP violation.
+
+Add `"style"` to [`morphIgnore`](/reference/config/htmx-config-morphIgnore) to skip it:
 
 ```html
 <meta name="htmx-config" content='{"morphIgnore":["data-htmx-powered","style"]}'>
 ```
-
-This tells htmx to skip `style` attributes when copying attributes during settle and morph operations. 
 
 Class-based CSS transitions continue to work normally.
 


### PR DESCRIPTION
## Description
This new hx-nonce extension adds some best practice security options for users with strict CSP compliance requirements

1. It adds a hx-nonce attribute which allows the CSP script nonce to be added to all active htmx elements to stamp them as approved by the server just like script tags support.  This prevents any non approved htmx content being added to the page helping prevent XSS vectors.
2. It supports proper nonce checking for script tags added via htmx requests without auto trusting all inserted script tags like inlineScriptNonce config does.
3. It provides an option to set safeEval config which replaces the built in eval Functions with custom ones that instead use nonced temporary script tags to safely execute the required javascript code without triggering unsafe-eval CSP exceptions.  We can only apply this upgrade because we now have a layer of nonce based security validating the eval code is sent from the server and safe to run.
4. We can also enable TrustedTypes that adds a new 'htmx' trusted type that can be added to your CSP which will restrict what can write to risky DOM syncs that can execute scripts.  The 'htmx' trusted type here does not perform any sanitization it is just certifying the update was done by htmx from the trusted server and allows you to block other third party JS from interacting with risky DOM operations.

Corresponding issue:

## Testing
Not able to use our standard test suite to test this extension so added a nonce manual test file to verify the core functionality.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
