### PR TITLE
Do not boost download links

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -982,7 +982,7 @@ var htmx = (() => {
             if (this.__shouldInitialize(elt)) {
                 if (elt.tagName === "A") {
                     if (elt.target === '' || elt.target === '_self') {
-                        return !elt.getAttribute('href')?.startsWith?.("#") && this.__isSameOrigin(elt.href)
+                        return !elt.hasAttribute('download') && !elt.getAttribute('href')?.startsWith?.("#") && this.__isSameOrigin(elt.href)
                     }
                 } else if (elt.tagName === "FORM") {
                     return elt.method !== 'dialog' &&  this.__isSameOrigin(elt.action);

--- a/test/tests/unit/__shouldBoost.js
+++ b/test/tests/unit/__shouldBoost.js
@@ -42,6 +42,12 @@ describe('__shouldBoost() unit tests', function() {
             assert.isFalse(result);
         });
 
+        it('should not boost links with download', function() {
+            const link = createDisconnectedHTML('<a href="/report.pdf" download>Download</a>');
+            const result = htmx.__shouldBoost(link);
+            assert.isFalse(result);
+        });
+
         it('should not boost links with target="_blank"', function() {
             const link = createDisconnectedHTML('<a href="/test" target="_blank">Link</a>');
             const result = htmx.__shouldBoost(link);

--- a/www/src/content/reference/01-attributes/20-hx-boost.md
+++ b/www/src/content/reference/01-attributes/20-hx-boost.md
@@ -95,9 +95,26 @@ Supported modifiers:
 - `target:SELECTOR` - Target element selector
 - `select:SELECTOR` - Content selection from response (works with `outerSync`; use `innerHTML strip` instead of `innerHTML` + `select` when targeting a non-body element)
 
+## Anchor Boosting
+
+Anchors are boosted when they navigate to the same origin in the current window:
+
+```html
+<a href="/example">Same-origin link</a>
+<a href="/example" target="_self">Same-origin link targeting this window</a>
+```
+
+These anchors are not boosted:
+
+```html
+<a href="https://other-domain.com/example">Different origin</a>
+<a href="#section">Local anchor</a>
+<a href="/report.pdf" download>Browser download</a>
+<a href="/example" target="_blank">New window or tab</a>
+```
+
 ## Notes
 
-* Only links that are to the same domain and that are not local anchors will be boosted
 * All requests are done via AJAX, so keep that in mind when doing things like redirects
 * To find out if the request results from a boosted anchor or form, look for
   [`HX-Boosted`](/reference/headers/HX-Boosted) in the request header


### PR DESCRIPTION
## Question

Should `hx-boost` boost `<a>` links that have the `download` attribute?

This PR assumes it should not. Was `download` support mistakenly left out of the anchor boost checks, or was boosting these links a deliberate choice?

## Changes

- Skip boosting anchors with `download`
- Add a unit test for `<a href="/report.pdf" download>`
- Document anchor boost behavior with examples
