### PR TITLE
Guard show target scroll method

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1220,7 +1220,7 @@ var htmx = (() => {
             }
             if (swapSpec.show === 'top' || swapSpec.show === 'bottom') {
                 let showTarget = swapSpec.showTarget ? this.__findExt(swapSpec.showTarget) : target;
-                showTarget?.scrollIntoView(swapSpec.show === 'top')
+                showTarget?.scrollIntoView?.(swapSpec.show === 'top')
             }
         }
 

--- a/test/tests/unit/__issueRequest.js
+++ b/test/tests/unit/__issueRequest.js
@@ -311,6 +311,28 @@ describe('__issueRequest unit tests', function() {
         assert.isFalse(errorFired)
     })
 
+    it('does not crash when show target is a text node after outerHTML swap', async function () {
+        let div = createProcessedHTML('<div hx-get="/test" hx-swap="outerHTML show:top"></div>')
+        let ctx = htmx.__createRequestContext(div, new Event('click'))
+
+        ctx.fetch = async () => ({
+            status: 200,
+            headers: new Headers(),
+            text: async () => 'Response'
+        })
+
+        let errorFired = false
+        let onError = () => errorFired = true
+        document.addEventListener('htmx:error', onError)
+
+        try {
+            await htmx.__issueRequest(ctx)
+            assert.isFalse(errorFired)
+        } finally {
+            document.removeEventListener('htmx:error', onError)
+        }
+    })
+
     it('throws clean error for unknown swap style with no extensions', async function () {
         let div = createProcessedHTML('<div hx-get="/test" hx-swap="foobar"></div>')
         let ctx = htmx.__createRequestContext(div, new Event('click'))


### PR DESCRIPTION
## Problem

`show` scrolling only checked whether the target exists:

```js
showTarget?.scrollIntoView(...)
```

If an `outerHTML` swap replaces the target with plain text, the follow-up `show:top` or `show:bottom` handling can receive a text node as the show target. Text nodes are truthy, but do not have `scrollIntoView`, so the request fires `htmx:error`.

## Fix

Guard the method call too:

```js
showTarget?.scrollIntoView?.(...)
```

Adds a regression test for an `outerHTML show:top` swap whose response is plain text.