### PR TITLE
move hx-trigger response header timing to after swap

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -626,6 +626,9 @@ var htmx = (() => {
                 this.__trigger(elt, "htmx:error", {ctx, error})
             } finally {
                 clearTimeout(ctx.requestTimeout);
+                if (ctx.hx?.trigger) { // HX-Trigger
+                    this.__handleTriggerHeader(ctx.hx.trigger, ctx.sourceElement);
+                }
                 this.__trigger(elt, "htmx:finally:request", {ctx})
                 if (!ctx.keepIndicators) {
                     this.__hideIndicators(indicators);
@@ -654,9 +657,6 @@ var htmx = (() => {
         // Handle response headers that abort normal swap processing.
         // Returns true if the response was fully handled by a header.
         __handleHeadersAndMaybeReturnEarly(ctx) {
-            if (ctx.hx.trigger) { // HX-Trigger
-                this.__handleTriggerHeader(ctx.hx.trigger, ctx.sourceElement);
-            }
             if (ctx.hx.refresh === 'true') { // HX-Refresh
                 location.reload();
                 return true

--- a/test/tests/unit/__handleHxHeadersAndMaybeReturnEarly.js
+++ b/test/tests/unit/__handleHxHeadersAndMaybeReturnEarly.js
@@ -8,26 +8,6 @@ describe('__handleHxHeadersAndMaybeReturnEarly unit tests', function() {
         cleanupTest();
     });
 
-    it('handles hx-trigger header', function () {
-        let triggerFired = false
-        let listener = () => { triggerFired = true }
-
-        let container = createProcessedHTML('<div></div>')
-        container.addEventListener('myEvent', listener)
-
-        let ctx = {
-            hx: {
-                trigger: 'myEvent'
-            },
-            sourceElement: container
-        }
-
-        let result = htmx.__handleHeadersAndMaybeReturnEarly(ctx)
-
-        assert.isNotOk(result)
-        assert.isTrue(triggerFired)
-    })
-
     it('returns false when no headers to handle', function () {
         let ctx = {
             hx: {},

--- a/test/tests/unit/__issueRequest.js
+++ b/test/tests/unit/__issueRequest.js
@@ -177,6 +177,23 @@ describe('__issueRequest unit tests', function() {
         assert.equal(capturedError, testError)
     })
 
+    it('fires HX-Trigger event after swap completes', async function () {
+        let div = createProcessedHTML('<div hx-get="/test" hx-swap="none"></div>')
+        let ctx = htmx.__createRequestContext(div, new Event('click'))
+
+        let triggerFired = false
+        div.addEventListener('myEvent', () => triggerFired = true)
+
+        ctx.fetch = async () => ({
+            status: 200,
+            headers: new Headers({ 'HX-Trigger': 'myEvent' }),
+            text: async () => ''
+        })
+
+        await htmx.__issueRequest(ctx)
+        assert.isTrue(triggerFired)
+    })
+
     it('always triggers htmx:finally:request', async function () {
         let div = createProcessedHTML('<div hx-get="/test" hx-swap="none"></div>')
         let ctx = htmx.__createRequestContext(div, new Event('click'))

--- a/www/src/content/reference/02-headers/10-HX-Trigger.md
+++ b/www/src/content/reference/02-headers/10-HX-Trigger.md
@@ -3,7 +3,7 @@ title: "HX-Trigger"
 description: "Triggers client-side events with `htmx.trigger()`"
 ---
 
-The `HX-Trigger` response header triggers client-side events when a response is received.
+The `HX-Trigger` response header triggers client-side events after the swap has completed.
 
 ## Basic Usage
 
@@ -103,6 +103,8 @@ _This example uses the [`hx-live`](/extensions/hx-live) extension._
 ## Notes
 
 Response headers are not processed on 3xx response codes. Return a 2xx status when using this header.
+
+In htmx 2, there were three variants: `HX-Trigger`, `HX-Trigger-After-Swap`, and `HX-Trigger-After-Settle`. In htmx 4, these were consolidated into a single `HX-Trigger` header that fires after the swap completes.
 
 ## See Also
 


### PR DESCRIPTION
## Description
we removed the hx-trigger-after-swap and hx-trigger-after-settle response headers as having 3 of the same thing is not really justified.  Now in htmx4 settle delay defaults to 1ms and swap normally happens straight away.  Since we now how only one hx-trigger to simplify things I tihnk it is better to move the triggering to after the request completes.  I've moved it to the finally stage so it triggers even if hx-location etc fires.  By having it trigger after the swap at the end we can cover the use cases for the old after-swap and after-settle with this one header and the only downside is you can't fire the manual trigger before the swap happens.  But in practice there is little need for a before swap trigger as the only reason to need this is to perform a custom action before removing some content with a swap and this kind of action would be much easier to be performed with a client side event listener for a htmx:before:swap type event rather than a hx-trigger header.

With this change all users who had after triggers can just move to using the single hx-trigger hopefully.

Corresponding issue:

## Testing
moved one test

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
