### PR TITLE
update hx-live to use xpath and handle alpine conflict

### DIFF
--- a/src/ext/hx-live.js
+++ b/src/ext/hx-live.js
@@ -455,20 +455,45 @@
         return proxy;
     }
 
-    function processLive(root) {
-        let extName = htmx.config.prefix + 'live';
-        let elts = [...(root.querySelectorAll?.('*') ?? [])];
-        if (root.nodeType === 1) elts.unshift(root);
-        for (let elt of elts) {
-            if (elt.closest('[hx-ignore]')) continue;
-            let prop = api.htmxProp(elt);
+    let liveQuery, bindPrefixes, bodyAttrs;
 
-            // Extended form: bare hx-live="code".
-            if (!prop.liveRegistered && (elt.hasAttribute('hx-live') || elt.hasAttribute(extName))) {
-                let attrName = elt.hasAttribute('hx-live') ? 'hx-live' : extName;
+    function buildLiveQuery() {
+        let mc = htmx.config.metaCharacter || ':';
+        let p = htmx.config.prefix;
+        bindPrefixes = ['hx-live' + mc];
+        if (p) bindPrefixes.push(p + 'live' + mc);
+        let extra = htmx.config.live?.bindPrefix;
+        if (extra === undefined) {
+            if (window.Alpine) {
+                extra = '';
+                console.warn('hx-live: Alpine.js detected — ":" short-form bindings disabled. Set htmx.config.live.bindPrefix to configure.');
+            } else {
+                extra = ':';
+            }
+        }
+        if (extra) bindPrefixes.push(extra);
+        bodyAttrs = ['hx-live'];
+        if (p) bodyAttrs.push(p + 'live');
+        let bind = bindPrefixes.map(bp => `starts-with(name(), "${bp}")`).join(' or ');
+        let body = bodyAttrs.map(n => `@${n}`).join(' or ');
+        liveQuery = new XPathEvaluator().createExpression(`.//*[@*[${bind}] or ${body}]`);
+    }
+
+    function extractBindingName(attrName) {
+        for (let p of bindPrefixes) {
+            if (attrName.startsWith(p) && attrName.length > p.length) return attrName.slice(p.length);
+        }
+    }
+
+    function processElement(elt) {
+        if (elt.closest('[hx-ignore]')) return;
+        let prop = api.htmxProp(elt);
+        if (!prop.liveRegistered) {
+            let bodyAttr = bodyAttrs.find(n => elt.hasAttribute(n));
+            if (bodyAttr) {
                 prop.liveRegistered = true;
                 ensureActive();
-                let code = elt.getAttribute(attrName);
+                let code = elt.getAttribute(bodyAttr)
                 let debounce = getDebounce(elt);
                 let run = async () => {
                     if (!elt.isConnected) {
@@ -484,19 +509,22 @@
                 fns.add(run);
                 run();
             }
-
-            // Simple form: each hx-live:<attr> or :<attr> attribute.
-            for (let a of elt.attributes) {
-                let attrName;
-                if (a.name.startsWith('hx-live:') && a.name.length > 8) attrName = a.name.slice(8);
-                else if (a.name.length > 1 && a.name[0] === ':') attrName = a.name.slice(1);
-                else continue;
-                prop.liveAttrs = prop.liveAttrs || new Set();
-                if (prop.liveAttrs.has(attrName)) continue;
-                prop.liveAttrs.add(attrName);
-                registerSimpleLive(elt, attrName, a.value);
-            }
         }
+        prop.liveAttrs ||= new Set();
+        for (let a of elt.attributes) {
+            let name = extractBindingName(a.name);
+            if (!name || prop.liveAttrs.has(name)) continue;
+            prop.liveAttrs.add(name);
+            registerSimpleLive(elt, name, a.value);
+        }
+    }
+
+    function processLive(root) {
+        if (!liveQuery) buildLiveQuery();
+        if (root.nodeType === 1) processElement(root);
+        let iter = liveQuery.evaluate(root), node, nodes = [];
+        while (node = iter.iterateNext()) nodes.push(node);
+        for (node of nodes) processElement(node);
     }
 
     function registerSimpleLive(elt, attrName, code) {

--- a/www/src/content/extensions/15-hx-live.md
+++ b/www/src/content/extensions/15-hx-live.md
@@ -41,6 +41,8 @@ The same shape works for any attribute:
 <input :required="q('#mode').value === 'final'">
 ```
 
+> ⚠️ **Alpine.js conflict:** The `:` short form uses the same syntax as Alpine.js (`x-bind:`). If Alpine is detected on the page at initialization time, hx-live automatically disables the `:` short form and logs a console warning. You can override this behavior by explicitly setting [`config.live.bindPrefix`](#configlivebindprefix).
+
 How each attribute is written (booleans, ARIA, property-backed, generic) is described in [Attribute writing rules](#attribute-writing-rules).
 
 ### `hx-live:<attr>`
@@ -566,12 +568,68 @@ htmx.live.refresh();
 
 Selector directionals (`next`, `previous`, `closest`) need an anchor and only work inside `hx-live` / `hx-on`, not from `htmx.live.q`.
 
+## Configuration
+
+### `config.live.bindPrefix`
+
+Controls the short-form prefix for binding attributes. Defaults to `':'` (or disabled automatically if Alpine.js is detected).
+
+| Value | Effect | Example attribute |
+|-------|--------|-------------------|
+| undefined (default) | `:attr` enabled, unless Alpine detected | `:hidden`, `:text`, `:.active` |
+| `':'` | `:attr` short form forced on | `:hidden`, `:text`, `:.active` |
+| `''` or falsy | Short form disabled, only `hx-live:attr` works | `hx-live:hidden` |
+| `'hx:'` | Custom prefix | `hx:hidden`, `hx:text`, `hx:.active` |
+
+The long form `hx-live:<attr>` always works regardless of this setting.
+
+**Alpine.js auto-detection**
+
+If `window.Alpine` exists when hx-live initializes and no `bindPrefix` is configured, the `:` short form is automatically disabled and a console warning is logged. To resolve:
+
+- Use the long form `hx-live:<attr>` (always works)
+- Or explicitly set a non-conflicting prefix:
+
+```html
+<!-- Use hx: as short form instead -->
+<meta name="htmx-config" content='{"live":{"bindPrefix":"hx:"}}'>
+```
+
+- Or force `:` if you know what you're doing:
+
+```html
+<meta name="htmx-config" content='{"live":{"bindPrefix":":"}}'>
+```
+
+**Manually disabling the short form**
+
+If Alpine loads after hx-live (or you want to be explicit), disable it yourself:
+
+```html
+<meta name="htmx-config" content='{"live":{"bindPrefix":""}}'>
+```
+
+With `bindPrefix: ''`, use the canonical long form:
+
+```html
+<!-- Alpine handles :class, hx-live handles hx-live:text -->
+<p :class="alpineVar" hx-live:text="q('#name').value"></p>
+```
+
+With `bindPrefix: 'hx:'`:
+
+```html
+<!-- Alpine handles :class, hx-live handles hx:text -->
+<p :class="alpineVar" hx:text="q('#name').value"></p>
+```
+
 ## Notes
 
 - Expressions run on any DOM mutation. There is no per-variable tracking. The microtask coalescing keeps this cheap, but expensive expressions should `debounce` or guard themselves.
 - The DOM is the source of truth. To share state between expressions, use ARIA attributes, `data-*` attributes (the `data` proxy makes this ergonomic), or hidden inputs.
 - Expressions must be safe to run repeatedly. Avoid unconditional `fetch()` calls. Use `debounce` or guard on a value change.
 - If your build pipeline strips `:`-prefixed attributes, use the canonical `hx-live:<attr>` form instead. Behavior is identical.
+- If using Alpine.js on the same page, hx-live auto-detects it and disables the `:` short form. See [Configuration](#configuration) for details.
 
 ## See also
 


### PR DESCRIPTION
## Description
hx-live should use xpath for more efficient scanning of hx-live:* attributes as it currently does inefficient full scans.

Also need to address the alpine compatibility issue.  Alpine uses the same :attr form as the proposed hx-live parsing and if they are both enabled then they both try and register the same behavior and the different syntaxes causes errors.  While we could move to a safer default short bind form like live:attr or hx:attr or _attr none of them are as nice and well understood as the alpine pattern.  So to avoid conflicts we could detect alpine and disable the default : short form prefix and post a warning to the console so users can opt in or out of the short form or pick an alternative short form.

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
