### PR TITLE
add history cache to htmax but make it opt in via config

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "build": "npm run build:iife && npm run build:esm && npm run build:minify && npm run build:ext && npm run build:htmax && npm run build:editors && npm run build:skills && npm run build:scripts && npm run build:types && npm run build:compress",
-    "build:htmax": "EXTS='hx-sse hx-ws hx-preload hx-browser-indicator hx-download hx-optimistic hx-targets hx-live'; cat dist/htmx.js $(for e in $EXTS; do echo dist/ext/$e.js; done) > dist/htmax.js && terser --compress --mangle --source-map -o dist/htmax.min.js dist/htmax.js",
+    "build:htmax": "EXTS='hx-sse hx-ws hx-preload hx-browser-indicator hx-download hx-optimistic hx-targets hx-live hx-history-cache'; cat dist/htmx.js $(for e in $EXTS; do echo dist/ext/$e.js; done) > dist/htmax.js && sed -i \"s/this\\.version = '\\(.*\\)'/this.version = '\\1-htmax'/\" dist/htmax.js && terser --compress --mangle --source-map -o dist/htmax.min.js dist/htmax.js",
     "build:skills": "mkdir -p dist/skills && cp src/skills/*.md dist/skills/",
     "build:iife": "sed -e 's/__proto__/@@PROTOKEY@@/g' -e 's/__/#/g' -e 's/@@PROTOKEY@@/__proto__/g' src/htmx.js > dist/htmx.js",
     "build:esm": "sed -e 's/__proto__/@@PROTOKEY@@/g' -e 's/__/#/g' -e 's/@@PROTOKEY@@/__proto__/g' src/htmx.js > dist/htmx.esm.js && printf '\\nif (typeof window !== \"undefined\") window.htmx = htmx;\\nexport default htmx;\\n' >> dist/htmx.esm.js",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "build": "npm run build:iife && npm run build:esm && npm run build:minify && npm run build:ext && npm run build:htmax && npm run build:editors && npm run build:skills && npm run build:scripts && npm run build:types && npm run build:compress",
-    "build:htmax": "EXTS='hx-sse hx-ws hx-preload hx-browser-indicator hx-download hx-optimistic hx-targets hx-live hx-history-cache'; cat dist/htmx.js $(for e in $EXTS; do echo dist/ext/$e.js; done) > dist/htmax.js && sed -i \"s/this\\.version = '\\(.*\\)'/this.version = '\\1-htmax'/\" dist/htmax.js && terser --compress --mangle --source-map -o dist/htmax.min.js dist/htmax.js",
+    "build:htmax": "EXTS='hx-sse hx-ws hx-preload hx-browser-indicator hx-download hx-optimistic hx-targets hx-live hx-history-cache hx-upsert hx-alpine-compat'; cat dist/htmx.js $(for e in $EXTS; do echo dist/ext/$e.js; done) > dist/htmax.js && sed -i \"s/this\\.version = '\\(.*\\)'/this.version = '\\1-htmax'/\" dist/htmax.js && terser --compress --mangle --source-map -o dist/htmax.min.js dist/htmax.js",
     "build:skills": "mkdir -p dist/skills && cp src/skills/*.md dist/skills/",
     "build:iife": "sed -e 's/__proto__/@@PROTOKEY@@/g' -e 's/__/#/g' -e 's/@@PROTOKEY@@/__proto__/g' src/htmx.js > dist/htmx.js",
     "build:esm": "sed -e 's/__proto__/@@PROTOKEY@@/g' -e 's/__/#/g' -e 's/@@PROTOKEY@@/__proto__/g' src/htmx.js > dist/htmx.esm.js && printf '\\nif (typeof window !== \"undefined\") window.htmx = htmx;\\nexport default htmx;\\n' >> dist/htmx.esm.js",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "build": "npm run build:iife && npm run build:esm && npm run build:minify && npm run build:ext && npm run build:htmax && npm run build:editors && npm run build:skills && npm run build:scripts && npm run build:types && npm run build:compress",
-    "build:htmax": "EXTS='hx-sse hx-ws hx-preload hx-browser-indicator hx-download hx-optimistic hx-targets hx-live hx-history-cache hx-upsert hx-alpine-compat'; cat dist/htmx.js $(for e in $EXTS; do echo dist/ext/$e.js; done) > dist/htmax.js && sed -i \"s/this\\.version = '\\(.*\\)'/this.version = '\\1-htmax'/\" dist/htmax.js && terser --compress --mangle --source-map -o dist/htmax.min.js dist/htmax.js",
+    "build:htmax": "EXTS='hx-sse hx-ws hx-preload hx-browser-indicator hx-download hx-optimistic hx-targets hx-live hx-history-cache hx-upsert hx-alpine-compat'; { cat dist/htmx.js; printf '\\nhtmx.version += \"-htmax\";\\nhtmx.config.historyCache ??= { disable: true };\\n'; for e in $EXTS; do cat dist/ext/$e.js; done; } > dist/htmax.js && terser --compress --mangle --source-map -o dist/htmax.min.js dist/htmax.js",
     "build:skills": "mkdir -p dist/skills && cp src/skills/*.md dist/skills/",
     "build:iife": "sed -e 's/__proto__/@@PROTOKEY@@/g' -e 's/__/#/g' -e 's/@@PROTOKEY@@/__proto__/g' src/htmx.js > dist/htmx.js",
     "build:esm": "sed -e 's/__proto__/@@PROTOKEY@@/g' -e 's/__/#/g' -e 's/@@PROTOKEY@@/__proto__/g' src/htmx.js > dist/htmx.esm.js && printf '\\nif (typeof window !== \"undefined\") window.htmx = htmx;\\nexport default htmx;\\n' >> dist/htmx.esm.js",

--- a/src/editors/jetbrains/htmx.web-types.json
+++ b/src/editors/jetbrains/htmx.web-types.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/web-types",
   "name": "htmx",
-  "version": "4.0.0-beta5",
+  "version": "4.0.0-beta6",
   "default-icon": "./htmx.svg",
   "js-types-syntax": "typescript",
   "description-markup": "markdown",

--- a/src/ext/hx-browser-indicator.js
+++ b/src/ext/hx-browser-indicator.js
@@ -9,7 +9,8 @@
     let cleanupNavigation = null;
 
     function shouldShowIndicator(elt) {
-        if (api.attributeValue(elt, 'hx-browser-indicator') === 'true') return true;
+        let val = api.attributeValue(elt, 'hx-browser-indicator');
+        if (val != null && val !== 'false') return true;
         if (htmx.config.boostBrowserIndicator && elt._htmx?.boosted) return true;
         return false;
     }

--- a/src/ext/hx-history-cache.js
+++ b/src/ext/hx-history-cache.js
@@ -193,7 +193,7 @@
             htmx.config.historyCache            ??= {};
             htmx.config.historyCache.size          ??= 10;
             htmx.config.historyCache.refreshOnMiss ??= false;
-            htmx.config.historyCache.disable       ??= htmx.version.endsWith('-htmax');
+            htmx.config.historyCache.disable       ??= false;
             htmx.config.historyCache.swapStyle     ??= 'outerSync';
             stampCurrentEntry();
         },

--- a/src/ext/hx-history-cache.js
+++ b/src/ext/hx-history-cache.js
@@ -193,7 +193,7 @@
             htmx.config.historyCache            ??= {};
             htmx.config.historyCache.size          ??= 10;
             htmx.config.historyCache.refreshOnMiss ??= false;
-            htmx.config.historyCache.disable       ??= false;
+            htmx.config.historyCache.disable       ??= htmx.version.endsWith('-htmax');
             htmx.config.historyCache.swapStyle     ??= 'outerSync';
             stampCurrentEntry();
         },

--- a/test/manual/htmax.html
+++ b/test/manual/htmax.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="htmx-config" content='{"logAll":true,"historyCache":{"disable":false}}'>
+    <script src="/htmax.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <style>
+        .htmx-indicator { opacity: 0; transition: opacity 200ms; }
+        .htmx-request .htmx-indicator { opacity: 1; }
+    </style>
+</head>
+<body class="max-w-3xl mx-auto p-6 my-8 space-y-12">
+
+<h1 class="text-2xl font-bold">htmax bundle — manual test</h1>
+<p class="text-sm text-neutral-500">
+    Version: <code id="version"></code>
+    <script>document.getElementById('version').textContent = htmx.version;</script>
+</p>
+
+<!-- ─── SSE ─────────────────────────────────────────────────────────────── -->
+<section class="space-y-3">
+    <h2 class="text-lg font-semibold">1. SSE (hx-sse)</h2>
+    <p class="text-sm text-neutral-500">Connects to a stream and receives 5 messages then closes.</p>
+    <div hx-sse:connect="/htmax/sse-stream">
+        <div hx-sse:swap="message" hx-sse:close="close" id="sse-out" class="p-3 bg-neutral-100 rounded min-h-8">
+            Waiting for stream…
+        </div>
+    </div>
+</section>
+
+<!-- ─── WebSockets ───────────────────────────────────────────────────────── -->
+<section class="space-y-3">
+    <h2 class="text-lg font-semibold">2. WebSockets (hx-ws)</h2>
+    <p class="text-sm text-neutral-500">Checks the extension is registered (full WS test requires <code>ws-server.js</code>).</p>
+    <button hx-get="/htmax/ws-status" hx-target="#ws-out"
+            class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+        Check WS extension
+    </button>
+    <div id="ws-out" class="p-3 bg-neutral-100 rounded min-h-8"></div>
+</section>
+
+<!-- ─── Preload ──────────────────────────────────────────────────────────── -->
+<section class="space-y-3">
+    <h2 class="text-lg font-semibold">3. Preload (hx-preload)</h2>
+    <p class="text-sm text-neutral-500">Hover the button to preload, then click to swap. Check Network tab — request fires on hover.</p>
+    <button hx-get="/htmax/preload-target" hx-target="#preload-out" hx-preload
+            class="px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700">
+        Hover then Click
+    </button>
+    <div id="preload-out" class="p-3 bg-neutral-100 rounded min-h-8"></div>
+</section>
+
+<!-- ─── Browser Indicator ────────────────────────────────────────────────── -->
+<section class="space-y-3">
+    <h2 class="text-lg font-semibold">4. Browser Indicator (hx-browser-indicator)</h2>
+    <p class="text-sm text-neutral-500">Browser's native loading spinner should appear during the 1.5s request.</p>
+    <button hx-get="/htmax/indicator" hx-target="#indicator-out" hx-browser-indicator
+            class="px-4 py-2 bg-yellow-600 text-white rounded hover:bg-yellow-700">
+        Trigger slow request
+    </button>
+    <div id="indicator-out" class="p-3 bg-neutral-100 rounded min-h-8"></div>
+</section>
+
+<!-- ─── Download ─────────────────────────────────────────────────────────── -->
+<section class="space-y-3">
+    <h2 class="text-lg font-semibold">5. Download (hx-download)</h2>
+    <p class="text-sm text-neutral-500">Should trigger a file download without navigating away.</p>
+    <button hx-get="/htmax/download" hx-download="htmax-test.txt"
+            class="px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-700">
+        Download file
+    </button>
+</section>
+
+<!-- ─── Optimistic ───────────────────────────────────────────────────────── -->
+<section class="space-y-3">
+    <h2 class="text-lg font-semibold">6. Optimistic (hx-optimistic)</h2>
+    <p class="text-sm text-neutral-500">Template content shows immediately; server response replaces it after 1.5s.</p>
+    <button hx-post="/htmax/optimistic" hx-target="#optimistic-out"
+            hx-optimistic="#optimistic-template"
+            class="px-4 py-2 bg-orange-600 text-white rounded hover:bg-orange-700">
+        Submit optimistically
+    </button>
+    <template id="optimistic-template">
+        <span class="text-orange-500 italic">⏳ Saving…</span>
+    </template>
+    <div id="optimistic-out" class="p-3 bg-neutral-100 rounded min-h-8"></div>
+</section>
+
+<!-- ─── Targets ──────────────────────────────────────────────────────────── -->
+<section class="space-y-3">
+    <h2 class="text-lg font-semibold">7. Targets (hx-targets)</h2>
+    <p class="text-sm text-neutral-500">Same response swapped into two elements simultaneously.</p>
+    <button hx-get="/htmax/targets" hx-targets="#targets-out-1, #targets-out-2"
+            class="px-4 py-2 bg-pink-600 text-white rounded hover:bg-pink-700">
+        Swap two targets
+    </button>
+    <div class="flex gap-4">
+        <div id="targets-out-1" class="flex-1 p-3 bg-neutral-100 rounded min-h-8">Target 1</div>
+        <div id="targets-out-2" class="flex-1 p-3 bg-neutral-100 rounded min-h-8">Target 2</div>
+    </div>
+</section>
+
+<!-- ─── Live ─────────────────────────────────────────────────────────────── -->
+<section class="space-y-3">
+    <h2 class="text-lg font-semibold">8. Live (hx-live)</h2>
+    <p class="text-sm text-neutral-500">Counter increments live as you type.</p>
+    <div class="flex gap-4 items-center">
+        <input id="live-input" type="text" placeholder="Type here…"
+               class="border rounded px-3 py-2 flex-1">
+        <span hx-live:text="document.getElementById('live-input').value.length + ' chars'"
+              class="text-lg font-mono w-24 text-right">0 chars</span>
+    </div>
+</section>
+
+<!-- ─── Upsert ───────────────────────────────────────────────────────────── -->
+<section class="space-y-3">
+    <h2 class="text-lg font-semibold">9. Upsert (hx-upsert)</h2>
+    <p class="text-sm text-neutral-500">Item 1 updates in place, Item 3 is inserted. Item 2 is preserved.</p>
+    <button hx-post="/htmax/upsert" hx-swap="none"
+            class="px-4 py-2 bg-violet-600 text-white rounded hover:bg-violet-700">
+        Upsert items
+    </button>
+    <div id="upsert-list" class="space-y-2 mt-2">
+        <div id="item-1" class="p-2 bg-neutral-100 rounded">Item 1 (original)</div>
+        <div id="item-2" class="p-2 bg-neutral-100 rounded">Item 2 (should stay)</div>
+    </div>
+</section>
+
+<!-- ─── Alpine Compat ────────────────────────────────────────────────────── -->
+<section class="space-y-3">
+    <h2 class="text-lg font-semibold">10. Alpine Compat (hx-alpine-compat)</h2>
+    <p class="text-sm text-neutral-500">
+        Alpine is not loaded here — extension should silently no-op.
+        Check console for errors (there should be none).
+    </p>
+    <button hx-get="/htmax/clicked" hx-target="#alpine-out"
+            class="px-4 py-2 bg-sky-600 text-white rounded hover:bg-sky-700">
+        Trigger swap (no Alpine errors)
+    </button>
+    <div id="alpine-out" class="p-3 bg-neutral-100 rounded min-h-8"></div>
+</section>
+
+<!-- ─── History Cache ────────────────────────────────────────────────────── -->
+<section class="space-y-3">
+    <h2 class="text-lg font-semibold">11. History Cache (hx-history-cache)</h2>
+    <p class="text-sm text-neutral-500">
+        Navigate to page 2, then hit the browser back button.
+        The restore should come from <code>sessionStorage</code> (no network request in DevTools).
+    </p>
+    <div id="history-content">
+        <p class="mb-2">Page 1 — initial content.</p>
+        <a hx-get="/htmax/page2" hx-target="#history-content" hx-push-url="/htmax/page2"
+           href="/htmax/page2"
+           class="text-blue-600 underline cursor-pointer">
+            Go to page 2
+        </a>
+    </div>
+</section>
+
+<footer class="pt-6 border-t border-neutral-200 text-sm text-neutral-400">
+    Check browser console — <code>htmx.config.logAll</code> is on.
+    History cache is enabled via <code>historyCache.disable:false</code> in the meta tag.
+</footer>
+
+</body>
+</html>

--- a/test/manual/server.js
+++ b/test/manual/server.js
@@ -27,6 +27,36 @@ const routes = {
     '/ios-sse':        serve('test/manual/ios-sse.html'),
     '/htmx.js':        serve('src/htmx.js', 'application/javascript'),
     '/ext/hx-sse.js':  serve('src/ext/hx-sse.js', 'application/javascript'),
+    '/htmax.js':       serve('dist/htmax.js', 'application/javascript'),
+    '/htmax':          serve('test/manual/htmax.html'),
+
+    // htmax test endpoints
+    '/htmax/clicked':       (req, res) => { res.writeHead(200, {'Content-Type': 'text/html'}); res.end('<span class="text-green-600 font-semibold">✓ SSE extension loaded (hx-sse registered)</span>'); },
+    '/htmax/ws-status':     (req, res) => { res.writeHead(200, {'Content-Type': 'text/html'}); res.end('<span class="text-green-600 font-semibold">✓ WS extension loaded (hx-ws registered)</span>'); },
+    '/htmax/preload-target':(req, res) => { res.writeHead(200, {'Content-Type': 'text/html'}); res.end('<span class="text-green-600 font-semibold">✓ Preloaded and swapped!</span>'); },
+    '/htmax/download':      (req, res) => { res.writeHead(200, {'Content-Type': 'text/plain', 'Content-Disposition': 'attachment; filename="htmax-test.txt"'}); res.end('htmax download test'); },
+    '/htmax/optimistic':    (req, res) => { setTimeout(() => { res.writeHead(200, {'Content-Type': 'text/html'}); res.end('<span class="text-green-600 font-semibold">✓ Server confirmed</span>'); }, 1500); },
+    '/htmax/targets':       (req, res) => { res.writeHead(200, {'Content-Type': 'text/html'}); res.end('<span class="text-green-600 font-semibold">✓ hx-targets swapped both elements</span>'); },
+    '/htmax/upsert':        (req, res) => { res.writeHead(200, {'Content-Type': 'text/html'}); res.end('<template hx type="upsert" hx-target="#upsert-list"><div id="item-1" class="p-2 bg-green-100 rounded">Item 1 (updated)</div><div id="item-3" class="p-2 bg-blue-100 rounded">Item 3 (new)</div></template>'); },
+    '/htmax/page2':         (req, res) => { res.writeHead(200, {'Content-Type': 'text/html'}); res.end('<div id="history-content" hx-push-url="/htmax/page2"><p>Page 2 content — hit back to test history cache restore.</p><a hx-get="/htmax/page1" hx-target="#history-content" hx-push-url="/htmax/page1" href="/htmax/page1">Back to page 1</a></div>'); },
+    '/htmax/page1':         (req, res) => { res.writeHead(200, {'Content-Type': 'text/html'}); res.end('<div id="history-content" hx-push-url="/htmax/page1"><p>Page 1 content — restored from cache!</p><a hx-get="/htmax/page2" hx-target="#history-content" hx-push-url="/htmax/page2" href="/htmax/page2">Go to page 2</a></div>'); },
+    '/htmax/indicator':     (req, res) => { setTimeout(() => { res.writeHead(200, {'Content-Type': 'text/html'}); res.end('<span class="text-green-600 font-semibold">✓ Request complete</span>'); }, 1500); },
+    '/htmax/live-count':    (req, res) => { res.writeHead(200, {'Content-Type': 'text/html'}); res.end('<span id="live-count">0</span>'); },
+
+    '/htmax/sse-stream': sse((req, res) => {
+        let n = 0;
+        const send = () => {
+            if (n++ < 5) {
+                res.write(`data: <span>SSE message #${n}</span>\n\n`);
+                setTimeout(send, 800);
+            } else {
+                res.write(`event: close\ndata: <span class="text-green-600 font-semibold">✓ Stream complete</span>\n\n`);
+            }
+        };
+        send();
+    }),
+
+    '/htmax/ws': (req, res) => { res.writeHead(200, {'Content-Type': 'text/html'}); res.end('<span class="text-green-600 font-semibold">✓ WS extension present (full WS test requires ws-server.js)</span>'); },
 
     '/heartbeat': sse((req, res) => {
         let count = 0;

--- a/www/src/content/docs.mdx
+++ b/www/src/content/docs.mdx
@@ -98,8 +98,6 @@ To enable history caching, opt in via the meta tag:
 
 ## Migration
 
-### Quick Migration
-
 There are two major behavioral changes between htmx 2.x and 4.x:
 
 * In htmx 2.0 attribute inheritance is *implicit* by default while in 4.0 it is explicit by default

--- a/www/src/content/docs.mdx
+++ b/www/src/content/docs.mdx
@@ -80,6 +80,8 @@ The `htmax.js` file bundles htmx with the most popular extensions in a single fi
 * [`hx-optimistic`](/extensions/hx-optimistic)
 * [`hx-targets`](/extensions/hx-targets)
 * [`hx-live`](/extensions/hx-live)
+* [`hx-upsert`](/extensions/hx-upsert)
+* [`hx-alpine-compat`](/extensions/hx-alpine-compat) _(no-op if Alpine.js is not present)_
 * [`hx-history-cache`](/extensions/hx-history-cache) _(included but disabled by default)_
 
 The extensions are automatically available, you can just use their attributes directly (e.g. `hx-sse:connect`, `hx-ws:connect`).

--- a/www/src/content/docs.mdx
+++ b/www/src/content/docs.mdx
@@ -80,6 +80,7 @@ The `htmax.js` file bundles htmx with the most popular extensions in a single fi
 * [`hx-optimistic`](/extensions/hx-optimistic)
 * [`hx-targets`](/extensions/hx-targets)
 * [`hx-live`](/extensions/hx-live)
+* [`hx-history-cache`](/extensions/hx-history-cache) _(included but disabled by default)_
 
 The extensions are automatically available, you can just use their attributes directly (e.g. `hx-sse:connect`, `hx-ws:connect`).
 
@@ -87,7 +88,15 @@ The extensions are automatically available, you can just use their attributes di
 <script src="/js/htmax.min.js"></script>
 ```
 
+To enable history caching, opt in via the meta tag:
+
+```html
+<meta name="htmx-config" content='{"historyCache": {"disable": false}}'>
+```
+
 ## Migration
+
+### Quick Migration
 
 There are two major behavioral changes between htmx 2.x and 4.x:
 

--- a/www/src/content/docs.mdx
+++ b/www/src/content/docs.mdx
@@ -81,7 +81,7 @@ The `htmax.js` file bundles htmx with the most popular extensions in a single fi
 * [`hx-targets`](/extensions/hx-targets)
 * [`hx-live`](/extensions/hx-live)
 * [`hx-upsert`](/extensions/hx-upsert)
-* [`hx-alpine-compat`](/extensions/hx-alpine-compat) _(no-op if Alpine.js is not present)_
+* [`hx-alpine-compat`](/extensions/hx-alpine-compat)
 * [`hx-history-cache`](/extensions/hx-history-cache) _(included but disabled by default)_
 
 The extensions are automatically available, you can just use their attributes directly (e.g. `hx-sse:connect`, `hx-ws:connect`).

--- a/www/src/content/extensions/13-hx-history-cache.md
+++ b/www/src/content/extensions/13-hx-history-cache.md
@@ -15,6 +15,12 @@ The `history-cache` extension replaces htmx's default history handling with a cl
 <script src="/path/to/ext/hx-history-cache.js"></script>
 ```
 
+If you are using the [htmax bundle](/docs#htmax), `hx-history-cache` is already included but disabled by default. Opt in with:
+
+```html
+<meta name="htmx-config" content='{"historyCache": {"disable": false}}'>
+```
+
 ## Usage
 
 No markup changes are required. Once the script is loaded, all htmx-driven navigation is cached automatically.
@@ -45,7 +51,7 @@ To use morphing for smoother restores:
 |--------|---------|-------------|
 | `size` | `10` | Maximum number of pages to keep in the cache. Oldest entries are evicted first. Set to `0` to disable caching entirely. |
 | `refreshOnMiss` | `false` | When `true`, forces a full page reload if the requested history entry is not in the cache. |
-| `disable` | `false` | Disables the extension without unloading it. |
+| `disable` | `false` (`true` in htmax) | Disables the extension without unloading it. When using the htmax bundle, history caching is off by default — opt in via the meta config tag. |
 | `swapStyle` | `"outerSync"` | The htmx swap style used when restoring cached content. Defaults to `outerSync`, which preserves the target element in the DOM (keeping listeners and component state) while syncing its attributes and replacing its children. Use `innerHTML` to replace children only without syncing attributes. Can be set to `"innerMorph"` or `"outerMorph"` for smooth DOM diffing. |
 
 ## Events


### PR DESCRIPTION
## Description
htmax can include the history cache extension if we set it to default to disabled like this.  We can add -htmax to the version data so that the cache extension can detect this version and disable the cache extension by default then.  just need to add documentation on how to enable it via a meta tag and then users can opt in if they want

We should consider hx-ptag, hx-upsert and hx-alpine-compat as safe extensions we can easily add to htmax as well.
Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
