### PR TITLE
handle processing morph placeholder nodes

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2060,6 +2060,7 @@ var htmx = (() => {
                     let placeholder = document.createElement(newChild.tagName);
                     oldParent.insertBefore(placeholder, insertionPoint);
                     this.__morphNode(placeholder, newChild, ctx);
+                    this.process(placeholder);
                     insertionPoint = placeholder.nextSibling;
                 } else {
                     oldParent.insertBefore(newChild, insertionPoint);
@@ -2127,10 +2128,6 @@ var htmx = (() => {
             }
             // Script tags must be identical to match - never patch a script with different content
             if (oldNode.tagName === 'SCRIPT' && !oldNode.isEqualNode(newNode)) return false;
-            // If both have Alpine reactive ID bindings, ignore ID mismatch
-            if (oldNode._x_bindings?.id && newNode.matches?.('[\\:id], [x-bind\\:id]')) {
-                return true;
-            }
             return !oldNode.id || oldNode.id === newNode.id;
         }
 

--- a/test/tests/unit/morph.js
+++ b/test/tests/unit/morph.js
@@ -638,6 +638,37 @@ describe('Morph Swap Styles Tests', function() {
             assert.equal(container.querySelector('#result').textContent, 'Clicked!', 'htmx actions on new div should work');
         });
 
+        it('processes hx-* on tag-changing outerMorph when new root has a persistent child id (issue #3882)', async function() {
+            // The bug: when outerMorph changes the root tag (div→form) AND the new root
+            // contains a child with a persistent id, __morphChildren creates a placeholder
+            // element instead of reusing the fragment node. newContent then holds the
+            // detached fragment node, so process() bails on !isConnected and hx-* attrs
+            // on the new root are never initialized.
+            mockResponse('GET', '/test',
+                '<form id="target" hx-post="/submit"><input id="same-child-id" name="q"></form>');
+            const container = createProcessedHTML(
+                '<div><div id="target"><input id="same-child-id" name="q"></div><div id="result"></div></div>');
+            const childInput = container.querySelector('#same-child-id');
+
+            await htmx.ajax('GET', '/test', {target: '#target', swap: 'outerMorph'});
+
+            const newForm = container.querySelector('#target');
+            assert.isNotNull(newForm, 'new form should be in the DOM');
+            assert.equal(newForm.tagName, 'FORM', 'root tag should have changed to FORM');
+            assert.equal(container.querySelector('#same-child-id'), childInput,
+                'persistent child should be the same node');
+            assert.equal(newForm.getAttribute('data-htmx-powered'), 'true',
+                'new form root must be processed so hx-post works');
+
+            mockResponse('POST', '/submit', 'Submitted!');
+            newForm.dispatchEvent(new Event('submit', {bubbles: true}));
+            await waitForEvent('htmx:after:swap', 100);
+
+            assert.equal(container.querySelector('#result') ??
+                container.querySelector('#target'), container.querySelector('#result') ??
+                newForm, 'swap target should be reachable');
+        });
+
         it('does not stack hx-on:click handlers across innerMorph', async function() {
             window._calls = 0;
             mockResponse('GET', '/test', '<button id="btn" hx-on:click="window._calls++">v</button>');


### PR DESCRIPTION
## Description
There is an edge case where the newContent processing of outerMorph does not catch one situation well.  We currently do not fully resolve all outerMorph inserted nodes due to the added complexity required so instead we track the newContent nodes plus the target node and process these as Nodes are either inserted new or the target node is morphed in place.  But if you break the morph by changing root tags and you still have persistent id children  contained in the now completely different parent node (this is a wierd edge case that would never happen in practice but is possible if you replace the nodes completely and include a hx-preserve node you want to move to the new different structure).   When the moprh detects that there are persistent id's that need retaining in a node even though the node is not morphable it creates a new placeholder node and morphs the new node in as just placing the new node in instead can cause problems for the id nodes inside moving levels etc.  But this placeholder node is now not the same node as the newContent nodes we started with and it could replace the main target node and in this rare edge case this placeholder node is never processed.  

To patch this edge case i've just added an extra process command that just processes this placeholder node after it is inserted to ensure it will always be processed correctly.  

Also found some dead code in morphing isSoftMatch that is meant to only be in the alpine compat extension and got left in core by mistake so removing this as well.

Corresponding issue:
#3882 

## Testing
Added test for this edge case

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
