### PR TITLE
Fix rename htmx:afterSettle event reference

### DIFF
--- a/www/src/content/docs.mdx
+++ b/www/src/content/docs.mdx
@@ -283,7 +283,7 @@ All events follow a new pattern: `htmx:phase:action[:sub-action]`. Most error ev
 | `htmx:afterOnLoad`          | [`htmx:after:init`](/reference/events/htmx-after-init)                            | renamed | —                                   |
 | `htmx:afterProcessNode`     | [`htmx:after:init`](/reference/events/htmx-after-init)                            | renamed | —                                   |
 | `htmx:afterRequest`         | [`htmx:after:request`](/reference/events/htmx-after-request)                      | renamed | —                                   |
-| `htmx:afterSettle`          | [`htmx:after:swap`](/reference/events/htmx-after-swap)                            | renamed | —                                   |
+| `htmx:afterSettle`          | [`htmx:after:settle`](/reference/events/htmx-after-settle)                        | renamed | —                                   |
 | `htmx:afterSwap`            | [`htmx:after:swap`](/reference/events/htmx-after-swap)                            | renamed | —                                   |
 | `htmx:beforeCleanupElement` | [`htmx:before:cleanup`](/reference/events/htmx-before-cleanup)                    | renamed | —                                   |
 | `htmx:beforeHistorySave`    | [`htmx:before:history:update`](/reference/events/htmx-before-history-update)      | renamed | —                                   |


### PR DESCRIPTION
## Description
Probably a copy-paste-mistake?

## Checklist

* [ x ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ x  ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
