### PR TITLE
prevent re-initilization of hx-on from process or morph

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1622,6 +1622,7 @@ var htmx = (() => {
         // hx-on:<event> binds to <event> directly
         // hx-on::<event> is shorthand for hx-on:htmx:<event> (htmx events)
         __handleHxOnAttributes(node) {
+            if (node._htmx?.onInitialized) return;
             let hxOnNames = this.__prefixes("hx-on");
             let mc = this.config.metaCharacter || ':';
             let handler = (code) => async (evt) => {
@@ -1635,6 +1636,7 @@ var htmx = (() => {
             for (let attr of node.getAttributeNames()) {
                 let prefix = hxOnNames.find(p => attr.startsWith(p));
                 if (!prefix) continue;
+                this.__htmxProp(node).onInitialized = true;
                 let rest = attr.substring(prefix.length);
                 let value = node.getAttribute(attr);
                 // hx-on="click once -> doA(); blur -> doB()"

--- a/test/tests/attributes/hx-on.js
+++ b/test/tests/attributes/hx-on.js
@@ -618,4 +618,26 @@ describe('hx-on="eventSpec -> code" syntax', function() {
         window.foo.should.equal(true);
         delete window.foo;
     });
+
+    it('calling process() multiple times does not duplicate hx-on listeners', function() {
+        window.fooCount = 0;
+        let btn = createProcessedHTML('<button hx-on:click="window.fooCount++">x</button>');
+        htmx.process(btn);
+        htmx.process(btn);
+        htmx.process(btn);
+        btn.click();
+        window.fooCount.should.equal(1);
+        delete window.fooCount;
+    });
+
+    it('calling process() multiple times does not duplicate hx-on= listeners', function() {
+        window.fooCount = 0;
+        let btn = createProcessedHTML('<button hx-on="click -> window.fooCount++">x</button>');
+        htmx.process(btn);
+        htmx.process(btn);
+        htmx.process(btn);
+        btn.click();
+        window.fooCount.should.equal(1);
+        delete window.fooCount;
+    });
 })


### PR DESCRIPTION
## Description
This prevents hx-on listeners being re applied when you morph or process existing nodes.  Without this the events can fire multiple times causing confusion.  

This does not resolve changing of existing hx-on attributes only preventing the duplication and change issues.  This matches how htmx 4 currently handles core hx-trigger actions as well which has a similar guard already.

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
