### PR TITLE
outerSync swap style option for cleaner body history replacment

### DIFF
--- a/src/ext/hx-history-cache.js
+++ b/src/ext/hx-history-cache.js
@@ -83,7 +83,7 @@
             el.removeAttribute('disabled');
             el.removeAttribute('data-disabled-by-htmx');
         });
-        return clone.innerHTML;
+        return clone.outerHTML;
     }
 
     // --- Stamp the current history entry with an htmxId and track it ---
@@ -191,7 +191,7 @@
             htmx.config.historyCache.size          ??= 10;
             htmx.config.historyCache.refreshOnMiss ??= false;
             htmx.config.historyCache.disable       ??= false;
-            htmx.config.historyCache.swapStyle     ??= 'innerHTML';
+            htmx.config.historyCache.swapStyle     ??= 'outerSync';
             stampCurrentEntry();
         },
 

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1031,9 +1031,7 @@ var htmx = (() => {
             if (startTag === 'html' || startTag === 'body') {
                 doc = this.__parseHTML(response);
                 fragment = document.createDocumentFragment();
-                while (doc.body.childNodes.length > 0) {
-                    fragment.append(doc.body.childNodes[0]);
-                }
+                fragment.append(doc.body);
             } else {
                 doc = this.__parseHTML(`<template>${response}</template>`);
                 fragment = doc.querySelector('template').content;
@@ -1291,6 +1289,11 @@ var htmx = (() => {
             }
             let swapStyle = swapSpec.style;
             if (swapStyle === 'none') return;
+            // full-page response: fragment has a <body> wrapper — upgrade outerHTML to outerSync, strip for everything else
+            if (fragment.firstElementChild?.tagName === 'BODY') {
+                if (swapStyle === 'outerHTML') swapStyle = 'outerSync';
+                else if (!swapStyle.startsWith('outer')) swapSpec.strip = true;
+            }
             if (swapSpec.strip && fragment.firstElementChild) {
                 fragment = document.createDocumentFragment();
                 fragment.append(...(task.fragment.firstElementChild.content || task.fragment.firstElementChild).childNodes);
@@ -1327,7 +1330,7 @@ var htmx = (() => {
             let pantry = this.__handlePreservedElements(fragment);
             let newContent = [...fragment.childNodes]
             try {
-                if (swapStyle === 'innerHTML' || (swapStyle === 'outerHTML' && target === document.body)) {
+                if (swapStyle === 'innerHTML') {
                     for (const child of target.children) {
                         this.__cleanup(child)
                     }
@@ -1344,6 +1347,12 @@ var htmx = (() => {
                         parentNode.removeChild(target);
                         target = newContent[0] || parentNode
                     }
+                } else if (swapStyle === 'outerSync') {
+                    this.__copyAttributes(target, fragment.firstElementChild);
+                    for (const child of target.children) {
+                        this.__cleanup(child)
+                    }
+                    target.replaceChildren(...fragment.firstElementChild.childNodes);
                 } else if (swapStyle === 'innerMorph') {
                     this.__morph(target, fragment, true);
                     newContent = [...target.childNodes];
@@ -1591,11 +1600,10 @@ var htmx = (() => {
                     location.reload();
                 } else {
                     this.#historyAbort = new AbortController();
-                    let isPartialTarget = historyElt !== document.body;
                     this.ajax('GET', path, {
                         target: historyElt,
-                        swap: `innerHTML${isPartialTarget ? ' strip:true' : ''}`,
-                        select: isPartialTarget ? this.__prefixSelector('[hx-history-elt]') : undefined,
+                        swap: 'outerSync',
+                        select: historyElt !== document.body ? this.__prefixSelector('[hx-history-elt]') : undefined,
                         request: {
                             headers: {'HX-History-Restore-Request': 'true'},
                             signal: this.#historyAbort.signal

--- a/test/tests/end2end/basic-history.js
+++ b/test/tests/end2end/basic-history.js
@@ -162,3 +162,88 @@ describe('hx-push-url and hx-replace-url attributes', function() {
         }
     });
 });
+
+
+describe('outerSync swap into document.body', function() {
+    let savedAttrs;
+    let savedChildren;
+
+    beforeEach(() => {
+        setupTest(this.currentTest);
+        savedAttrs = [...document.body.attributes].map(a => ({ name: a.name, value: a.value }));
+        savedChildren = [...document.body.childNodes];
+    });
+
+    afterEach(() => {
+        for (let a of [...document.body.attributes]) document.body.removeAttribute(a.name);
+        for (let a of savedAttrs) document.body.setAttribute(a.name, a.value);
+        document.body.replaceChildren(...savedChildren);
+        cleanupTest();
+    });
+
+    it('syncs body attributes from response and replaces children', async function() {
+        document.body.setAttribute('data-original', 'yes');
+        await htmx.swap({
+            target: document.body,
+            swap: 'outerSync',
+            text: '<html><body class="injected" data-test-x="1"><div id="bodyswap-marker"></div></body></html>',
+            sourceElement: document.body
+        });
+        document.body.classList.contains('injected').should.equal(true);
+        document.body.getAttribute('data-test-x').should.equal('1');
+        (document.body.getAttribute('data-original') === null).should.equal(true);
+        document.getElementById('bodyswap-marker').should.not.equal(null);
+    });
+
+    it('outerHTML on body auto-upgrades to outerSync and syncs attributes', async function() {
+        document.body.setAttribute('data-original', 'yes');
+        await htmx.swap({
+            target: document.body,
+            swap: 'outerHTML',
+            text: '<html><body class="injected" data-test-x="1"><div id="bodyswap-marker"></div></body></html>',
+            sourceElement: document.body
+        });
+        document.body.classList.contains('injected').should.equal(true);
+        document.body.getAttribute('data-test-x').should.equal('1');
+        (document.body.getAttribute('data-original') === null).should.equal(true);
+        document.getElementById('bodyswap-marker').should.not.equal(null);
+    });
+});
+
+describe('hx-history-elt scopes history restore', function() {
+
+    beforeEach(() => { setupTest(this.currentTest); });
+    afterEach(() => { cleanupTest(); });
+
+    it('restoring history with hx-history-elt swaps only that element and leaves siblings intact', async function() {
+        playground().innerHTML = `
+            <div id="sentinel">untouched</div>
+            <main hx-history-elt><p id="orig">old</p></main>
+            <div id="sentinel-after">also untouched</div>
+        `;
+        htmx.process(playground());
+
+        let response = `<html><head><title>x</title></head><body>
+            <header>HEADER LEAK</header>
+            <main hx-history-elt><p id="new">new</p></main>
+            <footer>FOOTER LEAK</footer>
+        </body></html>`;
+        mockResponse('GET', '/restore-test', response);
+
+        htmx.__restoreHistory('/restore-test');
+        await forRequest();
+
+        document.getElementById('sentinel').should.not.equal(null);
+        document.getElementById('sentinel').textContent.should.equal('untouched');
+        document.getElementById('sentinel-after').should.not.equal(null);
+        document.getElementById('sentinel-after').textContent.should.equal('also untouched');
+
+        let elt = playground().querySelector('[hx-history-elt]');
+        elt.should.not.equal(null);
+        elt.querySelector('#new').should.not.equal(null);
+        (elt.querySelector('#orig') === null).should.equal(true);
+
+        document.body.textContent.should.not.include('HEADER LEAK');
+        document.body.textContent.should.not.include('FOOTER LEAK');
+    });
+});

--- a/test/tests/ext/hx-history-cache.js
+++ b/test/tests/ext/hx-history-cache.js
@@ -24,7 +24,7 @@ describe('hx-history-cache extension', function () {
     beforeEach(() => {
         setupTest();
         sessionStorage.clear();
-        htmx.config.historyCache = { size: 10, refreshOnMiss: false, disable: false, swapStyle: 'innerHTML' };
+        htmx.config.historyCache = { size: 10, refreshOnMiss: false, disable: false, swapStyle: 'outerSync' };
 
         historyElt = document.createElement('div');
         historyElt.setAttribute('hx-history-elt', '');

--- a/test/tests/unit/__makeFragment.js
+++ b/test/tests/unit/__makeFragment.js
@@ -20,12 +20,14 @@ describe('__makeFragment unit tests', function() {
 
     it('handles html tag', function () {
         let {fragment} = htmx.__makeFragment('<html><body><div>Test</div></body></html>');
-        fragment.children[0].tagName.should.equal('DIV');
+        fragment.children[0].tagName.should.equal('BODY');
+        fragment.children[0].children[0].tagName.should.equal('DIV');
     })
 
     it('handles body tag', function () {
         let {fragment} = htmx.__makeFragment('<body><div>Test</div></body>');
-        fragment.children[0].tagName.should.equal('DIV');
+        fragment.children[0].tagName.should.equal('BODY');
+        fragment.children[0].children[0].tagName.should.equal('DIV');
     })
 
     it('converts partial tags to template', function () {

--- a/www/src/content/docs/06-extensions/15-history-cache.md
+++ b/www/src/content/docs/06-extensions/15-history-cache.md
@@ -36,7 +36,7 @@ All options live under `htmx.config.historyCache` and can be set via a meta tag:
 To use morphing for smoother restores:
 
 ```html
-<meta name="htmx-config" content='{"historyCache": {"swapStyle": "innerMorph"}}'>
+<meta name="htmx-config" content='{"historyCache": {"swapStyle": "outerMorph"}}'>
 ```
 
 | Option | Default | Description |
@@ -44,7 +44,7 @@ To use morphing for smoother restores:
 | `size` | `10` | Maximum number of pages to keep in the cache. Oldest entries are evicted first. Set to `0` to disable caching entirely. |
 | `refreshOnMiss` | `false` | When `true`, forces a full page reload if the requested history entry is not in the cache. |
 | `disable` | `false` | Disables the extension without unloading it. |
-| `swapStyle` | `"innerHTML"` | The htmx swap style used when restoring cached content. Can be set to `"innerMorph"` for smooth DOM diffing instead of a full replacement. |
+| `swapStyle` | `"outerSync"` | The htmx swap style used when restoring cached content. Defaults to `outerSync`, which preserves the target element in the DOM (keeping listeners and component state) while syncing its attributes and replacing its children. Use `innerHTML` to replace children only without syncing attributes. Can be set to `"innerMorph"` or `"outerMorph"` for smooth DOM diffing. |
 
 ## Events
 

--- a/www/src/content/reference/01-attributes/03-hx-swap.md
+++ b/www/src/content/reference/01-attributes/03-hx-swap.md
@@ -138,6 +138,21 @@ Exclude specific elements from morphing:
 - [`htmx.config.morphSkip`](/reference/config/htmx-config-morphskip) - Skip entire elements
 - [`htmx.config.morphSkipChildren`](/reference/config/htmx-config-morphskipchildren) - Skip children only
 
+### `outerSync`
+
+Syncs attributes from the response's outer element onto the target, then replaces the target's children. The target element itself stays in the DOM — listeners and component state are preserved.
+
+Useful when the server returns a full element (e.g. `<section class="active">...</section>`) and you want the target's attributes updated without replacing the element itself.
+
+```html
+<!-- Target keeps its listeners, gets new attrs + children -->
+<section id="main" hx-get="..." hx-swap="outerSync">
+  ...
+</section>
+```
+
+`outerHTML` on `document.body` automatically upgrades to `outerSync` so that body attributes (classes, data-attrs) are preserved across full-page swaps.
+
 ### `delete`
 
 Removes element (ignores response content).
@@ -284,5 +299,4 @@ Controls whether the outer element of the response content is removed before swa
 
 ## Caveats
 
-* Due to DOM limitations, it's not possible to use the `outerHTML` method on the `<body>` element.
-  htmx will change `outerHTML` on `<body>` to use `innerHTML`.
+* `outerHTML` on `document.body` automatically upgrades to `outerSync` to preserve body attributes (classes, data-attrs). Use `outerSync` explicitly if you want this behaviour on other elements.


### PR DESCRIPTION
## Description
Here is another possible way we could look at to resolve the outerHTML body swap issue with history restore.  The issue we want to solve is how can we replace body tag during history or hx-boost full page navigations when the body tag is blocked from dom replacment.  without having to morph the whole page we can instead just copyAttributes the body element and then innerHTML replace all the children which allows you to update ethe body attributes while keeping the body element in place with all event listeners.  

To simplify this we can just have makeFragment generate a fragment with the body as its first child instead of only its children.  Then We can add a new outerSync swap style that does a sync of the top elements attributes and then performs innerHTML swap of the elements children.  This new swap style is then useful for hx-history-elt replacment as the ideal swap style for this use case in core and history-cache extension.  

We can possibly try and find a better name than outerSync for this new swap style but having the outer prefix has the advantage that it works well with hx-swap-oob outer prefix check which sets if it should strip or not.  This swap style is kind of a mix of outerHTML and outerMorph.

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
