### PR TITLE
add ctx context to hx-confirm, hx-vals and hx-headers

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -409,10 +409,10 @@ var htmx = (() => {
             return headers;
         }
 
-        __handleHxHeaders(elt, headers) {
+        __handleHxHeaders(elt, ctx) {
             return this.__getAttributeObject(elt, "hx-headers", obj => {
-                for (let key in obj) headers[key] = String(obj[key]);
-            });
+                for (let key in obj) ctx.request.headers[key] = String(obj[key]);
+            }, {ctx});
         }
 
         __resolveTarget(elt, selector) {
@@ -455,7 +455,7 @@ var htmx = (() => {
             let valsResult = this.__getAttributeObject(elt, "hx-vals", obj => {
                 ctx.vals = obj; // make available for json extensions
                 for (let key in obj) body.set(key, obj[key]);
-            });
+            }, {ctx});
             if (valsResult) await valsResult; // Only await if it returned a promise
             if (ctx.values) {
                 for (let k in ctx.values) {
@@ -465,7 +465,7 @@ var htmx = (() => {
             }
 
             // Handle dynamic headers
-            let headersResult = this.__handleHxHeaders(elt, ctx.request.headers)
+            let headersResult = this.__handleHxHeaders(elt, ctx)
             if (headersResult) await headersResult  // Only await if it returned a promise
 
             // Setup event-dependent request details
@@ -525,7 +525,7 @@ var htmx = (() => {
                         let detail = {ctx, issueRequest: () => resolve(true), dropRequest: () => resolve(false)};
                         if (this.__trigger(elt, "htmx:confirm", detail)) {
                             let js = this.__extractJavascriptContent(ctx.confirm);
-                            resolve(js ? this.__executeJavaScript(elt, {}, js, true) : window.confirm(ctx.confirm));
+                            resolve(js ? this.__executeJavaScript(elt, {ctx}, js, true) : window.confirm(ctx.confirm));
                         }
                     });
                     if (!confirmed) return;
@@ -1762,7 +1762,7 @@ var htmx = (() => {
             }
         }
 
-        __getAttributeObject(elt, attrName, callback) {
+        __getAttributeObject(elt, attrName, callback, scope = {}) {
             let attrValue = this.__attributeValue(elt, attrName);
             if (!attrValue) return null;
 
@@ -1773,7 +1773,7 @@ var htmx = (() => {
                     javascriptContent = '{' + javascriptContent + '}';
                 }
                 // Return promise for async evaluation
-                return this.__executeJavaScript(elt, {}, javascriptContent, true).then(obj => {
+                return this.__executeJavaScript(elt, scope, javascriptContent, true).then(obj => {
                     callback(obj);
                 });
             } else {


### PR DESCRIPTION
## Description
to support proper hx-confirm js syntax you need to be able to access the ctx object to do things like set request headers based on confirmed data like prompts etc.  The initial intention of the hx-confirm js support was to allow implementaiton of hx-params like patterns but without ctx access this is just not easy.  

Also found We should have ctx in hx-vals and hx-headers so it can be used here when needed to access or check the action url or method etc.  ctx is already available in many hx-on situations where it makes sense so this just extends this pattern.

Corresponding issue:

## Testing
Tests still pass and no real change other than extra context in JS expressions

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
