### PR TITLE
Fix upgrade-check false positive for hx-history-elt

### DIFF
--- a/src/scripts/upgrade-check.py
+++ b/src/scripts/upgrade-check.py
@@ -27,7 +27,6 @@ REMOVED_ATTRS = {
     "hx-inherit": "not needed (inheritance is explicit in v4)",
     "hx-request": "use hx-config",
     "hx-history": "removed (no localStorage cache in v4)",
-    "hx-history-elt": "removed",
 }
 
 RENAMED_ATTRS = {


### PR DESCRIPTION
The `upgrade-check` tool is incorrectly flagging `hx-history-elt` as a removed attribute, when it was actually restored in v4 core.

## Problem

The `REMOVED_ATTRS` dictionary in `src/scripts/upgrade-check.py` contained:

```python
"hx-history-elt": "removed",
```

This caused the upgrade-check tool to warn users that `hx-history-elt` should be removed from their HTML, even though it's a valid, working attribute in htmx v4.

## Evidence

`hx-history-elt` was restored to v4 core in commit `2b39a899` (PR #3773):
- "Add back hx-history-elt and improve history cache extension"

The attribute is actively used in `src/htmx.js:1636`:

```javascript
let historyElt = document.querySelector(this.__prefixSelector('[hx-history-elt]')) || document.body;
```

And documented in CHANGELOG.md:

> Restored `hx-history-elt` from htmx 2 and improved the `hx-history-cache` extension.

## Fix

Removed `hx-history-elt` from the `REMOVED_ATTRS` dictionary in `src/scripts/upgrade-check.py`.

Note: `dist/scripts/upgrade-check.py` is a build copy and isn't updated here, per guidelines; should be regenerated on release.

## Testing

The upgrade-check tool will no longer flag `hx-history-elt` as removed, allowing users to keep this valid attribute in their HTML.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
