### PR TITLE
Improve Non form input and checkbox handling

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -451,7 +451,7 @@ var htmx = (() => {
                 : (elt.form || elt.closest("form"))
 
             // Build request body
-            let body = this.__collectFormData(elt, form, evt.submitter, ctx.request.validate)
+            let body = this.__collectFormData(elt, form, evt.submitter, ctx.request.validate, usesQueryParams)
             if (!body) return  // Validation failed
             let valsResult = this.__getAttributeObject(elt, "hx-vals", obj => {
                 ctx.vals = obj; // make available for json extensions
@@ -1733,14 +1733,14 @@ var htmx = (() => {
             }
         }
 
-        __collectFormData(elt, form, submitter, validate) {
+        __collectFormData(elt, form, submitter, validate, isGet) {
             if (validate && form && !form.reportValidity()) return
             
             let formData = form ? new FormData(form) : new FormData()
             let included = form ? new Set(form.elements) : new Set()
             if (!form) {
                 if (validate && elt.reportValidity && !elt.reportValidity()) return
-                this.__addInputValues(elt, included, formData);
+                this.__addInputValues(elt, included, formData, isGet);
             }
             if (submitter && submitter.name) {
                 formData.append(submitter.name, submitter.value)
@@ -1756,8 +1756,15 @@ var htmx = (() => {
             return formData
         }
 
-        __addInputValues(elt, included, formData) {
-            let inputs = this.__queryEltAndDescendants(elt, 'input, select, textarea, button');
+        __addInputValues(elt, included, formData, isGet) {
+            let tag = elt.tagName;
+            let inputs = [];
+            if (tag === 'BUTTON') {
+                inputs = [elt]; // buttons only send own value, never collect children
+            } else if (['INPUT', 'SELECT', 'TEXTAREA', 'FIELDSET'].includes(tag) || !isGet) {
+                inputs = this.__queryEltAndDescendants(elt, 'input, select, textarea');
+            }
+            // GET on non-form-control containers (div, etc.) sends nothing — use hx-include for explicit inclusion
 
             for (let input of inputs) {
                 if (!input.name || input.matches(':disabled') || included.has(input)) continue;

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1738,10 +1738,9 @@ var htmx = (() => {
             
             let formData = form ? new FormData(form) : new FormData()
             let included = form ? new Set(form.elements) : new Set()
-            if (!form && elt.name) {
+            if (!form) {
                 if (validate && elt.reportValidity && !elt.reportValidity()) return
-                formData.append(elt.name, elt.value)
-                included.add(elt);
+                this.__addInputValues(elt, included, formData);
             }
             if (submitter && submitter.name) {
                 formData.append(submitter.name, submitter.value)
@@ -1758,10 +1757,10 @@ var htmx = (() => {
         }
 
         __addInputValues(elt, included, formData) {
-            let inputs = this.__queryEltAndDescendants(elt, 'input:not([disabled]), select:not([disabled]), textarea:not([disabled])');
+            let inputs = this.__queryEltAndDescendants(elt, 'input, select, textarea, button');
 
             for (let input of inputs) {
-                if (!input.name || included.has(input)) continue;
+                if (!input.name || input.matches(':disabled') || included.has(input)) continue;
                 included.add(input);
 
                 let type = input.type;
@@ -1780,8 +1779,7 @@ var htmx = (() => {
                     for (let option of input.selectedOptions) {
                         formData.append(input.name, option.value);
                     }
-                } else if (input.matches('select, textarea, input')) {
-                    // Regular inputs, single selects, textareas
+                } else {
                     formData.append(input.name, input.value);
                 }
             }

--- a/test/tests/attributes/hx-include.js
+++ b/test/tests/attributes/hx-include.js
@@ -32,13 +32,6 @@ describe('hx-include attribute', function() {
         assert.equal(new URL(fetchMock.calls[0].url, location.href).searchParams.get('notify'), null)
     })
 
-    it('button via hx-include sends its value', async function () {
-        mockResponse('GET', '/include', "OK")
-        createProcessedHTML('<div><button id="extra" name="action" value="save">Save</button><button id="btn" hx-get="/include" hx-include="#extra">Go</button></div>')
-        find('#btn').click()
-        await forRequest()
-        new URL(fetchMock.calls[0].url, location.href).searchParams.get('action').should.equal('save')
-    })
 
     it('non-GET includes closest form', async function () {
         mockResponse('POST', '/include', "Dummy")

--- a/test/tests/attributes/hx-include.js
+++ b/test/tests/attributes/hx-include.js
@@ -16,6 +16,30 @@ describe('hx-include attribute', function() {
         fetchMock.calls[0].request.body.get("i1").should.equal("test");
     })
 
+    it('checked checkbox via hx-include is sent', async function () {
+        mockResponse('GET', '/include', "OK")
+        createProcessedHTML('<input type="checkbox" id="cb" name="notify" checked><button id="btn" hx-get="/include" hx-include="#cb">Go</button>')
+        find('#btn').click()
+        await forRequest()
+        new URL(fetchMock.calls[0].url, location.href).searchParams.get('notify').should.equal('on')
+    })
+
+    it('unchecked checkbox via hx-include is not sent', async function () {
+        mockResponse('GET', '/include', "OK")
+        createProcessedHTML('<input type="checkbox" id="cb" name="notify"><button id="btn" hx-get="/include" hx-include="#cb">Go</button>')
+        find('#btn').click()
+        await forRequest()
+        assert.equal(new URL(fetchMock.calls[0].url, location.href).searchParams.get('notify'), null)
+    })
+
+    it('button via hx-include sends its value', async function () {
+        mockResponse('GET', '/include', "OK")
+        createProcessedHTML('<div><button id="extra" name="action" value="save">Save</button><button id="btn" hx-get="/include" hx-include="#extra">Go</button></div>')
+        find('#btn').click()
+        await forRequest()
+        new URL(fetchMock.calls[0].url, location.href).searchParams.get('action').should.equal('save')
+    })
+
     it('non-GET includes closest form', async function () {
         mockResponse('POST', '/include', "Dummy")
         createProcessedHTML('<form hx-target="this"><div id="d1" hx-post="/include"></div><input name="i1" value="test"/></form>')

--- a/test/tests/unit/__collectFormData.js
+++ b/test/tests/unit/__collectFormData.js
@@ -104,6 +104,65 @@ describe('__collectFormData unit tests', function() {
         assert.equal(formData.get('foo'), 'bar')
     })
 
+    it('excludes unchecked checkbox trigger with no form', function () {
+        let input = createProcessedHTML('<input type="checkbox" name="expires">')
+        let formData = htmx.__collectFormData(input, null, null)
+        assert.equal(formData.get('expires'), null)
+    })
+
+    it('includes checked checkbox trigger with no form', function () {
+        let input = createProcessedHTML('<input type="checkbox" name="expires" checked>')
+        let formData = htmx.__collectFormData(input, null, null)
+        assert.equal(formData.get('expires'), 'on')
+    })
+
+    it('excludes unchecked radio trigger with no form', function () {
+        let input = createProcessedHTML('<input type="radio" name="size" value="large">')
+        let formData = htmx.__collectFormData(input, null, null)
+        assert.equal(formData.get('size'), null)
+    })
+
+    it('includes checked radio trigger with no form', function () {
+        let input = createProcessedHTML('<input type="radio" name="size" value="large" checked>')
+        let formData = htmx.__collectFormData(input, null, null)
+        assert.equal(formData.get('size'), 'large')
+    })
+
+    it('collects all selected options from select-multiple trigger with no form', function () {
+        let container = createProcessedHTML('<div><select name="color" multiple><option value="red">Red</option><option value="blue">Blue</option><option value="green">Green</option></select></div>')
+        let select = container.querySelector('select')
+        select.options[1].selected = true
+        select.options[2].selected = true
+        let formData = htmx.__collectFormData(select, null, null)
+        assert.deepEqual(formData.getAll('color'), ['blue', 'green'])
+    })
+
+    it('collects button trigger value with no form', function () {
+        let container = createProcessedHTML('<div><button name="intent" value="preview"></button></div>')
+        let btn = container.querySelector('button')
+        let formData = htmx.__collectFormData(btn, null, null)
+        assert.equal(formData.get('intent'), 'preview')
+    })
+
+    it('excludes disabled trigger element with no form', function () {
+        let container = createProcessedHTML('<div><input name="skip" value="nope" disabled></div>')
+        let input = container.querySelector('input')
+        let formData = htmx.__collectFormData(input, null, null)
+        assert.equal(formData.get('skip'), null)
+    })
+
+    it('excludes fieldset-disabled input via hx-include', function () {
+        let container = createProcessedHTML('<div><fieldset disabled><input id="blocked" name="blocked" value="nope"></fieldset><input id="active" name="active" value="yes"></div>')
+        let blocked = container.querySelector('#blocked')
+        let active = container.querySelector('#active')
+        let included = new Set()
+        let formData = new FormData()
+        htmx.__addInputValues(blocked, included, formData)
+        htmx.__addInputValues(active, included, formData)
+        assert.equal(formData.get('blocked'), null)
+        assert.equal(formData.get('active'), 'yes')
+    })
+
     it('collects submitter value', function () {
         let form = createProcessedHTML('<form><input name="a" value="1"><button name="submit" value="go">Go</button></form>')
         let submitter = form.querySelector('button')


### PR DESCRIPTION
## Description

# collectFormData / addInputValues Fixes

## Root Cause

`__collectFormData` had a separate code path for non-form trigger elements:

```js
if (!form && elt.name) {
    formData.append(elt.name, elt.value)  // unconditional, ignores checked state
}
```

This bypassed `__addInputValues` entirely, which meant checkbox/radio checked state, select-multiple, and disabled state were all ignored.

## Fixes

### 1. Checkbox/radio trigger sends correct value
Unchecked checkboxes and radios no longer send their value. Previously always sent `name=on` regardless of checked state.

### 2. Select-multiple trigger sends all selected values
Previously only sent the first selected option via `elt.value`. Now correctly sends all selected options.

### 3. Button trigger value preserved
Named buttons continue to send their value when used as a direct trigger element. The refactored `__addInputValues` handles buttons as a special case (self-only, no child collection) to maintain this existing behavior.

### 4. Disabled inputs excluded via `:disabled`
Changed `input.disabled` check to `input.matches(':disabled')`. The `disabled` property does not reflect `fieldset[disabled]` ancestry — the `:disabled` pseudo-class does. Both directly disabled inputs and inputs inside a disabled fieldset are now correctly excluded.

### 5. Fieldset and container elements collect child inputs (method-aware)

The old `elt.name` guard meant that any nameless trigger element sent nothing at all. Now `__addInputValues` handles collection with GET/POST awareness via an `isGet` parameter:

- **GET/DELETE on `input, select, textarea, fieldset`** — collects self and descendants
- **GET/DELETE on other elements (div, span, etc.)** — sends nothing (prevents junky URLs on div-as-anchor patterns)
- **POST/PUT/PATCH on any element** — always collects descendants (body isn't visible/limited)
- **Button (any method)** — only sends own value, never collects children

This enables the fieldset validation pattern while preserving the existing GET scoping rule — `<input hx-get="/validate/email">` inside a 20-field form still only sends itself (useful for per-field server-side validation on blur).

The GET restriction on containers (div, span) prevents the "div as anchor" problem where `<div hx-get="/page">` would accidentally vacuum up child inputs into the URL.  I think we could change this to always gather child inputs for div's and anchors etc if we wanted to as this would not impact elements inside forms not submitting the whole from in a get/delete.

When called from `hx-include` without `isGet`, it defaults to falsy — always collecting descendants. This is correct since `hx-include` is explicit inclusion.



## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
