### PR TITLE
improve morph preservation with focused buttons

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2104,8 +2104,8 @@ var htmx = (() => {
                 // Stop if too many ID elements would be displaced
                 displaceMatchCount += oldSet?.size || 0;
                 if (displaceMatchCount > nodeMatchCount) break;
-                // Don't move elements containing focus
-                if (cursor.contains(document.activeElement)) break;
+                // Don't move elements containing a focused typeable input
+                if (document.activeElement?.selectionStart != null && cursor.contains(document.activeElement)) break;
                 // Stop scanning if limit reached and no IDs to match
                 if (--scanLimit < 1 && nodeMatchCount === 0) break;
                 cursor = cursor.nextSibling;

--- a/test/tests/unit/morph.js
+++ b/test/tests/unit/morph.js
@@ -345,6 +345,53 @@ describe('Morph Swap Styles Tests', function() {
             assert.equal(checkbox.className, 'updated');
         });
 
+        it('preserves focused input node when validation error div is inserted before it', async function() {
+            // Without the guard, scan advances past the focused input to soft-match
+            // div.info for div.error, and the skip-over loop removes the focused input.
+            const div = createProcessedHTML(
+                '<div id="target"><input name="q" placeholder="Search"><div class="info">hint</div></div>'
+            );
+            const input = div.querySelector('input[name=q]');
+            input.value = 'hello';
+            input.focus();
+
+            await htmx.swap({
+                target: '#target',
+                text: '<div class="error">Required</div><input name="q" placeholder="Search"><div class="info">hint</div>',
+                swap: 'innerMorph',
+                sourceElement: div
+            });
+
+            assert.isNotNull(div.querySelector('.error'), 'error div should be inserted');
+            assert.equal(div.querySelector('input[name=q]'), input, 'focused input node should be preserved');
+            assert.equal(input.value, 'hello', 'typed value should be preserved');
+        });
+
+        it('does not block morph when a clicked button holds focus but is removed in new content', async function() {
+            // Without the fix, scan stopped at the focused button causing sibling
+            // inputs to be inserted fresh and losing their live values.
+            const div = createProcessedHTML('<div id="target"><button class="action">Go</button><input name="name"><input name="email"></div>');
+            const btn = div.querySelector('button');
+            const nameInput = div.querySelector('input[name=name]');
+            const emailInput = div.querySelector('input[name=email]');
+            nameInput.value = 'Alice';
+            emailInput.value = 'alice@example.com';
+            btn.focus();
+
+            await htmx.swap({
+                target: '#target',
+                text: '<input name="name"><input name="email">',
+                swap: 'innerMorph',
+                sourceElement: div
+            });
+
+            assert.equal(div.querySelector('input[name=name]'), nameInput, 'name input node should be reused');
+            assert.equal(div.querySelector('input[name=email]'), emailInput, 'email input node should be reused');
+            assert.equal(nameInput.value, 'Alice', 'name value should be preserved');
+            assert.equal(emailInput.value, 'alice@example.com', 'email value should be preserved');
+            assert.isNull(div.querySelector('button'), 'button should be removed');
+        });
+
 
     });
 


### PR DESCRIPTION
## Description
Fix morph scan blocking on focused non-text elements and add focused input protection test

When a morph response arrives while a button has transient focus (e.g. just clicked to trigger the request), the __findBestMatch scan was stopping at any element containing document.activeElement — including buttons. This caused sibling inputs after the button to be inserted fresh rather than morphed in place, losing any live values the user had typed.

The fix restricts the focus stop-guard to only halt the scan when the focused element is a typeable input (selectionStart != null). This correctly covers the case where a new element (e.g. a validation error div) is inserted before a focused text input in the response. Without the guard, the scan would advance past the focused input to soft-match a later sibling, and the skip-over loop would then displace and remove the input the user is actively typing into.  But for the non text case we do not need or want this guard to apply as we are doing a worse preservation match to save pointless focus.

Corresponding issue:

## Testing
Added a couple of tests

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
