### PR TITLE
Improve text node morphing for firefox support

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2003,6 +2003,8 @@ var htmx = (() => {
         }
 
         __findBestMatch(ctx, node, startPoint, endPoint) {
+            // text nodes match positionally — patch in place via __morphNode, 3 = TEXT_NODE
+            if (node.nodeType === 3) return startPoint?.nodeType === 3 ? startPoint : null;
             if (!(node instanceof Element)) return null;
             let softMatch = null, displaceMatchCount = 0, scanLimit = this.config.morphScanLimit;
             let newSet = ctx.idMap.get(node), nodeMatchCount = newSet?.size || 0;
@@ -2070,6 +2072,10 @@ var htmx = (() => {
         }
 
         __morphNode(oldNode, newNode, ctx) {
+            if (oldNode.nodeType === 3) { // text node
+                if (oldNode.nodeValue !== newNode.nodeValue) oldNode.nodeValue = newNode.nodeValue;
+                return;
+            }
             if (this.config.morphSkip && oldNode.matches?.(this.config.morphSkip)) return;
                 
             // Trigger extension hook - if returns false, skip morphing this node


### PR DESCRIPTION
## Description
There is an issue in the latest firevox 151 build where it now does not handle htmx morphing select options elements text nodes well and displays both before and after text node data in error.  When we morph text nodes we currently just block morphing so the new text node has to be inserted and the old one then removed.  This was done as a performance tweak to avoid wasting time mathing and morphing just text nodes that contain no preservable state.  But for a brief period both text nodes are in the options element which is not ideal and now triggering a bug in firefox.

To solve this I've added code to have a fast path to just match text nodes if both old and new nodes are both text nodes.  

Corresponding issue:
#3821 

## Testing
had to perform manual testing with firefox developer edition to validate the fix resolves the issue

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
