### PR TITLE
Fix: outerSync does not re-process correct body on browser history restore

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1355,6 +1355,7 @@ var htmx = (() => {
                         this.__cleanup(child)
                     }
                     target.replaceChildren(...fragment.firstElementChild.childNodes);
+                    newContent = [...target.childNodes];
                 } else if (swapStyle === 'innerMorph') {
                     this.__morph(target, fragment, true);
                     newContent = [...target.childNodes];

--- a/test/tests/end2end/basic-history.js
+++ b/test/tests/end2end/basic-history.js
@@ -272,6 +272,50 @@ describe('full-page response strip auto-upgrade', function() {
     });
 });
 
+describe('outerSync processes inserted nodes correctly', function() {
+
+    beforeEach(() => { setupTest(this.currentTest); });
+    afterEach(() => { cleanupTest(); });
+
+    it('processes hx-trigger="load" elements after outerSync swap (issue #3807)', async function() {
+        // Simulate the history restore scenario: outerSync into a target with a full-page response
+        // containing an element with hx-trigger="load". The load trigger must fire on the
+        // live DOM node, not on the detached <body> fragment.
+        mockResponse('GET', '/load-target', 'loaded by hx-trigger="load"');
+
+        let target = createProcessedHTML('<div id="sync-target"><p>old content</p></div>');
+
+        await htmx.swap({
+            target: '#sync-target',
+            swap: 'outerSync',
+            text: '<html><body><div id="sync-target"><span id="load-elt" hx-get="/load-target" hx-trigger="load" hx-swap="innerHTML">loading...</span></div></body></html>',
+            sourceElement: target
+        });
+
+        // The load trigger should have fired and issued a request
+        await forRequest();
+
+        let elt = document.getElementById('load-elt');
+        elt.should.not.equal(null);
+        elt.textContent.should.equal('loaded by hx-trigger="load"');
+    });
+
+    it('initializes htmx attributes on nodes inserted via outerSync', async function() {
+        let target = createProcessedHTML('<div id="sync-target"><p>old</p></div>');
+
+        await htmx.swap({
+            target: '#sync-target',
+            swap: 'outerSync',
+            text: '<html><body><div id="sync-target"><button id="btn" hx-get="/test" hx-swap="innerHTML">click</button></div></body></html>',
+            sourceElement: target
+        });
+
+        let btn = document.getElementById('btn');
+        btn.should.not.equal(null);
+        assert.isNotNull(btn._htmx, 'button should be initialized by htmx');
+    });
+});
+
 describe('hx-history-elt scopes history restore', function() {
 
     beforeEach(() => { setupTest(this.currentTest); });


### PR DESCRIPTION
## Description
In __insertContent, the outerSync branch captures newContent from fragment.childNodes before the swap occurs. After target.replaceChildren() moves the body's children into the live DOM, the subsequent this.process(elt) loop iterates over the now-detached empty <body> element instead of the actual inserted nodes. This means hx-trigger="load" elements (and any other htmx attributes) are never initialized after a history restore.

The fix adds newContent = [...target.childNodes] after the replaceChildren call so that processing runs against the live DOM nodes. This is the same solutuion we use for innerMorph style. 

Corresponding issue:
#3807 

## Testing
 A regression test confirms the load trigger fires correctly after an outerSync swap.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
