### PR TITLE
add nonce reuse protection to hx-nonce

### DIFF
--- a/src/ext/hx-nonce.js
+++ b/src/ext/hx-nonce.js
@@ -38,8 +38,7 @@
     function checkNonce(elt) {
         if (!pageNonce) return false;
         let eltNonce = getNonce(elt);
-        if (eltNonce === pageNonce) return;
-        if (stripHxAttributes(elt, eltNonce)) return false;
+        if (eltNonce !== pageNonce && stripHxAttributes(elt, eltNonce)) return false;
     }
 
     // Anchors to script-src/default-src to avoid matching nonces in other directives
@@ -59,13 +58,14 @@
         return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     }
 
-    // Rewrites responseNonce → pageNonce in raw HTML before DOM parsing,
+    // Rewrites responseNonce → replacement in raw HTML before DOM parsing,
     // covering hx-nonce and script nonce attributes in one pass.
-    function rewriteNoncesInText(text, responseNonce) {
+    // Pass replacement='' to strip nonce attributes entirely (stolen-nonce scrub).
+    function rewriteNoncesInText(text, responseNonce, replacement = pageNonce) {
         let escaped = escapeRegex(responseNonce);
         return text.replace(
             new RegExp(`(nonce=)(["'])${escaped}\\2`, 'gi'),
-            (_, attr, quote) => `${attr}${quote}${pageNonce}${quote}`
+            (_, attr, quote) => replacement ? `${attr}${quote}${replacement}${quote}` : ''
         );
     }
 
@@ -162,6 +162,9 @@
                 try { if (new URL(responseURL).origin !== location.origin) return; }
                 catch (_) { return; }
             }
+            // Scrub any pre-existing pageNonce from response — server can't know it,
+            // so its presence indicates injection using a stolen nonce.
+            ctx.text = rewriteNoncesInText(ctx.text, pageNonce, '');
             let responseNonce = extractNonceFromCSP(ctx?.response?.headers?.get('Content-Security-Policy'))
                              ?? extractNonceFromMetaTag(ctx?.text);
             if (responseNonce && responseNonce !== pageNonce) {

--- a/www/src/content/docs/06-extensions/16-nonce.md
+++ b/www/src/content/docs/06-extensions/16-nonce.md
@@ -97,7 +97,7 @@ Content-Security-Policy: script-src 'nonce-<response-nonce>'
 
 The extension rewrites the response nonce to the page nonce so swapped-in elements pass subsequent nonce checks. Before doing that rewrite, it scrubs any element that already carries the page nonce value from the raw response text.
 
-The server cannot know the page nonce — it only knows its own per-response nonce. So if the page nonce appears in a response, it was put there by an attacker, not the server. Scrubbing it first means the rewrite pass cannot accidentally promote attacker-controlled elements to trusted status.
+The server cannot know the page nonce - it only knows its own per-response nonce. So if the page nonce appears in a response, it was put there by an attacker, not the server. Scrubbing it first means the rewrite pass cannot accidentally promote attacker-controlled elements to trusted status.
 
 The risk: unlike `<script nonce>`, `hx-nonce` attributes are not blanked by browsers after parse, so they are a possible additional nonce exposure surface. The scrub step is a defence-in-depth measure to ensure a stolen nonce cannot be pre-stamped into injected content to pass nonce checks.
 

--- a/www/src/content/docs/06-extensions/16-nonce.md
+++ b/www/src/content/docs/06-extensions/16-nonce.md
@@ -99,7 +99,7 @@ The extension rewrites the response nonce to the page nonce so swapped-in elemen
 
 The server cannot know the page nonce - it only knows its own per-response nonce. So if the page nonce appears in a response, it was put there by an attacker, not the server. Scrubbing it first means the rewrite pass cannot accidentally promote attacker-controlled elements to trusted status.
 
-The risk: unlike `<script nonce>`, `hx-nonce` attributes are not blanked by browsers after parse, so they are a possible additional nonce exposure surface. The scrub step is a defence-in-depth measure to ensure a stolen nonce cannot be pre-stamped into injected content to pass nonce checks.
+The risk: unlike `<script nonce>`, `hx-nonce` attributes are not blanked by browsers after parse, so they are a possible additional nonce exposure surface. The scrub step is a defense-in-depth measure to ensure a stolen nonce cannot be pre-stamped into injected content to pass nonce checks.
 
 ## Inline Scripts in Swapped Content
 

--- a/www/src/content/docs/06-extensions/16-nonce.md
+++ b/www/src/content/docs/06-extensions/16-nonce.md
@@ -93,6 +93,14 @@ Partial responses should include a `Content-Security-Policy` header with a fresh
 Content-Security-Policy: script-src 'nonce-<response-nonce>'
 ```
 
+## Nonce Reuse Protection
+
+The extension rewrites the response nonce to the page nonce so swapped-in elements pass subsequent nonce checks. Before doing that rewrite, it scrubs any element that already carries the page nonce value from the raw response text.
+
+The server cannot know the page nonce — it only knows its own per-response nonce. So if the page nonce appears in a response, it was put there by an attacker, not the server. Scrubbing it first means the rewrite pass cannot accidentally promote attacker-controlled elements to trusted status.
+
+The risk: unlike `<script nonce>`, `hx-nonce` attributes are not blanked by browsers after parse, so they are a possible additional nonce exposure surface. The scrub step is a defence-in-depth measure to ensure a stolen nonce cannot be pre-stamped into injected content to pass nonce checks.
+
 ## Inline Scripts in Swapped Content
 
 When htmx swaps in HTML containing `<script>` tags, it re-creates them to trigger execution. The `hx-nonce` extension ensures the response nonce is rewritten to the page nonce before parsing, so script nonces are correctly promoted and execute under a strict `script-src 'nonce-<nonce>'` policy.


### PR DESCRIPTION
## Description
The extension rewrites the response nonce to the page nonce so swapped-in elements pass subsequent nonce checks. Before doing that rewrite, we can scrub any element that already carries the page nonce value from the raw response text.

The server cannot know the page nonce - it only knows its own per-response nonce. So if the page nonce appears in a response, it was put there by an attacker, not the server. Scrubbing it first means the rewrite pass cannot accidentally promote attacker-controlled elements to trusted status.

The risk: unlike `<script nonce>`, `hx-nonce` attributes are not blanked by browsers after parse, so they are a possible additional nonce exposure surface. The scrub step is a defense-in-depth measure to ensure a stolen nonce cannot be pre-stamped into injected content to pass nonce checks. 

Corresponding issue:

## Testing


## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
