### PR TITLE
Forward `protocols` to WebSocket constructor in hx-ws extension

### DIFF
--- a/src/ext/hx-ws.js
+++ b/src/ext/hx-ws.js
@@ -178,7 +178,7 @@
         }
 
         try {
-            connection.socket = new WebSocket(url);
+            connection.socket = new WebSocket(url, connection.config?.protocols);
             let ac = new AbortController();
             connection.abortController = ac;
             let opts = { signal: ac.signal };

--- a/test/tests/ext/hx-ws.js
+++ b/test/tests/ext/hx-ws.js
@@ -15,8 +15,9 @@ describe('hx-ws WebSocket extension', function() {
             static CLOSING = 2;
             static CLOSED = 3;
             
-            constructor(url) {
+            constructor(url, protocols) {
                 this.url = url;
+                this.protocols = protocols;
                 this.readyState = MockWebSocket.CONNECTING;
                 this.listeners = {};
                 mockWebSocketInstances.push(this);
@@ -1308,6 +1309,45 @@ describe('hx-ws WebSocket extension', function() {
             assert.isNotNull(beforeDetail.message.json, 'message.json should be set for JSON messages');
             assert.isDefined(beforeDetail.message.json.content, 'message.json should have content field');
         });
+        it('passes protocols to WebSocket constructor', async function() {
+            htmx.config.ws = { protocols: 'my-protocol' };
+
+            createProcessedHTML('<div hx-ws:connect="/ws/test"></div>');
+            await htmx.timeout(50);
+
+            let ws = mockWebSocketInstances[0];
+            assert.equal(ws.protocols, 'my-protocol', 'WebSocket should receive protocols from config');
+        });
+
+        it('passes protocols array to WebSocket constructor', async function() {
+            htmx.config.ws = { protocols: ['proto1', 'proto2'] };
+
+            createProcessedHTML('<div hx-ws:connect="/ws/test"></div>');
+            await htmx.timeout(50);
+
+            let ws = mockWebSocketInstances[0];
+            assert.isArray(ws.protocols);
+            assert.deepEqual(ws.protocols, ['proto1', 'proto2']);
+        });
+
+        it('protocols defaults to undefined when not configured', async function() {
+            createProcessedHTML('<div hx-ws:connect="/ws/test"></div>');
+            await htmx.timeout(50);
+
+            let ws = mockWebSocketInstances[0];
+            assert.isUndefined(ws.protocols, 'protocols should be undefined when not configured');
+        });
+
+        it('per-element protocols override global config', async function() {
+            htmx.config.ws = { protocols: 'global-proto' };
+
+            createProcessedHTML('<div hx-ws:connect="/ws/test" hx-config="ws.protocols:per-element-proto"></div>');
+            await htmx.timeout(50);
+
+            let ws = mockWebSocketInstances[0];
+            assert.equal(ws.protocols, 'per-element-proto', 'Per-element protocols should override global');
+        });
+
     });
 
     // ========================================

--- a/www/src/content/extensions/03-hx-ws.md
+++ b/www/src/content/extensions/03-hx-ws.md
@@ -208,7 +208,8 @@ htmx.config.ws = {
     reconnectMaxAttempts: Infinity,// Maximum reconnect attempts (default: Infinity)
     reconnectJitter: 0.3,         // Jitter factor 0-1 for randomizing delays (default: 0.3)
     pauseOnBackground: true,      // Pause connection when tab is backgrounded (default: true)
-    pendingRequestTTL: 30000      // TTL for pending requests in ms (default: 30000)
+    pendingRequestTTL: 30000,     // TTL for pending requests in ms (default: 30000)
+    protocols: null               // WebSocket subprotocol to negotiate (string or array, default: null)
 };
 ```
 
@@ -220,6 +221,21 @@ htmx.config.ws = {
 Delay values accept time strings: `"500ms"`, `"1s"`, `"2m"`, or raw milliseconds.
 
 Per-element config is read from the element that creates the connection and stored on the connection object for its lifetime.
+
+### Subprotocols
+
+Set `protocols` to negotiate a [WebSocket subprotocol](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/WebSocket#protocols) during the handshake. Accepts a string or array of strings.
+
+```html
+<!-- Global via <meta> tag -->
+<meta name="htmx-config" content='{"ws":{"protocols":"mqtt"}}'>
+
+<!-- Per-element via HCON -->
+<div hx-ws:connect="/ws" hx-config="ws.protocols:mqtt">
+
+<!-- Multiple protocols (browser negotiates the first supported one) -->
+<div hx-ws:connect="/ws" hx-config='{"ws":{"protocols":["mqtt","graphql-ws"]}}'>
+```
 
 ### Reconnection Strategy
 


### PR DESCRIPTION
The extension now forwards `connection.config.protocols` as the second argument to `new WebSocket()`, enabling `Sec-WebSocket-Protocol` negotiation.

**Before:** The WebSocket constructor was always called with just a URL. Subprotocols (MQTT, STOMP, GraphQL-WS, etc.) were impossible to set. 

 **After:**
                                                                                                                                                                                                   
 ```html                                                                                                                                                                                                           
   <meta name="htmx-config" content="ws.protocols:mqtt">                                                                                                                                                 
                                                                                                                                                                                                                   
   <div hx-ws:connect="/ws" hx-config="ws.protocols:mqtt">                                                                                                                                                         
 ```