### PR TITLE
update docs that SSE + idiomorph requires htmx-ext-sse 2.2.4+

### DIFF
--- a/www/content/extensions/idiomorph.md
+++ b/www/content/extensions/idiomorph.md
@@ -45,6 +45,8 @@ import `htmx.org`;
 import `idiomorph/htmx`;
 ```
 
+_Note: when used with the [SSE extension](@/extensions/sse.md), requires htmx-ext-sse 2.2.4+ ([#164](https://github.com/bigskysoftware/htmx-extensions/issues/164))._
+
 ## Usage
 
 Once you have referenced the idiomorph extension, you can register it with the name `morph` on the body and then begin

--- a/www/content/extensions/sse.md
+++ b/www/content/extensions/sse.md
@@ -52,6 +52,8 @@ import `htmx.org`;
 import `htmx-ext-sse`; 
 ```
 
+_Note: when used with the [idiomorph extension](@/extensions/idiomorph.md), requires htmx-ext-sse 2.2.4+ ([#164](https://github.com/bigskysoftware/htmx-extensions/issues/164))._
+
 ## Usage
 
 ```html


### PR DESCRIPTION
I noticed LLMs tend to use older versions of the sse & idiomorph extensions, which makes this a common issue. It might be worth adding a short note in the docs.

bigskysoftware/htmx-extensions#164

(Re-opened from #3827, which got auto-closed when I renamed the head branch on my fork.)