### PR TITLE
restrict fetch mode changes from hx-config

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -389,6 +389,7 @@ var htmx = (() => {
             let configAttr = this.__attributeValue(sourceElement, "hx-config");
             if (configAttr) {
                 this.__mergeConfig(configAttr, ctx.request);
+                ctx.request.mode = this.config.mode;  // mode is security-sensitive, never allow per-element override
             }
             return ctx;
         }

--- a/www/src/content/docs/07-security/01-best-practices.md
+++ b/www/src/content/docs/07-security/01-best-practices.md
@@ -77,6 +77,29 @@ A full discussion of CSPs is beyond the scope of this document, but
 the [MDN Article](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) provides a good jumping-off point
 for exploring this topic.
 
+### Controlling Cross-Origin Requests
+
+htmx defaults [`htmx.config.mode`](/reference/config/htmx-config-mode) to `"same-origin"`, which causes the
+browser to reject any cross-origin fetch — even if an attacker injects an `hx-get` pointing elsewhere.
+
+This setting is enforced globally: any `mode` value in a per-element `hx-config` attribute is ignored and
+reset to the global config value. This means injected markup like
+`hx-config='{"mode":"cors"}'` cannot widen request scope.
+
+If your application legitimately needs CORS (e.g. an API on a different subdomain):
+
+1. Set the mode globally:
+   ```javascript
+   htmx.config.mode = "cors";
+   ```
+2. Lock down reachable origins with `connect-src`:
+   ```html
+   <meta http-equiv="Content-Security-Policy"
+         content="connect-src 'self' https://api.example.com">
+   ```
+
+With both in place, htmx can reach your API but injected target URLs to other origins are blocked by CSP.
+
 ### hx-nonce Extension
 
 For sites using CSP script nonces, the [`hx-nonce` extension](/docs/extensions/nonce) provides deep integration:

--- a/www/src/content/reference/01-attributes/28-hx-config.md
+++ b/www/src/content/reference/01-attributes/28-hx-config.md
@@ -19,7 +19,6 @@ The `hx-config` attribute allows you to configure request behavior using JSON.
 |---------------|---------|----------------------------------------------------------|---------------|
 | `timeout`     | number  | Request timeout in milliseconds                          | 5000          |
 | `credentials` | string  | Fetch credentials mode: "omit", "same-origin", "include" | "include"     |
-| `mode`        | string  | Fetch mode: "cors", "no-cors", "same-origin"             | "cors"        |
 | `cache`       | string  | Fetch cache mode: "default", "no-cache", "reload", etc.  | "no-cache"    |
 | `redirect`    | string  | Fetch redirect mode: "follow", "error", "manual"         | "follow"      |
 | `referrer`    | string  | Referrer URL or "no-referrer"                            | "no-referrer" |
@@ -27,6 +26,13 @@ The `hx-config` attribute allows you to configure request behavior using JSON.
 | `validate`    | boolean | Whether to validate form before submission               | true          |
 
 These options map to the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
+
+> **Security note:** The `mode` option is intentionally excluded from `hx-config`. It is always
+> reset to the global `htmx.config.mode` value (default: `"same-origin"`) to prevent injection
+> attacks from widening request scope. To change the fetch mode, set it globally via
+> `htmx.config.mode` or a `<meta name="htmx-config">` tag. See the
+> [mode config reference](/reference/config/htmx-config-mode) and
+> [security best practices](/docs/security/best-practices) for details.
 
 ## Merging Configuration
 
@@ -56,12 +62,12 @@ Without `+`, the child config replaces the parent config entirely.
 </button>
 ```
 
-### Include credentials for CORS
+### Include credentials
 
 ```html
-<button hx-get="https://api.example.com/data"
-        hx-config='{"credentials": "include", "mode": "cors"}'>
-    Load External Data
+<button hx-get="/api/data"
+        hx-config='{"credentials": "include"}'>
+    Load Data
 </button>
 ```
 

--- a/www/src/content/reference/04-config/10-htmx-config-mode.md
+++ b/www/src/content/reference/04-config/10-htmx-config-mode.md
@@ -5,11 +5,15 @@ description: "Set request mode for fetch API"
 
 The `htmx.config.mode` option sets the `mode` option for fetch requests.
 
+This is the **only** way to set the fetch mode — the `mode` key in per-element `hx-config`
+attributes is ignored and always reset to this global value. This prevents injected markup
+from widening request scope (e.g. switching from `same-origin` to `cors`).
+
 **Default:** `"same-origin"`
 
 ## Valid Values
 
-- `"same-origin"` - Only allow same-origin requests
+- `"same-origin"` - Only allow same-origin requests (default, most secure)
 - `"cors"` - Allow cross-origin requests
 - `"no-cors"` - Limited cross-origin requests
 - `"navigate"` - Navigation mode
@@ -23,3 +27,19 @@ htmx.config.mode = "cors";
 ```html
 <meta name="htmx-config" content='{"mode":"cors"}'>
 ```
+
+## Security
+
+The default `"same-origin"` means the browser will reject any cross-origin fetch outright,
+even if an attacker injects an `hx-get` pointing to an external URL.
+
+If your app legitimately needs CORS (e.g. an API on a different subdomain), set `mode` globally
+and pair it with a `Content-Security-Policy` `connect-src` directive to limit reachable origins:
+
+```html
+<meta http-equiv="Content-Security-Policy"
+      content="connect-src 'self' https://api.example.com">
+```
+
+This way, even if an attacker injects a target URL, CSP blocks connections to origins you
+haven't explicitly allowed.


### PR DESCRIPTION
## Description
Overriding the fetch same-site mode to cors via hx-config attribute has a potential to be a possible security issue so we should probably block overriding this with htmx attributes and only use the global htmx config value we can trust instead.  This way users have to opt in the whole page to allow cors requests and understand the security implications of doing this.  Add documentation on how to correctly configure CSP to block or allow other api domains as this should be the prefered way to implement security protections rather than managing allowed origins manually inside htmx.

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
