### PR TITLE
Fix hx-live take to default to sibling scope

### DIFF
--- a/src/ext/hx-live.js
+++ b/src/ext/hx-live.js
@@ -237,12 +237,12 @@
         let isClass = name.startsWith('.');
         let key = isClass ? name.slice(1) : name;
         let isAria = name.startsWith('aria-');
-        // Default scope picks only matching sources, not the whole page.
-        let selector = scope == null
-            ? (isClass ? '.' + key : '[' + name + ']')
-            : typeof scope === 'string' ? scope
-            : scope.from || '*';
-        let sources = document.querySelectorAll(selector);
+        let auto = isClass ? '.' + key : '[' + name + ']';
+        let root = scope == null ? targets[0]?.parentElement
+            : scope.nodeType ? scope : null;
+        let sources = root
+            ? [root, ...root.querySelectorAll(auto)]
+            : document.querySelectorAll(typeof scope === 'string' ? scope : scope?.from || auto);
         let targetSet = new Set(targets);
         for (let s of sources) {
             if (targetSet.has(s)) continue;

--- a/test/tests/ext/hx-live.js
+++ b/test/tests/ext/hx-live.js
@@ -508,15 +508,99 @@ describe('hx-live extension', function () {
         tabs[2].classList.contains('selected').should.equal(true);
     });
 
-    it('take() with default whole-page scope', function() {
+    it('take() with no scope defaults to parent (sibling scope)', function() {
         playground().innerHTML = `
-            <button class="active">a</button>
-            <button id="t" class="">b</button>
-            <button class="active">c</button>
+            <nav>
+                <button class="active">a</button>
+                <button id="t">b</button>
+                <button class="active">c</button>
+            </nav>
+            <div class="active">unrelated</div>
         `;
         htmx.live.q('#t').take('.active');
-        playground().querySelectorAll('.active').length.should.equal(1);
+        // Siblings lose .active
+        let nav = playground().querySelector('nav');
+        nav.querySelectorAll('.active').length.should.equal(1);
         playground().querySelector('#t').classList.contains('active').should.equal(true);
+        // Unrelated element outside parent is untouched
+        playground().querySelector('div').classList.contains('active').should.equal(true);
+    });
+
+    it('take() with element scope searches within that container', function() {
+        playground().innerHTML = `
+            <nav id="nav1">
+                <button class="active">a</button>
+                <button id="t">b</button>
+            </nav>
+            <nav id="nav2">
+                <button class="active">x</button>
+                <button>y</button>
+            </nav>
+        `;
+        let nav1 = playground().querySelector('#nav1');
+        htmx.live.q('#t').take('.active', nav1);
+        playground().querySelector('#t').classList.contains('active').should.equal(true);
+        playground().querySelector('#nav1 button').classList.contains('active').should.equal(false);
+        // nav2 is untouched
+        playground().querySelector('#nav2 .active').should.not.be.null;
+    });
+
+    it('take() in hx-on with this as scope (tabs pattern)', function() {
+        playground().innerHTML = `
+            <nav hx-on:click="
+                let btn = event.target.closest('button');
+                if (!btn) return;
+                q(btn).take('.active', this);
+            ">
+                <button class="active">Home</button>
+                <button>About</button>
+                <button id="click-me">Contact</button>
+            </nav>
+            <div class="active">unrelated</div>
+        `;
+        htmx.process(playground());
+        playground().querySelector('#click-me').click();
+        let buttons = playground().querySelectorAll('nav button');
+        buttons[0].classList.contains('active').should.equal(false);
+        buttons[1].classList.contains('active').should.equal(false);
+        buttons[2].classList.contains('active').should.equal(true);
+        // Unrelated element outside nav is untouched
+        playground().querySelector('div').classList.contains('active').should.equal(true);
+    });
+
+    it('take() canonical sibling form in hx-on', function() {
+        playground().innerHTML = `
+            <nav>
+                <button class="active" hx-on:click="take('.active')">A</button>
+                <button hx-on:click="take('.active')">B</button>
+                <button hx-on:click="take('.active')" id="click-me">C</button>
+            </nav>
+            <button class="active">unrelated</button>
+        `;
+        htmx.process(playground());
+        playground().querySelector('#click-me').click();
+        let navBtns = playground().querySelectorAll('nav button');
+        navBtns[0].classList.contains('active').should.equal(false);
+        navBtns[1].classList.contains('active').should.equal(false);
+        navBtns[2].classList.contains('active').should.equal(true);
+        // Unrelated button outside nav is untouched
+        playground().querySelector('nav + button').classList.contains('active').should.equal(true);
+    });
+
+    it('take() with ARIA and no scope defaults to parent', function() {
+        playground().innerHTML = `
+            <div role="tablist">
+                <button role="tab" aria-selected="true">a</button>
+                <button role="tab" aria-selected="false" id="t">b</button>
+            </div>
+            <button aria-selected="true">unrelated</button>
+        `;
+        htmx.live.q('#t').take('aria-selected');
+        let tabs = playground().querySelectorAll('[role=tab]');
+        tabs[0].getAttribute('aria-selected').should.equal('false');
+        tabs[1].getAttribute('aria-selected').should.equal('true');
+        // Unrelated element outside parent is untouched
+        playground().querySelector('div + button').getAttribute('aria-selected').should.equal('true');
     });
 
     it('take() accepts options object { from: selector }', function() {


### PR DESCRIPTION
## Description
Recent improvements to hx-live have changed the default scope behavior of the take helper.  It now defaults to take from the whole page which could be a risky default.  The normal take case is to take a class or selection etc from your siblings in a list so it defaults to searching for the class inside the parentElement and removing the class from here and placing it on the selected element.  So I've reverted to this old behavior which I think makes more sense.   

Corresponding issue:

## Testing
Added tests for the default take from sibling case and removed the default from whole page test.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
