### PR TITLE
add `hx-prompt` extension to restore htmx 2 attribute

### DIFF
--- a/src/ext/hx-prompt.js
+++ b/src/ext/hx-prompt.js
@@ -1,0 +1,23 @@
+//==========================================================
+// hx-prompt.js
+//
+// Restores htmx 2's `hx-prompt` attribute. Prompts the user
+// before the request, sends the answer as `HX-Prompt` header,
+// aborts on cancel. Override `window.htmxPrompt` for a custom
+// (sync) dialog.
+//==========================================================
+(() => {
+    let api;
+    htmx.registerExtension('hx-prompt', {
+        init(internalAPI) { api = internalAPI },
+
+        htmx_config_request(elt, {ctx}) {
+            let question = api.attributeValue(ctx.sourceElement, 'hx-prompt');
+            if (question == null) return;
+            let answer = (window.htmxPrompt || window.prompt)(question);
+            if (answer === null) return false;
+            if (!htmx.trigger(ctx.sourceElement, 'htmx:prompt', { prompt: answer, target: ctx.target })) return false;
+            ctx.request.headers['HX-Prompt'] = answer;
+        }
+    });
+})();

--- a/src/scripts/upgrade-check.py
+++ b/src/scripts/upgrade-check.py
@@ -21,7 +21,7 @@ from html.parser import HTMLParser
 REMOVED_ATTRS = {
     "hx-vars": "use hx-vals with js: prefix",
     "hx-params": "use htmx:config:request event",
-    "hx-prompt": "use hx-confirm with js: prefix",
+    "hx-prompt": "load the hx-prompt extension to keep the same syntax",
     "hx-ext": "include extension scripts directly (no attribute needed in v4)",
     "hx-disinherit": "not needed (inheritance is explicit in v4)",
     "hx-inherit": "not needed (inheritance is explicit in v4)",

--- a/src/skills/htmx-debugging.md
+++ b/src/skills/htmx-debugging.md
@@ -174,7 +174,7 @@ Quick compatibility fixes:
 5. Replace `hx-disabled-elt` → `hx-disable`
 6. Replace `hx-disable` (old meaning of ignoring) → `hx-ignore`
 7. Replace `hx-vars` → `hx-vals` with `js:` prefix
-8. Replace `hx-prompt` → `hx-confirm` with `js:` prefix
+8. Load the `hx-prompt` extension to keep `hx-prompt` working
 9. Or load the `htmx-2-compat` extension for gradual migration
 
 ## Browser DevTools Techniques

--- a/src/skills/htmx-guidance.md
+++ b/src/skills/htmx-guidance.md
@@ -572,7 +572,7 @@ modifier on attributes, or colon-separated event names like `htmx:after:swap`. T
 | `hx-disable` (stops htmx processing) | `hx-ignore`                                                   | Different purpose in each version                 |
 | `hx-ext="my-ext"`                    | Just include the script file                                  | No attribute needed; config whitelist is optional  |
 | `hx-request='{"timeout":5000}'`      | `hx-config='{"timeout":5000}'`                                | Renamed                                           |
-| `hx-prompt="Enter value"`            | `hx-confirm="js:myPromptFn()"`                                | hx-prompt removed; use hx-confirm with js: prefix |
+| `hx-prompt="Enter value"`            | [`hx-prompt` extension](/extensions/hx-prompt) (same syntax), or [`hx-on::config:request` one-liner](/extensions/hx-prompt#without-the-extension) | Restored via extension                            |
 | `hx-disinherit="*"`                  | Not needed                                                    | Inheritance is explicit by default in htmx 4      |
 | `hx-vars`                            | `hx-vals` with `js:` prefix                                   | hx-vars removed                                   |
 | Attributes inherit implicitly        | Must use `:inherited` modifier                                | `hx-target:inherited="#out"`                      |

--- a/src/skills/htmx-upgrade-from-htmx2.md
+++ b/src/skills/htmx-upgrade-from-htmx2.md
@@ -40,7 +40,7 @@ hx-disabled-elt  →  hx-disable    (htmx 2's "disable elements during request")
 |-----------------------|-------------------------------------------------------------|
 | `hx-vars='...'`       | `hx-vals='js:...'` (wrap value in `js:` prefix)             |
 | `hx-params="..."`     | Remove; use `htmx:config:request` event to filter params    |
-| `hx-prompt="..."`     | `hx-confirm="js:myAsyncPromptFn()"` (write a JS function)   |
+| `hx-prompt="..."`     | Load the `hx-prompt` extension (same syntax as htmx 2)      |
 | `hx-ext="..."`        | Remove (just including the extension script is enough)      |
 | `hx-disinherit="..."` | Remove (inheritance is explicit by default)                 |
 | `hx-inherit="..."`    | Remove (use `:inherited` modifier on individual attributes) |
@@ -224,7 +224,7 @@ Removed configs (no equivalent): `refreshOnHistoryMiss`, `historyCacheSize`, `de
 | `HX-Trigger`      | `HX-Source`   | Was element ID → now `tag#id` (e.g. `button#submit`) |
 | `HX-Trigger-Name` | Removed       | Use `HX-Source`                                      |
 | `HX-Target`       | `HX-Target`   | Was element ID → now `tag#id`                        |
-| `HX-Prompt`       | Removed       | Use `hx-confirm` with `js:` prefix                   |
+| `HX-Prompt`       | Via extension | Load the `hx-prompt` extension to restore the header |
 
 New request header: `HX-Request-Type` (`"full"` or `"partial"`).
 

--- a/test/tests/ext/hx-prompt.js
+++ b/test/tests/ext/hx-prompt.js
@@ -1,0 +1,209 @@
+describe('hx-prompt extension', function() {
+
+    let extBackup;
+    let originalPrompt;
+
+    before(async () => {
+        extBackup = backupExtensions();
+        clearExtensions();
+        htmx.config.extensions = 'hx-prompt';
+
+        let script = document.createElement('script');
+        script.src = '../src/ext/hx-prompt.js';
+        await new Promise(resolve => {
+            script.onload = resolve;
+            document.head.appendChild(script);
+        });
+    });
+
+    after(() => {
+        restoreExtensions(extBackup);
+    });
+
+    beforeEach(() => {
+        setupTest();
+        originalPrompt = window.prompt;
+    });
+
+    afterEach(() => {
+        cleanupTest();
+        window.prompt = originalPrompt;
+        delete window.htmxPrompt;
+    });
+
+    it('sends prompt response as HX-Prompt header', async function() {
+        window.prompt = () => 'because';
+        mockResponse('DELETE', '/items/1', 'ok');
+
+        let btn = createProcessedHTML('<button hx-delete="/items/1" hx-prompt="Reason for deletion?">Delete</button>');
+        btn.click();
+        await forRequest();
+
+        assert.equal(lastFetch().request.headers['HX-Prompt'], 'because');
+    });
+
+    it('aborts the request when the user cancels', async function() {
+        window.prompt = () => null;
+        mockResponse('DELETE', '/items/1', 'ok');
+
+        let btn = createProcessedHTML('<button hx-delete="/items/1" hx-prompt="Reason for deletion?">Delete</button>');
+        btn.click();
+        await forRequest();
+
+        assert.isUndefined(fetchMock.getLastCall());
+    });
+
+    it('accepts an empty string as a valid answer', async function() {
+        window.prompt = () => '';
+        mockResponse('DELETE', '/items/1', 'ok');
+
+        let btn = createProcessedHTML('<button hx-delete="/items/1" hx-prompt="Reason for deletion?">Delete</button>');
+        btn.click();
+        await forRequest();
+
+        assert.equal(lastFetch().request.headers['HX-Prompt'], '');
+    });
+
+    it('does nothing when hx-prompt is absent', async function() {
+        let prompted = false;
+        window.prompt = () => { prompted = true; return 'x'; };
+        mockResponse('GET', '/items/1', 'ok');
+
+        let btn = createProcessedHTML('<button hx-get="/items/1">Go</button>');
+        btn.click();
+        await forRequest();
+
+        assert.isFalse(prompted);
+        assert.isUndefined(lastFetch().request.headers['HX-Prompt']);
+    });
+
+    it('inherits via :inherited from a container', async function() {
+        window.prompt = () => 'inherited';
+        mockResponse('DELETE', '/items/1', 'ok');
+
+        createProcessedHTML(`
+            <div hx-prompt:inherited="Reason?">
+                <button hx-delete="/items/1">Delete</button>
+                <button hx-delete="/items/2">Delete</button>
+            </div>
+        `);
+        find('button').click();
+        await forRequest();
+
+        assert.equal(lastFetch().request.headers['HX-Prompt'], 'inherited');
+    });
+
+    it('composes with hx-confirm (both pass)', async function() {
+        window.prompt = () => 'a reason';
+        let originalConfirm = window.confirm;
+        window.confirm = () => true;
+        mockResponse('DELETE', '/items/1', 'ok');
+
+        let btn = createProcessedHTML(
+            '<button hx-delete="/items/1" hx-prompt="Reason?" hx-confirm="Are you sure?">Delete</button>'
+        );
+        btn.click();
+        await forRequest();
+
+        assert.equal(lastFetch().request.headers['HX-Prompt'], 'a reason');
+        window.confirm = originalConfirm;
+    });
+
+    it('cancelling hx-prompt skips hx-confirm and the request', async function() {
+        window.prompt = () => null;
+        let confirmShown = false;
+        let originalConfirm = window.confirm;
+        window.confirm = () => { confirmShown = true; return true; };
+        mockResponse('DELETE', '/items/1', 'ok');
+
+        let btn = createProcessedHTML(
+            '<button hx-delete="/items/1" hx-prompt="Reason?" hx-confirm="Are you sure?">Delete</button>'
+        );
+        btn.click();
+        await forRequest();
+
+        assert.isFalse(confirmShown);
+        assert.isUndefined(fetchMock.getLastCall());
+        window.confirm = originalConfirm;
+    });
+
+    it('exposes prompt and target on the htmx:prompt event detail', async function() {
+        window.prompt = () => 'hello';
+        mockResponse('DELETE', '/items/1', 'ok');
+
+        let captured = null;
+        let btn = createProcessedHTML('<button hx-delete="/items/1" hx-prompt="Q?">Delete</button>');
+        btn.addEventListener('htmx:prompt', (e) => captured = e.detail);
+        btn.click();
+        await forRequest();
+
+        assert.equal(captured.prompt, 'hello');
+        assert.equal(captured.target, btn);
+    });
+
+    it('hx-on::prompt can preventDefault to abort the request', async function() {
+        mockResponse('DELETE', '/items/1', 'ok');
+        let btn = createProcessedHTML(
+            '<button hx-delete="/items/1" hx-prompt="Reason?" hx-on::prompt="if (prompt.length < 3) event.preventDefault()">Delete</button>'
+        );
+
+        window.prompt = () => 'no';
+        btn.click();
+        await forRequest();
+        assert.isUndefined(fetchMock.getLastCall());
+
+        window.prompt = () => 'long enough';
+        btn.click();
+        await forRequest();
+        assert.equal(lastFetch().request.headers['HX-Prompt'], 'long enough');
+    });
+
+    it('uses window.htmxPrompt when defined', async function() {
+        window.htmxPrompt = (question) => 'answered: ' + question;
+        window.prompt = () => { throw new Error('window.prompt should not be called'); };
+        mockResponse('DELETE', '/items/1', 'ok');
+
+        let btn = createProcessedHTML('<button hx-delete="/items/1" hx-prompt="Q?">Delete</button>');
+        btn.click();
+        await forRequest();
+
+        assert.equal(lastFetch().request.headers['HX-Prompt'], 'answered: Q?');
+    });
+
+    it('null from window.htmxPrompt aborts the request', async function() {
+        window.htmxPrompt = () => null;
+        mockResponse('DELETE', '/items/1', 'ok');
+
+        let btn = createProcessedHTML('<button hx-delete="/items/1" hx-prompt="Q?">Delete</button>');
+        btn.click();
+        await forRequest();
+
+        assert.isUndefined(fetchMock.getLastCall());
+    });
+
+    describe('hx-on recipe (no extension needed)', () => {
+        const recipe = "ctx.request.headers['HX-Prompt'] = prompt('Reason?') ?? event.preventDefault()";
+
+        it('sends HX-Prompt with the answer', async function() {
+            window.prompt = () => 'a reason';
+            mockResponse('DELETE', '/items/1', 'ok');
+
+            let btn = createProcessedHTML(`<button hx-delete="/items/1" hx-on::config:request="${recipe}">Delete</button>`);
+            btn.click();
+            await forRequest();
+
+            assert.equal(lastFetch().request.headers['HX-Prompt'], 'a reason');
+        });
+
+        it('aborts the request on cancel', async function() {
+            window.prompt = () => null;
+            mockResponse('DELETE', '/items/1', 'ok');
+
+            let btn = createProcessedHTML(`<button hx-delete="/items/1" hx-on::config:request="${recipe}">Delete</button>`);
+            btn.click();
+            await forRequest();
+
+            assert.isUndefined(fetchMock.getLastCall());
+        });
+    });
+});

--- a/www/src/content/docs.mdx
+++ b/www/src/content/docs.mdx
@@ -277,7 +277,7 @@ Rename in this order to avoid conflicts:
 |------------------|---------------------------------------------------------------------------------------------------|
 | `hx-vars`        | [`hx-vals`](/reference/attributes/hx-vals) with `js:` prefix                                      |
 | `hx-params`      | [`htmx:config:request`](/reference/events/htmx-config-request) event                              |
-| `hx-prompt`      | [`hx-confirm`](/reference/attributes/hx-confirm) with `js:` prefix                                |
+| `hx-prompt`      | [`hx-prompt` extension](/extensions/hx-prompt), or a [one-liner with `hx-on`](/extensions/hx-prompt#without-the-extension) |
 | `hx-ext`         | [Include extension script directly](#extensions)                            |
 | `hx-disinherit`  | Not needed (inheritance is explicit)                                                              |
 | `hx-inherit`     | Not needed (inheritance is explicit)                                                              |
@@ -375,7 +375,7 @@ customize their names have been removed.
 | `HX-Trigger`      | [`HX-Source`](/reference/headers/HX-Source)             | Format changed to `tagName#id` (e.g. `button#submit`)                  |
 | `HX-Target`       | [`HX-Target`](/reference/headers/HX-Target)             | Format changed to `tagName#id`                                         |
 | `HX-Trigger-Name` | removed                                                 | Use [`HX-Source`](/reference/headers/HX-Source)                        |
-| `HX-Prompt`       | removed                                                 | Use [`hx-confirm`](/reference/attributes/hx-confirm) with `js:` prefix |
+| `HX-Prompt`       | restored via extension                                  | Load the [`hx-prompt`](/extensions/hx-prompt) extension                |
 | *(new)*           | [`HX-Request-Type`](/reference/headers/HX-Request-Type) | `"full"` or `"partial"`                                                |
 | *(new)*           | [`Accept`](/reference/headers/Accept)                   | Now explicitly `text/html`                                             |
 

--- a/www/src/content/extensions/16-hx-prompt.md
+++ b/www/src/content/extensions/16-hx-prompt.md
@@ -1,0 +1,107 @@
+---
+title: "hx-prompt"
+description: "Prompt before a request, send the answer as a header"
+category: "UX"
+icon: "icon-[mdi--comment-question-outline]"
+keywords: ["prompt", "input", "header", "hx-prompt", "htmx2"]
+---
+
+The `hx-prompt` extension restores htmx 2's `hx-prompt` attribute.
+
+Before each request, it pops up a browser prompt. The answer becomes the `HX-Prompt` header. If the user cancels, the request never fires.
+
+## Installing
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/htmx.org@next/dist/htmx.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/htmx.org@next/dist/ext/hx-prompt.js"></script>
+```
+
+## Usage
+
+```html
+<button hx-delete="/items/1" hx-prompt="Reason for deletion?">
+    Delete
+</button>
+```
+
+On click:
+
+1. Browser asks `Reason for deletion?`.
+2. Cancel aborts.
+3. Any answer (even empty) fires a cancelable [`htmx:prompt` event](#htmxprompt-event) carrying it in `event.detail.prompt`.
+4. If nothing cancels it, htmx sends the request with the `HX-Prompt` header set to the answer.
+
+### `htmx:prompt` event
+
+The `htmx:prompt` event fires on the source element after a valid answer.
+
+Listen with `hx-on::prompt` and call `event.preventDefault()` to abort:
+
+```html
+<button hx-delete="/items/1"
+        hx-prompt="Reason?"
+        hx-on::prompt="if (prompt.length < 3) event.preventDefault()">
+    Delete
+</button>
+```
+
+`event.detail` carries `{ prompt, target }`. `hx-on` exposes it directly, so they're in scope without unwrapping.
+
+### Inheritance
+
+The `hx-prompt` attribute supports inheritance.
+
+```html
+<div hx-prompt:inherited="Reason?">
+    <button hx-delete="/items/1">Delete</button>
+    <button hx-delete="/items/2">Delete</button>
+</div>
+```
+
+### Composing with hx-confirm
+
+`hx-prompt` runs *before* `hx-confirm`. Both must pass for the request to proceed:
+
+```html
+<button hx-delete="/items/1"
+        hx-prompt="Reason?"
+        hx-confirm="Are you sure?">
+    Delete
+</button>
+```
+
+If the user cancels the prompt, the confirm dialog is not shown.
+
+### Custom Dialogs
+
+Assign a function to `window.htmxPrompt` to use a custom (synchronous) dialog.
+
+```js
+// receives the question, returns the answer string or null to cancel
+window.htmxPrompt = (question) => myCustomSyncDialog(question);
+```
+
+The extension uses [`window.prompt`](https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt) by default.
+
+### Server-Side Example
+
+`HX-Prompt` is a regular request header. Read it however your server reads headers.
+
+```python
+def delete_item(request, id):
+    reason = request.headers.get("HX-Prompt", "")
+    Item.objects.filter(id=id).delete(reason=reason)
+    return HttpResponse("")  # empty response removes the row
+```
+
+## Without the extension
+
+If you'd rather skip the extension, a single `hx-on` can do the same thing:
+
+```html
+<button hx-delete="/items/1"
+        hx-on::config:request="ctx.request.headers['HX-Prompt'] = prompt('Reason?') ?? event.preventDefault()">
+    Delete
+</button>
+```


### PR DESCRIPTION
Restores htmx 2's `hx-prompt` attribute as an opt-in extension and updates confusing migration docs.

Adds 13 tests for new extension.

Closes #3825.