### PR TITLE
Fix '__proto__' literal mangled to '#proto#' by build sed

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -257,7 +257,6 @@ var htmx = (() => {
         }
 
         __internalField(k) {
-            // Escape underscores so build:iife's `sed s/__/#/g` leaves the literal intact.
             return k === '_\x5fproto_\x5f' || k === 'constructor' || k === 'prototype';
         }
 

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -257,7 +257,8 @@ var htmx = (() => {
         }
 
         __internalField(k) {
-            return k === '__proto__' || k === 'constructor' || k === 'prototype';
+            // Escape underscores so build:iife's `sed s/__/#/g` leaves the literal intact.
+            return k === '_\x5fproto_\x5f' || k === 'constructor' || k === 'prototype';
         }
 
         __mergeConfig(configString, target) {


### PR DESCRIPTION
`src/htmx.js:260`

```js
    return k === '__proto__' || k === 'constructor' || k === 'prototype';
```

dist/htmx.js after `sed 's/__/#/g'`:
```js
    return k === '#proto#' || k === 'constructor' || k === 'prototype';
```

Guard never matches in the shipped IIFE/ESM build.

Repro:
```js
    <meta name="htmx-config" content="__proto__.polluted: true">
    // → Object.prototype.polluted === true
```

Fixed by hex-escaping the underscores so `sed` leaves the literal alone. Runtime value unchanged: `'_\x5fproto_\x5f' === '__proto__'`.

Tests in `test/tests/unit/__parseConfig.js` load `src/htmx.js` directly, so they couldn't catch the broken behaviour from `dist/`.