### PR TITLE
Fix reading attributeValue with custom metaCharacter

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -209,6 +209,7 @@ var htmx = (() => {
         }
 
         __attributeValue(elt, name, defaultVal, eltCollector) {
+            name = this.__maybeAdjustMetaCharacter(name);
             let inherited = this.__maybeAdjustMetaCharacter(":inherited");
             let append = this.__maybeAdjustMetaCharacter(":append");
 

--- a/test/tests/unit/htmx.config.metaCharacter.js
+++ b/test/tests/unit/htmx.config.metaCharacter.js
@@ -43,6 +43,15 @@ describe('htmx.config.metaCharacter functionality', function() {
         assert.equal(result, '"a":1,"b":2,"c":3');
     });
 
+    it('normalizes attribute names using custom meta character', function() {
+        const div = createDisconnectedHTML(
+            '<div hx-ws-connect="/ws" hx-ws-send></div>'
+        );
+
+        assert.equal(htmx.__attributeValue(div, 'hx-ws:connect'), '/ws');
+        assert.equal(htmx.__attributeValue(div, 'hx-ws:send'), '');
+    });
+
     it('onLoad works with custom meta character', function() {
         let fired = false;
         htmx.onLoad(() => fired = true);


### PR DESCRIPTION
## Description

When using a custom `metaCharacter`, `__attributeValue()` does not normalize the requested attribute name before reading it.

For example, with `metaCharacter = '-'`, `hx-ws:send` becomes `hx-ws-send`

But in `hx-ws.js`, the extension reads the value with:

```js
api.attributeValue(element, 'hx-ws:send')
```

So `hx-ws:send` should also be adjusted with the custom `metaCharacter` before lookup.

Fix:

```js
name = this.__maybeAdjustMetaCharacter(name);
```

inside `__attributeValue()` in `htmx.js`.

Corresponding issue:

## Testing

I tested this manually and added a new test in `htmx.config.metaCharacter.js`:

```js
it('normalizes attribute names using custom meta character', function() {
    const div = createDisconnectedHTML(
        '<div hx-ws-connect="/ws" hx-ws-send></div>'
    );

    assert.equal(htmx.__attributeValue(div, 'hx-ws:connect'), '/ws');
    assert.equal(htmx.__attributeValue(div, 'hx-ws:send'), '');
});
```

I also ran the test suite locally:

```bash
npm run test
```

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
