### PR TITLE
improve hx-csp nonce gating on all internal eval calls to cover extension use

### DIFF
--- a/src/ext/hx-csp.js
+++ b/src/ext/hx-csp.js
@@ -9,7 +9,8 @@
 //    nonces to prevent HTML injection attacks. Every htmx element
 //    must carry an hx-nonce attribute matching the page nonce or
 //    its htmx attributes are stripped. Fail closed if no page
-//    nonce is found.
+//    nonce is found. Also re-checks nonce presence before internal eval
+//    to also cover extension eval use like hx-live.
 //    Nonce source: script[nonce].nonce property on page load.
 //
 // 2. Trusted Types — creates an 'htmx' TT policy (passthrough —
@@ -118,23 +119,23 @@
                 return;
             }
 
-            let syncFn, asyncFn;
-            if (htmx.config.safeEval) {
-                // Replaces htmx's new Function() eval with nonce-based script injection,
-                // enabling hx-on:/hx-vals js:/hx-confirm js: without unsafe-eval in CSP.
-                let counter = 0;
-                function makeNoncedConstructor(isAsync) {
-                    return function(...keys) {
-                        let body = keys.pop();
-                        return {
-                            call: (thisArg, ...values) => {
-                                if (getNonce(thisArg) !== pageNonce) {
-                                    let tag = thisArg?.tagName?.toLowerCase();
-                                    let id = thisArg?.id ? `#${thisArg.id}` : '';
-                                    console.error(`htmx: [hx-csp] blocked eval on <${tag}${id}> — nonce mismatch`, { elt: thisArg });
-                                    htmx.trigger(thisArg, 'htmx:security:violation', { reason: 'nonce-mismatch-at-eval' });
-                                    return;
-                                }
+            let counter = 0;
+            let NativeFunction = Function;
+            let NativeAsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
+
+            function makeGatedConstructor(isAsync) {
+                return function(...keys) {
+                    let body = keys.pop();
+                    return {
+                        call: (thisArg, ...values) => {
+                            if (getNonce(thisArg) !== pageNonce) {
+                                let tag = thisArg?.tagName?.toLowerCase();
+                                let id = thisArg?.id ? `#${thisArg.id}` : '';
+                                console.error(`htmx: [hx-csp] blocked eval on <${tag}${id}> — nonce mismatch`, { elt: thisArg });
+                                htmx.trigger(thisArg, 'htmx:security:violation', { reason: 'nonce-mismatch-at-eval' });
+                                return;
+                            }
+                            if (htmx.config.safeEval) {
                                 let fn = `__htmx_eval_${++counter}`;
                                 let script = document.createElement('script');
                                 script.nonce = pageNonce;
@@ -145,14 +146,14 @@
                                 delete window[fn];
                                 return r;
                             }
-                        };
+                            let Ctor = isAsync ? NativeAsyncFunction : NativeFunction;
+                            return new Ctor(...keys, body).call(thisArg, ...values);
+                        }
                     };
-                }
-                syncFn = makeNoncedConstructor(false);
-                asyncFn = makeNoncedConstructor(true);
+                };
             }
 
-            api.initSecurity(ttPolicy, syncFn, asyncFn);
+            api.initSecurity(ttPolicy, makeGatedConstructor(false), makeGatedConstructor(true));
         },
 
         htmx_before_init: checkNonce,

--- a/test/tests/ext/hx-live.js
+++ b/test/tests/ext/hx-live.js
@@ -342,7 +342,7 @@ describe('hx-live extension', function () {
         } finally {
             console.warn = originalWarn;
         }
-        // add delay to allow runnaway protection to reset before other tests run
+        // add delay to allow runaway protection to reset before other tests run
         await htmx.timeout(1000);
     });
 


### PR DESCRIPTION
## Description
Add additional eval time protection to check hx-nonce is valid to also cover extension use of api.executeJavaScript.
We strip hx- attributes on missing/invalid nonces on htmx active element and during safe-eval replacement of internal eval we already re-check the hx-nonce attribute is in place at eval time as a defense in depth.  But we can also cover the non safe-eval use cases as well.

Corresponding issue:

## Testing
Re-ran manual hx-csp tests

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
