### PR TITLE
unify hx-on and hx-trigger modifier grammar

### DIFF
--- a/src/ext/hx-preload.js
+++ b/src/ext/hx-preload.js
@@ -8,7 +8,7 @@
         let preloadEvents = []
         let timeout = 5000;
         if (preloadSpec) {
-            let specs = api.parseTriggerSpecs(preloadSpec);
+            let specs = api.parseEventSpecs(preloadSpec);
             if (specs.length === 0) return;
             for (const spec of specs) {
                 preloadEvents.push(spec.name)

--- a/src/ext/hx-sse.js
+++ b/src/ext/hx-sse.js
@@ -288,7 +288,7 @@
         if (element._htmx?.sse) return; // already set up
 
         let specString = api.attributeValue(element, 'hx-trigger') || 'load';
-        api.onTrigger(element, specString, () => {
+        api.onEvent(element, specString, () => {
             if (element._htmx?.sse) return; // prevent duplicate connections
             htmx.ajax('GET', connectUrl, {source: element});
         });

--- a/src/ext/hx-ws.js
+++ b/src/ext/hx-ws.js
@@ -482,7 +482,7 @@
         if (!connectUrl) return;
 
         let specString = api.attributeValue(element, 'hx-trigger') || 'load';
-        api.onTrigger(element, specString, () => {
+        api.onEvent(element, specString, () => {
             if (element._htmx?.ws?.url) return;
             let connection = getOrCreateConnection(connectUrl, element);
             if (connection) {
@@ -505,7 +505,7 @@
                          'click';
         }
 
-        api.onTrigger(element, specString, async (evt) => {
+        api.onEvent(element, specString, async (evt) => {
             if (element.matches('form') && evt.type === 'submit') {
                 evt.preventDefault();
             }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1682,11 +1682,11 @@ var htmx = (() => {
                 }
             };
             for (let attr of node.getAttributeNames()) {
-                // hx-on="click once => doA(); blur => doB()"
+                // hx-on="click once -> doA(); blur -> doB()"
                 if (hxOnNames.includes(attr)) {
                     let value = node.getAttribute(attr);
                     // Split on ";" at depth 0 so braces protect multi-statement JS:
-                    //   "click => { a(); b() }; blur => c()"  →  ["click => { a(); b() }", " blur => c()"]
+                    //   "click -> { a(); b() }; blur -> c()"  →  ["click -> { a(); b() }", " blur -> c()"]
                     let parts = [], current = '', depth = 0;
                     for (let char of value) {
                         if (char === '{' || char === '(') depth++;
@@ -1695,8 +1695,8 @@ var htmx = (() => {
                         else current += char;
                     }
                     parts.push(current);
-                    for (let part of parts) { // e.g. "click once => doA()"
-                        let arrowIdx = part.indexOf('=>');
+                    for (let part of parts) { // e.g. "click once -> doA()"
+                        let arrowIdx = part.indexOf('->');
                         if (arrowIdx === -1) continue;
                         this.__onEvent(node,
                             part.substring(0, arrowIdx).trim(),  // "click once"

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -79,7 +79,7 @@ var htmx = (() => {
             this.#hxOnQuery = new XPathEvaluator().createExpression(`.//*[@*[${this.__prefixes("hx-on").map(p => `starts-with(name(), "${p}")`).join(' or ')}]]`);
             this.#internalAPI = {
                 attributeValue: this.__attributeValue.bind(this),
-                parseTriggerSpecs: this.__parseTriggerSpecs.bind(this),
+                parseEventSpecs: this.__parseEventSpecs.bind(this),
                 determineMethodAndAction: this.__determineMethodAndAction.bind(this),
                 createRequestContext: this.__createRequestContext.bind(this),
                 collectFormData: this.__collectFormData.bind(this),
@@ -92,7 +92,7 @@ var htmx = (() => {
                     if (syncFn) this.#Function = syncFn;
                     if (asyncFn) this.#AsyncFunction = asyncFn;
                 },
-                onTrigger: this.__onTrigger.bind(this),
+                onEvent: this.__onEvent.bind(this),
                 htmxProp: this.__htmxProp.bind(this),
                 triggerHtmxEvent: this.__trigger.bind(this),
                 executeJavaScript: this.__executeJavaScript.bind(this)
@@ -276,7 +276,7 @@ var htmx = (() => {
             return target;
         }
 
-        __parseTriggerSpecs(spec) {
+        __parseEventSpecs(spec) {
             // Split on commas that are NOT inside [...] — handles filters like click[myFunc(a,b)]
             return spec.split(/,(?![^\[]*\])/).flatMap(s => {
                 let [,name,rest] = s.match(/^\s*(\S+\[[^\]]*\]|\S+)\s*(.*?)\s*$/) ?? [];
@@ -319,7 +319,7 @@ var htmx = (() => {
 
         __htmxProp(elt) {
             if (!elt._htmx) {
-                elt._htmx = { listeners: [], triggerSpecs: [] };
+                elt._htmx = { listeners: [], eventSpecs: [] };
                 elt.setAttribute('data-htmx-powered', 'true');
             }
             return elt._htmx;
@@ -690,13 +690,14 @@ var htmx = (() => {
                     elt.matches("input:not([type=button]):not([type=submit]),select,textarea") ? "change" :
                         "click";
             }
-            this.__onTrigger(elt, specString, initialHandler)
+            this.__onEvent(elt, specString, initialHandler)
         }
 
-        // Wire up trigger listeners with full modifier support (delay, throttle, once, etc.)
-        __onTrigger(elt, specString, handler) {
-            let specs = this.__parseTriggerSpecs(specString)
-            this.__htmxProp(elt).triggerSpecs.push(...specs)
+        // Wire up event listeners with full modifier support (once, prevent, stop,
+        // delay, throttle, changed, capture, passive, from, filter, etc.)
+        __onEvent(elt, specString, handler) {
+            let specs = this.__parseEventSpecs(specString)
+            this.__htmxProp(elt).eventSpecs.push(...specs)
 
             for (let spec of specs) {
                 spec.handler = handler
@@ -705,14 +706,29 @@ var htmx = (() => {
 
                 let [eventName, filter] = this.__extractFilter(spec.name);
 
-                // should be first so logic is called only when all other filters pass
                 if (spec.once) {
                     let original = spec.handler
                     spec.handler = (evt) => {
                         original(evt)
-                        for (let listenerInfo of spec.listeners) {
-                            listenerInfo.fromElt.removeEventListener(listenerInfo.eventName, listenerInfo.handler)
+                        for (let info of spec.listeners) {
+                            info.fromElt.removeEventListener(info.eventName, info.handler, info)
                         }
+                    }
+                }
+
+                if (spec.halt || spec.prevent) {
+                    let original = spec.handler
+                    spec.handler = (evt) => {
+                        evt.preventDefault()
+                        original(evt)
+                    }
+                }
+
+                if (spec.halt || spec.stop || spec.consume) {
+                    let original = spec.handler
+                    spec.handler = (evt) => {
+                        evt.stopPropagation()
+                        original(evt)
                     }
                 }
 
@@ -757,7 +773,6 @@ var htmx = (() => {
                             spec.throttleTimeout = setTimeout(() => {
                                 spec.throttled = false
                                 if (spec.throttledEvent) {
-                                    // implement trailing-edge throttling
                                     let throttledEvent = spec.throttledEvent;
                                     spec.throttledEvent = null
                                     spec.handler(throttledEvent);
@@ -787,14 +802,6 @@ var htmx = (() => {
                     }, this.parseInterval(interval));
                 }
 
-                if (spec.consume) {
-                    let original = spec.handler
-                    spec.handler = (evt) => {
-                        evt.stopPropagation()
-                        original(evt)
-                    }
-                }
-
                 if (filter) {
                     let original = spec.handler
                     spec.handler = (evt) => {
@@ -807,7 +814,18 @@ var htmx = (() => {
                 }
 
                 let fromElts = [elt];
-                if (spec.from) {
+                if (spec.from === 'self') {
+                    let original = spec.handler
+                    spec.handler = (evt) => {
+                        if (evt.target === elt) original(evt)
+                    }
+                } else if (spec.from === 'outside') {
+                    fromElts = [document];
+                    let original = spec.handler
+                    spec.handler = (evt) => {
+                        if (!elt.contains(evt.target)) original(evt)
+                    }
+                } else if (spec.from) {
                     fromElts = this.__findAllExt(elt, spec.from)
                 }
 
@@ -834,10 +852,11 @@ var htmx = (() => {
                 }
 
                 for (let fromElt of fromElts) {
-                    let listenerInfo = {fromElt, eventName, handler: spec.handler};
+                    let listenerInfo = {fromElt, eventName, handler: spec.handler,
+                        capture: !!spec.capture, passive: !!spec.passive};
                     elt._htmx.listeners.push(listenerInfo)
                     spec.listeners.push(listenerInfo)
-                    fromElt.addEventListener(eventName, spec.handler);
+                    fromElt.addEventListener(eventName, spec.handler, listenerInfo);
                 }
             }
         }
@@ -969,14 +988,14 @@ var htmx = (() => {
         __cleanup(elt) {
             if (elt._htmx) {
                 this.__trigger(elt, "htmx:before:cleanup")
-                for (let spec of elt._htmx.triggerSpecs || []) {
+                for (let spec of elt._htmx.eventSpecs || []) {
                     if (spec.interval) clearInterval(spec.interval);
                     if (spec.timeout) clearTimeout(spec.timeout);
                     if (spec.throttleTimeout) clearTimeout(spec.throttleTimeout);
                     spec.observer?.disconnect()
                 }
                 for (let listenerInfo of elt._htmx.listeners || []) {
-                    listenerInfo.fromElt.removeEventListener(listenerInfo.eventName, listenerInfo.handler);
+                    listenerInfo.fromElt.removeEventListener(listenerInfo.eventName, listenerInfo.handler, listenerInfo);
                 }
                 this.__trigger(elt, "htmx:after:cleanup")
             }
@@ -1651,36 +1670,49 @@ var htmx = (() => {
 
         // hx-on:<event> binds to <event> directly
         // hx-on::<event> is shorthand for hx-on:htmx:<event> (htmx events)
-        // Modifiers (dot-separated): .prevent .stop .halt .once .self .outside .capture .passive .cc
         __handleHxOnAttributes(node) {
-            let searchStrings = this.__prefixes("hx-on:").map(p => this.__maybeAdjustMetaCharacter(p));
-            let mc = this.config.metaCharacter || ':';
+            let prefixes = this.__prefixes("hx-on:").map(p => this.__maybeAdjustMetaCharacter(p)); // e.g. ["hx-on:"]
+            let hxOnNames = this.__prefixes("hx-on"); // e.g. ["hx-on"]
+            let handler = (code) => async (evt) => {
+                try {
+                    await this.__executeJavaScript(node, { event: evt },
+                        `with(event?.detail||{}){${code}}`, false);
+                } catch (e) {
+                    if (typeof e !== 'symbol') this.__trigger(node, 'htmx:error', { error: e });
+                }
+            };
             for (let attr of node.getAttributeNames()) {
-                let searchString = searchStrings.find(s => attr.startsWith(s));
-                if (!searchString) continue;
-                let [evtName, ...mods] = attr.substring(searchString.length).split('.');
-                let has = m => mods.includes(m);
-                if (evtName.startsWith(mc)) evtName = 'htmx' + evtName;
-                if (has('cc')) evtName = evtName.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
-                let code = node.getAttribute(attr);
-                let target = has('outside') ? document : node;
-                let opts = { capture: has('capture'), passive: has('passive') };
-                let halt = has('halt');
-                let handler = async (evt) => {
-                    if (has('self') && evt.target !== node) return;
-                    if (has('outside') && node.contains(evt.target)) return;
-                    if (halt || has('prevent')) evt.preventDefault();
-                    if (halt || has('stop')) evt.stopPropagation();
-                    if (has('once')) target.removeEventListener(evtName, handler, opts);
-                    try {
-                        await this.__executeJavaScript(node, { event: evt },
-                            `with(event?.detail||{}){${code}}`, false);
-                    } catch (e) {
-                        if (typeof e !== 'symbol') this.__trigger(node, 'htmx:error', { error: e });
+                // hx-on="click once => doA(); blur => doB()"
+                if (hxOnNames.includes(attr)) {
+                    let value = node.getAttribute(attr);
+                    // Split on ";" at depth 0 so braces protect multi-statement JS:
+                    //   "click => { a(); b() }; blur => c()"  →  ["click => { a(); b() }", " blur => c()"]
+                    let parts = [], current = '', depth = 0;
+                    for (let char of value) {
+                        if (char === '{' || char === '(') depth++;
+                        else if (char === '}' || char === ')') depth--;
+                        if (char === ';' && depth === 0) { parts.push(current); current = '' }
+                        else current += char;
                     }
-                };
-                target.addEventListener(evtName, handler, opts);
-                this.__htmxProp(node).listeners.push({fromElt: target, eventName: evtName, handler});
+                    parts.push(current);
+                    for (let part of parts) { // e.g. "click once => doA()"
+                        let arrowIdx = part.indexOf('=>');
+                        if (arrowIdx === -1) continue;
+                        this.__onEvent(node,
+                            part.substring(0, arrowIdx).trim(),  // "click once"
+                            handler(part.substring(arrowIdx + 2).trim())); // "doA()"
+                    }
+                    continue;
+                }
+                // hx-on:click="code" (simple, no modifiers)
+                let prefix = prefixes.find(p => attr.startsWith(p));
+                if (!prefix) continue;
+                let eventName = attr.substring(prefix.length);
+                // hx-on::before:request → eventName starts as ":before:request"
+                // expand the :: shorthand to "htmx:before:request"
+                let metaChar = this.config.metaCharacter || ':';
+                if (eventName.startsWith(metaChar)) eventName = 'htmx' + eventName;
+                this.__onEvent(node, eventName, handler(node.getAttribute(attr)));
             }
         }
 

--- a/src/skills/htmx-extension-authoring.md
+++ b/src/skills/htmx-extension-authoring.md
@@ -151,7 +151,7 @@ init: (internalAPI) => { api = internalAPI; },
 | Method | Description |
 |--------|-------------|
 | `api.attributeValue(elt, name, defaultVal, returnElt)` | Get attribute value with inheritance support |
-| `api.parseTriggerSpecs(spec)` | Parse trigger spec string into array of spec objects |
+| `api.parseEventSpecs(spec)` | Parse event spec string into array of spec objects |
 | `api.determineMethodAndAction(elt, evt)` | Get `{method, action}` for an element |
 | `api.createRequestContext(elt, evt)` | Create a full request context object |
 | `api.collectFormData(elt, form, submitter)` | Collect form data as FormData |
@@ -237,7 +237,7 @@ From `src/ext/hx-preload.js` -- prefetches requests on trigger events:
             let preloadSpec = api.attributeValue(elt, "hx-preload");
             if (!preloadSpec) return;
 
-            let specs = api.parseTriggerSpecs(preloadSpec);
+            let specs = api.parseEventSpecs(preloadSpec);
             let preloadListener = async (evt) => {
                 let {method} = api.determineMethodAndAction(elt, evt);
                 if (method !== 'GET') return;

--- a/test/test.html
+++ b/test/test.html
@@ -105,7 +105,7 @@
     <script src="./tests/unit/__normalizeSwapStyle.js"></script>
     <script src="./tests/unit/__parseConfig.js"></script>
     <script src="./tests/unit/__parseSwapSpec.js"></script>
-    <script src="./tests/unit/__parseTriggerSpecs.js"></script>
+    <script src="./tests/unit/__parseEventSpecs.js"></script>
     <script src="./tests/unit/__queryEltAndDescendants.js"></script>
     <script src="./tests/unit/__resolveTarget.js"></script>
     <script src="./tests/unit/__shouldBoost.js"></script>

--- a/test/tests/attributes/hx-on.js
+++ b/test/tests/attributes/hx-on.js
@@ -140,7 +140,7 @@ describe('hx-on attribute', function() {
 
 })
 
-describe('hx-on="eventSpec => code" syntax', function() {
+describe('hx-on="eventSpec -> code" syntax', function() {
 
     beforeEach(() => { setupTest(this.currentTest); });
     afterEach(() => { cleanupTest(); });
@@ -148,28 +148,28 @@ describe('hx-on="eventSpec => code" syntax', function() {
     // --- basic ---
 
     it('basic: fires handler on event', function() {
-        let btn = createProcessedHTML('<button hx-on="click => window.foo = true">x</button>');
+        let btn = createProcessedHTML('<button hx-on="click -> window.foo = true">x</button>');
         btn.click();
         window.foo.should.equal(true);
         delete window.foo;
     });
 
     it('this refers to the element', function() {
-        let btn = createProcessedHTML('<button hx-on="click => window.foo = this">x</button>');
+        let btn = createProcessedHTML('<button hx-on="click -> window.foo = this">x</button>');
         btn.click();
         window.foo.should.equal(btn);
         delete window.foo;
     });
 
     it('event is available in handler', function() {
-        let btn = createProcessedHTML('<button hx-on="click => window.foo = event.type">x</button>');
+        let btn = createProcessedHTML('<button hx-on="click -> window.foo = event.type">x</button>');
         btn.click();
         window.foo.should.equal('click');
         delete window.foo;
     });
 
     it('event.detail keys are exposed as bare names', function() {
-        let btn = createProcessedHTML('<button hx-on="zap => window.foo = path">x</button>');
+        let btn = createProcessedHTML('<button hx-on="zap -> window.foo = path">x</button>');
         btn.dispatchEvent(new CustomEvent('zap', { detail: { path: 'hello' } }));
         window.foo.should.equal('hello');
         delete window.foo;
@@ -179,7 +179,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
 
     it('once: removes listener after first fire', function() {
         window.fooCount = 0;
-        let btn = createProcessedHTML('<button hx-on="click once => window.fooCount++">x</button>');
+        let btn = createProcessedHTML('<button hx-on="click once -> window.fooCount++">x</button>');
         btn.click();
         btn.click();
         btn.click();
@@ -190,7 +190,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
     // --- prevent ---
 
     it('prevent: calls preventDefault before handler', function() {
-        let form = createProcessedHTML('<form hx-on="submit prevent => window.foo = event.defaultPrevented"><button type="submit">go</button></form>');
+        let form = createProcessedHTML('<form hx-on="submit prevent -> window.foo = event.defaultPrevented"><button type="submit">go</button></form>');
         let evt = new SubmitEvent('submit', { cancelable: true, bubbles: true });
         form.dispatchEvent(evt);
         evt.defaultPrevented.should.equal(true);
@@ -201,7 +201,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
     // --- stop ---
 
     it('stop: calls stopPropagation before handler', function() {
-        playground().innerHTML = '<div id="outer"><button hx-on="click stop => window.foo = \'inner\'">x</button></div>';
+        playground().innerHTML = '<div id="outer"><button hx-on="click stop -> window.foo = \'inner\'">x</button></div>';
         htmx.process(playground());
         let outerFired = false;
         playground().querySelector('#outer').addEventListener('click', () => outerFired = true);
@@ -214,7 +214,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
     // --- halt (shorthand for prevent + stop) ---
 
     it('halt: preventDefault and stopPropagation', function() {
-        playground().innerHTML = '<div id="outer"><button hx-on="click halt => window.foo = 1">x</button></div>';
+        playground().innerHTML = '<div id="outer"><button hx-on="click halt -> window.foo = 1">x</button></div>';
         htmx.process(playground());
         let outerFired = false;
         playground().querySelector('#outer').addEventListener('click', () => outerFired = true);
@@ -229,7 +229,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
     // --- prevent + stop ---
 
     it('prevent stop: equivalent to halt', function() {
-        playground().innerHTML = '<div id="outer"><button hx-on="click prevent stop => window.foo = 1">x</button></div>';
+        playground().innerHTML = '<div id="outer"><button hx-on="click prevent stop -> window.foo = 1">x</button></div>';
         htmx.process(playground());
         let outerFired = false;
         playground().querySelector('#outer').addEventListener('click', () => outerFired = true);
@@ -245,7 +245,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
 
     it('delay: debounces handler', async function() {
         window.fooCount = 0;
-        playground().innerHTML = '<button hx-on="click delay:30ms => window.fooCount++">x</button>';
+        playground().innerHTML = '<button hx-on="click delay:30ms -> window.fooCount++">x</button>';
         htmx.process(playground());
         let btn = playground().querySelector('button');
         btn.click();
@@ -261,7 +261,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
 
     it('throttle: throttles handler with trailing edge', async function() {
         window.fooCount = 0;
-        playground().innerHTML = '<button hx-on="click throttle:30ms => window.fooCount++">x</button>';
+        playground().innerHTML = '<button hx-on="click throttle:30ms -> window.fooCount++">x</button>';
         htmx.process(playground());
         let btn = playground().querySelector('button');
         btn.click(); // fires immediately (first)
@@ -277,7 +277,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
 
     it('changed: only fires when value changes', function() {
         window.fooCount = 0;
-        playground().innerHTML = '<input value="a" hx-on="input changed => window.fooCount++">';
+        playground().innerHTML = '<input value="a" hx-on="input changed -> window.fooCount++">';
         htmx.process(playground());
         let inp = playground().querySelector('input');
         // First fire: value is "a", no previous — should fire
@@ -297,7 +297,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
 
     it('from:document: listens on document', function() {
         window.foo = false;
-        let btn = createProcessedHTML('<button hx-on="custom-evt from:document => window.foo = true">x</button>');
+        let btn = createProcessedHTML('<button hx-on="custom-evt from:document -> window.foo = true">x</button>');
         document.dispatchEvent(new CustomEvent('custom-evt'));
         window.foo.should.equal(true);
         // Clean up document-level listener
@@ -309,7 +309,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
 
     it('from:self: only fires when event.target is the element', function() {
         window.fooCount = 0;
-        playground().innerHTML = '<div hx-on="click from:self => window.fooCount++"><span>child</span></div>';
+        playground().innerHTML = '<div hx-on="click from:self -> window.fooCount++"><span>child</span></div>';
         htmx.process(playground());
         let div = playground().querySelector('div');
         playground().querySelector('span').click(); // bubbles, target=span → skip
@@ -323,7 +323,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
 
     it('from:outside: fires only when event is outside the element', function() {
         window.outsideCount = 0;
-        playground().innerHTML = '<button hx-on="click from:outside => window.outsideCount++">x</button><div id="other"></div>';
+        playground().innerHTML = '<button hx-on="click from:outside -> window.outsideCount++">x</button><div id="other"></div>';
         htmx.process(playground());
         let btn = playground().querySelector('button');
         btn.click(); // inside → skip
@@ -339,7 +339,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
 
     it('capture: fires during capture phase', function() {
         let order = [];
-        playground().innerHTML = '<div id="outer"><button hx-on="click capture => window.captureOrder.push(\'capture\')">x</button></div>';
+        playground().innerHTML = '<div id="outer"><button hx-on="click capture -> window.captureOrder.push(\'capture\')">x</button></div>';
         window.captureOrder = order;
         htmx.process(playground());
         // Add a bubbling listener on the same button for comparison
@@ -357,7 +357,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
         // passive handlers cannot call preventDefault without a browser warning,
         // so we just verify the handler fires (option is passed internally)
         window.foo = false;
-        let btn = createProcessedHTML('<button hx-on="click passive => window.foo = true">x</button>');
+        let btn = createProcessedHTML('<button hx-on="click passive -> window.foo = true">x</button>');
         btn.click();
         window.foo.should.equal(true);
         delete window.foo;
@@ -367,7 +367,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
 
     it('[filter]: only fires when filter expression is truthy', function() {
         window.fooCount = 0;
-        let btn = createProcessedHTML('<button hx-on="keydown[key==\'Enter\'] => window.fooCount++">x</button>');
+        let btn = createProcessedHTML('<button hx-on="keydown[key==\'Enter\'] -> window.fooCount++">x</button>');
         btn.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
         window.fooCount.should.equal(0);
         btn.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
@@ -379,7 +379,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
 
     it('changed + delay: debounced changed-only handler', async function() {
         window.fooCount = 0;
-        playground().innerHTML = '<input value="a" hx-on="input changed delay:30ms => window.fooCount++">';
+        playground().innerHTML = '<input value="a" hx-on="input changed delay:30ms -> window.fooCount++">';
         htmx.process(playground());
         let inp = playground().querySelector('input');
         // Rapid changes — should debounce
@@ -397,7 +397,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
 
     it('once + from:self: only counts toward once when self matches', function() {
         window.fooCount = 0;
-        playground().innerHTML = '<div hx-on="click once from:self => window.fooCount++"><span>child</span></div>';
+        playground().innerHTML = '<div hx-on="click once from:self -> window.fooCount++"><span>child</span></div>';
         htmx.process(playground());
         let div = playground().querySelector('div');
         let span = playground().querySelector('span');
@@ -413,7 +413,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
 
     it('once + from:outside: only counts toward once when outside matches', function() {
         window.outsideCount = 0;
-        playground().innerHTML = '<button hx-on="click once from:outside => window.outsideCount++">x</button><div id="other"></div>';
+        playground().innerHTML = '<button hx-on="click once from:outside -> window.outsideCount++">x</button><div id="other"></div>';
         htmx.process(playground());
         let btn = playground().querySelector('button');
         let other = playground().querySelector('#other');
@@ -433,7 +433,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
     it('multiple events: separated by semicolons', function() {
         window.focusFired = false;
         window.blurFired = false;
-        playground().innerHTML = '<input hx-on="focus => window.focusFired = true; blur => window.blurFired = true">';
+        playground().innerHTML = '<input hx-on="focus -> window.focusFired = true; blur -> window.blurFired = true">';
         htmx.process(playground());
         let inp = playground().querySelector('input');
         inp.dispatchEvent(new Event('focus'));
@@ -448,7 +448,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
 
     it('multi-statement JS works with braces', function() {
         window.foo = 0;
-        let btn = createProcessedHTML('<button hx-on="click => { window.foo++; window.foo++ }">x</button>');
+        let btn = createProcessedHTML('<button hx-on="click -> { window.foo++; window.foo++ }">x</button>');
         btn.click();
         window.foo.should.equal(2);
         delete window.foo;
@@ -456,7 +456,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
 
     it('semicolons inside nested braces are preserved', function() {
         window.foo = 0;
-        let btn = createProcessedHTML('<button hx-on="click => { if (true) { window.foo++; window.foo++ } }">x</button>');
+        let btn = createProcessedHTML('<button hx-on="click -> { if (true) { window.foo++; window.foo++ } }">x</button>');
         btn.click();
         window.foo.should.equal(2);
         delete window.foo;
@@ -464,7 +464,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
 
     it('semicolons inside parens are preserved', function() {
         window.foo = 0;
-        let btn = createProcessedHTML('<button hx-on="click => (window.foo++, window.foo++)">x</button>');
+        let btn = createProcessedHTML('<button hx-on="click -> (window.foo++, window.foo++)">x</button>');
         btn.click();
         window.foo.should.equal(2);
         delete window.foo;
@@ -474,7 +474,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
 
     it('comma: multiple events fire the same handler', function() {
         window.fooCount = 0;
-        let btn = createProcessedHTML('<button hx-on="click, customevt => window.fooCount++">x</button>');
+        let btn = createProcessedHTML('<button hx-on="click, customevt -> window.fooCount++">x</button>');
         btn.click();
         btn.dispatchEvent(new CustomEvent('customevt'));
         window.fooCount.should.equal(2);
@@ -484,7 +484,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
     // --- arrow functions in JS code ---
 
     it('arrow functions in JS code do not break parsing', function() {
-        let btn = createProcessedHTML('<button hx-on="click => window.foo = [1,2,3].filter(x => x > 1)">x</button>');
+        let btn = createProcessedHTML('<button hx-on="click -> window.foo = [1,2,3].filter(x => x > 1)">x</button>');
         btn.click();
         window.foo.should.deep.equal([2, 3]);
         delete window.foo;
@@ -495,7 +495,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
     it('multi-statement and multi-event combined', function() {
         window.clickCount = 0;
         window.blurFired = false;
-        playground().innerHTML = '<button hx-on="click => { window.clickCount++; window.clickCount++ }; blur => window.blurFired = true">x</button>';
+        playground().innerHTML = '<button hx-on="click -> { window.clickCount++; window.clickCount++ }; blur -> window.blurFired = true">x</button>';
         htmx.process(playground());
         let btn = playground().querySelector('button');
         btn.click();
@@ -510,7 +510,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
 
     it('from:.selector: listens on matching elements', function() {
         window.foo = false;
-        playground().innerHTML = '<div id="source"></div><button hx-on="customevt from:#source => window.foo = true">x</button>';
+        playground().innerHTML = '<div id="source"></div><button hx-on="customevt from:#source -> window.foo = true">x</button>';
         htmx.process(playground());
         playground().querySelector('#source').dispatchEvent(new CustomEvent('customevt'));
         window.foo.should.equal(true);
@@ -522,7 +522,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
     it('hx-on: and hx-on= coexist on the same element', function() {
         window.colonFired = false;
         window.arrowFired = false;
-        let btn = createProcessedHTML('<button hx-on:click="window.colonFired = true" hx-on="customevt => window.arrowFired = true">x</button>');
+        let btn = createProcessedHTML('<button hx-on:click="window.colonFired = true" hx-on="customevt -> window.arrowFired = true">x</button>');
         btn.click();
         window.colonFired.should.equal(true);
         btn.dispatchEvent(new CustomEvent('customevt'));
@@ -535,20 +535,20 @@ describe('hx-on="eventSpec => code" syntax', function() {
 
     it('load: fires immediately when element is processed', function() {
         window.foo = false;
-        createProcessedHTML('<div hx-on="load => window.foo = true">x</div>');
+        createProcessedHTML('<div hx-on="load -> window.foo = true">x</div>');
         window.foo.should.equal(true);
         delete window.foo;
     });
 
     it('load: works with modifiers', function() {
         window.foo = false;
-        createProcessedHTML('<div hx-on="load once => window.foo = true">x</div>');
+        createProcessedHTML('<div hx-on="load once -> window.foo = true">x</div>');
         window.foo.should.equal(true);
         delete window.foo;
     });
 
     it('load: provides this and event', function() {
-        let div = createProcessedHTML('<div hx-on="load => { window.fooThis = this; window.fooType = event.type }">x</div>');
+        let div = createProcessedHTML('<div hx-on="load -> { window.fooThis = this; window.fooType = event.type }">x</div>');
         window.fooThis.should.equal(div);
         window.fooType.should.equal('load');
         delete window.fooThis;
@@ -557,7 +557,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
 
     it('every: fires repeatedly on interval', async function() {
         window.fooCount = 0;
-        playground().innerHTML = '<div hx-on="every 50ms => window.fooCount++">x</div>';
+        playground().innerHTML = '<div hx-on="every 50ms -> window.fooCount++">x</div>';
         htmx.process(playground());
         window.fooCount.should.equal(0);
         await htmx.timeout(130);
@@ -581,7 +581,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
             observerCallback = cb;
             return { observe: function() {}, disconnect: function() {} };
         };
-        let div = createProcessedHTML('<div hx-on="revealed => this.classList.add(\'visible\')">x</div>');
+        let div = createProcessedHTML('<div hx-on="revealed -> this.classList.add(\'visible\')">x</div>');
         div.classList.contains('visible').should.equal(false);
         observerCallback([{ isIntersecting: true }]);
         div.classList.contains('visible').should.equal(true);
@@ -595,7 +595,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
             observerCallback = cb;
             return { observe: function() {}, disconnect: function() { disconnected = true; } };
         };
-        let div = createProcessedHTML('<div hx-on="intersect once => this.classList.add(\'in-view\')">x</div>');
+        let div = createProcessedHTML('<div hx-on="intersect once -> this.classList.add(\'in-view\')">x</div>');
         div.classList.contains('in-view').should.equal(false);
         observerCallback([{ isIntersecting: true }]);
         div.classList.contains('in-view').should.equal(true);
@@ -603,7 +603,7 @@ describe('hx-on="eventSpec => code" syntax', function() {
     });
 
     it('every: updates text content on interval', async function() {
-        let div = createProcessedHTML('<div hx-on="every 50ms => this.textContent = \'updated\'">original</div>');
+        let div = createProcessedHTML('<div hx-on="every 50ms -> this.textContent = \'updated\'">original</div>');
         div.textContent.should.equal('original');
         await htmx.timeout(80);
         div.textContent.should.equal('updated');

--- a/test/tests/attributes/hx-on.js
+++ b/test/tests/attributes/hx-on.js
@@ -95,15 +95,102 @@ describe('hx-on attribute', function() {
         assert.equal(window.foo, undefined)
     })
 
+    it('event.detail keys are exposed as bare names in handler scope', function() {
+        let btn = createProcessedHTML('<button hx-on:zap="window.foo = path.toUpperCase()">x</button>');
+        btn.dispatchEvent(new CustomEvent('zap', { detail: { path: 'hello' } }));
+        window.foo.should.equal('HELLO');
+        delete window.foo;
+    });
+
+    // --- synthetic events in simple form ---
+
+    it('hx-on:load fires immediately when element is processed', function() {
+        window.foo = false;
+        createProcessedHTML('<div hx-on:load="window.foo = true">x</div>');
+        window.foo.should.equal(true);
+        delete window.foo;
+    });
+
+    it('hx-on:load provides this as the element', function() {
+        let div = createProcessedHTML('<div hx-on:load="window.foo = this">x</div>');
+        window.foo.should.equal(div);
+        delete window.foo;
+    });
+
+    it('hx-on:load fires on children inside a swap response', function() {
+        window.parentLoaded = false;
+        window.childLoaded = false;
+        playground().innerHTML = '<div id="target">old</div>';
+        htmx.process(playground());
+        let target = playground().querySelector('#target');
+        // Simulate what htmx does during a swap: insert new content and process it
+        target.innerHTML = '<div hx-on:load="window.parentLoaded = true"><span hx-on:load="window.childLoaded = true">new</span></div>';
+        htmx.process(target);
+        window.parentLoaded.should.equal(true);
+        window.childLoaded.should.equal(true);
+        delete window.parentLoaded;
+        delete window.childLoaded;
+    });
+
+    it('hx-on:load passes a CustomEvent as event', function() {
+        createProcessedHTML('<div hx-on:load="window.foo = event.type">x</div>');
+        window.foo.should.equal('load');
+        delete window.foo;
+    });
+
 })
 
-describe('hx-on attribute modifiers', function() {
+describe('hx-on="eventSpec => code" syntax', function() {
 
     beforeEach(() => { setupTest(this.currentTest); });
     afterEach(() => { cleanupTest(); });
 
-    it('.prevent calls preventDefault before body', function() {
-        let form = createProcessedHTML('<form hx-on:submit.prevent="window.foo = event.defaultPrevented"><button type="submit">go</button></form>');
+    // --- basic ---
+
+    it('basic: fires handler on event', function() {
+        let btn = createProcessedHTML('<button hx-on="click => window.foo = true">x</button>');
+        btn.click();
+        window.foo.should.equal(true);
+        delete window.foo;
+    });
+
+    it('this refers to the element', function() {
+        let btn = createProcessedHTML('<button hx-on="click => window.foo = this">x</button>');
+        btn.click();
+        window.foo.should.equal(btn);
+        delete window.foo;
+    });
+
+    it('event is available in handler', function() {
+        let btn = createProcessedHTML('<button hx-on="click => window.foo = event.type">x</button>');
+        btn.click();
+        window.foo.should.equal('click');
+        delete window.foo;
+    });
+
+    it('event.detail keys are exposed as bare names', function() {
+        let btn = createProcessedHTML('<button hx-on="zap => window.foo = path">x</button>');
+        btn.dispatchEvent(new CustomEvent('zap', { detail: { path: 'hello' } }));
+        window.foo.should.equal('hello');
+        delete window.foo;
+    });
+
+    // --- once ---
+
+    it('once: removes listener after first fire', function() {
+        window.fooCount = 0;
+        let btn = createProcessedHTML('<button hx-on="click once => window.fooCount++">x</button>');
+        btn.click();
+        btn.click();
+        btn.click();
+        window.fooCount.should.equal(1);
+        delete window.fooCount;
+    });
+
+    // --- prevent ---
+
+    it('prevent: calls preventDefault before handler', function() {
+        let form = createProcessedHTML('<form hx-on="submit prevent => window.foo = event.defaultPrevented"><button type="submit">go</button></form>');
         let evt = new SubmitEvent('submit', { cancelable: true, bubbles: true });
         form.dispatchEvent(evt);
         evt.defaultPrevented.should.equal(true);
@@ -111,8 +198,10 @@ describe('hx-on attribute modifiers', function() {
         delete window.foo;
     });
 
-    it('.stop calls stopPropagation before body', function() {
-        playground().innerHTML = '<div id="outer"><button hx-on:click.stop="window.foo = \'inner\'">x</button></div>';
+    // --- stop ---
+
+    it('stop: calls stopPropagation before handler', function() {
+        playground().innerHTML = '<div id="outer"><button hx-on="click stop => window.foo = \'inner\'">x</button></div>';
         htmx.process(playground());
         let outerFired = false;
         playground().querySelector('#outer').addEventListener('click', () => outerFired = true);
@@ -122,8 +211,10 @@ describe('hx-on attribute modifiers', function() {
         delete window.foo;
     });
 
-    it('.halt is shorthand for .prevent.stop', function() {
-        playground().innerHTML = '<div id="outer"><button hx-on:click.halt="window.foo = 1">x</button></div>';
+    // --- halt (shorthand for prevent + stop) ---
+
+    it('halt: preventDefault and stopPropagation', function() {
+        playground().innerHTML = '<div id="outer"><button hx-on="click halt => window.foo = 1">x</button></div>';
         htmx.process(playground());
         let outerFired = false;
         playground().querySelector('#outer').addEventListener('click', () => outerFired = true);
@@ -135,101 +226,396 @@ describe('hx-on attribute modifiers', function() {
         delete window.foo;
     });
 
-    it('.once removes the listener after first fire', function() {
+    // --- prevent + stop ---
+
+    it('prevent stop: equivalent to halt', function() {
+        playground().innerHTML = '<div id="outer"><button hx-on="click prevent stop => window.foo = 1">x</button></div>';
+        htmx.process(playground());
+        let outerFired = false;
+        playground().querySelector('#outer').addEventListener('click', () => outerFired = true);
+        let btn = playground().querySelector('button');
+        let evt = new MouseEvent('click', { cancelable: true, bubbles: true });
+        btn.dispatchEvent(evt);
+        evt.defaultPrevented.should.equal(true);
+        outerFired.should.equal(false);
+        delete window.foo;
+    });
+
+    // --- delay ---
+
+    it('delay: debounces handler', async function() {
         window.fooCount = 0;
-        let btn = createProcessedHTML('<button hx-on:click.once="window.fooCount++">x</button>');
+        playground().innerHTML = '<button hx-on="click delay:30ms => window.fooCount++">x</button>';
+        htmx.process(playground());
+        let btn = playground().querySelector('button');
         btn.click();
         btn.click();
         btn.click();
+        window.fooCount.should.equal(0);
+        await htmx.timeout(60);
         window.fooCount.should.equal(1);
         delete window.fooCount;
     });
 
-    it('.self only fires when event.target is the element', function() {
+    // --- throttle ---
+
+    it('throttle: throttles handler with trailing edge', async function() {
         window.fooCount = 0;
-        playground().innerHTML = '<div hx-on:click.self="window.fooCount++"><span>child</span></div>';
+        playground().innerHTML = '<button hx-on="click throttle:30ms => window.fooCount++">x</button>';
+        htmx.process(playground());
+        let btn = playground().querySelector('button');
+        btn.click(); // fires immediately (first)
+        btn.click(); // queued
+        btn.click(); // replaces queued
+        window.fooCount.should.equal(1);
+        await htmx.timeout(60);
+        window.fooCount.should.equal(2); // trailing edge fires
+        delete window.fooCount;
+    });
+
+    // --- changed ---
+
+    it('changed: only fires when value changes', function() {
+        window.fooCount = 0;
+        playground().innerHTML = '<input value="a" hx-on="input changed => window.fooCount++">';
+        htmx.process(playground());
+        let inp = playground().querySelector('input');
+        // First fire: value is "a", no previous — should fire
+        inp.dispatchEvent(new Event('input', { bubbles: true }));
+        window.fooCount.should.equal(1);
+        // Second fire: value still "a" — should NOT fire
+        inp.dispatchEvent(new Event('input', { bubbles: true }));
+        window.fooCount.should.equal(1);
+        // Change value and fire — should fire
+        inp.value = 'b';
+        inp.dispatchEvent(new Event('input', { bubbles: true }));
+        window.fooCount.should.equal(2);
+        delete window.fooCount;
+    });
+
+    // --- from ---
+
+    it('from:document: listens on document', function() {
+        window.foo = false;
+        let btn = createProcessedHTML('<button hx-on="custom-evt from:document => window.foo = true">x</button>');
+        document.dispatchEvent(new CustomEvent('custom-evt'));
+        window.foo.should.equal(true);
+        // Clean up document-level listener
+        for (let l of (btn._htmx?.listeners || [])) l.fromElt.removeEventListener(l.eventName, l.handler);
+        delete window.foo;
+    });
+
+    // --- from:self ---
+
+    it('from:self: only fires when event.target is the element', function() {
+        window.fooCount = 0;
+        playground().innerHTML = '<div hx-on="click from:self => window.fooCount++"><span>child</span></div>';
         htmx.process(playground());
         let div = playground().querySelector('div');
-        playground().querySelector('span').click(); // bubbles to div, target=span → skip
+        playground().querySelector('span').click(); // bubbles, target=span → skip
         window.fooCount.should.equal(0);
         div.click(); // target=div → fire
         window.fooCount.should.equal(1);
         delete window.fooCount;
     });
 
-    it('.outside fires only when click happens outside the element', function() {
+    // --- from:outside ---
+
+    it('from:outside: fires only when event is outside the element', function() {
         window.outsideCount = 0;
-        let btn;
-        playground().innerHTML = '<button hx-on:click.outside="window.outsideCount++">x</button><div id="other"></div>';
+        playground().innerHTML = '<button hx-on="click from:outside => window.outsideCount++">x</button><div id="other"></div>';
         htmx.process(playground());
-        btn = playground().querySelector('button');
+        let btn = playground().querySelector('button');
         btn.click(); // inside → skip
         window.outsideCount.should.equal(0);
         playground().querySelector('#other').click(); // outside → fire
         window.outsideCount.should.equal(1);
-        // Manually remove the document-level listener so it doesn't leak across tests
-        for (let l of btn._htmx.listeners) l.fromElt.removeEventListener(l.eventName, l.handler);
+        // Clean up document-level listener
+        for (let l of (btn._htmx?.listeners || [])) l.fromElt.removeEventListener(l.eventName, l.handler);
         delete window.outsideCount;
     });
 
-    it('.cc camel-cases the event name', function() {
-        window.foo = null;
-        let btn = createProcessedHTML('<button hx-on:my-event.cc="window.foo = event.type">x</button>');
-        btn.dispatchEvent(new CustomEvent('myEvent'));
-        window.foo.should.equal('myEvent');
+    // --- capture ---
+
+    it('capture: fires during capture phase', function() {
+        let order = [];
+        playground().innerHTML = '<div id="outer"><button hx-on="click capture => window.captureOrder.push(\'capture\')">x</button></div>';
+        window.captureOrder = order;
+        htmx.process(playground());
+        // Add a bubbling listener on the same button for comparison
+        playground().querySelector('button').addEventListener('click', () => order.push('bubble'));
+        playground().querySelector('button').click();
+        // Capture fires before bubble
+        order[0].should.equal('capture');
+        order[1].should.equal('bubble');
+        delete window.captureOrder;
+    });
+
+    // --- passive ---
+
+    it('passive: addEventListener is called with passive option', function() {
+        // passive handlers cannot call preventDefault without a browser warning,
+        // so we just verify the handler fires (option is passed internally)
+        window.foo = false;
+        let btn = createProcessedHTML('<button hx-on="click passive => window.foo = true">x</button>');
+        btn.click();
+        window.foo.should.equal(true);
         delete window.foo;
     });
 
-    it('event.detail keys are exposed as bare names in handler scope', function() {
-        let btn = createProcessedHTML('<button hx-on:zap="window.foo = path.toUpperCase()">x</button>');
-        btn.dispatchEvent(new CustomEvent('zap', { detail: { path: 'hello' } }));
-        window.foo.should.equal('HELLO');
-        delete window.foo;
-    });
+    // --- filter ---
 
-    it('multiple modifiers can be chained (.halt.once)', function() {
+    it('[filter]: only fires when filter expression is truthy', function() {
         window.fooCount = 0;
-        let btn = createProcessedHTML('<button hx-on:click.halt.once="window.fooCount++">x</button>');
-        let evt = new MouseEvent('click', { cancelable: true, bubbles: true });
-        btn.dispatchEvent(evt);
-        evt.defaultPrevented.should.equal(true);
-        btn.dispatchEvent(new MouseEvent('click', { cancelable: true, bubbles: true }));
+        let btn = createProcessedHTML('<button hx-on="keydown[key==\'Enter\'] => window.fooCount++">x</button>');
+        btn.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+        window.fooCount.should.equal(0);
+        btn.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
         window.fooCount.should.equal(1);
         delete window.fooCount;
     });
 
-    it('.self.once only counts toward "once" when self condition matches', function() {
-        // A bubbled event from a child should NOT consume the .once budget.
+    // --- combined ---
+
+    it('changed + delay: debounced changed-only handler', async function() {
         window.fooCount = 0;
-        playground().innerHTML = '<div hx-on:click.self.once="window.fooCount++"><span>child</span></div>';
+        playground().innerHTML = '<input value="a" hx-on="input changed delay:30ms => window.fooCount++">';
+        htmx.process(playground());
+        let inp = playground().querySelector('input');
+        // Rapid changes — should debounce
+        inp.value = 'b';
+        inp.dispatchEvent(new Event('input', { bubbles: true }));
+        inp.value = 'c';
+        inp.dispatchEvent(new Event('input', { bubbles: true }));
+        inp.value = 'd';
+        inp.dispatchEvent(new Event('input', { bubbles: true }));
+        window.fooCount.should.equal(0);
+        await htmx.timeout(60);
+        window.fooCount.should.equal(1);
+        delete window.fooCount;
+    });
+
+    it('once + from:self: only counts toward once when self matches', function() {
+        window.fooCount = 0;
+        playground().innerHTML = '<div hx-on="click once from:self => window.fooCount++"><span>child</span></div>';
         htmx.process(playground());
         let div = playground().querySelector('div');
         let span = playground().querySelector('span');
-        span.click(); // bubbles, target=span → skipped, listener should remain
-        span.click(); // same, listener still there
+        span.click(); // bubbles, target=span → skipped
+        span.click(); // same
         window.fooCount.should.equal(0);
-        div.click(); // target=div → fires; THIS is the once
+        div.click(); // target=div → fires; this is the once
         window.fooCount.should.equal(1);
         div.click(); // listener now removed
         window.fooCount.should.equal(1);
         delete window.fooCount;
     });
 
-    it('.outside.once only counts toward "once" when outside condition matches', function() {
+    it('once + from:outside: only counts toward once when outside matches', function() {
         window.outsideCount = 0;
-        playground().innerHTML = '<button hx-on:click.outside.once="window.outsideCount++">x</button><div id="other"></div>';
+        playground().innerHTML = '<button hx-on="click once from:outside => window.outsideCount++">x</button><div id="other"></div>';
         htmx.process(playground());
         let btn = playground().querySelector('button');
         let other = playground().querySelector('#other');
-        btn.click(); // inside → skipped, listener should remain
+        btn.click(); // inside → skipped
         btn.click(); // same
         window.outsideCount.should.equal(0);
         other.click(); // outside → fires; consumes once
         window.outsideCount.should.equal(1);
         other.click(); // listener now removed
         window.outsideCount.should.equal(1);
-        // Clean up document-level listener if any remain
         for (let l of (btn._htmx?.listeners || [])) l.fromElt.removeEventListener(l.eventName, l.handler);
         delete window.outsideCount;
+    });
+
+    // --- multiple events ---
+
+    it('multiple events: separated by semicolons', function() {
+        window.focusFired = false;
+        window.blurFired = false;
+        playground().innerHTML = '<input hx-on="focus => window.focusFired = true; blur => window.blurFired = true">';
+        htmx.process(playground());
+        let inp = playground().querySelector('input');
+        inp.dispatchEvent(new Event('focus'));
+        window.focusFired.should.equal(true);
+        inp.dispatchEvent(new Event('blur'));
+        window.blurFired.should.equal(true);
+        delete window.focusFired;
+        delete window.blurFired;
+    });
+
+    // --- multi-statement JS ---
+
+    it('multi-statement JS works with braces', function() {
+        window.foo = 0;
+        let btn = createProcessedHTML('<button hx-on="click => { window.foo++; window.foo++ }">x</button>');
+        btn.click();
+        window.foo.should.equal(2);
+        delete window.foo;
+    });
+
+    it('semicolons inside nested braces are preserved', function() {
+        window.foo = 0;
+        let btn = createProcessedHTML('<button hx-on="click => { if (true) { window.foo++; window.foo++ } }">x</button>');
+        btn.click();
+        window.foo.should.equal(2);
+        delete window.foo;
+    });
+
+    it('semicolons inside parens are preserved', function() {
+        window.foo = 0;
+        let btn = createProcessedHTML('<button hx-on="click => (window.foo++, window.foo++)">x</button>');
+        btn.click();
+        window.foo.should.equal(2);
+        delete window.foo;
+    });
+
+    // --- comma: multiple events, same code ---
+
+    it('comma: multiple events fire the same handler', function() {
+        window.fooCount = 0;
+        let btn = createProcessedHTML('<button hx-on="click, customevt => window.fooCount++">x</button>');
+        btn.click();
+        btn.dispatchEvent(new CustomEvent('customevt'));
+        window.fooCount.should.equal(2);
+        delete window.fooCount;
+    });
+
+    // --- arrow functions in JS code ---
+
+    it('arrow functions in JS code do not break parsing', function() {
+        let btn = createProcessedHTML('<button hx-on="click => window.foo = [1,2,3].filter(x => x > 1)">x</button>');
+        btn.click();
+        window.foo.should.deep.equal([2, 3]);
+        delete window.foo;
+    });
+
+    // --- multiple events + multi-statement combined ---
+
+    it('multi-statement and multi-event combined', function() {
+        window.clickCount = 0;
+        window.blurFired = false;
+        playground().innerHTML = '<button hx-on="click => { window.clickCount++; window.clickCount++ }; blur => window.blurFired = true">x</button>';
+        htmx.process(playground());
+        let btn = playground().querySelector('button');
+        btn.click();
+        window.clickCount.should.equal(2);
+        btn.dispatchEvent(new Event('blur'));
+        window.blurFired.should.equal(true);
+        delete window.clickCount;
+        delete window.blurFired;
+    });
+
+    // --- from with CSS selector ---
+
+    it('from:.selector: listens on matching elements', function() {
+        window.foo = false;
+        playground().innerHTML = '<div id="source"></div><button hx-on="customevt from:#source => window.foo = true">x</button>';
+        htmx.process(playground());
+        playground().querySelector('#source').dispatchEvent(new CustomEvent('customevt'));
+        window.foo.should.equal(true);
+        delete window.foo;
+    });
+
+    // --- hx-on: and hx-on= coexist ---
+
+    it('hx-on: and hx-on= coexist on the same element', function() {
+        window.colonFired = false;
+        window.arrowFired = false;
+        let btn = createProcessedHTML('<button hx-on:click="window.colonFired = true" hx-on="customevt => window.arrowFired = true">x</button>');
+        btn.click();
+        window.colonFired.should.equal(true);
+        btn.dispatchEvent(new CustomEvent('customevt'));
+        window.arrowFired.should.equal(true);
+        delete window.colonFired;
+        delete window.arrowFired;
+    });
+
+    // --- synthetic events ---
+
+    it('load: fires immediately when element is processed', function() {
+        window.foo = false;
+        createProcessedHTML('<div hx-on="load => window.foo = true">x</div>');
+        window.foo.should.equal(true);
+        delete window.foo;
+    });
+
+    it('load: works with modifiers', function() {
+        window.foo = false;
+        createProcessedHTML('<div hx-on="load once => window.foo = true">x</div>');
+        window.foo.should.equal(true);
+        delete window.foo;
+    });
+
+    it('load: provides this and event', function() {
+        let div = createProcessedHTML('<div hx-on="load => { window.fooThis = this; window.fooType = event.type }">x</div>');
+        window.fooThis.should.equal(div);
+        window.fooType.should.equal('load');
+        delete window.fooThis;
+        delete window.fooType;
+    });
+
+    it('every: fires repeatedly on interval', async function() {
+        window.fooCount = 0;
+        playground().innerHTML = '<div hx-on="every 50ms => window.fooCount++">x</div>';
+        htmx.process(playground());
+        window.fooCount.should.equal(0);
+        await htmx.timeout(130);
+        window.fooCount.should.be.at.least(2);
+        // Clean up: remove element so interval stops (checks elt.isConnected)
+        playground().innerHTML = '';
+        delete window.fooCount;
+    });
+
+    // --- doc examples: synthetic events ---
+
+    it('load: focuses first input when element is processed', function() {
+        let div = createProcessedHTML('<div hx-on:load="this.querySelector(\'input\')?.focus()"><input id="myinput"></div>');
+        document.activeElement.id.should.equal('myinput');
+    });
+
+    it('revealed: adds class when element intersects', function() {
+        let originalIO = window.IntersectionObserver;
+        let observerCallback;
+        window.IntersectionObserver = function(cb, opts) {
+            observerCallback = cb;
+            return { observe: function() {}, disconnect: function() {} };
+        };
+        let div = createProcessedHTML('<div hx-on="revealed => this.classList.add(\'visible\')">x</div>');
+        div.classList.contains('visible').should.equal(false);
+        observerCallback([{ isIntersecting: true }]);
+        div.classList.contains('visible').should.equal(true);
+        window.IntersectionObserver = originalIO;
+    });
+
+    it('intersect once: adds class when element becomes visible', function() {
+        let originalIO = window.IntersectionObserver;
+        let observerCallback, disconnected = false;
+        window.IntersectionObserver = function(cb, opts) {
+            observerCallback = cb;
+            return { observe: function() {}, disconnect: function() { disconnected = true; } };
+        };
+        let div = createProcessedHTML('<div hx-on="intersect once => this.classList.add(\'in-view\')">x</div>');
+        div.classList.contains('in-view').should.equal(false);
+        observerCallback([{ isIntersecting: true }]);
+        div.classList.contains('in-view').should.equal(true);
+        window.IntersectionObserver = originalIO;
+    });
+
+    it('every: updates text content on interval', async function() {
+        let div = createProcessedHTML('<div hx-on="every 50ms => this.textContent = \'updated\'">original</div>');
+        div.textContent.should.equal('original');
+        await htmx.timeout(80);
+        div.textContent.should.equal('updated');
+        playground().innerHTML = '';
+    });
+
+    // --- backward compat ---
+
+    it('hx-on:click still works (backward compat)', function() {
+        let btn = createProcessedHTML('<button hx-on:click="window.foo = true">x</button>');
+        btn.click();
+        window.foo.should.equal(true);
+        delete window.foo;
     });
 })

--- a/test/tests/ext/hx-live.js
+++ b/test/tests/ext/hx-live.js
@@ -783,4 +783,82 @@ describe('hx-live extension', function () {
         window.foo.should.equal('tgt');
         delete window.foo;
     });
+
+    // -------------------------------------------------------------------------
+    // hx-live helpers inside hx-on="event => code" syntax
+    // -------------------------------------------------------------------------
+
+    it('q() works inside hx-on="event => code"', function() {
+        playground().innerHTML = '<button hx-on="click => window.foo = q(\'next #target\').textContent">x</button><div id="target">tgt</div>';
+        htmx.process(playground());
+        playground().querySelector('button').click();
+        window.foo.should.equal('tgt');
+        delete window.foo;
+    });
+
+    it('take() works inside hx-on="event => code"', function() {
+        playground().innerHTML = `
+            <div class="tabs">
+                <button class="tab selected">a</button>
+                <button class="tab">b</button>
+                <button class="tab" hx-on="click => take('selected', '.tab')">c</button>
+            </div>
+        `;
+        htmx.process(playground());
+        let tabs = playground().querySelectorAll('.tab');
+        tabs[2].click();
+        tabs[0].classList.contains('selected').should.equal(false);
+        tabs[1].classList.contains('selected').should.equal(false);
+        tabs[2].classList.contains('selected').should.equal(true);
+    });
+
+    it('toggle() works inside hx-on="event => code"', function() {
+        playground().innerHTML = '<button hx-on="click => toggle(\'.active\', \'@aria-pressed=true|false\')">x</button>';
+        htmx.process(playground());
+        let btn = playground().querySelector('button');
+        btn.click();
+        btn.classList.contains('active').should.equal(true);
+        btn.getAttribute('aria-pressed').should.equal('true');
+        btn.click();
+        btn.classList.contains('active').should.equal(false);
+        btn.getAttribute('aria-pressed').should.equal('false');
+    });
+
+    it('debounce() works inside hx-on="event => code"', async function() {
+        window.__dbCount = 0;
+        playground().innerHTML = '<button hx-on="click => debounce(30, () => { window.__dbCount++ })">x</button>';
+        htmx.process(playground());
+        let btn = playground().querySelector('button');
+        btn.click();
+        btn.click();
+        btn.click();
+        await htmx.timeout(60);
+        window.__dbCount.should.equal(1);
+        delete window.__dbCount;
+    });
+
+    it('trigger() works inside hx-on="event => code"', function() {
+        let fired = null;
+        playground().innerHTML = '<button hx-on="click => trigger(\'zap\', { x: 1 })">x</button>';
+        htmx.process(playground());
+        let btn = playground().querySelector('button');
+        btn.addEventListener('zap', e => fired = e);
+        btn.click();
+        assert.isNotNull(fired);
+        fired.detail.x.should.equal(1);
+    });
+
+    it('hx-live helpers work with hx-on modifiers', async function() {
+        window.__dbCount = 0;
+        playground().innerHTML = '<input hx-on="input changed delay:30ms => debounce(20, () => { window.__dbCount++ })">';
+        htmx.process(playground());
+        let inp = playground().querySelector('input');
+        inp.value = 'a';
+        inp.dispatchEvent(new Event('input', { bubbles: true }));
+        inp.value = 'b';
+        inp.dispatchEvent(new Event('input', { bubbles: true }));
+        await htmx.timeout(80);
+        window.__dbCount.should.equal(1);
+        delete window.__dbCount;
+    });
 });

--- a/test/tests/ext/hx-live.js
+++ b/test/tests/ext/hx-live.js
@@ -785,23 +785,23 @@ describe('hx-live extension', function () {
     });
 
     // -------------------------------------------------------------------------
-    // hx-live helpers inside hx-on="event => code" syntax
+    // hx-live helpers inside hx-on="event -> code" syntax
     // -------------------------------------------------------------------------
 
-    it('q() works inside hx-on="event => code"', function() {
-        playground().innerHTML = '<button hx-on="click => window.foo = q(\'next #target\').textContent">x</button><div id="target">tgt</div>';
+    it('q() works inside hx-on="event -> code"', function() {
+        playground().innerHTML = '<button hx-on="click -> window.foo = q(\'next #target\').textContent">x</button><div id="target">tgt</div>';
         htmx.process(playground());
         playground().querySelector('button').click();
         window.foo.should.equal('tgt');
         delete window.foo;
     });
 
-    it('take() works inside hx-on="event => code"', function() {
+    it('take() works inside hx-on="event -> code"', function() {
         playground().innerHTML = `
             <div class="tabs">
                 <button class="tab selected">a</button>
                 <button class="tab">b</button>
-                <button class="tab" hx-on="click => take('selected', '.tab')">c</button>
+                <button class="tab" hx-on="click -> take('selected', '.tab')">c</button>
             </div>
         `;
         htmx.process(playground());
@@ -812,8 +812,8 @@ describe('hx-live extension', function () {
         tabs[2].classList.contains('selected').should.equal(true);
     });
 
-    it('toggle() works inside hx-on="event => code"', function() {
-        playground().innerHTML = '<button hx-on="click => toggle(\'.active\', \'@aria-pressed=true|false\')">x</button>';
+    it('toggle() works inside hx-on="event -> code"', function() {
+        playground().innerHTML = '<button hx-on="click -> toggle(\'.active\', \'@aria-pressed=true|false\')">x</button>';
         htmx.process(playground());
         let btn = playground().querySelector('button');
         btn.click();
@@ -824,9 +824,9 @@ describe('hx-live extension', function () {
         btn.getAttribute('aria-pressed').should.equal('false');
     });
 
-    it('debounce() works inside hx-on="event => code"', async function() {
+    it('debounce() works inside hx-on="event -> code"', async function() {
         window.__dbCount = 0;
-        playground().innerHTML = '<button hx-on="click => debounce(30, () => { window.__dbCount++ })">x</button>';
+        playground().innerHTML = '<button hx-on="click -> debounce(30, () => { window.__dbCount++ })">x</button>';
         htmx.process(playground());
         let btn = playground().querySelector('button');
         btn.click();
@@ -837,9 +837,9 @@ describe('hx-live extension', function () {
         delete window.__dbCount;
     });
 
-    it('trigger() works inside hx-on="event => code"', function() {
+    it('trigger() works inside hx-on="event -> code"', function() {
         let fired = null;
-        playground().innerHTML = '<button hx-on="click => trigger(\'zap\', { x: 1 })">x</button>';
+        playground().innerHTML = '<button hx-on="click -> trigger(\'zap\', { x: 1 })">x</button>';
         htmx.process(playground());
         let btn = playground().querySelector('button');
         btn.addEventListener('zap', e => fired = e);
@@ -850,7 +850,7 @@ describe('hx-live extension', function () {
 
     it('hx-live helpers work with hx-on modifiers', async function() {
         window.__dbCount = 0;
-        playground().innerHTML = '<input hx-on="input changed delay:30ms => debounce(20, () => { window.__dbCount++ })">';
+        playground().innerHTML = '<input hx-on="input changed delay:30ms -> debounce(20, () => { window.__dbCount++ })">';
         htmx.process(playground());
         let inp = playground().querySelector('input');
         inp.value = 'a';

--- a/test/tests/unit/__parseEventSpecs.js
+++ b/test/tests/unit/__parseEventSpecs.js
@@ -1,34 +1,34 @@
-describe('__parseTriggerSpecs unit tests', function() {
+describe('__parseEventSpecs unit tests', function() {
 
     it('parses single event', function () {
-        let specs = htmx.__parseTriggerSpecs('click')
+        let specs = htmx.__parseEventSpecs('click')
         assert.equal(specs.length, 1)
         assert.equal(specs[0].name, 'click')
     })
 
     it('parses multiple events with comma', function () {
-        let specs = htmx.__parseTriggerSpecs('click, change')
+        let specs = htmx.__parseEventSpecs('click, change')
         assert.equal(specs.length, 2)
         assert.equal(specs[0].name, 'click')
         assert.equal(specs[1].name, 'change')
     })
 
     it('parses event with modifier value', function () {
-        let specs = htmx.__parseTriggerSpecs('click delay:100ms')
+        let specs = htmx.__parseEventSpecs('click delay:100ms')
         assert.equal(specs.length, 1)
         assert.equal(specs[0].name, 'click')
         assert.equal(specs[0].delay, '100ms')
     })
 
     it('parses event with boolean modifier', function () {
-        let specs = htmx.__parseTriggerSpecs('click once')
+        let specs = htmx.__parseEventSpecs('click once')
         assert.equal(specs.length, 1)
         assert.equal(specs[0].name, 'click')
         assert.equal(specs[0].once, true)
     })
 
     it('parses event with multiple modifiers', function () {
-        let specs = htmx.__parseTriggerSpecs('click delay:100ms throttle:200ms once')
+        let specs = htmx.__parseEventSpecs('click delay:100ms throttle:200ms once')
         assert.equal(specs.length, 1)
         assert.equal(specs[0].name, 'click')
         assert.equal(specs[0].delay, '100ms')
@@ -37,53 +37,53 @@ describe('__parseTriggerSpecs unit tests', function() {
     })
 
     it('parses event with from modifier', function () {
-        let specs = htmx.__parseTriggerSpecs('click from:#other')
+        let specs = htmx.__parseEventSpecs('click from:#other')
         assert.equal(specs.length, 1)
         assert.equal(specs[0].name, 'click')
         assert.equal(specs[0].from, '#other')
     })
 
     it('parses event with target modifier', function () {
-        let specs = htmx.__parseTriggerSpecs('click target:.item')
+        let specs = htmx.__parseEventSpecs('click target:.item')
         assert.equal(specs.length, 1)
         assert.equal(specs[0].name, 'click')
         assert.equal(specs[0].target, '.item')
     })
 
     it('parses event with consume modifier', function () {
-        let specs = htmx.__parseTriggerSpecs('click consume')
+        let specs = htmx.__parseEventSpecs('click consume')
         assert.equal(specs.length, 1)
         assert.equal(specs[0].name, 'click')
         assert.equal(specs[0].consume, true)
     })
 
     it('parses event with changed modifier', function () {
-        let specs = htmx.__parseTriggerSpecs('change changed')
+        let specs = htmx.__parseEventSpecs('change changed')
         assert.equal(specs.length, 1)
         assert.equal(specs[0].name, 'change')
         assert.equal(specs[0].changed, true)
     })
 
     it('parses event with filter', function () {
-        let specs = htmx.__parseTriggerSpecs('click[ctrlKey]')
+        let specs = htmx.__parseEventSpecs('click[ctrlKey]')
         assert.equal(specs.length, 1)
         assert.equal(specs[0].name, 'click[ctrlKey]')
     })
 
     it('parses event with filter containing spaces', function () {
-        let specs = htmx.__parseTriggerSpecs('click[event.detail > 5]')
+        let specs = htmx.__parseEventSpecs('click[event.detail > 5]')
         assert.equal(specs.length, 1)
         assert.equal(specs[0].name, 'click[event.detail > 5]')
     })
 
     it('preserves whitespace in string literals in filters', function () {
-        let specs = htmx.__parseTriggerSpecs('click[event.detail === "hello world"]')
+        let specs = htmx.__parseEventSpecs('click[event.detail === "hello world"]')
         assert.equal(specs.length, 1)
         assert.equal(specs[0].name, 'click[event.detail === "hello world"]')
     })
 
     it('parses multiple events with different modifiers', function () {
-        let specs = htmx.__parseTriggerSpecs('click once, change delay:100ms')
+        let specs = htmx.__parseEventSpecs('click once, change delay:100ms')
         assert.equal(specs.length, 2)
         assert.equal(specs[0].name, 'click')
         assert.equal(specs[0].once, true)
@@ -92,37 +92,37 @@ describe('__parseTriggerSpecs unit tests', function() {
     })
 
     it('parses every trigger', function () {
-        let specs = htmx.__parseTriggerSpecs('every 1s')
+        let specs = htmx.__parseEventSpecs('every 1s')
         assert.equal(specs.length, 1)
         assert.equal(specs[0].name, 'every')
         assert.equal(specs[0]['1s'], true)
     })
 
     it('handles empty string', function () {
-        let specs = htmx.__parseTriggerSpecs('')
+        let specs = htmx.__parseEventSpecs('')
         assert.equal(specs.length, 0)
     })
 
     it('handles whitespace only', function () {
-        let specs = htmx.__parseTriggerSpecs('   ')
+        let specs = htmx.__parseEventSpecs('   ')
         assert.equal(specs.length, 0)
     })
 
     it('throws on unterminated filter', function () {
         assert.throws(() => {
-            htmx.__parseTriggerSpecs('click[ctrlKey')
+            htmx.__parseEventSpecs('click[ctrlKey')
         })
     })
 
     it('does not split on comma inside function call filter when combined with other events', function () {
-        let specs = htmx.__parseTriggerSpecs('click[myFunc(a,b)], keyup')
+        let specs = htmx.__parseEventSpecs('click[myFunc(a,b)], keyup')
         assert.equal(specs.length, 2)
         assert.equal(specs[0].name, 'click[myFunc(a,b)]')
         assert.equal(specs[1].name, 'keyup')
     })
 
-    it('parses complex trigger spec', function () {
-        let specs = htmx.__parseTriggerSpecs('click[ctrlKey] delay:100ms throttle:200ms from:body target:.item once')
+    it('parses complex event spec', function () {
+        let specs = htmx.__parseEventSpecs('click[ctrlKey] delay:100ms throttle:200ms from:body target:.item once')
         assert.equal(specs.length, 1)
         assert.equal(specs[0].name, 'click[ctrlKey]')
         assert.equal(specs[0].delay, '100ms')

--- a/test/tests/unit/bootstrap.js
+++ b/test/tests/unit/bootstrap.js
@@ -77,23 +77,23 @@ describe('bootstrap unit tests', function() {
         assert.equal(result, 'default');
     })
 
-    it("__parseTriggerSpecs parses simple event", function() {
-        const result = htmx.__parseTriggerSpecs('click');
+    it("__parseEventSpecs parses simple event", function() {
+        const result = htmx.__parseEventSpecs('click');
 
         assert.equal(result.length, 1);
         assert.equal(result[0].name, 'click');
     })
 
-    it("__parseTriggerSpecs parses event with option", function() {
-        const result = htmx.__parseTriggerSpecs('click delay:500');
+    it("__parseEventSpecs parses event with option", function() {
+        const result = htmx.__parseEventSpecs('click delay:500');
 
         assert.equal(result.length, 1);
         assert.equal(result[0].name, 'click');
         assert.equal(result[0].delay, '500');
     })
 
-    it("__parseTriggerSpecs parses event with multiple options", function() {
-        const result = htmx.__parseTriggerSpecs('click delay:500 throttle:100');
+    it("__parseEventSpecs parses event with multiple options", function() {
+        const result = htmx.__parseEventSpecs('click delay:500 throttle:100');
 
         assert.equal(result.length, 1);
         assert.equal(result[0].name, 'click');
@@ -101,8 +101,8 @@ describe('bootstrap unit tests', function() {
         assert.equal(result[0].throttle, '100');
     })
 
-    it("__parseTriggerSpecs parses event with boolean opts", function() {
-        const result = htmx.__parseTriggerSpecs('click once changed');
+    it("__parseEventSpecs parses event with boolean opts", function() {
+        const result = htmx.__parseEventSpecs('click once changed');
 
         assert.equal(result.length, 1);
         assert.equal(result[0].name, 'click');
@@ -110,8 +110,8 @@ describe('bootstrap unit tests', function() {
         assert.equal(result[0].changed, true);
     })
 
-    it("__parseTriggerSpecs parses event with options and boolean opts", function() {
-        const result = htmx.__parseTriggerSpecs('click delay:1s once changed');
+    it("__parseEventSpecs parses event with options and boolean opts", function() {
+        const result = htmx.__parseEventSpecs('click delay:1s once changed');
 
         assert.equal(result.length, 1);
         assert.equal(result[0].name, 'click');
@@ -120,16 +120,16 @@ describe('bootstrap unit tests', function() {
         assert.equal(result[0].changed, true);
     })
 
-    it("__parseTriggerSpecs parses multiple events", function() {
-        const result = htmx.__parseTriggerSpecs('click, submit');
+    it("__parseEventSpecs parses multiple events", function() {
+        const result = htmx.__parseEventSpecs('click, submit');
 
         assert.equal(result.length, 2);
         assert.equal(result[0].name, 'click');
         assert.equal(result[1].name, 'submit');
     })
 
-    it("__parseTriggerSpecs parses multiple events with options", function() {
-        const result = htmx.__parseTriggerSpecs('click delay:500, keyup changed');
+    it("__parseEventSpecs parses multiple events with options", function() {
+        const result = htmx.__parseEventSpecs('click delay:500, keyup changed');
 
         assert.equal(result.length, 2);
         assert.equal(result[0].name, 'click');
@@ -138,36 +138,36 @@ describe('bootstrap unit tests', function() {
         assert.equal(result[1].changed, true);
     })
 
-    it("__parseTriggerSpecs parses event filter", function() {
-        const result = htmx.__parseTriggerSpecs('click[ctrlKey]');
+    it("__parseEventSpecs parses event filter", function() {
+        const result = htmx.__parseEventSpecs('click[ctrlKey]');
 
         assert.equal(result.length, 1);
         assert.equal(result[0].name, 'click[ctrlKey]');
     })
 
-    it("__parseTriggerSpecs parses event filter with spaces", function() {
-        const result = htmx.__parseTriggerSpecs('click[target.value == "test"]');
+    it("__parseEventSpecs parses event filter with spaces", function() {
+        const result = htmx.__parseEventSpecs('click[target.value == "test"]');
 
         assert.equal(result.length, 1);
         assert.equal(result[0].name, 'click[target.value == "test"]');
     })
 
-    it("__parseTriggerSpecs parses event with from option", function() {
-        const result = htmx.__parseTriggerSpecs('click from:body');
+    it("__parseEventSpecs parses event with from option", function() {
+        const result = htmx.__parseEventSpecs('click from:body');
 
         assert.equal(result.length, 1);
         assert.equal(result[0].name, 'click');
         assert.equal(result[0].from, 'body');
     })
 
-    it("__parseTriggerSpecs throws on unterminated filter", function() {
+    it("__parseEventSpecs throws on unterminated filter", function() {
         assert.throws(() => {
-            htmx.__parseTriggerSpecs('click[ctrlKey');
+            htmx.__parseEventSpecs('click[ctrlKey');
         }, /unterminated/);
     })
 
-    it("__parseTriggerSpecs handles complex real-world spec", function() {
-        const result = htmx.__parseTriggerSpecs('keyup[target.value.length > 3] changed delay:500ms from:input');
+    it("__parseEventSpecs handles complex real-world spec", function() {
+        const result = htmx.__parseEventSpecs('keyup[target.value.length > 3] changed delay:500ms from:input');
 
         assert.equal(result.length, 1);
         assert.equal(result[0].name, 'keyup[target.value.length > 3]');
@@ -176,8 +176,8 @@ describe('bootstrap unit tests', function() {
         assert.equal(result[0].from, 'input');
     })
 
-    it("__parseTriggerSpecs handles complex real-world spec w string and preserves spaces in string", function() {
-        const result = htmx.__parseTriggerSpecs('keyup[target.value == "hello world"] changed delay:500ms from:input');
+    it("__parseEventSpecs handles complex real-world spec w string and preserves spaces in string", function() {
+        const result = htmx.__parseEventSpecs('keyup[target.value == "hello world"] changed delay:500ms from:input');
 
         assert.equal(result.length, 1);
         assert.equal(result[0].name, 'keyup[target.value == "hello world"]');

--- a/www/src/content/docs/01-get-started/02-migration.md
+++ b/www/src/content/docs/01-get-started/02-migration.md
@@ -129,6 +129,19 @@ In htmx 4, the main content swaps first. OOB and [`<hx-partial>`](/docs/core-con
 This matters if an OOB swap creates or modifies DOM that the main swap depends on. If your app relies on that ordering,
 restructure so each swap is independent.
 
+### `hx-trigger` `queue` modifier removed
+
+The `queue` modifier on [`hx-trigger`](/reference/attributes/hx-trigger) (e.g. `hx-trigger="click queue:all"`) no longer
+works. Request queuing is now controlled exclusively by [`hx-sync`](/reference/attributes/hx-sync).
+
+```html
+<!-- htmx 2 -->
+<div hx-trigger="click queue:all" hx-get="/test">...</div>
+
+<!-- htmx 4: use hx-sync instead -->
+<div hx-trigger="click" hx-get="/test" hx-sync="this:queue all">...</div>
+```
+
 ### 60-second timeout
 
 htmx 2 had no timeout (`0`). htmx 4 sets [`defaultTimeout`](/reference/config/htmx-config-defaultTimeout) to `60000`.

--- a/www/src/content/docs/02-core-concepts/04-client-scripting.md
+++ b/www/src/content/docs/02-core-concepts/04-client-scripting.md
@@ -184,3 +184,9 @@ htmx.onLoad((content) => {
 ```
 
 This will ensure that as new content is added to the DOM by htmx, sortable elements are properly initialized.
+
+## See Also
+
+- [`hx-on`](/reference/attributes/hx-on) (attribute)
+- [Hypermedia-Friendly Scripting](/essays/hypermedia-friendly-scripting) (essay)
+- [Locality of Behaviour](/essays/locality-of-behaviour) (essay)

--- a/www/src/content/reference/01-attributes/06-hx-trigger.md
+++ b/www/src/content/reference/01-attributes/06-hx-trigger.md
@@ -3,65 +3,105 @@ title: "hx-trigger"
 description: "Control when an element issues a request"
 ---
 
-The `hx-trigger` attribute specifies what triggers an AJAX request.
+The `hx-trigger` attribute controls which event(s) trigger an element's AJAX request (set via [`hx-get`](/reference/attributes/hx-get), [`hx-post`](/reference/attributes/hx-post), etc.).
 
-## Examples
+Defaults to:
+- [`change`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event) → `<input>` / `<textarea>` / `<select>`
+- [`submit`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit_event) → `<form>`
+- [`click`](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event) → `<input type=button>`, `<input type=submit>`, and everything else
+
+## Syntax
 
 ```html
-<!-- Trigger on click -->
-<div hx-trigger="click" hx-get="...">Click Me</div>
+<!-- hx-trigger="<event>[<filter>] <modifiers> [, ...]" -->
 
-<!-- Search with debounce -->
-<input hx-trigger="input changed delay:1s" hx-get="...">
+<!-- Basic (click is the default) -->
+<button hx-get="...">
 
-<!-- Lazy load on scroll -->
-<div hx-trigger="revealed" hx-get="...">Loading...</div>
+<!-- With from: modifier — listen on a different element -->
+<button hx-trigger="click from:outside" hx-get="...">
 
-<!-- Poll every 2 seconds -->
-<div hx-trigger="every 2s" hx-get="...">Waiting...</div>
+<!-- With a filter -->
+<button hx-trigger="click[shiftKey]" hx-get="...">
+
+<!-- Multiple triggers -->
+<button hx-trigger="click, keyup[key=='Enter']" hx-get="...">
 ```
-
-A trigger value can be:
-
-* A [standard event](#standard-events): `click`, `input`, `keyup`
-* A [synthetic event](#synthetic-events): `load`, `revealed`, `intersect`
-* A [polling](#polling) expression: `every 1s`
-* [Multiple triggers](#multiple-triggers) (comma-separated)
-
-Events can be refined with [filters](#event-filters) and [modifiers](#event-modifiers) (e.g. `input changed delay:1s`).
-
-## Defaults
-
-When `hx-trigger` is omitted, htmx uses a sensible default based on the element:
-
-| Element | Default trigger |
-|---|---|
-| `<input>`, `<textarea>`, `<select>` | `change` |
-| `<form>` | `submit` |
-| Everything else | `click` |
 
 ## Standard Events
 
-`hx-trigger` accepts any [DOM event](https://developer.mozilla.org/en-US/docs/Web/API/Element#events): [`click`](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event), [`input`](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event), [`keyup`](https://developer.mozilla.org/en-US/docs/Web/API/Element/keyup_event), [`submit`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit_event), etc.
+`hx-trigger` accepts any DOM event: `click`, `input`, `keyup`, `submit`, etc.
 
 ```html
-<button hx-trigger="click" hx-post="...">Submit</button>
+<button hx-trigger="click" hx-post="...">
 <input hx-trigger="input" hx-get="...">
 <form hx-trigger="submit" hx-post="...">
 <div hx-trigger="mouseenter" hx-get="...">
 ```
 
-[Custom events](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent) work too. You can trigger them from JavaScript or from the server via the [`HX-Trigger`](/reference/headers/HX-Trigger) response header.
+## Custom Events
+
+Custom events work too. Dispatch them from JavaScript with [`htmx.trigger()`](/reference/methods/htmx-trigger), or from the server via the [`HX-Trigger`](/reference/headers/HX-Trigger) response header.
+
+Events from `HX-Trigger` are dispatched on the `body`, so use [`from:body`](#from) to listen for them:
 
 ```html
-<div hx-trigger="my-custom-event" hx-get="...">...</div>
+<div hx-trigger="productsUpdated from:body" hx-get="...">...</div>
+```
+
+## Synthetic Events
+
+htmx provides synthetic events beyond standard DOM events:
+
+### `load`
+
+Fires when the element is loaded into the DOM. Useful for [lazy-loading](/patterns/loading/lazy-load) content.
+
+```html
+<div hx-trigger="load" hx-get="...">Loading...</div>
+```
+
+### `revealed`
+
+Fires when the element is scrolled into the viewport. Useful for [infinite scroll](/patterns/loading/infinite-scroll).
+
+```html
+<div hx-trigger="revealed" hx-get="...">Loading...</div>
+```
+
+_Note: `revealed` always observes the browser viewport. For scrollable containers with `overflow`, use [`intersect`](#intersect) with `root` instead._
+
+### `intersect`
+
+Fires when an element becomes visible in the viewport. 
+
+Uses the [IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver#options) and supports [`root`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/root) and [`threshold`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/thresholds) as modifiers.
+
+```html
+<div hx-trigger="intersect once" hx-get="...">...</div>
+<div hx-trigger="intersect root:#scroll-container" hx-get="...">...</div>
+<div hx-trigger="intersect threshold:0.5" hx-get="...">...</div>
+```
+
+### `every <time>`
+
+Fires repeatedly on an interval.
+
+```html
+<div hx-trigger="every 1s" hx-get="/updates">...</div>
+```
+
+To add a filter to polling, add it after the interval:
+
+```html
+<div hx-trigger="every 1s [someConditional]" hx-get="/updates">...</div>
 ```
 
 ## Event Modifiers
 
 ### `[filter]`
 
-Only fires when the `[expression]` after the event name is `true`.
+A JavaScript expression in brackets after the event name. Only fires when it evaluates to `true`.
 
 ```html
 <input hx-trigger="keyup[key == 'Enter']" hx-get="/search">
@@ -92,7 +132,7 @@ Only fires if the element's `value` changed since last time.
 
 Note: [`change`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event) is a DOM event. `changed` is an htmx modifier. Different things.
 
-### `delay`
+### `delay:<time>`
 
 Waits before firing. If the event fires again, the delay resets (debounce).
 
@@ -100,7 +140,7 @@ Waits before firing. If the event fires again, the delay resets (debounce).
 <input hx-trigger="input delay:1s" hx-get="...">
 ```
 
-### `throttle`
+### `throttle:<time>`
 
 Fires, then ignores further events for the given interval.
 
@@ -108,17 +148,19 @@ Fires, then ignores further events for the given interval.
 <div hx-trigger="scroll throttle:500ms" hx-get="...">...</div>
 ```
 
-### `from`
+### `from:<selector>`
 
-Listens on a different element. Takes a CSS selector or an [extended selector](/docs/features/extended-selectors).
+Listens on a different element. Takes a CSS selector or an [extended selector](/docs/features/extended-selectors). Two special values: `self` (only the element itself, not children) and `outside` (anything outside the element).
 
 ```html
 <div hx-trigger="keyup[key=='Enter'] from:body" hx-get="...">...</div>
 <div hx-trigger="my-event from:document" hx-get="...">...</div>
 <div hx-trigger="submit from:closest form" hx-get="...">...</div>
+<div hx-trigger="click from:self" hx-get="...">...</div>
+<div hx-trigger="click from:outside" hx-get="...">...</div>
 ```
 
-### `target`
+### `target:<selector>`
 
 Only fires if `event.target` matches the given CSS selector.
 
@@ -126,28 +168,53 @@ Only fires if `event.target` matches the given CSS selector.
 <div hx-trigger="click target:.child-button" hx-get="...">...</div>
 ```
 
+### `prevent`
+
+Calls `event.preventDefault()`.
+
+```html
+<form hx-trigger="submit prevent" hx-post="...">...</form>
+```
+
+### `stop`
+
+Calls `event.stopPropagation()`. The event still reaches other listeners on the same element.
+
+```html
+<button hx-trigger="click stop" hx-get="...">...</button>
+```
+
+### `halt`
+
+Shorthand for `prevent stop`.
+
+```html
+<a hx-trigger="click halt" hx-get="...">...</a>
+```
+
 ### `consume`
 
-Calls `event.stopPropagation()` *and* stops other listeners on the same element.
+Calls `event.stopPropagation()` *and* stops other listeners on the same element. Stricter than `stop`.
 
 ```html
 <button hx-trigger="click consume" hx-get="...">...</button>
 ```
 
-### `queue`
+### `capture`
 
-Queues events while a request is already in flight.
+Listens during the capture phase (top-down) instead of the bubble phase (bottom-up).
 
 ```html
-<div hx-trigger="click queue:all" hx-get="...">...</div>
+<div hx-trigger="click capture" hx-get="...">...</div>
 ```
 
-Options:
+### `passive`
 
-* `first` - queue the first event
-* `last` - queue the last event (default)
-* `all` - queue all events (issue a request for each)
-* `none` - do not queue new events
+Tells the browser the handler won't call `preventDefault()`, so the browser can scroll without waiting for your code to finish.
+
+```html
+<div hx-trigger="scroll passive" hx-get="...">...</div>
+```
 
 ### Example
 
@@ -160,106 +227,15 @@ A search box that searches on `input`, but only if the value has [`changed`](#ch
        hx-target="#search-results"/>
 ```
 
-## Synthetic Events
-
-htmx provides some synthetic events beyond the standard web API events:
-
-### `load`
-
-Fires when the element is loaded into the DOM. Useful for [lazy-loading](/patterns/loading/lazy-load) content.
-
-```html
-<div hx-trigger="load" hx-get="...">Loading...</div>
-```
-
-### `revealed`
-
-Fires when the element is scrolled into the viewport. Also useful for lazy-loading.
-
-```html
-<div hx-trigger="revealed" hx-get="...">Loading...</div>
-```
-
-If you are using `overflow` in CSS (e.g. `overflow-y: scroll`), use [`intersect`](#intersect) [`once`](#once) instead.
-
-### `intersect`
-
-Fires once when an element first intersects the viewport.
-
-```html
-<tr hx-trigger="intersect once"
-    hx-get="..."
-    hx-swap="outerHTML">
-  <td>Loading more...</td>
-</tr>
-```
-
-#### `root`
-
-A CSS selector of the root element for intersection.
-
-```html
-<div hx-trigger="intersect root:#scroll-container" hx-get="...">...</div>
-```
-
-#### `threshold`
-
-A float between 0.0 and 1.0 indicating what amount of intersection to fire the event on.
-
-```html
-<div hx-trigger="intersect threshold:0.5" hx-get="...">...</div>
-```
-
-## HX-Trigger Header
-
-To fire an event from the `HX-Trigger` response header, you will likely want to use the [`from:body`](#from) modifier. For example, if you send `HX-Trigger: my-custom-event` with a response:
-
-```html
-<div hx-trigger="my-custom-event from:body" hx-get="...">
-  Triggered by HX-Trigger header...
-</div>
-```
-
-This is because the header triggers the event in a different DOM hierarchy than the element you want to trigger. For a similar reason, you will often listen for hot keys [`from`](#from) the body.
-
-## Polling
-
-Using `every <timing declaration>` you can have an element poll periodically:
-
-```html
-<div hx-trigger="every 1s" hx-get="/updates">
-  Nothing Yet!
-</div>
-```
-
-To add a filter to polling, add it after the poll declaration:
-
-```html
-<div hx-trigger="every 1s [someConditional]" hx-get="/updates">
-  Nothing Yet!
-</div>
-```
-
-## Multiple Triggers
-
-Multiple triggers can be provided, separated by commas. Each trigger gets its own options.
-
-```html
-<div hx-trigger="load, click delay:1s" hx-get="/news"></div>
-```
-
-This loads `/news` immediately on page load, and then again with a 1 second delay after each click.
-
-## Via JavaScript
-
-The AJAX request can be triggered via JavaScript using [`htmx.trigger()`](/reference/methods/htmx-trigger).
-
 ## Notes
 
-* `hx-trigger` can be used without an AJAX request, in which case it will only fire the `htmx:trigger` event.
-* To pass a CSS selector that contains whitespace (e.g. `form input`) to the [`from`](#from) or [`target`](#target) modifier, surround the selector in parentheses or curly brackets (e.g. `from:(form input)` or `from:closest (form input)`).
-* A `reset` event in `hx-trigger` (e.g. `hx-trigger="change, reset"`) might not work as intended, since htmx builds its values and sends a request before the browser resets the form. As a workaround, add a delay: `hx-trigger="change, reset delay:0.01s"`.
+* Selectors with whitespace in [`from`](#from) or [`target`](#target) need parentheses: `from:(form input)`.
+* `hx-trigger="change, reset"` may fire before the browser resets the form. As a workaround, add a short delay: `hx-trigger="change, reset delay:0.01s"`.
 
 ## See Also
 
-- [`hx-on`](/reference/attributes/hx-on) — run inline JavaScript when an event fires, using the same event modifiers, filters, and synthetic events
+- [`hx-on`](/reference/attributes/hx-on) (attribute)
+- [Extended Selectors](/docs/features/extended-selectors) (reference)
+- [Lazy Load](/patterns/loading/lazy-load) (pattern)
+- [Infinite Scroll](/patterns/loading/infinite-scroll) (pattern)
+- [Progress Bar](/patterns/loading/progress-bar) (pattern)

--- a/www/src/content/reference/01-attributes/10-hx-on.md
+++ b/www/src/content/reference/01-attributes/10-hx-on.md
@@ -21,33 +21,33 @@ One event, one expression:
 
 **Extended form**
 
-Builds on [`hx-trigger`](/reference/attributes/hx-trigger)'s grammar, adding `=>` to wire events to JavaScript:
+Builds on [`hx-trigger`](/reference/attributes/hx-trigger)'s grammar, adding `->` to wire events to JavaScript:
 
 ```html
-<!-- hx-on="<event>[<filter>] <modifiers> [, ...] => <js> | { <js>; ... } [; ...]" -->
+<!-- hx-on="<event>[<filter>] <modifiers> [, ...] -> <js> | { <js>; ... } [; ...]" -->
 
 <!-- Open dialog on page load / swap -->
-<dialog hx-on="load => this.showModal()">
+<dialog hx-on="load -> this.showModal()">
 
 <!-- Unfocus input on Escape -->
-<input hx-on="keydown[key=='Escape'] => this.blur()">
+<input hx-on="keydown[key=='Escape'] -> this.blur()">
     
 <!-- Close dialog on custom event (e.g. HX-Trigger: closeDialog) -->
-<dialog hx-on="closeDialog from:body => this.close()">
+<dialog hx-on="closeDialog from:body -> this.close()">
     
 <!-- Close on backdrop click OR custom event -->
-<dialog hx-on="click from:self, closeDialog from:body => this.close()">
+<dialog hx-on="click from:self, closeDialog from:body -> this.close()">
 
 <!-- Run multiple statements -->
-<dialog hx-on="close => { this.remove(); log('dialog removed') }">
+<dialog hx-on="close -> { this.remove(); log('dialog removed') }">
         
 <!-- Different code for different events -->
-<dialog hx-on="load => this.showModal();
-               click from:self, closeDialog from:body => this.close();
-               close => { this.remove(); log('removed') }">
+<dialog hx-on="load -> this.showModal();
+               click from:self, closeDialog from:body -> this.close();
+               close -> { this.remove(); log('removed') }">
 ```
 
-- `=>` event(s) on the left, JavaScript code on the right
+- `->` event(s) on the left, JavaScript code on the right
 - `,` multiple events, same code
 - `;` separate event -> code pairs
 - `{ }` multi-statement JavaScript
@@ -70,14 +70,14 @@ Custom events work too. Dispatch them from JavaScript with [`htmx.trigger()`](/r
 Events from `HX-Trigger` are dispatched on the `body`, so use [`from:body`](#from) to listen for them:
 
 ```html
-<div hx-on="productsUpdated from:body => log('Products updated!')">
+<div hx-on="productsUpdated from:body -> log('Products updated!')">
 ```
 
 ## Synthetic Events
 
 htmx provides synthetic events beyond standard DOM events.
 
-These work with both the simple form (`hx-on:load`) and the extended form (`hx-on="load => ..."`).
+These work with both the simple form (`hx-on:load`) and the extended form (`hx-on="load -> ..."`).
 
 ### `load`
 
@@ -104,7 +104,7 @@ Fires when an element becomes visible in the viewport.
 Uses the [IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver#options) and supports [`root`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/root) and [`threshold`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/thresholds) as modifiers.
 
 ```html
-<div hx-on="intersect once => this.classList.add('in-view')">
+<div hx-on="intersect once -> this.classList.add('in-view')">
 ```
 
 ### `every <time>`
@@ -112,7 +112,7 @@ Uses the [IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web
 Fires repeatedly on an interval. Only available in the extended form.
 
 ```html
-<div hx-on="every 1s => this.textContent = new Date().toLocaleTimeString()">
+<div hx-on="every 1s -> this.textContent = new Date().toLocaleTimeString()">
 ```
 
 ## Event Modifiers
@@ -122,7 +122,7 @@ Fires repeatedly on an interval. Only available in the extended form.
 A JavaScript expression in brackets after the event name. Only fires when it evaluates to `true`.
 
 ```html
-<button hx-on="click[ctrlKey] => navigator.clipboard.writeText(this.textContent)">
+<button hx-on="click[ctrlKey] -> navigator.clipboard.writeText(this.textContent)">
 ```
 
 Inside the brackets, all properties of the event are available as bare names:
@@ -137,7 +137,7 @@ Global functions work too: `click[hasUnsavedChanges()]`.
 Fires once, then stops listening.
 
 ```html
-<button hx-on="click once => this.textContent = 'Done!'">Click me</button>
+<button hx-on="click once -> this.textContent = 'Done!'">Click me</button>
 ```
 
 ### `changed`
@@ -145,7 +145,7 @@ Fires once, then stops listening.
 Only fires if the element's `value` changed since last time.
 
 ```html
-<input hx-on="input changed => console.log(this.value)">
+<input hx-on="input changed -> console.log(this.value)">
 ```
 
 Note: [`change`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event) is a DOM event. `changed` is an htmx modifier. Different things.
@@ -155,7 +155,7 @@ Note: [`change`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/ch
 Waits before firing. If the event fires again, the delay resets (debounce).
 
 ```html
-<input hx-on="input delay:500ms => console.log(this.value)">
+<input hx-on="input delay:500ms -> console.log(this.value)">
 ```
 
 ### `throttle:<time>`
@@ -163,7 +163,7 @@ Waits before firing. If the event fires again, the delay resets (debounce).
 Fires, then ignores further events for the given interval.
 
 ```html
-<div hx-on="scroll throttle:100ms => this.dataset.scrollY = window.scrollY"></div>
+<div hx-on="scroll throttle:100ms -> this.dataset.scrollY = window.scrollY"></div>
 ```
 
 ### `from:<selector>`
@@ -171,8 +171,8 @@ Fires, then ignores further events for the given interval.
 Listens on a different element. Takes a CSS selector or an [extended selector](/docs/features/extended-selectors). Two special values: `self` (only the element itself, not children) and `outside` (anything outside the element).
 
 ```html
-<div hx-on="keydown[key=='Escape'] from:body => this.hidden = true">
-<div hx-on="click from:outside => this.hidden = true">
+<div hx-on="keydown[key=='Escape'] from:body -> this.hidden = true">
+<div hx-on="click from:outside -> this.hidden = true">
 ```
 
 ### `target:<selector>`
@@ -180,7 +180,7 @@ Listens on a different element. Takes a CSS selector or an [extended selector](/
 Only fires if `event.target` matches the given CSS selector.
 
 ```html
-<ul hx-on="click target:li => event.target.classList.toggle('selected')"></ul>
+<ul hx-on="click target:li -> event.target.classList.toggle('selected')"></ul>
 ```
 
 ### `prevent`
@@ -188,7 +188,7 @@ Only fires if `event.target` matches the given CSS selector.
 Calls `event.preventDefault()`.
 
 ```html
-<form hx-on="submit prevent => console.log(new FormData(this))"></form>
+<form hx-on="submit prevent -> console.log(new FormData(this))"></form>
 ```
 
 ### `stop`
@@ -196,7 +196,7 @@ Calls `event.preventDefault()`.
 Calls `event.stopPropagation()`. The event still reaches other listeners on the same element.
 
 ```html
-<button hx-on="click stop => this.textContent = 'clicked'"></button>
+<button hx-on="click stop -> this.textContent = 'clicked'"></button>
 ```
 
 ### `halt`
@@ -204,7 +204,7 @@ Calls `event.stopPropagation()`. The event still reaches other listeners on the 
 Shorthand for `prevent stop`.
 
 ```html
-<a hx-on="click halt => console.log(this.href)"></a>
+<a hx-on="click halt -> console.log(this.href)"></a>
 ```
 
 ### `consume`
@@ -212,7 +212,7 @@ Shorthand for `prevent stop`.
 Calls `event.stopPropagation()` *and* stops other listeners on the same element. Stricter than `stop`.
 
 ```html
-<button hx-on="click consume => this.textContent = 'consumed'"></button>
+<button hx-on="click consume -> this.textContent = 'consumed'"></button>
 ```
 
 ### `capture`
@@ -220,7 +220,7 @@ Calls `event.stopPropagation()` *and* stops other listeners on the same element.
 Listens during the capture phase (top-down) instead of the bubble phase (bottom-up).
 
 ```html
-<div hx-on="click capture => console.log('capture:', event.target.tagName)"></div>
+<div hx-on="click capture -> console.log('capture:', event.target.tagName)"></div>
 ```
 
 ### `passive`
@@ -228,7 +228,7 @@ Listens during the capture phase (top-down) instead of the bubble phase (bottom-
 Tells the browser the handler won't call `preventDefault()`, so the browser can scroll without waiting for your code to finish.
 
 ```html
-<div hx-on="scroll passive => this.dataset.scrollY = window.scrollY"></div>
+<div hx-on="scroll passive -> this.dataset.scrollY = window.scrollY"></div>
 ```
 
 ## Symbols
@@ -251,7 +251,7 @@ Any properties on `event.detail` are unpacked into scope, so you can write `mess
 
 ```html
 <!-- dispatched with detail: { message: 'hello' } -->
-<div hx-on="my-event => alert(message)">
+<div hx-on="my-event -> alert(message)">
 <!-- equivalent to: alert(event.detail.message) -->
 </div>
 ```
@@ -271,7 +271,7 @@ In the simple form (`hx-on:<event>`), `hx-on::` is shorthand for `hx-on:htmx:`
 * Works with any event, including [htmx events](/reference#events).
 * `hx-on` is _not_ inherited, but events on children still [bubble up](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#event_bubbling_and_capture) and trigger it.
 * Both forms (`hx-on:event` and `hx-on="..."`) can coexist on the same element.
-* Browsers lowercase attribute names, so `hx-on:myEvent` won't match a `myEvent` dispatch. Use the extended form: `hx-on="myEvent => ..."`.
+* Browsers lowercase attribute names, so `hx-on:myEvent` won't match a `myEvent` dispatch. Use the extended form: `hx-on="myEvent -> ..."`.
 
 ## See Also
 

--- a/www/src/content/reference/01-attributes/10-hx-on.md
+++ b/www/src/content/reference/01-attributes/10-hx-on.md
@@ -3,89 +3,279 @@ title: "hx-on"
 description: "Run inline JavaScript when an event fires"
 ---
 
-The `hx-on*` attributes allow you to embed scripts inline to respond to events directly on an element; similar to the
-[`onevent` properties](https://developer.mozilla.org/en-US/docs/Web/Events/Event_handlers#using_onevent_properties)
-found in HTML, such as `onClick`.
+The `hx-on` attribute wires inline JavaScript to run when an event fires. 
 
-The `hx-on*` attributes improve upon `onevent` by enabling the handling of any arbitrary JavaScript event,
-for enhanced [Locality of Behaviour (LoB)](/essays/locality-of-behaviour) even when dealing with non-standard DOM
-events. For example, these
-attributes allow you to handle [htmx events](/reference#events).
+It is an enhanced version of [`onevent` properties](https://developer.mozilla.org/en-US/docs/Web/Events/Event_handlers#using_onevent_properties) that keeps behavior in the markup ([Locality of Behaviour](/essays/locality-of-behaviour)).
 
 ## Syntax
 
-```html
-<div hx-on:click="alert('Clicked!')">Click</div>
-```
+**Simple form**
 
-With `hx-on` attributes, you specify the event name as part of the attribute name, after a colon. So, for example, if
-you want to respond to a `click` event, you would use the attribute `hx-on:click`:
+One event, one expression:
 
 ```html
+<!-- hx-on:<event>=<js> -->
 
-<div hx-on:click="alert('Clicked!')">Click</div>
+<dialog hx-on:load="this.showModal()">
 ```
 
-Note that this syntax can be used to capture all htmx events, as well as most other custom events, in addition to the
-standard DOM events.
+**Extended form**
 
-One gotcha to note is that DOM attributes do not preserve case. This means, unfortunately, an attribute like
-`hx-on:htmx:beforeRequest` **will not work**, because the DOM lowercases the attribute names. Fortunately, htmx supports
-both camel case event names and also [kebab-case event names](/reference/events), so you can use
-`hx-on:htmx:before:request` instead.
-
-In order to make writing htmx-based event handlers a little easier, you can use the shorthand double-colon `hx-on::` for
-htmx
-events, and omit the "htmx" part:
+Builds on [`hx-trigger`](/reference/attributes/hx-trigger)'s grammar, adding `=>` to wire events to JavaScript:
 
 ```html
-<!-- These two are equivalent -->
-<button hx-get="/info" hx-on:htmx:before:request="alert('Making a request!')">
-    Get Info!
-</button>
+<!-- hx-on="<event>[<filter>] <modifiers> [, ...] => <js> | { <js>; ... } [; ...]" -->
 
-<button hx-get="/info" hx-on::before:request="alert('Making a request!')">
-    Get Info!
-</button>
+<!-- Open dialog on page load / swap -->
+<dialog hx-on="load => this.showModal()">
 
+<!-- Unfocus input on Escape -->
+<input hx-on="keydown[key=='Escape'] => this.blur()">
+    
+<!-- Close dialog on custom event (e.g. HX-Trigger: closeDialog) -->
+<dialog hx-on="closeDialog from:body => this.close()">
+    
+<!-- Close on backdrop click OR custom event -->
+<dialog hx-on="click from:self, closeDialog from:body => this.close()">
+
+<!-- Run multiple statements -->
+<dialog hx-on="close => { this.remove(); log('dialog removed') }">
+        
+<!-- Different code for different events -->
+<dialog hx-on="load => this.showModal();
+               click from:self, closeDialog from:body => this.close();
+               close => { this.remove(); log('removed') }">
 ```
 
-If you wish to handle multiple different events, you can simply add multiple attributes to an element:
+- `=>` event(s) on the left, JavaScript code on the right
+- `,` multiple events, same code
+- `;` separate event -> code pairs
+- `{ }` multi-statement JavaScript
+
+## Standard Events
+
+`hx-on` works with any DOM event: `click`, `input`, `keyup`, `submit`, etc.
 
 ```html
-
-<button hx-get="/info"
-        hx-on::before:request="alert('Making a request!')"
-        hx-on::after:request="alert('Done making a request!')">
-    Get Info!
-</button>
+<button hx-on:click="...">
+<input hx-on:input="...">
+<form hx-on:submit="...">
+<div hx-on:mouseenter="...">
 ```
 
-Finally, in order to make this feature compatible with some templating languages (
-e.g. [JSX](https://react.dev/learn/writing-markup-with-jsx)) that do not like having a colon (`:`)
-in HTML attributes, you may use dashes in the place of colons for both the long form and the shorthand form:
+## Custom Events
+
+Custom events work too. Dispatch them from JavaScript with [`htmx.trigger()`](/reference/methods/htmx-trigger), or from the server via the [`HX-Trigger`](/reference/headers/HX-Trigger) response header.
+
+Events from `HX-Trigger` are dispatched on the `body`, so use [`from:body`](#from) to listen for them:
 
 ```html
-<!-- These two are equivalent -->
-<button hx-get="/info" hx-on-htmx-before:request="alert('Making a request!')">
-    Get Info!
-</button>
-
-<button hx-get="/info" hx-on--before:request="alert('Making a request!')">
-    Get Info!
-</button>
-
+<div hx-on="productsUpdated from:body => log('Products updated!')">
 ```
 
-### Symbols
+## Synthetic Events
+
+htmx provides synthetic events beyond standard DOM events.
+
+These work with both the simple form (`hx-on:load`) and the extended form (`hx-on="load => ..."`).
+
+### `load`
+
+Fires when the element is loaded into the DOM.
+
+```html
+<div hx-on:load="this.classList.add('loaded')">
+```
+
+### `revealed`
+
+Fires when the element is scrolled into the viewport.
+
+```html
+<div hx-on:revealed="this.classList.add('visible')">
+```
+
+_Note: `revealed` always observes the browser viewport. For scrollable containers with `overflow`, use [`intersect`](#intersect) with `root` instead._
+
+### `intersect`
+
+Fires when an element becomes visible in the viewport.
+
+Uses the [IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver#options) and supports [`root`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/root) and [`threshold`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/thresholds) as modifiers.
+
+```html
+<div hx-on="intersect once => this.classList.add('in-view')">
+```
+
+### `every <time>`
+
+Fires repeatedly on an interval. Only available in the extended form.
+
+```html
+<div hx-on="every 1s => this.textContent = new Date().toLocaleTimeString()">
+```
+
+## Event Modifiers
+
+### `[filter]`
+
+A JavaScript expression in brackets after the event name. Only fires when it evaluates to `true`.
+
+```html
+<button hx-on="click[ctrlKey] => navigator.clipboard.writeText(this.textContent)">
+```
+
+Inside the brackets, all properties of the event are available as bare names:
+
+- [`click`](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent#instance_properties) → `altKey`, `ctrlKey`, `shiftKey`, `metaKey`, ...
+- [`keydown`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#instance_properties) → `key`, `code`, `repeat`, ...
+
+Global functions work too: `click[hasUnsavedChanges()]`.
+
+### `once`
+
+Fires once, then stops listening.
+
+```html
+<button hx-on="click once => this.textContent = 'Done!'">Click me</button>
+```
+
+### `changed`
+
+Only fires if the element's `value` changed since last time.
+
+```html
+<input hx-on="input changed => console.log(this.value)">
+```
+
+Note: [`change`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event) is a DOM event. `changed` is an htmx modifier. Different things.
+
+### `delay:<time>`
+
+Waits before firing. If the event fires again, the delay resets (debounce).
+
+```html
+<input hx-on="input delay:500ms => console.log(this.value)">
+```
+
+### `throttle:<time>`
+
+Fires, then ignores further events for the given interval.
+
+```html
+<div hx-on="scroll throttle:100ms => this.dataset.scrollY = window.scrollY"></div>
+```
+
+### `from:<selector>`
+
+Listens on a different element. Takes a CSS selector or an [extended selector](/docs/features/extended-selectors). Two special values: `self` (only the element itself, not children) and `outside` (anything outside the element).
+
+```html
+<div hx-on="keydown[key=='Escape'] from:body => this.hidden = true">
+<div hx-on="click from:outside => this.hidden = true">
+```
+
+### `target:<selector>`
+
+Only fires if `event.target` matches the given CSS selector.
+
+```html
+<ul hx-on="click target:li => event.target.classList.toggle('selected')"></ul>
+```
+
+### `prevent`
+
+Calls `event.preventDefault()`.
+
+```html
+<form hx-on="submit prevent => console.log(new FormData(this))"></form>
+```
+
+### `stop`
+
+Calls `event.stopPropagation()`. The event still reaches other listeners on the same element.
+
+```html
+<button hx-on="click stop => this.textContent = 'clicked'"></button>
+```
+
+### `halt`
+
+Shorthand for `prevent stop`.
+
+```html
+<a hx-on="click halt => console.log(this.href)"></a>
+```
+
+### `consume`
+
+Calls `event.stopPropagation()` *and* stops other listeners on the same element. Stricter than `stop`.
+
+```html
+<button hx-on="click consume => this.textContent = 'consumed'"></button>
+```
+
+### `capture`
+
+Listens during the capture phase (top-down) instead of the bubble phase (bottom-up).
+
+```html
+<div hx-on="click capture => console.log('capture:', event.target.tagName)"></div>
+```
+
+### `passive`
+
+Tells the browser the handler won't call `preventDefault()`, so the browser can scroll without waiting for your code to finish.
+
+```html
+<div hx-on="scroll passive => this.dataset.scrollY = window.scrollY"></div>
+```
+
+## Symbols
 
 Like `onevent`, two symbols are made available to event handler scripts:
 
-* `this` - The element on which the `hx-on` attribute is defined
-* `event` - The event that triggered the handler
+### `this`
 
-### Notes
+The element the `hx-on` attribute is on.
 
-* `hx-on` is _not_ inherited, however due to
-  [event bubbling](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#event_bubbling_and_capture),
-  `hx-on` attributes on parent elements will typically be triggered by events on child elements
+```html
+<button hx-on:click="this.classList.toggle('active')">Toggle</button>
+```
+
+### `event`
+
+The event that fired.
+
+Any properties on `event.detail` are unpacked into scope, so you can write `message` instead of `event.detail.message`:
+
+```html
+<!-- dispatched with detail: { message: 'hello' } -->
+<div hx-on="my-event => alert(message)">
+<!-- equivalent to: alert(event.detail.message) -->
+</div>
+```
+
+## `::` shorthand
+
+In the simple form (`hx-on:<event>`), `hx-on::` is shorthand for `hx-on:htmx:`
+
+```html
+<!-- These are equivalent -->
+<button hx-on:htmx:after:request="hideSpinner()">
+<button hx-on::after:request="hideSpinner()">
+```
+
+## Notes
+
+* Works with any event, including [htmx events](/reference#events).
+* `hx-on` is _not_ inherited, but events on children still [bubble up](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#event_bubbling_and_capture) and trigger it.
+* Both forms (`hx-on:event` and `hx-on="..."`) can coexist on the same element.
+* Browsers lowercase attribute names, so `hx-on:myEvent` won't match a `myEvent` dispatch. Use the extended form: `hx-on="myEvent => ..."`.
+
+## See Also
+
+- [`hx-trigger`](/reference/attributes/hx-trigger) (attribute)
+- [Client Scripting](/docs/core-concepts/client-scripting) (guide)
+- [Extended Selectors](/docs/features/extended-selectors) (reference)
+- [Locality of Behaviour](/essays/locality-of-behaviour) (essay)


### PR DESCRIPTION
- enable `hx-on="eventSpec => code"` syntax that supports all existing `hx-trigger` modifiers (e.g. `[filter]`, `once`, `delay`, `changed`, `from`, etc.).

- add new modifiers to both hx-on and hx-trigger: `prevent`, `stop`, `halt`, `capture`, `passive`, `from:self`, `from:outside`
- remove undocumented dot modifiers (.prevent, .stop, .halt, .once, .self, .outside, .capture, .passive, .cc) from hx-on:event syntax
- rename `__onTrigger` -> `__onEvent`
- rename `__parseTriggerSpecs` -> `__parseEventSpecs`
- remove `hx-trigger` queue modifier from docs (no-op in 4.0)
- update tests, docs, and extension references
