### PR TITLE
make hx-encode fall back to form enctype

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -559,7 +559,7 @@ var htmx = (() => {
                     ctx.request.action = url.href;
                 }
                 ctx.request.body = null;
-            } else if (this.__attributeValue(elt, "hx-encoding") !== "multipart/form-data") {
+            } else if ((this.__attributeValue(elt, "hx-encoding") ?? form?.enctype) !== "multipart/form-data") {
                 ctx.request.body = new URLSearchParams(ctx.request.body);
             }
 

--- a/test/tests/unit/__handleTriggerEvent.js
+++ b/test/tests/unit/__handleTriggerEvent.js
@@ -239,6 +239,23 @@ describe('__handleTriggerEvent unit tests', function() {
         assert.equal(ctx.request.submitter, button)
     })
 
+    it('keeps multipart form data as FormData when form enctype is multipart/form-data', async function () {
+        let form = createProcessedHTML('<form enctype="multipart/form-data"><input name="field" value="test"><button hx-post="js:"></button></form>')
+        let button = form.querySelector('button')
+        let ctx = htmx.__createRequestContext(button, new Event('click'))
+        await htmx.__handleTriggerEvent(ctx)
+        assert.instanceOf(ctx.request.body, FormData)
+    })
+
+    it('hx-encoding takes precedence over form enctype', async function () {
+        let form = createProcessedHTML('<form enctype="multipart/form-data"><input name="field" value="test"><button hx-post="/test" hx-encoding="application/x-www-form-urlencoded"></button></form>')
+        let button = form.querySelector('button')
+        let ctx = htmx.__createRequestContext(button, new Event('click'))
+        ctx.fetch = async () => ({ status: 200, headers: new Headers(), text: async () => '' })
+        await htmx.__handleTriggerEvent(ctx)
+        assert.instanceOf(ctx.request.body, URLSearchParams)
+    })
+
     it('sets credentials to same-origin', async function () {
         let div = createProcessedHTML('<div hx-get="js:"></div>')
         let ctx = htmx.__createRequestContext(div, new Event('click'))


### PR DESCRIPTION
## Description
fall back to form enctype attribute when hx-encoding is not set.

Previously, htmx ignored a form's native enctype attribute when determining how to encode request bodies. Now, if hx-encoding is absent, the form's enctype is used as a fallback — so a form with enctype="multipart/form-data" will correctly send FormData without needing an explicit hx-encoding attribute. hx-encoding still takes precedence when present.

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
