### PR TITLE
cache compiled eval tags in safeEval feature for better hx-live perf

### DIFF
--- a/src/ext/hx-csp.js
+++ b/src/ext/hx-csp.js
@@ -122,6 +122,10 @@
             let counter = 0;
             let NativeFunction = Function;
             let NativeAsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
+            // Cache compiled script-injected functions by "keys|body" so each unique
+            // expression is only injected once — critical for hx-live which re-evaluates
+            // the same expressions on every DOM/input tick.
+            let safeEvalCache = new Map();
 
             function makeGatedConstructor(isAsync) {
                 return function(...keys) {
@@ -136,15 +140,20 @@
                                 return;
                             }
                             if (htmx.config.safeEval) {
-                                let fn = `__htmx_eval_${++counter}`;
-                                let script = document.createElement('script');
-                                script.nonce = pageNonce;
-                                script.textContent = ttPolicy.createScript(`window.${fn} = ${isAsync ? 'async ' : ''}function(${keys.join(',')}) { ${body} }`);
-                                document.head.appendChild(script);
-                                script.remove();
-                                let r = window[fn].call(thisArg, ...values);
-                                delete window[fn];
-                                return r;
+                                let cacheKey = keys.join(',') + '|' + body;
+                                let compiled = safeEvalCache.get(cacheKey);
+                                if (!compiled) {
+                                    let fn = `__htmx_eval_${++counter}`;
+                                    let script = document.createElement('script');
+                                    script.nonce = pageNonce;
+                                    script.textContent = ttPolicy.createScript(`window.${fn} = ${isAsync ? 'async ' : ''}function(${keys.join(',')}) { ${body} }`);
+                                    document.head.appendChild(script);
+                                    script.remove();
+                                    compiled = window[fn];
+                                    delete window[fn];
+                                    safeEvalCache.set(cacheKey, compiled);
+                                }
+                                return compiled.call(thisArg, ...values);
                             }
                             let Ctor = isAsync ? NativeAsyncFunction : NativeFunction;
                             return new Ctor(...keys, body).call(thisArg, ...values);


### PR DESCRIPTION
## Description
Found that hx-csp creates temporary script tags via its safeEval feature but when using things like hx-live this means it re-creates the same eval script each dom update.  We can easily cache the functions and reuse them so they do not need to be be re-created every time.

Corresponding issue:

## Testing
Tested this manually in a test project to confirm faster performance during events.  It went from ~2ms to fire a small batch of expressions down to ~1.2ms.  before safe-eval was a bit slower by design than normal eval but now it is just a little bit faster but the perf difference is hard to notice comparing the two.  

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
