### PR TITLE
handle ws early load events by waiting for connection to open

### DIFF
--- a/src/ext/hx-ws.js
+++ b/src/ext/hx-ws.js
@@ -340,6 +340,16 @@
 
         let normalizedUrl = normalizeWebSocketUrl(url);
         let connection = connections.get(normalizedUrl);
+
+        // Wait for socket to open if still connecting
+        if (connection && connection.socket && connection.socket.readyState === WebSocket.CONNECTING) {
+            await new Promise(resolve => {
+                connection.socket.addEventListener('open', resolve, { once: true });
+                connection.socket.addEventListener('close', resolve, { once: true });
+                connection.socket.addEventListener('error', resolve, { once: true });
+            });
+        }
+
         if (!connection || !connection.socket || connection.socket.readyState !== WebSocket.OPEN) {
             api.triggerHtmxEvent(element, 'htmx:ws:error', { url: normalizedUrl, error: 'Connection not open' });
             return;

--- a/test/tests/ext/hx-ws.js
+++ b/test/tests/ext/hx-ws.js
@@ -281,6 +281,20 @@ describe('hx-ws WebSocket extension', function() {
     
     describe('Message Sending', function() {
         
+        it('sends message on load trigger (waits for socket open)', async function() {
+            let div = createProcessedHTML(`
+                <div hx-ws:connect="/ws/test">
+                    <div id="load-sender" hx-ws:send hx-trigger="load" hx-vals='{"test": "load"}'></div>
+                </div>
+            `);
+            await htmx.timeout(50);
+
+            let ws = mockWebSocketInstances[0];
+            assert.isDefined(ws.lastSent, 'Should have sent a message on load');
+            let sent = JSON.parse(ws.lastSent);
+            assert.equal(sent.body.test, 'load');
+        });
+
         it('sends message with hx-ws:send on form submit', async function() {
             let div = createProcessedHTML(`
                 <div hx-ws:connect="/ws/chat">


### PR DESCRIPTION
## Description
load event triggers in websocket extension don't work if the connection has not yet been established.  So add code to detect if the connection is in progress and await it first.

Corresponding issue:

## Testing
Added test case for load trigger to ws tests

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
