### PR TITLE
support comma in trigger spec config

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -242,18 +242,24 @@ var htmx = (() => {
             return defaultVal;
         }
 
-        __parseConfig(configString) {
+        __parseConfig(configString, lazy) {
             if (!configString) return {};
             if (configString[0] === '{') return JSON.parse(configString);
-            let configPattern = /(?:"([^"]+)"|([^\s,:]+))(?:\s*:\s*(?:"([^"]*)"|'([^']*)'|<([^>]+)\/>|([^\s,]+)))?(?=\s|,|$)/g;
-            return [...configString.matchAll(configPattern)].reduce((result, match) => {
+            let configPattern = /(?:"([^"]+)"|([^\s,:]+))(?:\s*:\s*(?:"([^"]*)"|'([^']*)'|<([^>]+)\/>|([^\s,]+)))?(?=\s*(,)|\s|$)/g;
+            let config = {};
+            let cursor = 0;
+            let match;
+            while ((match = configPattern.exec(configString))) {
                 let keyPath = (match[1] ?? match[2]).split('.');
                 let value = (match[3] ?? match[4] ?? match[5] ?? match[6] ?? 'true').trim();
                 try { value = JSON.parse(value); } catch {}
-                if (keyPath.some(k => this.__internalField(k))) return result;
-                keyPath.slice(0, -1).reduce((obj, key) => obj[key] ??= {}, result)[keyPath.at(-1)] = value;
-                return result;
-            }, {});
+                if (!keyPath.some(k => this.__internalField(k))) {
+                    keyPath.slice(0, -1).reduce((obj, key) => obj[key] ??= {}, config)[keyPath.at(-1)] = value;
+                }
+                cursor = match.index + match[0].length;
+                if (lazy && match[7]) break;  // this pair is followed by a comma. stop and report cursor
+            }
+            return lazy ? { config, cursor } : config;
         }
 
         __internalField(k) {
@@ -275,13 +281,22 @@ var htmx = (() => {
         }
 
         __parseTriggerSpecs(spec) {
-            // Split on commas that are NOT inside [...] — handles filters like click[myFunc(a,b)]
-            return spec.split(/,(?![^\[]*\])/).flatMap(s => {
-                let [,name,rest] = s.match(/^\s*(\S+\[[^\]]*\]|\S+)\s*(.*?)\s*$/) ?? [];
-                if (!name) return [];  // skip empty/whitespace-only tokens
+            let specs = [];
+            let remaining = spec.trim();
+            while (remaining) {
+                let [,name,comma,rest] = remaining.match(/^[\s,]*([^\s,]+\[[^\]]*\]|[^\s,]+)\s*(,)?\s*([\s\S]*)$/) ?? [];
+                if (!name) break; // no more spec to parse
                 if (/\[[^\]]*$/.test(name)) throw "unterminated:" + name;  // e.g. click[ctrlKey
-                return [{name, ...this.__parseConfig(rest)}];  // spread modifiers (delay, throttle, etc.) onto result
-            });
+                if (comma) {  // name immediately followed by a separator. this spec has no config
+                    specs.push({name});
+                    remaining = rest;
+                } else {
+                    let {config, cursor} = this.__parseConfig(rest, true);
+                    specs.push({name, ...config});  // spread modifiers (delay, throttle, etc.) onto result
+                    remaining = rest.slice(cursor);
+                }
+            }
+            return specs;
         }
 
         __determineMethodAndAction(elt, evt) {

--- a/test/tests/unit/__parseTriggerSpecs.js
+++ b/test/tests/unit/__parseTriggerSpecs.js
@@ -132,4 +132,17 @@ describe('__parseTriggerSpecs unit tests', function() {
         assert.equal(specs[0].once, true)
     })
 
+    it('from clause works with multiple extended selectors', function () {
+        let specs = htmx.__parseTriggerSpecs('click[ctrlKey] from:"form input"')
+        assert.equal(specs.length, 1)
+        assert.equal(specs[0].name, 'click[ctrlKey]')
+        assert.equal(specs[0].from, 'form input')
+    })
+
+    it('from clause works with multiple extended selectors including comma', function () {
+        let specs = htmx.__parseTriggerSpecs('click[ctrlKey] from:"previous button, next a"')
+        assert.equal(specs.length, 1)
+        assert.equal(specs[0].name, 'click[ctrlKey]')
+        assert.equal(specs[0].from, 'previous button, next a')
+    })
 });


### PR DESCRIPTION
e.g. `hx-trigger='click[ctrlKey] from:"previous button, next a"'`

Close: #3854

## Description

Implemented lazy mode in `__parseConfig` to stop on comma separator. This allows parsing `hx-trigger` spec like `click from:"input, textarea"`.

```
__parseConfig(configString [, lazy])
```
When `lazy` is truthy and first character is not `{`, `__parseConfig` will return `{config, cursor}` where cursor pointing at separator `,`.

`__parseTriggerSpecs` will walk through the given string instead of aggressively separating with comma first. This allows `,` to be handled from `__parseConfig` with the knowledge of HCON format.

Corresponding issue:

## Testing
added new test cases for:
```
click[ctrlKey] from:"form input"
```
and
```
click[ctrlKey] from:"previous button, next a"
```

First one was already passing without changes, but I added it to compare with second case.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded