### PR TITLE
Handle history scroll restoration using navigation api except for firefox

### DIFF
--- a/src/ext/hx-history-cache.js
+++ b/src/ext/hx-history-cache.js
@@ -198,7 +198,7 @@
         // Before core pushes/replaces, save the outgoing page
         htmx_before_history_update: (elt, detail) => {
             if (cfg().disable) return;
-            if (!_currentId) stampCurrentEntry();
+            stampCurrentEntry();
             saveCurrentPage();
         },
 

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1600,16 +1600,19 @@ var htmx = (() => {
             if (!history.state) {
                 history.replaceState({htmx: true}, '', location.href);
             }
-            window.addEventListener('popstate', (event) => {
-                if (event.state && event.state.htmx) {
-                    this.#historyAbort?.abort();
-                    this.__restoreHistory();
-                }
-            });
+            if (window.navigation && !/firefox/i.test(navigator.userAgent)) {
+                navigation.addEventListener('navigate', (event) => {
+                    if (event.navigationType === 'traverse' && event.canIntercept && !event.hashChange)
+                        event.intercept({handler: () => this.__restoreHistory()});
+                });
+            } else {
+                window.addEventListener('popstate', (event) => this.__restoreHistory(event.state));
+            }
         }
 
         __pushUrlIntoHistory(path) {
             if (!this.config.history) return;
+            if (!history.state) history.replaceState({htmx: true}, '', location.href);
             history.pushState({htmx: true}, '', path);
             this.__trigger(document, "htmx:after:history:push", {path});
         }
@@ -1620,7 +1623,11 @@ var htmx = (() => {
             this.__trigger(document, "htmx:after:history:replace", {path});
         }
 
-        __restoreHistory(path) {
+        async __restoreHistory(state, path) {
+            await this.timeout(1);
+            state ??= history.state;
+            if (!state?.htmx) return;
+            this.#historyAbort?.abort();
             path = path || location.pathname + location.search;
             let historyElt = document.querySelector(this.__prefixSelector('[hx-history-elt]')) || document.body;
             if (this.__trigger(document, "htmx:before:history:restore", {path, cacheMiss: true})) {
@@ -1628,7 +1635,7 @@ var htmx = (() => {
                     location.reload();
                 } else {
                     this.#historyAbort = new AbortController();
-                    this.ajax('GET', path, {
+                    return this.ajax('GET', path, {
                         target: historyElt,
                         swap: 'outerSync',
                         select: historyElt !== document.body ? this.__prefixSelector('[hx-history-elt]') : undefined,

--- a/test/lib/helpers.js
+++ b/test/lib/helpers.js
@@ -63,7 +63,14 @@ function cleanupTest() {
         }
         fetchMock.reset()
     }
-    history.replaceState(null, '', savedUrl);
+    let saved = new URL(savedUrl);
+    if (location.pathname !== saved.pathname || location.search !== saved.search) {
+        // Use location.replace() instead of history.replaceState() to avoid
+        // the browser's 100 replaceState/10s rate limit across large test suites.
+        // location.replace() navigates to the URL without adding a history entry
+        // and is not subject to the replaceState rate limit.
+        history.replaceState(null, '', savedUrl);
+    }
 }
 
 //================================================================================

--- a/test/tests/end2end/basic-history.js
+++ b/test/tests/end2end/basic-history.js
@@ -153,7 +153,7 @@ describe('hx-push-url and hx-replace-url attributes', function() {
         try {
             mockResponse('GET', '/restore-test', '<div id="restored">Restored Content</div>');
             
-            htmx.__restoreHistory('/restore-test');
+            htmx.__restoreHistory({htmx: true}, '/restore-test');
             await forRequest();
             
             document.body.innerHTML.should.include('Restored Content');
@@ -336,7 +336,7 @@ describe('hx-history-elt scopes history restore', function() {
         </body></html>`;
         mockResponse('GET', '/restore-test', response);
 
-        htmx.__restoreHistory('/restore-test');
+        htmx.__restoreHistory({htmx: true}, '/restore-test');
         await forRequest();
 
         document.getElementById('sentinel').should.not.equal(null);
@@ -353,3 +353,231 @@ describe('hx-history-elt scopes history restore', function() {
         document.body.textContent.should.not.include('FOOTER LEAK');
     });
 });
+
+
+
+describe('scroll restoration on history traversal', function() {
+
+    const hasNavigationAPI = typeof Navigation === 'function' && !/Firefox\//.test(navigator.userAgent);
+
+    beforeEach(() => { setupTest(this.currentTest); });
+
+    afterEach(() => {
+        window.scrollTo(0, 0);
+        cleanupTest();
+    });
+
+    async function untilScrollY(y, timeout = 1500) {
+        let start = performance.now();
+        while (window.scrollY !== y && performance.now() - start < timeout) {
+            await new Promise(r => requestAnimationFrame(r));
+        }
+    }
+
+    it('boosted back restores content, then the browser restores scroll', async function() {
+        if (!hasNavigationAPI) this.skip();
+        playground().innerHTML = '<main hx-history-elt><div style="height:3000px">page A</div></main>';
+        htmx.process(playground());
+        history.replaceState({htmx: true}, '', '/scroll-page-a');
+        window.scrollTo(0, 500);
+
+        htmx.__pushUrlIntoHistory('/scroll-page-b');
+        playground().innerHTML = '<main hx-history-elt><p>page B</p></main>';
+        window.scrollTo(0, 0);
+
+        mockResponse('GET', '/scroll-page-a', () => new Promise(resolve =>
+            setTimeout(() => resolve(new MockResponse(
+                '<html><body><main hx-history-elt><div style="height:3000px">page A restored</div></main></body></html>'
+            )), 100)));
+
+        history.back();
+        await forRequest(400);
+        await untilScrollY(500);
+
+        playground().textContent.should.include('page A restored');
+        assert.equal(window.scrollY, 500);
+    });
+
+    it('back returns to the latest scroll position after re-scrolling', async function() {
+        if (!hasNavigationAPI) this.skip();
+        this.timeout(5000);
+        playground().innerHTML = '<main hx-history-elt><div style="height:3000px">page A</div></main>';
+        htmx.process(playground());
+        history.replaceState({htmx: true}, '', '/scroll-page-a');
+        window.scrollTo(0, 500);
+
+        htmx.__pushUrlIntoHistory('/scroll-page-b');
+        playground().innerHTML = '<main hx-history-elt><div style="height:3000px">page B</div></main>';
+        window.scrollTo(0, 0);
+
+        mockResponse('GET', '/scroll-page-a',
+            '<html><body><main hx-history-elt><div style="height:3000px">page A</div></main></body></html>');
+        mockResponse('GET', '/scroll-page-b',
+            '<html><body><main hx-history-elt><div style="height:3000px">page B</div></main></body></html>');
+
+        history.back();
+        await forRequest();
+        await untilScrollY(500);
+
+        window.scrollTo(0, 800);
+        history.forward();
+        await forRequest();
+        await untilScrollY(0);
+
+        history.back();
+        await forRequest();
+        await untilScrollY(800);
+
+        assert.equal(window.scrollY, 800);
+    });
+
+    it('back to an entry created by an anchor jump still restores content', async function() {
+        if (!hasNavigationAPI) this.skip();
+        playground().innerHTML = '<main hx-history-elt><div style="height:3000px">reference page</div></main>';
+        htmx.process(playground());
+        history.replaceState({htmx: true}, '', '/scroll-ref');
+
+        location.hash = '#events';
+        assert.isNull(history.state);
+        window.scrollTo(0, 500);
+
+        htmx.__pushUrlIntoHistory('/scroll-hxget');
+        playground().innerHTML = '<main hx-history-elt><p>hx-get page</p></main>';
+        window.scrollTo(0, 0);
+
+        mockResponse('GET', '/scroll-ref', () => new Promise(resolve =>
+            setTimeout(() => resolve(new MockResponse(
+                '<html><body><main hx-history-elt><div style="height:3000px">reference restored</div></main></body></html>'
+            )), 100)));
+
+        history.back();
+        await forRequest(400);
+        await untilScrollY(500);
+
+        playground().textContent.should.include('reference restored');
+        assert.equal(location.hash, '#events');
+        assert.equal(window.scrollY, 500);
+    });
+
+    it('restores horizontal scroll as well', async function() {
+        if (!hasNavigationAPI) this.skip();
+        playground().innerHTML = '<main hx-history-elt><div style="height:3000px;width:3000px">wide page</div></main>';
+        htmx.process(playground());
+        history.replaceState({htmx: true}, '', '/scroll-wide');
+        window.scrollTo(300, 500);
+
+        htmx.__pushUrlIntoHistory('/scroll-narrow');
+        playground().innerHTML = '<main hx-history-elt><p>narrow page</p></main>';
+        window.scrollTo(0, 0);
+
+        mockResponse('GET', '/scroll-wide', () => new Promise(resolve =>
+            setTimeout(() => resolve(new MockResponse(
+                '<html><body><main hx-history-elt><div style="height:3000px;width:3000px">wide restored</div></main></body></html>'
+            )), 100)));
+
+        history.back();
+        await forRequest(400);
+        await untilScrollY(500);
+
+        assert.equal(window.scrollY, 500);
+        assert.equal(window.scrollX, 300);
+    });
+
+    it('ignores traversal to non-htmx history entries', async function() {
+        history.replaceState({foreign: true}, '', '/foreign-page');
+        history.pushState({htmx: true}, '', '/scroll-page-b');
+
+        history.back();
+        let evt = await forRequest(150);
+
+        assert.isNull(evt);
+    });
+    it('ignores hash-only traversal', async function() {
+        if (!hasNavigationAPI) this.skip();
+        history.replaceState({htmx: true}, '', location.pathname + '#a');
+        history.pushState({htmx: true}, '', location.pathname + '#b');
+
+        history.back();
+        let evt = await forRequest(150);
+
+        assert.isNull(evt);
+        assert.equal(location.hash, '#a');
+    });
+});
+
+describe('history restore edge cases', function() {
+
+    beforeEach(() => { setupTest(this.currentTest); });
+    afterEach(() => { cleanupTest(); });
+
+    it('a second back aborts the in-flight restore', async function() {
+        this.timeout(5000);
+        playground().innerHTML = '<main hx-history-elt><p>page C</p></main>';
+        htmx.process(playground());
+        history.replaceState({htmx: true}, '', '/edge-a');
+        htmx.__pushUrlIntoHistory('/edge-b');
+        htmx.__pushUrlIntoHistory('/edge-c');
+
+        mockResponse('GET', '/edge-a',
+            '<html><body><main hx-history-elt><p>page A</p></main></body></html>');
+        mockResponse('GET', '/edge-b', () => new Promise(resolve =>
+            setTimeout(() => resolve(new MockResponse(
+                '<html><body><main hx-history-elt><p>page B</p></main></body></html>'
+            )), 150)));
+
+        history.back();
+        await new Promise(r => setTimeout(r, 50));
+        history.back();
+        await new Promise(r => setTimeout(r, 500));
+
+        assert.equal(location.pathname, '/edge-a');
+        playground().textContent.should.include('page A');
+    });
+
+    it('restores the replaced URL after a replace', async function() {
+        playground().innerHTML = '<main hx-history-elt><p>replaced page</p></main>';
+        htmx.process(playground());
+        history.replaceState({htmx: true}, '', '/edge-orig');
+        htmx.__pushUrlIntoHistory('/edge-next');
+        htmx.__replaceUrlInHistory('/edge-replaced');
+
+        mockResponse('GET', '/edge-orig',
+            '<html><body><main hx-history-elt><p>original restored</p></main></body></html>');
+        mockResponse('GET', '/edge-replaced',
+            '<html><body><main hx-history-elt><p>replaced restored</p></main></body></html>');
+
+        history.back();
+        await forRequest();
+        playground().textContent.should.include('original restored');
+        assert.equal(location.pathname, '/edge-orig');
+        await new Promise(r => setTimeout(r, 50));
+
+        history.forward();
+        await forRequest();
+        playground().textContent.should.include('replaced restored');
+        assert.equal(location.pathname, '/edge-replaced');
+    });
+
+    it('skips a foreign entry but restores the htmx entry behind it', async function() {
+        playground().innerHTML = '<main hx-history-elt><p>after page</p></main>';
+        htmx.process(playground());
+        history.replaceState({htmx: true}, '', '/edge-mine');
+        history.pushState({vue: true}, '', '/edge-foreign');
+        htmx.__pushUrlIntoHistory('/edge-after');
+
+        mockResponse('GET', '/edge-mine',
+            '<html><body><main hx-history-elt><p>mine restored</p></main></body></html>');
+
+        history.back();
+        let evt = await forRequest(150);
+        assert.isNull(evt);
+        playground().textContent.should.include('after page');
+        assert.equal(location.pathname, '/edge-foreign');
+
+        history.back();
+        await forRequest();
+        playground().textContent.should.include('mine restored');
+        assert.equal(location.pathname, '/edge-mine');
+    });
+});
+

--- a/test/tests/end2end/basic-history.js
+++ b/test/tests/end2end/basic-history.js
@@ -380,10 +380,12 @@ describe('scroll restoration on history traversal', function() {
         htmx.process(playground());
         history.replaceState({htmx: true}, '', '/scroll-page-a');
         window.scrollTo(0, 500);
+        await new Promise(r => setTimeout(r, 20));
 
         htmx.__pushUrlIntoHistory('/scroll-page-b');
         playground().innerHTML = '<main hx-history-elt><p>page B</p></main>';
         window.scrollTo(0, 0);
+        await new Promise(r => setTimeout(r, 20));
 
         mockResponse('GET', '/scroll-page-a', () => new Promise(resolve =>
             setTimeout(() => resolve(new MockResponse(
@@ -391,6 +393,7 @@ describe('scroll restoration on history traversal', function() {
             )), 100)));
 
         history.back();
+        await new Promise(r => setTimeout(r, 20));
         await forRequest(400);
         await untilScrollY(500);
 
@@ -405,11 +408,11 @@ describe('scroll restoration on history traversal', function() {
         htmx.process(playground());
         history.replaceState({htmx: true}, '', '/scroll-page-a');
         window.scrollTo(0, 500);
-
+        await new Promise(r => setTimeout(r, 10));
         htmx.__pushUrlIntoHistory('/scroll-page-b');
         playground().innerHTML = '<main hx-history-elt><div style="height:3000px">page B</div></main>';
         window.scrollTo(0, 0);
-
+        await new Promise(r => setTimeout(r, 10));
         mockResponse('GET', '/scroll-page-a',
             '<html><body><main hx-history-elt><div style="height:3000px">page A</div></main></body></html>');
         mockResponse('GET', '/scroll-page-b',
@@ -418,12 +421,13 @@ describe('scroll restoration on history traversal', function() {
         history.back();
         await forRequest();
         await untilScrollY(500);
-
+        await new Promise(r => setTimeout(r, 10));
         window.scrollTo(0, 800);
+        await new Promise(r => setTimeout(r, 10));
         history.forward();
         await forRequest();
         await untilScrollY(0);
-
+        await new Promise(r => setTimeout(r, 10));
         history.back();
         await forRequest();
         await untilScrollY(800);
@@ -440,10 +444,12 @@ describe('scroll restoration on history traversal', function() {
         location.hash = '#events';
         assert.isNull(history.state);
         window.scrollTo(0, 500);
+        await new Promise(r => setTimeout(r, 20));
 
         htmx.__pushUrlIntoHistory('/scroll-hxget');
         playground().innerHTML = '<main hx-history-elt><p>hx-get page</p></main>';
         window.scrollTo(0, 0);
+        await new Promise(r => setTimeout(r, 20));
 
         mockResponse('GET', '/scroll-ref', () => new Promise(resolve =>
             setTimeout(() => resolve(new MockResponse(

--- a/test/tests/ext/hx-alpine-compat-history.js
+++ b/test/tests/ext/hx-alpine-compat-history.js
@@ -78,7 +78,7 @@
         history.replaceState({ htmx: true, htmxId }, '', cachedPath);
         await new Promise(resolve => {
             document.addEventListener('htmx:history:cache:after:restore', resolve, { once: true });
-            htmx.__restoreHistory(cachedPath);
+            htmx.__restoreHistory(history.state, cachedPath);
         });
         await htmx.timeout(50);
         return historyElt;
@@ -108,7 +108,7 @@
         history.replaceState({ htmx: true, htmxId }, '', cachedPath);
         await new Promise(resolve => {
             document.addEventListener('htmx:history:cache:after:restore', resolve, { once: true });
-            htmx.__restoreHistory(cachedPath);
+            htmx.__restoreHistory(history.state, cachedPath);
         });
         await htmx.timeout(50);
 
@@ -138,7 +138,7 @@
         history.replaceState({ htmx: true, htmxId }, '', cachedPath);
         await new Promise(resolve => {
             document.addEventListener('htmx:history:cache:after:restore', resolve, { once: true });
-            htmx.__restoreHistory(cachedPath);
+            htmx.__restoreHistory(history.state, cachedPath);
         });
         await htmx.timeout(50);
 
@@ -183,7 +183,7 @@
         history.replaceState({ htmx: true, htmxId }, '', cachedPath);
         await new Promise(resolve => {
             document.addEventListener('htmx:history:cache:after:restore', resolve, { once: true });
-            htmx.__restoreHistory(cachedPath);
+            htmx.__restoreHistory(history.state, cachedPath);
         });
         await htmx.timeout(50);
 

--- a/test/tests/ext/hx-history-cache.js
+++ b/test/tests/ext/hx-history-cache.js
@@ -275,7 +275,6 @@ describe('hx-history-cache extension', function () {
     });
 
     it('cache:hit cancellation falls through to server fetch', async function () {
-        let cachedPath = location.pathname + location.search;
         createProcessedHTML(`
             <div hx-history-elt><p>cached</p></div>
             <button hx-get="/page2" hx-push-url="/page2">go</button>
@@ -288,14 +287,14 @@ describe('hx-history-cache extension', function () {
 
         let index = JSON.parse(sessionStorage.getItem('htmx-history-index') || '[]');
         let htmxId = index[index.length - 1];
-        history.replaceState({ htmx: true, htmxId }, '', cachedPath);
+        history.replaceState({ htmx: true, htmxId }, '', '/page1');
         document.addEventListener('htmx:history:cache:hit', e => e.preventDefault(), { once: true });
         document.addEventListener('htmx:before:swap', e => e.preventDefault(), { once: true });
 
         let serverFetched = false;
-        mockResponse('GET', cachedPath, () => { serverFetched = true; return '<p>from server</p>'; });
+        mockResponse('GET', '/page1', () => { serverFetched = true; return '<p>from server</p>'; });
 
-        htmx.__restoreHistory(history.state, cachedPath);
+        htmx.__restoreHistory(history.state, '/page1');
         await forRequest();
 
         assert.isTrue(serverFetched);

--- a/test/tests/ext/hx-history-cache.js
+++ b/test/tests/ext/hx-history-cache.js
@@ -267,7 +267,7 @@ describe('hx-history-cache extension', function () {
 
         await new Promise(resolve => {
             document.addEventListener('htmx:history:cache:after:restore', resolve, { once: true });
-            htmx.__restoreHistory(cachedPath);
+            htmx.__restoreHistory(history.state, cachedPath);
         });
 
         assert.isFalse(serverFetched);
@@ -295,7 +295,7 @@ describe('hx-history-cache extension', function () {
         let serverFetched = false;
         mockResponse('GET', cachedPath, () => { serverFetched = true; return '<p>from server</p>'; });
 
-        htmx.__restoreHistory(cachedPath);
+        htmx.__restoreHistory(history.state, cachedPath);
         await forRequest();
 
         assert.isTrue(serverFetched);
@@ -324,7 +324,7 @@ describe('hx-history-cache extension', function () {
 
         await new Promise(resolve => {
             document.addEventListener('htmx:history:cache:after:restore', resolve, { once: true });
-            htmx.__restoreHistory(cachedPath);
+            htmx.__restoreHistory(history.state, cachedPath);
         });
 
         assert.include(historyElt.innerHTML, 'mutated');
@@ -350,7 +350,7 @@ describe('hx-history-cache extension', function () {
 
         await new Promise(resolve => {
             document.addEventListener('htmx:history:cache:after:restore', resolve, { once: true });
-            htmx.__restoreHistory(cachedPath);
+            htmx.__restoreHistory(history.state, cachedPath);
         });
 
         assert.equal(document.title, 'My Cached Title');
@@ -365,8 +365,9 @@ describe('hx-history-cache extension', function () {
         document.addEventListener('htmx:history:cache:miss', e => { missDetail = e.detail; }, { once: true });
         document.addEventListener('htmx:before:swap', e => e.preventDefault(), { once: true });
 
+        history.replaceState({ htmx: true }, '', location.href);
         mockResponse('GET', '/missing', '<p>from server</p>');
-        htmx.__restoreHistory('/missing');
+        htmx.__restoreHistory(history.state, '/missing');
         await forRequest();
 
         assert.isNotNull(missDetail);
@@ -383,8 +384,9 @@ describe('hx-history-cache extension', function () {
         }, { once: true });
         document.addEventListener('htmx:before:swap', e => e.preventDefault(), { once: true });
 
+        history.replaceState({ htmx: true }, '', location.href);
         mockResponse('GET', '/missing-reload', '<p>from server</p>');
-        htmx.__restoreHistory('/missing-reload');
+        htmx.__restoreHistory(history.state, '/missing-reload');
         await forRequest();
 
         assert.isTrue(reloadWouldHaveFired);
@@ -421,7 +423,7 @@ describe('hx-history-cache extension', function () {
 
             await new Promise(resolve => {
                 document.addEventListener('htmx:history:cache:after:restore', resolve, { once: true });
-                htmx.__restoreHistory(cachedPath);
+                htmx.__restoreHistory(history.state, cachedPath);
             });
 
             assert.include(historyElt.innerHTML, 'tier 2 content');
@@ -449,7 +451,7 @@ describe('hx-history-cache extension', function () {
 
         await new Promise(resolve => {
             document.addEventListener('htmx:history:cache:after:restore', resolve, { once: true });
-            htmx.__restoreHistory(cachedPath);
+            htmx.__restoreHistory(history.state, cachedPath);
         });
 
         assert.include(historyElt.innerHTML, 'swap style test');
@@ -477,7 +479,7 @@ describe('hx-history-cache extension', function () {
         history.replaceState({ htmx: true, htmxId }, '', cachedPath);
         await new Promise(resolve => {
             document.addEventListener('htmx:history:cache:after:restore', resolve, { once: true });
-            htmx.__restoreHistory(cachedPath);
+            htmx.__restoreHistory(history.state, cachedPath);
         });
         return historyElt;
     }
@@ -589,6 +591,48 @@ describe('hx-history-cache extension', function () {
             div.scrollTop = 80;
         });
         assert.equal(elt.querySelector('div').scrollTop, 80);
+    });
+
+    // -------------------------------------------------------------------------
+    // anchor-jump entry stamping
+    // -------------------------------------------------------------------------
+
+    it('stamps and saves an anchor-jump entry before pushing a new URL', async function () {
+        let cachedPath = location.pathname + location.search;
+        createProcessedHTML(`
+            <div hx-history-elt><p>anchor page</p></div>
+            <button hx-get="/page2" hx-push-url="/page2">go</button>
+        `);
+        historyElt = playground().querySelector('[hx-history-elt]');
+
+        location.hash = '#section';
+        assert.isNull(history.state);
+
+        mockResponse('GET', '/page2', '<p>page 2</p>');
+        playground().querySelector('button').click();
+        await forRequest();
+
+        let index = JSON.parse(sessionStorage.getItem('htmx-history-index') || '[]');
+
+        // the anchor-jump entry must get its own htmxId stamped and saved.
+        // the original entry is never saved (nothing navigated away from it via htmx),
+        // so the index has exactly 1 entry belonging to the anchor-jump entry.
+        assert.equal(index.length, 1, 'expected exactly one cache entry for the anchor-jump entry');
+
+        let anchorHtmxId = index[0];
+        history.replaceState({ htmx: true, htmxId: anchorHtmxId }, '', cachedPath + '#section');
+        historyElt.innerHTML = '<p>current page</p>';
+
+        let serverFetched = false;
+        mockResponse('GET', cachedPath, () => { serverFetched = true; return '<p>server</p>'; });
+
+        await new Promise(resolve => {
+            document.addEventListener('htmx:history:cache:after:restore', resolve, { once: true });
+            htmx.__restoreHistory(history.state, cachedPath);
+        });
+
+        assert.isFalse(serverFetched, 'should have served from cache, not server');
+        assert.include(historyElt.innerHTML, 'anchor page');
     });
 
     // -------------------------------------------------------------------------

--- a/test/tests/unit/morph.js
+++ b/test/tests/unit/morph.js
@@ -661,7 +661,7 @@ describe('Morph Swap Styles Tests', function() {
                 'new form root must be processed so hx-post works');
 
             mockResponse('POST', '/submit', 'Submitted!');
-            newForm.dispatchEvent(new Event('submit', {bubbles: true}));
+            newForm.dispatchEvent(new Event('submit', {bubbles: true, cancelable: true}));
             await waitForEvent('htmx:after:swap', 100);
 
             assert.equal(container.querySelector('#result') ??


### PR DESCRIPTION

## Description
Another possible way to fix the history scroll issues.  We can use the navigation api for chome and safari which backup and restore the scroll positions well using the navigation intercept function.  Firefox has implemented the navigation api recently as well but their impliementation is not as good and it has an issue where the auto restoration triggers BEFORE the navigation intercept api fires which is not what we want as it just causes worse scroll issues.  By reverting firefox back to the popstate handler it performs better but is not perfect all the time.

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
