### PR TITLE
Allow custom methods like query

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -527,7 +527,7 @@ var htmx = (() => {
             })
 
             if (!this.__trigger(elt, "htmx:config:request", {ctx: ctx})) return
-            if (!this.#verbs.includes(ctx.request.method.toLowerCase())) return
+            if (ctx.request.method === 'DIALOG') return
 
             let javascriptContent = this.__extractJavascriptContent(ctx.request.action);
             if (javascriptContent != null) {

--- a/test/lib/fetch-mock.js
+++ b/test/lib/fetch-mock.js
@@ -85,7 +85,7 @@ class FetchMock {
     // Mock a response for a specific URL pattern
     mockResponse(method, urlPattern, response, options = {}) {
         let upperCasedMethod = method.toUpperCase();
-        if (['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].indexOf(upperCasedMethod) < 0) {
+        if (['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'QUERY'].indexOf(upperCasedMethod) < 0) {
             throw Error("Invalid HTTP method: " + method)
         }
         if (typeof response === 'string') {

--- a/test/tests/attributes/hx-action.js
+++ b/test/tests/attributes/hx-action.js
@@ -53,4 +53,13 @@ describe('hx-action attribute', function() {
         playground().innerHTML.should.equal('Put!')
     })
 
+    it('hx-action with hx-method QUERY issues a QUERY request', async function() {
+        mockResponse('QUERY', '/test', 'Queried!')
+        let btn = createProcessedHTML('<button hx-action="/test" hx-method="QUERY">Click Me!</button>')
+        btn.click()
+        await forRequest()
+        fetchMock.calls[0].request.method.should.equal('QUERY')
+        btn.innerHTML.should.equal('Queried!')
+    })
+
 })

--- a/test/tests/unit/__handleTriggerEvent.js
+++ b/test/tests/unit/__handleTriggerEvent.js
@@ -107,14 +107,6 @@ describe('__handleTriggerEvent unit tests', function() {
         assert.isUndefined(window.testExecuted)
     })
 
-    it('returns early if method not in verbs list', async function () {
-        let div = createProcessedHTML('<div hx-get="js:window.testExecuted = true"></div>')
-        let ctx = htmx.__createRequestContext(div, new Event('click'))
-        ctx.request.method = 'INVALID'
-        await htmx.__handleTriggerEvent(ctx)
-        assert.isUndefined(window.testExecuted)
-    })
-
     it('executes javascript when action starts with js:', async function () {
         let div = createProcessedHTML('<div hx-get="js:window.testExecuted = true"></div>')
         let ctx = htmx.__createRequestContext(div, new Event('click'))


### PR DESCRIPTION
## Description
We can allow custom methods with hx-action and h-method like the new Query method which is being implemented.  before we had a guard blocking all non standard methods but we only need to block the special case of 'dialog' which we have to ignore to let the browser handle it.

Corresponding issue:

## Testing
Added a test for hx-method of query

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
