### PR TITLE
make hx-preload use passive event listeners to avoid touchstart warnings

### DIFF
--- a/src/ext/hx-preload.js
+++ b/src/ext/hx-preload.js
@@ -60,7 +60,7 @@
             }
         };
         for (let eventName of preloadEvents) {
-            elt.addEventListener(eventName, preloadListener);
+            elt.addEventListener(eventName, preloadListener, { passive: true });
         }
         elt._htmx.preloadListener = preloadListener;
         elt._htmx.preloadEvents = preloadEvents;


### PR DESCRIPTION
## Description
Make preload use passive event listeners as they are not preventable so don't need to slow down the browsers touchstart events to wait for event completion.  Without this browsers constantly throw warnings on certain events that preload can use.  core htmx event listeners we have the passive:true trigger modifer but its safe to just apply it always in preload as we just fire and forget the events with no cancel option.

Corresponding issue:
#3843

## Testing
Tests still pass

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
