### PR TITLE
Allow click modifers to pass though only on links

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -657,6 +657,7 @@ var htmx = (() => {
 
         __isModifierKeyClick(evt) {
             return evt.type === 'click' && (evt.ctrlKey || evt.metaKey || evt.shiftKey)
+                && !!evt.currentTarget?.closest?.('a[href]')
         }
 
         __shouldCancel(evt) {

--- a/test/tests/unit/__handleTriggerEvent.js
+++ b/test/tests/unit/__handleTriggerEvent.js
@@ -16,12 +16,22 @@ describe('__handleTriggerEvent unit tests', function() {
         assert.isUndefined(window.testExecuted)
     })
 
-    it('returns early if modifier key click', async function () {
+    it('returns early if modifier key click on a link', async function () {
+        let link = createProcessedHTML('<a href="/test" hx-get="js:window.testExecuted = true">link</a>')
+        let evt = new MouseEvent('click', {ctrlKey: true, bubbles: true, cancelable: true})
+        Object.defineProperty(evt, 'currentTarget', {value: link})
+        let ctx = htmx.__createRequestContext(link, evt)
+        await htmx.__handleTriggerEvent(ctx)
+        assert.isUndefined(window.testExecuted)
+    })
+
+    it('does not return early if modifier key click on a non-link', async function () {
         let div = createProcessedHTML('<div hx-get="js:window.testExecuted = true"></div>')
         let evt = new MouseEvent('click', {ctrlKey: true})
         let ctx = htmx.__createRequestContext(div, evt)
         await htmx.__handleTriggerEvent(ctx)
-        assert.isUndefined(window.testExecuted)
+        assert.isTrue(window.testExecuted)
+        delete window.testExecuted
     })
 
     it('prevents default when shouldCancel returns true', async function () {


### PR DESCRIPTION
## Description
we allow click modifiers like ctrl and shift and cmd to go though to the native browser so that links work as users expect and open new tabs and windows.  But this also happens to cover non links as well which prevents you using shift and ctrl keys as modifiers on other htmx only elements.  We also have some examples in the docs on how to use event filters that don't work because of this.

So We can simply check if the modifer click has a closest 'a' and only block htmx when its a link.
Corresponding issue:

## Testing
Updated the test for this and added a new one for the link and non link cases.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
