### PR TITLE
handle trusted type polices in optimistic extension using cloneNode

### DIFF
--- a/src/ext/hx-optimistic.js
+++ b/src/ext/hx-optimistic.js
@@ -29,7 +29,8 @@
         let optimisticDiv = document.createElement('div');
         optimisticDiv.style.cssText = 'all: initial';
         optimisticDiv.classList.add('hx-optimistic');
-        optimisticDiv.innerHTML = sourceElt.innerHTML;
+        let sourceNodes = sourceElt instanceof HTMLTemplateElement ? sourceElt.content.childNodes : sourceElt.childNodes;
+        for (let child of sourceNodes) optimisticDiv.appendChild(child.cloneNode(true));
 
         // Set data-* for each request param
         if (ctx.optimisticBody) {


### PR DESCRIPTION
## Description
Found that hx-csp trusted type feature blocks optimistic extension as it uses innerHTML set which is then blocked.  Using a cloneNode of the template data solve this easily.

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
