### PR TITLE
Expose HCON to extensions

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -166,6 +166,7 @@ var htmx = (() => {
             this.#actionSelector = this.__prefixSelector('[hx-action],[hx-get],[hx-post],[hx-put],[hx-patch],[hx-delete]');
             this.#hxOnQuery = new XPathEvaluator().createExpression(`.//*[@*[${this.__prefixes("hx-on").map(p => `starts-with(name(), "${p}")`).join(' or ')}]]`);
             this.#internalAPI = {
+                HCON,
                 attributeValue: this.__attributeValue.bind(this),
                 parseTriggerSpecs: this.__parseTriggerSpecs.bind(this),
                 determineMethodAndAction: this.__determineMethodAndAction.bind(this),


### PR DESCRIPTION
Expose the existing `HCON` object through the extension internal API (`api.HCON`).