### PR TITLE
improve hx-live perf by skipping no change updates

### DIFF
--- a/src/ext/hx-live.js
+++ b/src/ext/hx-live.js
@@ -120,7 +120,6 @@
 
         let value = rest[0];
         for (let e of elts) {
-            if (applyAttr([e], name) === value) continue;
             if (isClass) {
                 e.classList.toggle(name.slice(1), !!value);
                 if (e.classList.length === 0) e.removeAttribute('class');
@@ -615,7 +614,9 @@
             return;
         }
         if (attrName === 'style') { applyStyleBinding(elt, value); return; }
-        // Everything else (class, .class, aria-*, boolean, property-sync, regular) → applyAttr.
+        // Always write aria-* and property-backed attrs (getter type differs from setter).
+        // For everything else skip if unchanged.
+        if (!attrName.startsWith('aria-') && !PROPERTY_ATTRS.has(attrName) && applyAttr([elt], attrName) === value) return;
         applyAttr([elt], attrName, value);
     }
 

--- a/src/ext/hx-live.js
+++ b/src/ext/hx-live.js
@@ -11,6 +11,7 @@
     let dbSym = Symbol();
     let observer = null;
     let recomputeBound = null;
+    let inputBound = null;
     let swaps = 0;
     let i = 0;
     let start = 0;
@@ -24,10 +25,8 @@
     function ensureActive() {
         if (observer) return;
         recomputeBound = () => schedule();
-        document.addEventListener('input', () => {
-            clearTimeout(inputDebounceId);
-            inputDebounceId = setTimeout(schedule, INPUT_DEBOUNCE_MS);
-        }, true);
+        inputBound = () => { clearTimeout(inputDebounceId); inputDebounceId = setTimeout(schedule, INPUT_DEBOUNCE_MS); };
+        document.addEventListener('input', inputBound, true);
         document.addEventListener('change', recomputeBound, true);
         observer = new MutationObserver(recomputeBound);
         observer.observe(document.documentElement, OBSERVE_OPTIONS);
@@ -37,7 +36,8 @@
         if (!observer) return;
         clearTimeout(inputDebounceId);
         inputDebounceId = null;
-        document.removeEventListener('input', recomputeBound, true);
+        document.removeEventListener('input', inputBound, true);
+        inputBound = null;
         document.removeEventListener('change', recomputeBound, true);
         observer.disconnect();
         observer = null;

--- a/src/ext/hx-live.js
+++ b/src/ext/hx-live.js
@@ -18,10 +18,16 @@
 
     const OBSERVE_OPTIONS = { childList: true, subtree: true, attributes: true, characterData: true };
 
+    let inputDebounceId = null;
+    const INPUT_DEBOUNCE_MS = htmx.config.live?.inputDebounceMs ?? 100;
+
     function ensureActive() {
         if (observer) return;
         recomputeBound = () => schedule();
-        document.addEventListener('input', recomputeBound, true);
+        document.addEventListener('input', () => {
+            clearTimeout(inputDebounceId);
+            inputDebounceId = setTimeout(schedule, INPUT_DEBOUNCE_MS);
+        }, true);
         document.addEventListener('change', recomputeBound, true);
         observer = new MutationObserver(recomputeBound);
         observer.observe(document.documentElement, OBSERVE_OPTIONS);
@@ -29,6 +35,8 @@
 
     function deactivate() {
         if (!observer) return;
+        clearTimeout(inputDebounceId);
+        inputDebounceId = null;
         document.removeEventListener('input', recomputeBound, true);
         document.removeEventListener('change', recomputeBound, true);
         observer.disconnect();
@@ -112,6 +120,7 @@
 
         let value = rest[0];
         for (let e of elts) {
+            if (applyAttr([e], name) === value) continue;
             if (isClass) {
                 e.classList.toggle(name.slice(1), !!value);
                 if (e.classList.length === 0) e.removeAttribute('class');
@@ -595,8 +604,16 @@
     }
 
     function writeAttrBinding(elt, attrName, value) {
-        if (attrName === 'text') { elt.textContent = value == null ? '' : String(value); return; }
-        if (attrName === 'html') { elt.innerHTML = value == null ? '' : String(value); return; }
+        if (attrName === 'text') {
+            let s = value == null ? '' : String(value);
+            if (elt.textContent !== s) elt.textContent = s;
+            return;
+        }
+        if (attrName === 'html') {
+            let s = value == null ? '' : String(value);
+            if (elt.innerHTML !== s) elt.innerHTML = s;
+            return;
+        }
         if (attrName === 'style') { applyStyleBinding(elt, value); return; }
         // Everything else (class, .class, aria-*, boolean, property-sync, regular) → applyAttr.
         applyAttr([elt], attrName, value);


### PR DESCRIPTION
## Description
We can improve hx-live performance so we can support maybe 1000 live bindings on a page by guarding writes that don't change anything so it avoids wasted time updating the dom with no changes.  This gives a 2-3x speed increase

Also added a possible 100ms debounce for input events so typing into an input does not overload the live tasks at the cost of slowing down the updates from typing.  change and dom mutations fire instantly still.

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
