### PR TITLE
add empty swap handling override and make sse default to not swap empty responses

### DIFF
--- a/src/ext/hx-sse.js
+++ b/src/ext/hx-sse.js
@@ -258,7 +258,7 @@
 
                         // Swap content using the ctx from core (target/swap already resolved)
                         ctx.text = detail.message.data;
-                        if (!ctx.swap.includes('empty')) ctx.swap += ' empty:false';
+                        if (!ctx.swap.includes('swapEmpty')) ctx.swap += ' swapEmpty:false';
                         await htmx.swap(ctx);
                         delete detail.message.cancelled;
                         api.triggerHtmxEvent(element, 'htmx:after:sse:message', detail);

--- a/src/ext/hx-sse.js
+++ b/src/ext/hx-sse.js
@@ -258,6 +258,7 @@
 
                         // Swap content using the ctx from core (target/swap already resolved)
                         ctx.text = detail.message.data;
+                        if (!ctx.swap.includes('empty')) ctx.swap += ' empty:false';
                         await htmx.swap(ctx);
                         delete detail.message.cancelled;
                         api.triggerHtmxEvent(element, 'htmx:after:sse:message', detail);

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1307,7 +1307,7 @@ var htmx = (() => {
                 swapSpec.style === 'delete' ||    // delete always runs regardless of content
                 fragment.childElementCount > 0 || // or fragment has elements
                 fragment.textContent.trim() ||    // or fragment has text
-                (swapSpec.empty ?? this.config.defaultSwapEmpty ?? !partialTasks.length) // empty:true/false overrides, default: allow if no partials
+                (swapSpec.swapEmpty ?? this.config.defaultSwapEmpty ?? !partialTasks.length) // swapEmpty:true/false overrides, default: allow if no partials
             ) {
                 if (ctx.select) {
                     let selected = fragment.querySelectorAll(ctx.select);

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1302,8 +1302,13 @@ var htmx = (() => {
         __processMainSwap(ctx, fragment, partialTasks) {
             // Create main task if needed
             let swapSpec = this.__parseSwapSpec(ctx.swap || this.config.defaultSwap);
-            // skip creating main swap if extracting partials resulted in empty response except for delete style
-            if (swapSpec.style === 'delete' || fragment.childElementCount > 0 || /\S/.test(fragment.textContent) || !partialTasks.length) {
+            // skip main swap if fragment is empty after hx-partial removal but respect empty modifier
+            if (
+                swapSpec.style === 'delete' ||           // delete always runs regardless of content
+                fragment.childElementCount > 0 ||        // or fragment has elements
+                fragment.textContent.trim() ||           // or fragment has text
+                (swapSpec.empty ?? !partialTasks.length) // empty:true/false overrides, default: allow if no partials
+            ) {
                 if (ctx.select) {
                     let selected = fragment.querySelectorAll(ctx.select);
                     fragment = document.createDocumentFragment();

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1304,10 +1304,10 @@ var htmx = (() => {
             let swapSpec = this.__parseSwapSpec(ctx.swap || this.config.defaultSwap);
             // skip main swap if fragment is empty after hx-partial removal but respect empty modifier
             if (
-                swapSpec.style === 'delete' ||           // delete always runs regardless of content
-                fragment.childElementCount > 0 ||        // or fragment has elements
-                fragment.textContent.trim() ||           // or fragment has text
-                (swapSpec.empty ?? !partialTasks.length) // empty:true/false overrides, default: allow if no partials
+                swapSpec.style === 'delete' ||    // delete always runs regardless of content
+                fragment.childElementCount > 0 || // or fragment has elements
+                fragment.textContent.trim() ||    // or fragment has text
+                (swapSpec.empty ?? this.config.defaultSwapEmpty ?? !partialTasks.length) // empty:true/false overrides, default: allow if no partials
             ) {
                 if (ctx.select) {
                     let selected = fragment.querySelectorAll(ctx.select);

--- a/test/tests/ext/hx-sse.js
+++ b/test/tests/ext/hx-sse.js
@@ -1060,6 +1060,51 @@ describe('hx-sse SSE extension', function() {
         stream.close();
     });
 
+    it('oob-only SSE message does not blank main target by default', async function() {
+        const stream = mockStreamResponse('/oob-only');
+        createProcessedHTML('<div id="target" hx-sse:connect="/oob-only" hx-swap="innerHTML">Original</div><div id="oob">OOB</div>');
+
+        await htmx.timeout(1);
+
+        stream.send('<div id="oob" hx-swap-oob="true">Updated</div>');
+        await waitForEvent('htmx:after:sse:message');
+
+        assertTextContentIs('#target', 'Original');
+        assertTextContentIs('#oob', 'Updated');
+
+        stream.close();
+    });
+
+    it('oob-only SSE message blanks main target when empty:true explicitly set', async function() {
+        const stream = mockStreamResponse('/oob-empty-true');
+        createProcessedHTML('<div id="target" hx-sse:connect="/oob-empty-true" hx-swap="innerHTML empty:true">Original</div><div id="oob">OOB</div>');
+
+        await htmx.timeout(1);
+
+        stream.send('<div id="oob" hx-swap-oob="true">Updated</div>');
+        await waitForEvent('htmx:after:sse:message');
+
+        assertTextContentIs('#target', '');
+        assertTextContentIs('#oob', 'Updated');
+
+        stream.close();
+    });
+
+    it('SSE message with real content alongside oob still swaps main target', async function() {
+        const stream = mockStreamResponse('/oob-with-content');
+        createProcessedHTML('<div id="target" hx-sse:connect="/oob-with-content" hx-swap="innerHTML">Original</div><div id="oob">OOB</div>');
+
+        await htmx.timeout(1);
+
+        stream.send('<div>New Content</div><div id="oob" hx-swap-oob="true">Updated</div>');
+        await waitForEvent('htmx:after:sse:message');
+
+        assertTextContentIs('#oob', 'Updated');
+        find('#target').innerText.trim().should.equal('New Content');
+
+        stream.close();
+    });
+
     it('supports legacy sse-connect attribute with deprecation warning', async function() {
         let warnCalled = false;
         let originalWarn = console.warn;

--- a/test/tests/ext/hx-sse.js
+++ b/test/tests/ext/hx-sse.js
@@ -1075,9 +1075,9 @@ describe('hx-sse SSE extension', function() {
         stream.close();
     });
 
-    it('oob-only SSE message blanks main target when empty:true explicitly set', async function() {
+    it('oob-only SSE message blanks main target when swapEmpty:true explicitly set', async function() {
         const stream = mockStreamResponse('/oob-empty-true');
-        createProcessedHTML('<div id="target" hx-sse:connect="/oob-empty-true" hx-swap="innerHTML empty:true">Original</div><div id="oob">OOB</div>');
+        createProcessedHTML('<div id="target" hx-sse:connect="/oob-empty-true" hx-swap="innerHTML swapEmpty:true">Original</div><div id="oob">OOB</div>');
 
         await htmx.timeout(1);
 

--- a/test/tests/unit/swap.js
+++ b/test/tests/unit/swap.js
@@ -647,30 +647,30 @@ describe('swap() unit tests', function() {
         playground().querySelectorAll('.target').forEach(el => el.innerText.should.equal('Updated'))
     })
 
-    it('empty:false prevents main swap when response is only oob', async function () {
+    it('swapEmpty:false prevents main swap when response is only oob', async function () {
         createProcessedHTML("<div id='target'>Original</div><div id='oob'>OOB</div>")
-        await htmx.swap({"target":"#target", "swap":"innerHTML empty:false", "text":"<div id='oob' hx-swap-oob='true'>Updated</div>"})
+        await htmx.swap({"target":"#target", "swap":"innerHTML swapEmpty:false", "text":"<div id='oob' hx-swap-oob='true'>Updated</div>"})
         find('#target').innerText.should.equal('Original');
         find('#oob').innerText.should.equal('Updated');
     })
 
-    it('empty:false prevents main swap when response is only partials', async function () {
+    it('swapEmpty:false prevents main swap when response is only partials', async function () {
         createProcessedHTML("<div id='target'>Original</div><div id='partial'>Partial</div>")
-        await htmx.swap({"target":"#target", "swap":"innerHTML empty:false", "text":"<hx-partial hx-target='#partial'>Updated</hx-partial>"})
+        await htmx.swap({"target":"#target", "swap":"innerHTML swapEmpty:false", "text":"<hx-partial hx-target='#partial'>Updated</hx-partial>"})
         find('#target').innerText.should.equal('Original');
         find('#partial').innerText.should.equal('Updated');
     })
 
-    it('empty:true forces main swap even on empty response with partials', async function () {
+    it('swapEmpty:true forces main swap even on empty response with partials', async function () {
         createProcessedHTML("<div id='target'>Original</div><div id='partial'>Partial</div>")
-        await htmx.swap({"target":"#target", "swap":"innerHTML empty:true", "text":"<hx-partial hx-target='#partial'>Updated</hx-partial>"})
+        await htmx.swap({"target":"#target", "swap":"innerHTML swapEmpty:true", "text":"<hx-partial hx-target='#partial'>Updated</hx-partial>"})
         find('#target').innerText.should.equal('');
         find('#partial').innerText.should.equal('Updated');
     })
 
-    it('empty:false still swaps main target when response has real content alongside oob', async function () {
+    it('swapEmpty:false still swaps main target when response has real content alongside oob', async function () {
         createProcessedHTML("<div id='target'>Original</div><div id='oob'>OOB</div>")
-        await htmx.swap({"target":"#target", "swap":"innerHTML empty:false", "text":"<div>New Content</div><div id='oob' hx-swap-oob='true'>Updated</div>"})
+        await htmx.swap({"target":"#target", "swap":"innerHTML swapEmpty:false", "text":"<div>New Content</div><div id='oob' hx-swap-oob='true'>Updated</div>"})
         find('#target').innerText.trim().should.equal('New Content');
         find('#oob').innerText.should.equal('Updated');
     })

--- a/test/tests/unit/swap.js
+++ b/test/tests/unit/swap.js
@@ -647,6 +647,34 @@ describe('swap() unit tests', function() {
         playground().querySelectorAll('.target').forEach(el => el.innerText.should.equal('Updated'))
     })
 
+    it('empty:false prevents main swap when response is only oob', async function () {
+        createProcessedHTML("<div id='target'>Original</div><div id='oob'>OOB</div>")
+        await htmx.swap({"target":"#target", "swap":"innerHTML empty:false", "text":"<div id='oob' hx-swap-oob='true'>Updated</div>"})
+        find('#target').innerText.should.equal('Original');
+        find('#oob').innerText.should.equal('Updated');
+    })
+
+    it('empty:false prevents main swap when response is only partials', async function () {
+        createProcessedHTML("<div id='target'>Original</div><div id='partial'>Partial</div>")
+        await htmx.swap({"target":"#target", "swap":"innerHTML empty:false", "text":"<hx-partial hx-target='#partial'>Updated</hx-partial>"})
+        find('#target').innerText.should.equal('Original');
+        find('#partial').innerText.should.equal('Updated');
+    })
+
+    it('empty:true forces main swap even on empty response with partials', async function () {
+        createProcessedHTML("<div id='target'>Original</div><div id='partial'>Partial</div>")
+        await htmx.swap({"target":"#target", "swap":"innerHTML empty:true", "text":"<hx-partial hx-target='#partial'>Updated</hx-partial>"})
+        find('#target').innerText.should.equal('');
+        find('#partial').innerText.should.equal('Updated');
+    })
+
+    it('empty:false still swaps main target when response has real content alongside oob', async function () {
+        createProcessedHTML("<div id='target'>Original</div><div id='oob'>OOB</div>")
+        await htmx.swap({"target":"#target", "swap":"innerHTML empty:false", "text":"<div>New Content</div><div id='oob' hx-swap-oob='true'>Updated</div>"})
+        find('#target').innerText.trim().should.equal('New Content');
+        find('#oob').innerText.should.equal('Updated');
+    })
+
     it('restores focus to textarea after innerHTML swap', async function () {
         createProcessedHTML("<textarea id='focused-textarea'>hello world</textarea>")
         let textarea = find('#focused-textarea')

--- a/www/src/content/docs.mdx
+++ b/www/src/content/docs.mdx
@@ -1420,7 +1420,7 @@ The modifiers available on `hx-swap` are (parsed as [HCON](#hcon)):
 | ignoreTitle  | If set to true, any title found in the new content will be ignored and not update the document title |
 | strip        | true or false, whether to strip the outer element when swapping (unwrap the content)                 |
 | focus-scroll | true or false, whether to scroll focused elements into view                                          |
-| empty        | true or false, whether to skip the swap when the response body is empty. Defaults to [`htmx.config.defaultSwapEmpty`](/reference/config/htmx-config-defaultSwapEmpty) |
+| swapEmpty    | true or false, whether to skip the swap when the response body is empty. Defaults to [`htmx.config.defaultSwapEmpty`](/reference/config/htmx-config-defaultSwapEmpty) |
 | scroll       | top or bottom, will scroll the target element to its top or bottom                                   |
 | show         | top or bottom, will scroll the target element's top or bottom into view                              |
 | target       | A selector to retarget the swap to a different element                                               |
@@ -1870,10 +1870,10 @@ content to swap.
 </hx-partial>
 ```
 
-If you also want the main target cleared, add `empty:true` to `hx-swap` on the triggering element:
+If you also want the main target cleared, add `swapEmpty:true` to `hx-swap` on the triggering element:
 
 ```html
-<button hx-post="/submit" hx-swap="outerHTML empty:true">Submit</button>
+<button hx-post="/submit" hx-swap="outerHTML swapEmpty:true">Submit</button>
 ```
 
 Or set the global default via [`htmx.config.defaultSwapEmpty`](/reference/config/htmx-config-defaultSwapEmpty).

--- a/www/src/content/docs.mdx
+++ b/www/src/content/docs.mdx
@@ -1420,6 +1420,7 @@ The modifiers available on `hx-swap` are (parsed as [HCON](#hcon)):
 | ignoreTitle  | If set to true, any title found in the new content will be ignored and not update the document title |
 | strip        | true or false, whether to strip the outer element when swapping (unwrap the content)                 |
 | focus-scroll | true or false, whether to scroll focused elements into view                                          |
+| empty        | true or false, whether to skip the swap when the response body is empty. Defaults to [`htmx.config.defaultSwapEmpty`](/reference/config/htmx-config-defaultSwapEmpty) |
 | scroll       | top or bottom, will scroll the target element to its top or bottom                                   |
 | show         | top or bottom, will scroll the target element's top or bottom into view                              |
 | target       | A selector to retarget the swap to a different element                                               |
@@ -1851,6 +1852,31 @@ Either `hx-target` or `id` is required. If both are present, `hx-target` takes p
 <summary>Alternative syntax for template languages that strip unknown tags</summary>
 You can use the equivalent <code>&lt;template&gt;</code> form: <code>&lt;template hx type="partial" hx-target="..." hx-swap="..."&gt;</code>. htmx converts <code>&lt;hx-partial&gt;</code> to this form internally.
 </details>
+
+#### Empty Response Behaviour
+
+When a response contains only `<hx-partial>` elements and no main content, htmx will **not** perform the main swap.
+This is the opposite default to [`hx-swap-oob`](/reference/attributes/hx-swap-oob): with partials, an
+all-partial response signals intent — the server is explicitly routing multiple targeted updates and there is no main
+content to swap.
+
+```html
+<!-- Server returns only partials — main target is left untouched -->
+<hx-partial hx-target="#notifications">
+    <span class="badge">5</span>
+</hx-partial>
+<hx-partial hx-target="#messages" hx-swap="beforeend">
+    <div class="message">New message</div>
+</hx-partial>
+```
+
+If you also want the main target cleared, add `empty:true` to `hx-swap` on the triggering element:
+
+```html
+<button hx-post="/submit" hx-swap="outerHTML empty:true">Submit</button>
+```
+
+Or set the global default via [`htmx.config.defaultSwapEmpty`](/reference/config/htmx-config-defaultSwapEmpty).
 
 #### When to Use Partials
 

--- a/www/src/content/extensions/02-hx-sse.md
+++ b/www/src/content/extensions/02-hx-sse.md
@@ -117,13 +117,13 @@ data: {"title": "New message", "body": "Hello!"}
 
 Messages without an `event:` field are swapped into the DOM as HTML content.
 
-SSE messages default to `empty:false` — if a message contains only `hx-swap-oob` or `<hx-partial>` elements and no
+SSE messages default to `swapEmpty:false` — if a message contains only `hx-swap-oob` or `<hx-partial>` elements and no
 main content, the connected element is left untouched. This differs from standard htmx requests where an OOB-only
-response clears the main target. Override per-element with the [`empty`](/reference/attributes/hx-swap#empty) modifier:
+response clears the main target. Override per-element with the [`swapEmpty`](/reference/attributes/hx-swap#swapempty) modifier:
 
 ```html
 <!-- Clear the connected element when an empty message arrives -->
-<div hx-sse:connect="/stream" hx-swap="innerHTML empty:true">
+<div hx-sse:connect="/stream" hx-swap="innerHTML swapEmpty:true">
 ```
 
 ## Configuration

--- a/www/src/content/extensions/02-hx-sse.md
+++ b/www/src/content/extensions/02-hx-sse.md
@@ -117,6 +117,15 @@ data: {"title": "New message", "body": "Hello!"}
 
 Messages without an `event:` field are swapped into the DOM as HTML content.
 
+SSE messages default to `empty:false` — if a message contains only `hx-swap-oob` or `<hx-partial>` elements and no
+main content, the connected element is left untouched. This differs from standard htmx requests where an OOB-only
+response clears the main target. Override per-element with the [`empty`](/reference/attributes/hx-swap#empty) modifier:
+
+```html
+<!-- Clear the connected element when an empty message arrives -->
+<div hx-sse:connect="/stream" hx-swap="innerHTML empty:true">
+```
+
 ## Configuration
 
 Configure SSE behavior globally via `htmx.config.sse` or per-element via [`hx-config`](/reference/attributes/hx-config) ([HCON](/docs#hx-config) or JSON):

--- a/www/src/content/reference/01-attributes/07-hx-swap.md
+++ b/www/src/content/reference/01-attributes/07-hx-swap.md
@@ -297,6 +297,20 @@ Controls whether the outer element of the response content is removed before swa
 <div hx-swap="innerHTML strip:true"></div>
 ```
 
+### `empty`
+
+Skips the swap when the response body is empty.
+
+```html
+<!-- Skip swap on empty response -->
+<div hx-swap="innerHTML empty"></div>
+
+<!-- Explicitly proceed with swap even if response is empty -->
+<div hx-swap="innerHTML empty:false"></div>
+```
+
+Defaults to [`htmx.config.defaultSwapEmpty`](/reference/config/htmx-config-defaultSwapEmpty).
+
 ## Caveats
 
 * `outerHTML` on `document.body` automatically upgrades to `outerSync` to preserve body attributes (classes, data-attrs). Use `outerSync` explicitly if you want this behaviour on other elements.

--- a/www/src/content/reference/01-attributes/07-hx-swap.md
+++ b/www/src/content/reference/01-attributes/07-hx-swap.md
@@ -297,16 +297,16 @@ Controls whether the outer element of the response content is removed before swa
 <div hx-swap="innerHTML strip:true"></div>
 ```
 
-### `empty`
+### `swapEmpty`
 
 Skips the swap when the response body is empty.
 
 ```html
 <!-- Skip swap on empty response -->
-<div hx-swap="innerHTML empty"></div>
+<div hx-swap="innerHTML swapEmpty"></div>
 
 <!-- Explicitly proceed with swap even if response is empty -->
-<div hx-swap="innerHTML empty:false"></div>
+<div hx-swap="innerHTML swapEmpty:false"></div>
 ```
 
 Defaults to [`htmx.config.defaultSwapEmpty`](/reference/config/htmx-config-defaultSwapEmpty).

--- a/www/src/content/reference/01-attributes/13-hx-swap-oob.md
+++ b/www/src/content/reference/01-attributes/13-hx-swap-oob.md
@@ -143,6 +143,33 @@ This behavior can be changed by setting the config `htmx.config.allowNestedOobSw
 is `false`, OOB swaps are only processed when the element is *adjacent to* the main response element, OOB swaps
 elsewhere will be ignored and oob-swap-related attributes stripped.
 
+## Empty Response Behaviour
+
+When a response contains only `hx-swap-oob` elements and no main content, htmx still performs the main swap with an
+empty fragment. You might for example submit a form, return an empty response to remove the form
+from the page, and include `hx-swap-oob` elements to place the result elsewhere.
+
+```html
+<!-- Server returns this to remove the form and update the list -->
+<div id="item-list" hx-swap-oob="beforeend">
+    <li>New item</li>
+</div>
+<!-- no main content = form gets swapped with empty fragment, removing it -->
+```
+
+If you want to prevent the empty main swap, use the [`empty`](/reference/attributes/hx-swap#empty) modifier:
+
+```html
+<form hx-post="/submit" hx-swap="outerHTML empty:false">
+```
+
+Or set the global default via [`htmx.config.defaultSwapEmpty`](/reference/config/htmx-config-defaultSwapEmpty).
+
+[`<hx-partial>`](/docs#partials-hx-partial) has the opposite default: a response containing only `<hx-partial>` elements
+and no main content will **not** trigger an empty main swap. This is because `<hx-partial>`-only responses signal
+intent — the server is explicitly routing multiple targeted updates with no main content to swap. Use `empty:true` on
+the triggering element if you need the main swap to run anyway.
+
 ## See Also
 
 - [`<hx-partial>`](/docs#partials-hx-partial), an alternative for multi-target updates with explicit control over targeting and swap strategy

--- a/www/src/content/reference/01-attributes/13-hx-swap-oob.md
+++ b/www/src/content/reference/01-attributes/13-hx-swap-oob.md
@@ -157,17 +157,17 @@ from the page, and include `hx-swap-oob` elements to place the result elsewhere.
 <!-- no main content = form gets swapped with empty fragment, removing it -->
 ```
 
-If you want to prevent the empty main swap, use the [`empty`](/reference/attributes/hx-swap#empty) modifier:
+If you want to prevent the empty main swap, use the [`swapEmpty`](/reference/attributes/hx-swap#swapempty) modifier:
 
 ```html
-<form hx-post="/submit" hx-swap="outerHTML empty:false">
+<form hx-post="/submit" hx-swap="outerHTML swapEmpty:false">
 ```
 
 Or set the global default via [`htmx.config.defaultSwapEmpty`](/reference/config/htmx-config-defaultSwapEmpty).
 
 [`<hx-partial>`](/docs#partials-hx-partial) has the opposite default: a response containing only `<hx-partial>` elements
 and no main content will **not** trigger an empty main swap. This is because `<hx-partial>`-only responses signal
-intent — the server is explicitly routing multiple targeted updates with no main content to swap. Use `empty:true` on
+intent — the server is explicitly routing multiple targeted updates with no main content to swap. Use `swapEmpty:true` on
 the triggering element if you need the main swap to run anyway.
 
 ## See Also

--- a/www/src/content/reference/04-config/26-htmx-config-defaultSwapEmpty.md
+++ b/www/src/content/reference/04-config/26-htmx-config-defaultSwapEmpty.md
@@ -1,0 +1,33 @@
+---
+title: "htmx.config.defaultSwapEmpty"
+description: "Whether to skip swaps when the response body is empty"
+---
+
+The `htmx.config.defaultSwapEmpty` option controls whether htmx skips the swap when the server returns an empty response body.
+
+**Default:** `false`
+
+## Values
+
+- `false` — proceed with the swap even when the response is empty (default)
+- `true` — skip the swap when the response is empty
+
+## Example
+
+```javascript
+htmx.config.defaultSwapEmpty = true;
+```
+
+```html
+<meta name="htmx-config" content='{"defaultSwapEmpty":true}'>
+```
+
+Override per element with the [`empty`](/reference/attributes/hx-swap#empty) modifier on `hx-swap`:
+
+```html
+<!-- skip swap on empty response for this element only -->
+<div hx-swap="innerHTML empty"></div>
+
+<!-- always proceed, regardless of global default -->
+<div hx-swap="innerHTML empty:false"></div>
+```

--- a/www/src/content/reference/04-config/26-htmx-config-defaultSwapEmpty.md
+++ b/www/src/content/reference/04-config/26-htmx-config-defaultSwapEmpty.md
@@ -22,12 +22,12 @@ htmx.config.defaultSwapEmpty = true;
 <meta name="htmx-config" content='{"defaultSwapEmpty":true}'>
 ```
 
-Override per element with the [`empty`](/reference/attributes/hx-swap#empty) modifier on `hx-swap`:
+Override per element with the [`swapEmpty`](/reference/attributes/hx-swap#swapempty) modifier on `hx-swap`:
 
 ```html
 <!-- skip swap on empty response for this element only -->
-<div hx-swap="innerHTML empty"></div>
+<div hx-swap="innerHTML swapEmpty"></div>
 
 <!-- always proceed, regardless of global default -->
-<div hx-swap="innerHTML empty:false"></div>
+<div hx-swap="innerHTML swapEmpty:false"></div>
 ```


### PR DESCRIPTION
## Description
When using sse with hx-swap-oob swaps it can easily blank out the target if only hx-swap-oob are passed in a response.  We already have new behavior where if only hx-partial commands are included in a swapped response we now special case this and block the main swap if it is empty as sending only partial commands is a new advanced action and this new behavior is not a breaking change from before.  But for hx-swap-oob to retain support for valid legacy users who may have hx-swap-oob responses that also blank out the requesting form as well as swapping in the form response into a oob target we should keep the old behavior by default.  

So to allow users to control the swap on empty behavior and allow sse to set a safer default i've added a new empty swap modifier and set it up to have a defaultSwapEmpty config or empty:true/false modifier.

Corresponding issue:

## Testing
Added sse and swap tests

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
