### PR TITLE
encode unicode id

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -394,7 +394,7 @@ var htmx = (() => {
         }
 
         __buildIdentifier(elt) {
-            return `${elt.tagName.toLowerCase()}${elt.id ? '#' + elt.id : ''}`;
+            return `${elt.tagName.toLowerCase()}${elt.id ? '#' + encodeURI(elt.id) : ''}`;
         }
 
         __createCoreHeaders(elt) {
@@ -572,6 +572,7 @@ var htmx = (() => {
 
             } catch (error) {
                 ctx.status = "error: " + error;
+                console.warn(`htmx: request error for ${ctx.request.method} ${ctx.request.action}`, error, ctx)
                 this.__trigger(elt, "htmx:error", {ctx, error})
             } finally {
                 clearTimeout(ctx.requestTimeout);

--- a/test/tests/unit/headers.js
+++ b/test/tests/unit/headers.js
@@ -119,6 +119,12 @@ describe('Request Headers', function() {
             htmx.__buildIdentifier(document.body).should.equal('body');
         });
 
+        it('encodes unicode characters in id for safe header usage', function() {
+            let div = document.createElement('div');
+            div.id = '🚀';
+            htmx.__buildIdentifier(div).should.equal('div#%F0%9F%9A%80');
+        });
+
     });
 
 });


### PR DESCRIPTION
## Description
We have to encode id's containing unicode before we send in target/source headers as otherwise these will be rejected as invalid

Also added error reporting to make it much easier to debug htmx errors in future.  It outputs a warning to console logs with all the error detail and ctx object data.

Corresponding issue:
#3781

## Testing
Added a basic test for unicode but fetch mock does not throw the error making it hard to fully test e2e

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
