### PR TITLE
Improve hx-live updates, debounce, and warnings

### DIFF
--- a/src/ext/hx-live.js
+++ b/src/ext/hx-live.js
@@ -314,21 +314,6 @@
         });
     }
 
-    /**
-     * Toggle or cycle a class, ARIA attribute, or attribute on an element.
-     *
-     * @param {Element} elt - DOM element to mutate.
-     * @param {string} name - Class (`.foo`) or attribute name.
-     * @param {string|string[]} [values] - Cycle list (pipe-delimited string or array). Omit for binary flip.
-     *
-     * @example
-     * toggle('.active')                      // toggle class
-     * toggle('aria-expanded')                // flip "true" ↔ "false"
-     * toggle('hidden')                       // toggle attribute presence
-     * toggle('data-view', 'grid|list|table') // cycle attribute through values
-     * toggle('.size', 'sm|md|lg')            // cycle classes (one at a time)
-     * toggle('data-open', 'on|')             // 'on' ↔ absent slot
-     */
     function toggle(elt, name, values) {
         let isClass = name.startsWith('.');
         let key = isClass ? name.slice(1) : name;

--- a/src/ext/hx-live.js
+++ b/src/ext/hx-live.js
@@ -20,12 +20,15 @@
     const OBSERVE_OPTIONS = { childList: true, subtree: true, attributes: true, characterData: true };
 
     let inputDebounceId = null;
-    const INPUT_DEBOUNCE_MS = htmx.config.live?.inputDebounceMs ?? 100;
 
     function ensureActive() {
         if (observer) return;
         recomputeBound = () => schedule();
-        inputBound = () => { clearTimeout(inputDebounceId); inputDebounceId = setTimeout(schedule, INPUT_DEBOUNCE_MS); };
+        let inputDelay = htmx.parseInterval(htmx.config.live?.inputDebounce ?? 100) ?? 100;
+        inputBound = () => {
+            clearTimeout(inputDebounceId);
+            inputDebounceId = setTimeout(schedule, inputDelay);
+        };
         document.addEventListener('input', inputBound, true);
         document.addEventListener('change', recomputeBound, true);
         observer = new MutationObserver(recomputeBound);
@@ -78,114 +81,123 @@
         'formnovalidate','async','defer','ismap','typemustmatch',
         'allowfullscreen','itemscope','nomodule'
     ]);
-    let PROPERTY_ATTRS = new Set(['checked','value','selected']);
+    let BOOLEAN_PROPERTY_ATTRS = new Set(['checked','selected']);
+    let STRING_PROPERTY_ATTRS = new Set(['value']);
     let STRINGY_BOOLEAN_ATTRS = new Set(['contenteditable','draggable','spellcheck']);
 
-    /**
-     * Get or set an attribute, class, or property-backed value on one or more elements.
-     *
-     * @param {Element[]} elts - Target elements.
-     * @param {string} name - Class (`.foo`), `'class'`, or attribute name.
-     * @param {*} [value] - Value to set. Omit for getter (reads from first element).
-     * @returns {*} Getter result; setter returns nothing.
-     *
-     * @example
-     * attr('hidden')                  // boolean: is hidden present?
-     * attr('hidden', true)            // set hidden=""
-     * attr('.active')                 // boolean: has class .active?
-     * attr('.active', cond)           // add/remove class
-     * attr('class', 'foo bar')        // multi-class string
-     * attr('class', { active: cond }) // multi-class object
-     * attr('aria-expanded', open)     // ARIA: always "true"/"false"
-     * attr('value', 'hello')          // sync DOM property + attribute
-     * attr('contenteditable', false)  // "false", not removed
-     * attr('data-x', null)            // remove attribute
-     */
-    function applyAttr(elts, name, ...rest) {
-        let isClass = name.startsWith('.');
-        let isMultiClass = name === 'class';
-        let isAria = name.startsWith('aria-');
-        let isPropAttr = PROPERTY_ATTRS.has(name);
+    function getAttr(elts, name) {
+        let elt = elts[0];
+        if (!elt) return undefined;
+        if (name.startsWith('.')) return elt.classList.contains(name.slice(1));
+        if (name === 'class') return elt.getAttribute('class');
+        if (name.startsWith('aria-')) return elt.getAttribute(name) === 'true';
+        if (BOOLEAN_ATTRS.has(name)) return elt.hasAttribute(name);
+        if (BOOLEAN_PROPERTY_ATTRS.has(name) || STRING_PROPERTY_ATTRS.has(name)) return elt[name];
+        return elt.getAttribute(name);
+    }
 
-        if (rest.length === 0) {
-            let e = elts[0];
-            if (!e) return undefined;
-            if (isClass) return e.classList.contains(name.slice(1));
-            if (isMultiClass) return e.getAttribute('class');
-            if (isAria) return e.getAttribute(name) === 'true';
-            if (BOOLEAN_ATTRS.has(name)) return e.hasAttribute(name);
-            if (isPropAttr) return e[name];
-            return e.getAttribute(name);
-        }
-
-        let value = rest[0];
-        for (let e of elts) {
-            if (isClass) {
-                e.classList.toggle(name.slice(1), !!value);
-                if (e.classList.length === 0) e.removeAttribute('class');
-            } else if (isMultiClass) {
-                applyMultiClass(e, value);
-            } else if (isAria) {
-                // Strings and numbers pass through (e.g. aria-current="page",
-                // aria-pressed="mixed", aria-valuenow="50"). Other values coerce
-                // to "true"/"false". Never removed.
-                let attrVal = (typeof value === 'string' || typeof value === 'number')
-                    ? String(value)
-                    : (value ? 'true' : 'false');
-                e.setAttribute(name, attrVal);
-            } else if (isPropAttr) {
-                if (value === false || value == null) {
-                    e[name] = (typeof e[name] === 'boolean') ? false : '';
-                    e.removeAttribute(name);
-                } else if (value === true) {
-                    e[name] = true;
-                    e.setAttribute(name, '');
-                } else {
-                    e[name] = value;
-                    e.setAttribute(name, String(value));
-                }
-            } else if (BOOLEAN_ATTRS.has(name)) {
-                if (value) e.setAttribute(name, '');
-                else e.removeAttribute(name);
-            } else if (STRINGY_BOOLEAN_ATTRS.has(name)) {
-                if (value === null || value === undefined) e.removeAttribute(name);
-                else if (value === true) e.setAttribute(name, 'true');
-                else if (value === false) e.setAttribute(name, 'false');
-                else e.setAttribute(name, String(value));
-            } else {
-                if (value === null || value === undefined || value === false) e.removeAttribute(name);
-                else e.setAttribute(name, value === true ? '' : String(value));
-            }
+    function setDomAttr(elt, name, value) {
+        if (value == null) {
+            if (elt.hasAttribute(name)) elt.removeAttribute(name);
+        } else if (elt.getAttribute(name) !== value) {
+            elt.setAttribute(name, value);
         }
     }
 
-    function applyStyleBinding(elt, value) {
-        let prop = api.htmxProp(elt);
-        let oldManaged = prop.liveStyles || new Set();
-        let newManaged = new Set();
+    function setAttr(elts, name, value) {
+        if (name.startsWith('.')) {
+            let className = name.slice(1);
+            let present = !!value;
+            for (let elt of elts) {
+                if (elt.classList.contains(className) !== present) elt.classList.toggle(className, present);
+                if (elt.classList.length === 0 && elt.hasAttribute('class')) elt.removeAttribute('class');
+            }
+            return;
+        }
+        if (name === 'class') {
+            for (let elt of elts) setClasses(elt, value);
+            return;
+        }
+        if (BOOLEAN_PROPERTY_ATTRS.has(name)) {
+            let present = !!value;
+            let attrValue = present ? '' : null;
+            for (let elt of elts) {
+                if (elt[name] === present && elt.getAttribute(name) === attrValue) continue;
+                elt[name] = present;
+                setDomAttr(elt, name, attrValue);
+            }
+            return;
+        }
+        if (STRING_PROPERTY_ATTRS.has(name)) {
+            let propValue = value == null ? '' : String(value);
+            let attrValue = value == null ? null : propValue;
+            for (let elt of elts) {
+                if (elt[name] === propValue && elt.getAttribute(name) === attrValue) continue;
+                elt[name] = propValue;
+                setDomAttr(elt, name, attrValue);
+            }
+            return;
+        }
+        let attrValue;
+        if (name.startsWith('aria-')) {
+            // Strings and numbers pass through. Other values become "true" or "false".
+            attrValue = (typeof value === 'string' || typeof value === 'number')
+                ? String(value)
+                : String(!!value);
+        } else if (BOOLEAN_ATTRS.has(name)) {
+            attrValue = value ? '' : null;
+        } else if (STRINGY_BOOLEAN_ATTRS.has(name)) {
+            attrValue = value == null ? null : String(value);
+        } else {
+            attrValue = value == null || value === false ? null : (value === true ? '' : String(value));
+        }
+        for (let elt of elts) setDomAttr(elt, name, attrValue);
+    }
 
+    function parseStyles(value) {
+        let styles = [];
         if (typeof value === 'string') {
-            for (let decl of value.split(';')) {
-                let idx = decl.indexOf(':');
-                if (idx < 0) continue;
-                let k = decl.slice(0, idx).trim();
-                let v = decl.slice(idx + 1).trim();
-                if (k) {
-                    newManaged.add(k);
-                    elt.style.setProperty(k, v);
-                }
+            for (let declaration of value.split(';')) {
+                let colon = declaration.indexOf(':');
+                if (colon < 0) continue;
+                let name = declaration.slice(0, colon).trim();
+                if (name) styles.push([name, declaration.slice(colon + 1).trim()]);
             }
         } else if (value && typeof value === 'object') {
-            for (let [k, v] of Object.entries(value)) {
-                let cssProp = camelToKebab(k);
-                newManaged.add(cssProp);
-                if (v == null || v === '') elt.style.removeProperty(cssProp);
-                else elt.style.setProperty(cssProp, String(v));
+            for (let [name, styleValue] of Object.entries(value)) {
+                styles.push([camelToKebab(name), styleValue == null || styleValue === '' ? null : String(styleValue)]);
             }
         }
-        for (let k of oldManaged) if (!newManaged.has(k)) elt.style.removeProperty(k);
-        if (elt.style.length === 0) elt.removeAttribute('style');
-        prop.liveStyles = newManaged;
+        return styles;
+    }
+
+    function setStyleValue(style, name, value) {
+        let before = style.cssText;
+        if (value == null) style.removeProperty(name);
+        else style.setProperty(name, value);
+        return style.cssText !== before;
+    }
+
+    function setStyles(elt, value) {
+        let prop = api.htmxProp(elt);
+        let oldStyles = prop.liveStyles || new Set();
+        let styles = parseStyles(value);
+        let styleNames = new Set(styles.map(([name]) => name));
+        let parsed = elt.ownerDocument.createElement('div').style;
+        let writes = [];
+        parsed.cssText = elt.style.cssText;
+
+        for (let name of oldStyles) {
+            if (!styleNames.has(name) && setStyleValue(parsed, name, null)) writes.push([name, null]);
+        }
+        for (let [name, styleValue] of styles) {
+            if (setStyleValue(parsed, name, styleValue)) writes.push([name, styleValue]);
+        }
+        if (elt.style.cssText !== parsed.cssText) {
+            for (let [name, styleValue] of writes) setStyleValue(elt.style, name, styleValue);
+        }
+        if (elt.style.length === 0 && elt.hasAttribute('style')) elt.removeAttribute('style');
+        prop.liveStyles = styleNames;
     }
 
     function camelToKebab(s) {
@@ -238,55 +250,48 @@
         });
     }
 
-    function applyMultiClass(elt, value) {
-        let prop = api.htmxProp(elt);
-        let oldManaged = prop.liveClasses || new Set();
-        let newManaged = new Set();
-
+    function parseClasses(value) {
+        let classes = new Map();
         if (typeof value === 'string') {
-            for (let c of value.trim().split(/\s+/).filter(Boolean)) {
-                newManaged.add(c);
-                elt.classList.add(c);
-            }
+            for (let name of value.trim().split(/\s+/).filter(Boolean)) classes.set(name, true);
         } else if (value && typeof value === 'object') {
-            for (let [key, cond] of Object.entries(value)) {
-                for (let c of key.trim().split(/\s+/).filter(Boolean)) {
-                    newManaged.add(c);
-                    elt.classList.toggle(c, !!cond);
-                }
+            for (let [names, present] of Object.entries(value)) {
+                for (let name of names.trim().split(/\s+/).filter(Boolean)) classes.set(name, !!present);
             }
         }
-        for (let c of oldManaged) if (!newManaged.has(c)) elt.classList.remove(c);
-        if (elt.classList.length === 0) elt.removeAttribute('class');
-        prop.liveClasses = newManaged;
+        return classes;
     }
 
-    function applyTake(targets, name, scope) {
-        let isClass = name.startsWith('.');
-        let key = isClass ? name.slice(1) : name;
-        let isAria = name.startsWith('aria-');
-        let auto = isClass ? '.' + key : '[' + name + ']';
-        let root = scope == null ? targets[0]?.parentElement
+    function setClasses(elt, value) {
+        let prop = api.htmxProp(elt);
+        let oldClasses = prop.liveClasses || new Set();
+        let classes = parseClasses(value);
+
+        for (let [name, present] of classes) {
+            if (elt.classList.contains(name) !== present) elt.classList.toggle(name, present);
+        }
+        for (let name of oldClasses) {
+            if (!classes.has(name) && elt.classList.contains(name)) elt.classList.remove(name);
+        }
+        if (elt.classList.length === 0 && elt.hasAttribute('class')) elt.removeAttribute('class');
+        prop.liveClasses = new Set(classes.keys());
+    }
+
+    function take(elts, name, scope) {
+        let selector = name.startsWith('.') ? name : '[' + name + ']';
+        let root = scope == null ? elts[0]?.parentElement
             : scope.nodeType ? scope : null;
         let sources = root
-            ? [root, ...root.querySelectorAll(auto)]
-            : document.querySelectorAll(typeof scope === 'string' ? scope : scope?.from || auto);
-        let targetSet = new Set(targets);
-        for (let s of sources) {
-            if (targetSet.has(s)) continue;
-            if (isClass) {
-                s.classList?.remove(key);
-                if (s.classList?.length === 0) s.removeAttribute('class');
-            } else if (isAria) {
-                s.setAttribute(name, 'false');
-            } else {
-                s.removeAttribute(name);
-            }
-        }
-        for (let t of targets) {
-            if (isClass) t.classList?.add(key);
-            else if (isAria) t.setAttribute(name, 'true');
-            else t.setAttribute(name, '');
+            ? [root, ...root.querySelectorAll(selector)]
+            : document.querySelectorAll(typeof scope === 'string' ? scope : scope?.from || selector);
+        let targets = new Set(elts);
+        let others = [...sources].filter(elt => !targets.has(elt));
+        if (name.startsWith('.') || name.startsWith('aria-')) {
+            setAttr(others, name, false);
+            setAttr(elts, name, true);
+        } else {
+            for (let elt of others) setDomAttr(elt, name, null);
+            for (let elt of elts) setDomAttr(elt, name, '');
         }
     }
 
@@ -315,9 +320,9 @@
     /**
      * Toggle or cycle a class, ARIA attribute, or attribute on an element.
      *
+     * @param {Element} elt - DOM element to mutate.
      * @param {string} name - Class (`.foo`) or attribute name.
      * @param {string|string[]} [values] - Cycle list (pipe-delimited string or array). Omit for binary flip.
-     * @param {Element} element - DOM element to mutate.
      *
      * @example
      * toggle('.active')                      // toggle class
@@ -327,7 +332,7 @@
      * toggle('.size', 'sm|md|lg')            // cycle classes (one at a time)
      * toggle('data-open', 'on|')             // 'on' ↔ absent slot
      */
-    function applyToggle(name, values, element) {
+    function toggle(elt, name, values) {
         let isClass = name.startsWith('.');
         let key = isClass ? name.slice(1) : name;
         let isAria = name.startsWith('aria-');
@@ -336,26 +341,26 @@
             : values);
 
         if (!asArray) {
-            if (isClass) element.classList.toggle(key);
+            if (isClass) elt.classList.toggle(key);
             else if (isAria) {
-                let cur = element.getAttribute(name);
-                element.setAttribute(name, cur === 'true' ? 'false' : 'true');
+                let cur = elt.getAttribute(name);
+                elt.setAttribute(name, cur === 'true' ? 'false' : 'true');
             } else {
-                element.toggleAttribute(name);
+                elt.toggleAttribute(name);
             }
             return;
         }
         if (isClass) {
-            let cur = asArray.findIndex(v => v && element.classList.contains(v));
-            if (cur >= 0) element.classList.remove(asArray[cur]);
+            let cur = asArray.findIndex(v => v && elt.classList.contains(v));
+            if (cur >= 0) elt.classList.remove(asArray[cur]);
             let next = asArray[(cur + 1) % asArray.length];
-            if (next) element.classList.add(next);
+            if (next) elt.classList.add(next);
         } else {
-            let curVal = element.getAttribute(name) ?? '';
+            let curVal = elt.getAttribute(name) ?? '';
             let cur = asArray.indexOf(curVal);
             let next = asArray[(cur + 1) % asArray.length];
-            if (next === '') element.removeAttribute(name);
-            else element.setAttribute(name, next);
+            if (next === '') elt.removeAttribute(name);
+            else elt.setAttribute(name, next);
         }
     }
 
@@ -461,11 +466,11 @@
                 };
                 if (p === 'trigger') return (t, d, b) => { elts.forEach(e => htmx.trigger(e, t, d, b)); return proxy; };
                 if (p === 'insert') return (pos, s) => { elts.forEach(e => e.insertAdjacentHTML(positions[pos], s)); return proxy; };
-                if (p === 'take') return (name, scope) => { applyTake(elts, name, scope); return proxy; };
-                if (p === 'toggle') return (name, values) => { elts.forEach(e => applyToggle(name, values, e)); return proxy; };
+                if (p === 'take') return (name, scope) => { take(elts, name, scope); return proxy; };
+                if (p === 'toggle') return (name, values) => { elts.forEach(elt => toggle(elt, name, values)); return proxy; };
                 if (p === 'attr') return (name, ...rest) => {
-                    if (rest.length === 0) return applyAttr(elts, name);
-                    applyAttr(elts, name, ...rest);
+                    if (rest.length === 0) return getAttr(elts, name);
+                    setAttr(elts, name, rest[0]);
                     return proxy;
                 };
                 if (p === 'data') return elts[0] ? makeDataProxy(elts[0]) : undefined;
@@ -567,7 +572,7 @@
         for (node of nodes) processElement(node);
     }
 
-    function registerSimpleLive(elt, attrName, code) {
+    function registerSimpleLive(elt, bindingName, code) {
         ensureActive();
         let debounce = getDebounce(elt);
         let isAsync = /\bawait\b/.test(code);
@@ -577,11 +582,11 @@
                 return;
             }
             try {
-                let value = await api.executeJavaScript(elt, { debounce }, code, true);
-                writeAttrBinding(elt, attrName, value);
+                let exprResult = await api.executeJavaScript(elt, { debounce }, code, true);
+                renderBinding(elt, bindingName, exprResult);
                 observer?.takeRecords();
             } catch (e) {
-                if (e !== dbSym) console.error('htmx: hx-live expression threw', e, { elt, attr: attrName });
+                if (e !== dbSym) console.error('htmx: hx-live expression threw', e, { elt, attr: bindingName });
             }
         } : () => {
             if (!elt.isConnected) {
@@ -589,10 +594,10 @@
                 return;
             }
             try {
-                let value = api.executeJavaScript(elt, { debounce }, code, true, false);
-                writeAttrBinding(elt, attrName, value);
+                let exprResult = api.executeJavaScript(elt, { debounce }, code, true, false);
+                renderBinding(elt, bindingName, exprResult);
             } catch (e) {
-                if (e !== dbSym) console.error('htmx: hx-live expression threw', e, { elt, attr: attrName });
+                if (e !== dbSym) console.error('htmx: hx-live expression threw', e, { elt, attr: bindingName });
             }
         };
         fns.add(run);
@@ -602,22 +607,20 @@
         run();
     }
 
-    function writeAttrBinding(elt, attrName, value) {
-        if (attrName === 'text') {
-            let s = value == null ? '' : String(value);
-            if (elt.textContent !== s) elt.textContent = s;
+    /** Render one evaluated `:<name>` binding to its DOM target. */
+    function renderBinding(elt, name, exprResult) {
+        if (name === 'text') {
+            let text = exprResult == null ? '' : String(exprResult);
+            if (elt.textContent !== text) elt.textContent = text;
             return;
         }
-        if (attrName === 'html') {
-            let s = value == null ? '' : String(value);
-            if (elt.innerHTML !== s) elt.innerHTML = s;
+        if (name === 'html') {
+            let html = exprResult == null ? '' : String(exprResult);
+            if (elt.innerHTML !== html) elt.innerHTML = html;
             return;
         }
-        if (attrName === 'style') { applyStyleBinding(elt, value); return; }
-        // Always write aria-* and property-backed attrs (getter type differs from setter).
-        // For everything else skip if unchanged.
-        if (!attrName.startsWith('aria-') && !PROPERTY_ATTRS.has(attrName) && applyAttr([elt], attrName) === value) return;
-        applyAttr([elt], attrName, value);
+        if (name === 'style') { setStyles(elt, exprResult); return; }
+        setAttr([elt], name, exprResult);
     }
 
     let asTargets = t => t == null ? []
@@ -629,9 +632,11 @@
         q: s => makeQ(document.documentElement)(s),
         debounce: makeDebounce(),
         refresh: () => schedule(),
-        take: (target, name, scope) => applyTake([...asTargets(target)], name, scope),
-        toggle: (target, name, values) => [...asTargets(target)].forEach(e => applyToggle(name, values, e)),
-        attr: (target, name, ...rest) => applyAttr([...asTargets(target)], name, ...rest),
+        take: (target, name, scope) => take([...asTargets(target)], name, scope),
+        toggle: (target, name, values) => [...asTargets(target)].forEach(elt => toggle(elt, name, values)),
+        attr: (target, name, ...rest) => rest.length === 0
+            ? getAttr([...asTargets(target)], name)
+            : setAttr([...asTargets(target)], name, rest[0]),
         forEvent: (...args) => forEvent(null, ...args),
         nextFrame: () => new Promise(r => requestAnimationFrame(r))
     };
@@ -663,9 +668,11 @@
                 nextFrame: () => new Promise(r => requestAnimationFrame(r)),
                 trigger: (type, detail, bubbles) => htmx.trigger(elt, type, detail, bubbles),
                 debounce: getDebounce(elt),
-                take: (name, scope) => applyTake([elt], name, scope),
-                toggle: (name, values) => applyToggle(name, values, elt),
-                attr: (name, ...rest) => applyAttr([elt], name, ...rest),
+                take: (name, scope) => take([elt], name, scope),
+                toggle: (name, values) => toggle(elt, name, values),
+                attr: (name, ...rest) => rest.length === 0
+                    ? getAttr([elt], name)
+                    : setAttr([elt], name, rest[0]),
                 insert: (pos, html) => elt.insertAdjacentHTML(positions[pos], html),
                 matches: (sel) => elt.matches(sel),
                 style: elt.style,

--- a/src/ext/hx-live.js
+++ b/src/ext/hx-live.js
@@ -10,10 +10,9 @@
     let pending = false;
     let dbSym = Symbol();
     let observer = null;
-    let recomputeBound = null;
-    let inputBound = null;
+    let inputListener = null;
     let swaps = 0;
-    let recomputeMonitor = null;
+    let recomputeWarned = false;
 
     const OBSERVE_OPTIONS = { childList: true, subtree: true, attributes: true, characterData: true };
     const RECOMPUTE_WARN_MS = 16;
@@ -22,41 +21,38 @@
 
     function ensureActive() {
         if (observer) return;
-        recomputeMonitor = makeRecomputeMonitor();
-        recomputeBound = () => schedule();
-        let inputDelay = htmx.parseInterval(htmx.config.live?.inputDebounce ?? 100) ?? 100;
-        inputBound = () => {
+        recomputeWarned = false;
+        let inputDebounceMs = htmx.parseInterval(htmx.config.live?.inputDebounce) ?? 100;
+        inputListener = () => {
             clearTimeout(inputDebounceId);
-            inputDebounceId = setTimeout(schedule, inputDelay);
+            inputDebounceId = setTimeout(schedule, inputDebounceMs);
         };
-        document.addEventListener('input', inputBound, true);
-        document.addEventListener('change', recomputeBound, true);
-        observer = new MutationObserver(recomputeBound);
+        document.addEventListener('input', inputListener, true);
+        document.addEventListener('change', schedule, true);
+        observer = new MutationObserver(schedule);
         observer.observe(document.documentElement, OBSERVE_OPTIONS);
     }
 
-    function makeRecomputeMonitor() {
-        let hasWarned = false;
-
-        return (startedAt, expressionCount) => {
-            let elapsed = performance.now() - startedAt;
-            if (hasWarned || elapsed <= RECOMPUTE_WARN_MS) return;
-            console.warn(`htmx: hx-live overloaded: ${elapsed.toFixed(1)}ms pass; ${expressionCount} expr/pass`);
-            hasWarned = true;
-        };
+    function runRecomputePass() {
+        let expressionCount = liveExpressions.size;
+        if (expressionCount === 0) return;
+        let startedAt = performance.now();
+        liveExpressions.forEach(run => run());
+        let elapsed = performance.now() - startedAt;
+        if (recomputeWarned || elapsed <= RECOMPUTE_WARN_MS) return;
+        console.warn(`htmx: hx-live overloaded: ${elapsed.toFixed(1)}ms pass; ${expressionCount} expr/pass`);
+        recomputeWarned = true;
     }
 
     function deactivate() {
         if (!observer) return;
         clearTimeout(inputDebounceId);
         inputDebounceId = null;
-        document.removeEventListener('input', inputBound, true);
-        inputBound = null;
-        document.removeEventListener('change', recomputeBound, true);
+        document.removeEventListener('input', inputListener, true);
+        inputListener = null;
+        document.removeEventListener('change', schedule, true);
         observer.disconnect();
         observer = null;
-        recomputeBound = null;
-        recomputeMonitor = null;
     }
 
     function schedule() {
@@ -65,10 +61,7 @@
         queueMicrotask(() => {
             // Detach observer while writing so our own writes don't queue records.
             observer?.disconnect();
-            let expressionCount = liveExpressions.size;
-            let startedAt = expressionCount > 0 ? performance.now() : 0;
-            liveExpressions.forEach(run => run());
-            if (expressionCount > 0) recomputeMonitor(startedAt, expressionCount);
+            runRecomputePass();
             if (liveExpressions.size === 0) {
                 deactivate();
             } else {

--- a/src/ext/hx-live.js
+++ b/src/ext/hx-live.js
@@ -1,28 +1,28 @@
 // hx-live extension: reactive live expressions + q() proxy + scope helpers.
 // Hooks:
 //   htmx:after:process  find new [hx-live] elements and register them
-//   htmx:before:swap    increment swap depth (defer recomputes)
-//   htmx:finally:swap   decrement, fire one consolidated recompute
+//   htmx:before:swap    increment swap depth (defer recompute passes)
+//   htmx:finally:swap   decrement, fire one consolidated recompute pass
 //   htmx:scope          inject q, wait, trigger, debounce into JS expression scopes
 (() => {
     let api;
-    let fns = new Set();
+    let liveExpressions = new Set();
     let pending = false;
     let dbSym = Symbol();
     let observer = null;
     let recomputeBound = null;
     let inputBound = null;
     let swaps = 0;
-    let i = 0;
-    let start = 0;
-    let warned = false;
+    let recomputeMonitor = null;
 
     const OBSERVE_OPTIONS = { childList: true, subtree: true, attributes: true, characterData: true };
+    const RECOMPUTE_WARN_MS = 16;
 
     let inputDebounceId = null;
 
     function ensureActive() {
         if (observer) return;
+        recomputeMonitor = makeRecomputeMonitor();
         recomputeBound = () => schedule();
         let inputDelay = htmx.parseInterval(htmx.config.live?.inputDebounce ?? 100) ?? 100;
         inputBound = () => {
@@ -35,6 +35,17 @@
         observer.observe(document.documentElement, OBSERVE_OPTIONS);
     }
 
+    function makeRecomputeMonitor() {
+        let hasWarned = false;
+
+        return (startedAt, expressionCount) => {
+            let elapsed = performance.now() - startedAt;
+            if (hasWarned || elapsed <= RECOMPUTE_WARN_MS) return;
+            console.warn(`htmx: hx-live overloaded: ${elapsed.toFixed(1)}ms pass; ${expressionCount} expr/pass`);
+            hasWarned = true;
+        };
+    }
+
     function deactivate() {
         if (!observer) return;
         clearTimeout(inputDebounceId);
@@ -45,27 +56,20 @@
         observer.disconnect();
         observer = null;
         recomputeBound = null;
+        recomputeMonitor = null;
     }
 
     function schedule() {
-        if (pending) return;
-        if (swaps > 0) return;
-        let now = Date.now();
-        if (now - start > 1000) {
-            start = now;
-            i = 0;
-            warned = false;
-        }
-        if (++i > 50 && !warned) {
-            console.warn('htmx: hx-live recompute exceeded 50/sec.');
-            warned = true;
-        }
+        if (pending || swaps > 0) return;
         pending = true;
         queueMicrotask(() => {
             // Detach observer while writing so our own writes don't queue records.
             observer?.disconnect();
-            fns.forEach(f => f());
-            if (fns.size === 0) {
+            let expressionCount = liveExpressions.size;
+            let startedAt = expressionCount > 0 ? performance.now() : 0;
+            liveExpressions.forEach(run => run());
+            if (expressionCount > 0) recomputeMonitor(startedAt, expressionCount);
+            if (liveExpressions.size === 0) {
                 deactivate();
             } else {
                 observer.observe(document.documentElement, OBSERVE_OPTIONS);
@@ -522,7 +526,7 @@
     function cleanupLive(elt) {
         let prop = elt._htmx;
         if (!prop?.liveRuns) return;
-        for (let run of prop.liveRuns) fns.delete(run);
+        for (let run of prop.liveRuns) liveExpressions.delete(run);
         delete prop.liveRuns;
         delete prop.liveRegistered;
         delete prop.liveAttrs;
@@ -540,7 +544,7 @@
                 let debounce = getDebounce(elt);
                 let run = async () => {
                     if (!elt.isConnected) {
-                        fns.delete(run);
+                        liveExpressions.delete(run);
                         return;
                     }
                     try {
@@ -549,7 +553,7 @@
                         if (e !== dbSym) console.error('htmx: hx-live expression threw', e, { elt });
                     }
                 };
-                fns.add(run);
+                liveExpressions.add(run);
                 prop.liveRuns = prop.liveRuns || new Set();
                 prop.liveRuns.add(run);
                 run();
@@ -578,7 +582,7 @@
         let isAsync = /\bawait\b/.test(code);
         let run = isAsync ? async () => {
             if (!elt.isConnected) {
-                fns.delete(run);
+                liveExpressions.delete(run);
                 return;
             }
             try {
@@ -590,7 +594,7 @@
             }
         } : () => {
             if (!elt.isConnected) {
-                fns.delete(run);
+                liveExpressions.delete(run);
                 return;
             }
             try {
@@ -600,7 +604,7 @@
                 if (e !== dbSym) console.error('htmx: hx-live expression threw', e, { elt, attr: bindingName });
             }
         };
-        fns.add(run);
+        liveExpressions.add(run);
         let prop = api.htmxProp(elt);
         prop.liveRuns = prop.liveRuns || new Set();
         prop.liveRuns.add(run);
@@ -659,7 +663,7 @@
             swaps++;
         },
         htmx_finally_swap: () => {
-            if (--swaps === 0 && fns.size > 0) schedule();
+            if (--swaps === 0 && liveExpressions.size > 0) schedule();
         },
         htmx_scope: (elt, detail) => {
             Object.assign(detail.scope, {

--- a/src/ext/hx-live.js
+++ b/src/ext/hx-live.js
@@ -315,16 +315,18 @@
     }
 
     function toggle(elt, name, values) {
-        let isClass = name.startsWith('.');
-        let key = isClass ? name.slice(1) : name;
+        if (name.startsWith('.')) {
+            elt.classList.toggle(name.slice(1));
+            return;
+        }
+
         let isAria = name.startsWith('aria-');
         let asArray = values && (typeof values === 'string'
             ? values.split('|').map(v => v.trim())
             : values);
 
         if (!asArray) {
-            if (isClass) elt.classList.toggle(key);
-            else if (isAria) {
+            if (isAria) {
                 let cur = elt.getAttribute(name);
                 elt.setAttribute(name, cur === 'true' ? 'false' : 'true');
             } else {
@@ -332,18 +334,12 @@
             }
             return;
         }
-        if (isClass) {
-            let cur = asArray.findIndex(v => v && elt.classList.contains(v));
-            if (cur >= 0) elt.classList.remove(asArray[cur]);
-            let next = asArray[(cur + 1) % asArray.length];
-            if (next) elt.classList.add(next);
-        } else {
-            let curVal = elt.getAttribute(name) ?? '';
-            let cur = asArray.indexOf(curVal);
-            let next = asArray[(cur + 1) % asArray.length];
-            if (next === '') elt.removeAttribute(name);
-            else elt.setAttribute(name, next);
-        }
+
+        let curVal = elt.getAttribute(name) ?? '';
+        let cur = asArray.indexOf(curVal);
+        let next = asArray[(cur + 1) % asArray.length];
+        if (next === '') elt.removeAttribute(name);
+        else elt.setAttribute(name, next);
     }
 
     function makeDebounce() {

--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -178,21 +178,29 @@ export interface QProxy {
   q(selector: string): QProxy;
   /**
    * Get an attribute, class, or property from the first matched element.
-   * - `.foo` — class presence as `true`/`false`
-   * - `aria-*` — coerces `"true"`/`"false"` to boolean
-   * - boolean attrs (`hidden`, `disabled`, etc.) — `true`/`false`
-   * - `value`, `checked`, `selected` — DOM property
-   * - anything else — `getAttribute(name)`
+   *
+   * @example
+   * q('#selector').attr('hidden')     // boolean: is hidden present?
+   * q('#selector').attr('.active')    // boolean: has class .active?
+   * q('#selector').attr('value')      // DOM property
+   * q('#selector').attr('data-x')     // attribute string or null
    */
   attr(name: string): any;
   /**
-   * Set an attribute, class, or property on all matched elements. Returns the proxy for chaining.
-   * - `.foo` — adds/removes class by truthiness
-   * - `'class'` — space-separated string or `{ className: condition }` object
-   * - `aria-*` — strings/numbers pass through; others coerce to `"true"`/`"false"`
-   * - `value`, `checked`, `selected` — syncs DOM property and HTML attribute
-   * - boolean attrs — truthy adds, falsy removes
-   * - anything else — `null`/`undefined`/`false` removes; otherwise sets as string
+   * Set an attribute, class, or property on every matched element.
+   *
+   * @param value - Value to set.
+   * @returns The proxy, for chaining.
+   *
+   * @example
+   * q('.selector').attr('hidden', true)              // add hidden (falsy removes)
+   * q('.selector').attr('.active', cond)             // add/remove class
+   * q('.selector').attr('class', 'foo bar')          // multi-class string
+   * q('.selector').attr('class', { active: cond })   // multi-class object
+   * q('.selector').attr('aria-expanded', open)       // ARIA: writes "true"/"false"
+   * q('.selector').attr('value', 'hello')            // sync property + attribute
+   * q('.selector').attr('contenteditable', false)    // "false", not removed
+   * q('.selector').attr('data-x', null)              // remove attribute
    */
   attr(name: string, value: any): QProxy;
   /**
@@ -201,8 +209,17 @@ export interface QProxy {
    */
   take(name: string, scope?: string | Node | { from: string }): QProxy;
   /**
-   * Toggle (binary flip) or cycle (with `values`) a class or attribute on all matched elements.
-   * @param values - Pipe-delimited string (`'grid|list'`) or array to cycle through.
+   * Toggle a class or attribute, or cycle through attribute values, on every matched element.
+   *
+   * @param values - Attribute values as a pipe-delimited string or array. Omit for a binary toggle.
+   * @returns The proxy, for chaining.
+   *
+   * @example
+   * q('.selector').toggle('.active')                      // toggle class
+   * q('.selector').toggle('aria-expanded')               // flip "true" ↔ "false"
+   * q('.selector').toggle('hidden')                      // toggle attribute presence
+   * q('.selector').toggle('data-view', 'grid|list|table') // cycle attribute values
+   * q('.selector').toggle('data-open', 'on|')            // "on" ↔ absent
    */
   toggle(name: string, values?: string | string[]): QProxy;
   /**
@@ -252,11 +269,11 @@ export interface HtmxLive {
   refresh(): void;
   /** Move a class or attribute from sibling/scoped elements to the target. */
   take(target: string | Element | NodeList, name: string, scope?: string | Node | { from: string }): void;
-  /** Toggle or cycle a class or attribute on the target. */
+  /** Toggle a class or attribute, or cycle through attribute values. See {@link QProxy.toggle}. */
   toggle(target: string | Element | NodeList, name: string, values?: string | string[]): void;
-  /** Get an attribute, class, or property from the first matched element. See `QProxy.attr`. */
+  /** Get an attribute, class, or property from the first matched element. See {@link QProxy.attr}. */
   attr(target: string | Element | NodeList, name: string): any;
-  /** Set an attribute, class, or property on all matched elements. See `QProxy.attr`. */
+  /** Set an attribute, class, or property on all matched elements. See {@link QProxy.attr}. */
   attr(target: string | Element | NodeList, name: string, value: any): void;
   /**
    * Resolves on the next matching event, timeout, or interval — whichever fires first.

--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -1,10 +1,10 @@
 /** Configures the hx-live extension. */
 export interface HtmxLiveConfig {
   /**
-   * Debounces `input` events in milliseconds.
+   * Debounces recomputes from `input` events. Accepts milliseconds or an interval string.
    * @default 100
    */
-  inputDebounceMs?: number;
+  inputDebounce?: number | string;
   /**
    * Sets the short binding prefix (`':'` -> `:text`, `'hx:'` -> `hx:text`, `''`/`false` -> disabled).
    * Alpine.js detection disables the default.

--- a/test/manual/hx-live/index.html
+++ b/test/manual/hx-live/index.html
@@ -40,7 +40,7 @@
 <body hx-ext="hx-live">
 
 <h1>hx-live playground</h1>
-<p class="small">Open DevTools. Type, click, change inputs. Verify state updates without server round-trips.</p>
+<p class="small">Open DevTools. Type, click, change inputs. Verify state updates without server round-trips. <a href="recompute-warning.html">Stress-test the recompute warning.</a></p>
 
 <!-- =================================================================== -->
 <section>

--- a/test/manual/hx-live/recompute-warning.html
+++ b/test/manual/hx-live/recompute-warning.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>hx-live recompute warning</title>
+<script src="../../../src/htmx.js"></script>
+<script src="../../../src/ext/hx-live.js"></script>
+<style>
+  :root { color-scheme: light dark; font-family: system-ui, sans-serif; }
+  body { max-width: 760px; margin: 2rem auto; padding: 0 1rem; line-height: 1.5; }
+  button { margin: 0 0.35rem 0.5rem 0; padding: 0.4rem 0.7rem; font: inherit; }
+  code, pre { padding: 0.15rem 0.35rem; border-radius: 4px; background: color-mix(in srgb, CanvasText 8%, Canvas); }
+  pre { min-height: 4.5rem; padding: 0.75rem; overflow-wrap: anywhere; white-space: pre-wrap; }
+  table { width: 100%; border-collapse: collapse; }
+  th, td { padding: 0.4rem; border-bottom: 1px solid color-mix(in srgb, CanvasText 20%, Canvas); text-align: left; }
+  canvas { width: 100%; height: 60px; border: 1px solid color-mix(in srgb, CanvasText 25%, Canvas); }
+  #stress-bindings { display: grid; grid-template-columns: repeat(10, 1fr); gap: 2px; max-height: 130px; overflow: hidden; }
+  #stress-bindings output { padding: 2px; background: color-mix(in srgb, CanvasText 6%, Canvas); font: 11px monospace; }
+  .status { font-weight: 700; }
+  .note { color: color-mix(in srgb, CanvasText 70%, Canvas); }
+</style>
+</head>
+<body hx-ext="hx-live">
+
+<h1>hx-live recompute warning</h1>
+
+<p>Open DevTools Console, keep this tab visible, then run one scenario. The page also copies the latest hx-live warning below.</p>
+
+<table>
+  <thead>
+    <tr><th>Trigger</th><th>Warning</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>One recompute pass above 16ms</td><td>Immediate</td></tr>
+    <tr><td>Above 100ms total synchronous time in a period</td><td>After two consecutive periods</td></tr>
+  </tbody>
+</table>
+
+<p>A measurement period starts with its first recompute pass and closes on the first pass more than one second later. One high period arms the warning. A second consecutive high period emits it.</p>
+
+<p>hx-live warns once per high-load period. <strong>Stop and reset</strong> removes every binding, deactivates hx-live, and clears that warning state.</p>
+
+<h2>Run a scenario</h2>
+
+<p>
+  <button id="long-pass">Run one long pass</button>
+  <button id="heavy-jank">Start heavy binding jank</button>
+  <button id="sustained-work">Start sustained work</button>
+  <button id="stop">Stop and reset</button>
+</p>
+
+<p id="status" class="status">Stopped. No live expressions are registered.</p>
+
+<canvas id="fps" width="720" height="60" aria-label="Frames per second"></canvas>
+<p class="note">The meter shows frame rate. Heavy binding jank should push it well below 60 FPS.</p>
+
+<h2>Latest warning</h2>
+<pre id="warning">No warning yet.</pre>
+
+<h2>Live binding output</h2>
+<div id="stress-bindings"></div>
+
+<h2>What each scenario does</h2>
+<ul>
+  <li><strong>One long pass:</strong> 200 bindings do about 0.12ms each, once. Expect an immediate warning.</li>
+  <li><strong>Heavy binding jank:</strong> 200 bindings do about 0.15ms each, every frame. Expect an immediate warning and visible frame loss.</li>
+  <li><strong>Sustained work:</strong> 50 bindings do about 0.05ms each, every frame. Each pass stays below 16ms, but total work exceeds 100ms per period. Expect a warning after about two seconds.</li>
+</ul>
+
+<p class="note">Timings vary by browser and machine. Reload if a preset lands close to a threshold.</p>
+
+<p class="note">From the repository root, run <code>bunx http-server -c-1 .</code>, then open <code>/test/manual/hx-live/recompute-warning.html</code>.</p>
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+    let tick = 0;
+    let workPerBinding = 0;
+    let animationFrame = null;
+    let warningCount = 0;
+
+    const bindings = document.querySelector('#stress-bindings');
+    const status = document.querySelector('#status');
+    const warning = document.querySelector('#warning');
+    const context = document.querySelector('#fps').getContext('2d');
+    const originalWarn = console.warn.bind(console);
+
+    console.warn = (...args) => {
+        originalWarn(...args);
+        if (String(args[0]).startsWith('warning: hx-live overloaded')) {
+            warningCount++;
+            warning.textContent = `Warning ${warningCount}\n${args[0]}`;
+        }
+    };
+
+    window.stressBinding = index => {
+        let value = tick + index;
+        let end = performance.now() + workPerBinding;
+        while (performance.now() < end) value = Math.sqrt(value * value + 1);
+        return `${index}: ${tick}`;
+    };
+
+    function stop() {
+        if (animationFrame !== null) cancelAnimationFrame(animationFrame);
+        animationFrame = null;
+    }
+
+    async function reset() {
+        stop();
+        bindings.replaceChildren();
+        htmx.live.refresh();
+        await Promise.resolve();
+        status.textContent = 'Stopped. No live expressions are registered.';
+    }
+
+    function build(bindingCount, bindingWork) {
+        workPerBinding = bindingWork;
+        let fragment = document.createDocumentFragment();
+        for (let index = 0; index < bindingCount; index++) {
+            let output = document.createElement('output');
+            output.setAttribute(':text', `stressBinding(${index})`);
+            fragment.append(output);
+        }
+        bindings.replaceChildren(fragment);
+        htmx.process(bindings);
+    }
+
+    function startFrames() {
+        let run = () => {
+            tick++;
+            htmx.live.refresh();
+            animationFrame = requestAnimationFrame(run);
+        };
+        animationFrame = requestAnimationFrame(run);
+    }
+
+    document.querySelector('#long-pass').addEventListener('click', async () => {
+        await reset();
+        build(200, 0.12);
+        status.textContent = 'Running one pass with 200 expensive bindings.';
+        htmx.live.refresh();
+    });
+
+    document.querySelector('#heavy-jank').addEventListener('click', async () => {
+        await reset();
+        build(200, 0.15);
+        status.textContent = 'Running 200 expensive bindings every frame.';
+        startFrames();
+    });
+
+    document.querySelector('#sustained-work').addEventListener('click', async () => {
+        await reset();
+        build(50, 0.05);
+        status.textContent = 'Running 50 moderate bindings every frame.';
+        startFrames();
+    });
+
+    document.querySelector('#stop').addEventListener('click', reset);
+
+    let frames = 0;
+    let measuredAt = performance.now();
+    function drawFps(now) {
+        frames++;
+        if (now - measuredAt >= 500) {
+            let fps = Math.round(frames * 1000 / (now - measuredAt));
+            context.clearRect(0, 0, 720, 60);
+            context.font = 'bold 30px system-ui';
+            context.fillStyle = fps < 40 ? '#d33' : '#2a6';
+            context.fillText(`${fps} FPS`, 12, 40);
+            frames = 0;
+            measuredAt = now;
+        }
+        requestAnimationFrame(drawFps);
+    }
+    requestAnimationFrame(drawFps);
+});
+</script>
+
+</body>
+</html>

--- a/test/tests/ext/hx-live.js
+++ b/test/tests/ext/hx-live.js
@@ -1070,20 +1070,6 @@ describe('hx-live extension', function () {
         div.getAttribute('data-mode').should.equal('light');
     });
 
-    it('toggle(".class", "a|b|c") cycles through classes (only one at a time)', function() {
-        playground().innerHTML = '<div></div>';
-        let div = playground().querySelector('div');
-        let p = htmx.live.q('div');
-        p.toggle('.size', 'sm|md|lg');
-        div.classList.contains('sm').should.equal(true);
-        p.toggle('.size', 'sm|md|lg');
-        div.classList.contains('md').should.equal(true);
-        div.classList.contains('sm').should.equal(false);
-        p.toggle('.size', 'sm|md|lg');
-        div.classList.contains('lg').should.equal(true);
-        div.classList.contains('md').should.equal(false);
-    });
-
     it('toggle is chainable', function() {
         playground().innerHTML = '<button></button>';
         let r = htmx.live.q('button').toggle('.active').toggle('aria-pressed').trigger('changed');

--- a/test/tests/ext/hx-live.js
+++ b/test/tests/ext/hx-live.js
@@ -197,7 +197,7 @@ describe('hx-live extension', function () {
         assert.isUndefined(out.dataset.v);
     });
 
-    it('coalesces multiple sync mutations into one recompute', async function() {
+    it('coalesces multiple sync mutations into one recompute pass', async function() {
         window.__liveCount = 0;
         let elt = createProcessedHTML('<output hx-live="window.__liveCount++"></output>');
         let initial = window.__liveCount;
@@ -210,14 +210,14 @@ describe('hx-live extension', function () {
         document.body.removeAttribute('data-c');
         await htmx.timeout(5);
         let added = window.__liveCount - initial;
-        assert.isAtMost(added, 2, 'expected at most 2 coalesced recomputes');
+        assert.isAtMost(added, 2, 'expected at most 2 coalesced recompute passes');
         delete window.__liveCount;
     });
 
     it('does not re-recompute when a binding writes its own attribute', async function() {
         // A :hidden binding writing the hidden attribute would, if MutationObserver
-        // were active during the write, queue a record and trigger another recompute.
-        // Verify the change-event causes exactly one recompute, not two.
+        // were active during the write, queue a record and trigger another recompute pass.
+        // Verify the change-event causes exactly one recompute pass, not two.
         window.__selfWriteCount = 0;
         playground().innerHTML = `
             <input id="src" type="checkbox">
@@ -231,7 +231,7 @@ describe('hx-live extension', function () {
         inp.dispatchEvent(new Event('change', { bubbles: true }));
         await htmx.timeout(20);
         let added = window.__selfWriteCount - initial;
-        assert.equal(added, 1, 'expected 1 recompute, got ' + added);
+        assert.equal(added, 1, 'expected 1 recompute pass, got ' + added);
         delete window.__selfWriteCount;
     });
 
@@ -421,7 +421,7 @@ describe('hx-live extension', function () {
         div.querySelector('output').dataset.v.should.equal('dynamic');
     });
 
-    it('coalesces recomputes during a swap', async function() {
+    it('coalesces recompute passes during a swap', async function() {
         window.__swapCountLive = 0;
         playground().innerHTML = `
             <div id="content"><span data-id="1"></span></div>
@@ -437,34 +437,100 @@ describe('hx-live extension', function () {
 
         let added = window.__swapCountLive - beforeSwap;
         // During-swap mutations are coalesced (swaps>0 guard). Pre/post-swap mutations
-        // (e.g. htmx-request indicator class) legitimately trigger a recompute each.
-        assert.isAtMost(added, 3, 'expected at most a few recomputes, got ' + added);
+        // (e.g. htmx-request indicator class) legitimately trigger a recompute pass each.
+        assert.isAtMost(added, 3, 'expected at most a few recompute passes, got ' + added);
         delete window.__swapCountLive;
     });
 
-    it.skip('iteration cap warns on runaway', async function() {
-        let warned = false;
-        let originalWarn = console.warn;
-        console.warn = (...args) => {
-            if (typeof args[0] === 'string' && args[0].includes('hx-live recompute exceeded')) warned = true;
-            originalWarn.apply(console, args);
-        };
-        try {
-            window.__runawayCountLive = 0;
-            playground().innerHTML = '<output hx-live="window.__runawayCountLive++"></output>';
-            htmx.process(playground());
+    describe('recompute pass diagnostics', function() {
+        let originalNow, originalWarn, now, cost, performanceCalls, warnings;
 
-            for (let i = 0; i < 100; i++) {
-                document.body.setAttribute('data-runaway-test-live', String(i));
-                await htmx.timeout(5);
-            }
+        beforeEach(async function() {
+            htmx.live.refresh();
+            await Promise.resolve();
 
-            warned.should.equal(true);
-            document.body.removeAttribute('data-runaway-test-live');
-            delete window.__runawayCountLive;
-        } finally {
+            originalNow = Object.getOwnPropertyDescriptor(performance, 'now');
+            now = 1;
+            cost = 0;
+            performanceCalls = 0;
+            Object.defineProperty(performance, 'now', {
+                configurable: true,
+                value: () => performanceCalls++ % 2 === 0 ? now : now += cost
+            });
+            originalWarn = console.warn;
+            warnings = [];
+            console.warn = message => warnings.push(message);
+        });
+
+        afterEach(function() {
+            if (originalNow) Object.defineProperty(performance, 'now', originalNow);
+            else delete performance.now;
             console.warn = originalWarn;
+            delete window.__diagnosticRunsLive;
+        });
+
+        function addExpressions(count = 1) {
+            window.__diagnosticRunsLive = 0;
+            playground().innerHTML = Array.from({ length: count }, () =>
+                '<output hx-live="window.__diagnosticRunsLive++"></output>'
+            ).join('');
+            htmx.process(playground());
         }
+
+        async function recompute(elapsed) {
+            cost = elapsed;
+            let callsBefore = performanceCalls;
+            htmx.live.refresh();
+            await Promise.resolve();
+            (performanceCalls - callsBefore).should.equal(2);
+        }
+
+        it('coalesces refresh calls into one recompute pass', async function() {
+            addExpressions();
+            let initial = window.__diagnosticRunsLive;
+
+            for (let i = 0; i < 10; i++) htmx.live.refresh();
+            await Promise.resolve();
+
+            window.__diagnosticRunsLive.should.equal(initial + 1);
+        });
+
+        it('does not warn when every pass stays within the limit', async function() {
+            addExpressions();
+
+            for (let i = 0; i < 20; i++) await recompute(10);
+
+            warnings.should.deep.equal([]);
+        });
+
+        it('warns once when a pass exceeds 16ms', async function() {
+            addExpressions(2);
+
+            await recompute(16);
+            warnings.should.deep.equal([]);
+            await recompute(16.1);
+
+            warnings.length.should.equal(1);
+            warnings[0].should.include('htmx: hx-live overloaded');
+            warnings[0].should.include('16.1ms pass');
+            warnings[0].should.include('2 expr/pass');
+
+            await recompute(50);
+            warnings.length.should.equal(1);
+        });
+
+        it('warns again after reactivation', async function() {
+            addExpressions();
+            await recompute(17);
+            warnings.length.should.equal(1);
+
+            playground().querySelector('output').remove();
+            await recompute(0);
+
+            addExpressions();
+            await recompute(17);
+            warnings.length.should.equal(2);
+        });
     });
 
     // -------------------------------------------------------------------------
@@ -832,8 +898,8 @@ describe('hx-live extension', function () {
         btn.getAttribute('aria-pressed').should.equal('false');
     });
 
-    it('toggle() in hx-live applies to the current element on each recompute', async function() {
-        // Use a one-shot recompute to flip a class once and confirm targeting.
+    it('toggle() in hx-live applies to the current element on each recompute pass', async function() {
+        // Use a one-shot recompute pass to flip a class once and confirm targeting.
         let elt = createProcessedHTML(
             `<output hx-live="!this.dataset.s && (this.dataset.s='1', toggle('.flipped'))"></output>`
         );
@@ -1048,7 +1114,7 @@ describe('hx-live extension', function () {
         assert.isFunction(htmx.live.q);
     });
 
-    it('htmx.live namespace exposes q, debounce, and refresh', function() {
+    it('htmx.live namespace exposes its public helpers', function() {
         assert.isObject(htmx.live);
         assert.isFunction(htmx.live.q);
         assert.isFunction(htmx.live.debounce);
@@ -2384,7 +2450,7 @@ describe('hx-live extension', function () {
             });
 
             let countAfterMorph = window.__morphRemovedCount;
-            // Trigger a recompute cycle — the old fn should no longer be in fns.
+            // Trigger a recompute pass. The old expression should no longer run.
             document.body.setAttribute('data-morph-test-trigger', '1');
             await htmx.timeout(5);
             document.body.removeAttribute('data-morph-test-trigger');
@@ -2450,7 +2516,7 @@ describe('hx-live extension', function () {
             delete window.__morphAttrCount;
         });
 
-        it('morph cycle does not accumulate duplicate fns across multiple morphs', async function() {
+        it('morph cycle does not accumulate duplicate expressions', async function() {
             window.__morphMultiCount = 0;
             playground().innerHTML = '<div id="wrap"><output id="o" :data-v="(window.__morphMultiCount++, \'x\')"></output></div>';
             htmx.process(playground());
@@ -2475,7 +2541,7 @@ describe('hx-live extension', function () {
 
             // Should only fire once per binding, not once per morph cycle.
             let delta = window.__morphMultiCount - baseline;
-            assert.isAtMost(delta, 2, 'should not accumulate duplicate fns across morph cycles');
+            assert.isAtMost(delta, 2, 'should not accumulate duplicate expressions across morph cycles');
             delete window.__morphMultiCount;
         });
 

--- a/test/tests/ext/hx-live.js
+++ b/test/tests/ext/hx-live.js
@@ -1,9 +1,41 @@
 describe('hx-live extension', function () {
 
     let extBackup;
+    let liveConfigBackup;
+
+    async function flushMicrotasks() {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+    }
+
+    function installFakeTimeouts() {
+        let setTimeout = window.setTimeout;
+        let clearTimeout = window.clearTimeout;
+        let timers = [];
+        window.setTimeout = (fn, delay = 0, ...args) => {
+            let timer = { delay, run: () => fn(...args) };
+            timers.push(timer);
+            return timer;
+        };
+        window.clearTimeout = timer => {
+            let index = timers.indexOf(timer);
+            if (index >= 0) timers.splice(index, 1);
+        };
+        return {
+            timers: () => timers,
+            run: () => timers.splice(0).forEach(timer => timer.run()),
+            restore: () => {
+                window.setTimeout = setTimeout;
+                window.clearTimeout = clearTimeout;
+            }
+        };
+    }
 
     before(async () => {
         extBackup = backupExtensions();
+        liveConfigBackup = htmx.config.live;
+        htmx.config.live = { ...liveConfigBackup, inputDebounce: 0 };
         clearExtensions();
         htmx.config.extensions = 'hx-live';
         htmx.__approvedExt = 'hx-live';
@@ -18,6 +50,8 @@ describe('hx-live extension', function () {
 
     after(() => {
         restoreExtensions(extBackup);
+        if (liveConfigBackup === undefined) delete htmx.config.live;
+        else htmx.config.live = liveConfigBackup;
     });
 
     beforeEach(() => { setupTest(this.currentTest); });
@@ -61,6 +95,72 @@ describe('hx-live extension', function () {
         sel.dispatchEvent(new Event('change', { bubbles: true }));
         await htmx.timeout(5);
         out.dataset.v.should.equal('b');
+    });
+
+    it('debounces input and cleans up its listener and timer', async function() {
+        htmx.live.refresh();
+        await flushMicrotasks();
+        let clock = installFakeTimeouts();
+        let removeEventListener = document.removeEventListener;
+        let removed = false;
+        delete htmx.config.live.inputDebounce;
+        window.__liveInputCount = 0;
+        try {
+            let input = createProcessedHTML(`
+                <input>
+                <output hx-live="window.__liveInputCount++"></output>
+            `);
+            await flushMicrotasks();
+            let initial = window.__liveInputCount;
+
+            input.dispatchEvent(new Event('input', { bubbles: true }));
+            input.dispatchEvent(new Event('input', { bubbles: true }));
+            input.dispatchEvent(new Event('input', { bubbles: true }));
+            await flushMicrotasks();
+            window.__liveInputCount.should.equal(initial);
+            clock.timers().length.should.equal(1);
+            clock.timers()[0].delay.should.equal(100);
+            clock.run();
+            await flushMicrotasks();
+            window.__liveInputCount.should.equal(initial + 1);
+
+            input.dispatchEvent(new Event('input', { bubbles: true }));
+
+            document.removeEventListener = function(type, ...args) {
+                if (type === 'input') removed = true;
+                return removeEventListener.call(this, type, ...args);
+            };
+            htmx.__cleanup(playground());
+            htmx.live.refresh();
+            await flushMicrotasks();
+            removed.should.equal(true);
+            clock.timers().length.should.equal(0);
+            clock.run();
+            await flushMicrotasks();
+            window.__liveInputCount.should.equal(initial + 1);
+        } finally {
+            htmx.config.live.inputDebounce = 0;
+            document.removeEventListener = removeEventListener;
+            clock.restore();
+            delete window.__liveInputCount;
+        }
+    });
+
+    it('parses the configured input debounce', async function() {
+        htmx.live.refresh();
+        await flushMicrotasks();
+        let clock = installFakeTimeouts();
+        htmx.config.live.inputDebounce = '20ms';
+        try {
+            let input = createProcessedHTML('<input><output hx-live=""></output>');
+            input.dispatchEvent(new Event('input', { bubbles: true }));
+            clock.timers()[0].delay.should.equal(20);
+            clock.run();
+            await flushMicrotasks();
+        } finally {
+            htmx.config.live.inputDebounce = 0;
+            clock.restore();
+        }
     });
 
     it('recomputes on DOM mutation (attribute change)', async function() {
@@ -704,6 +804,20 @@ describe('hx-live extension', function () {
         tabs[2].getAttribute('aria-selected').should.equal('true');
     });
 
+    it('take() moves a property-backed attribute without changing its property', function() {
+        playground().innerHTML = '<input value="source"><input>';
+        let [source, target] = playground().querySelectorAll('input');
+        source.value = 'edited';
+        target.value = 'keep';
+
+        htmx.live.q(target).take('value');
+
+        assert.isNull(source.getAttribute('value'));
+        source.value.should.equal('edited');
+        target.getAttribute('value').should.equal('');
+        target.value.should.equal('keep');
+    });
+
     it('toggle() is available at top-level in hx-on expressions and applies to current element', function() {
         playground().innerHTML = `
             <button aria-pressed="false" hx-on:click="toggle('.active'); toggle('aria-pressed')">x</button>
@@ -1174,26 +1288,33 @@ describe('hx-live extension', function () {
         div.classList.contains('baz').should.equal(false);
     });
 
-    it('attr() setter: checked syncs property and attribute', function() {
-        playground().innerHTML = '<input id="a" type="checkbox">';
-        let inp = playground().querySelector('#a');
-        htmx.live.attr('#a', 'checked', true);
-        inp.checked.should.equal(true);
-        inp.hasAttribute('checked').should.equal(true);
-        htmx.live.attr('#a', 'checked', false);
-        inp.checked.should.equal(false);
-        inp.hasAttribute('checked').should.equal(false);
+    it('attr() setter: boolean properties sync with attribute presence', function() {
+        playground().innerHTML = '<input type="checkbox"><option></option>';
+        for (let [elt, name] of [[playground().querySelector('input'), 'checked'], [playground().querySelector('option'), 'selected']]) {
+            for (let value of [true, 1, 'yes']) {
+                htmx.live.attr(elt, name, value);
+                elt[name].should.equal(true);
+                elt.hasAttribute(name).should.equal(true);
+            }
+            for (let value of [false, null, 0, '']) {
+                htmx.live.attr(elt, name, value);
+                elt[name].should.equal(false);
+                elt.hasAttribute(name).should.equal(false);
+            }
+        }
     });
 
-    it('attr() setter: value syncs property and attribute', function() {
-        playground().innerHTML = '<input id="a" type="text">';
-        let inp = playground().querySelector('#a');
-        htmx.live.attr('#a', 'value', 'hello');
-        inp.value.should.equal('hello');
-        inp.getAttribute('value').should.equal('hello');
-        htmx.live.attr('#a', 'value', null);
-        inp.value.should.equal('');
-        inp.hasAttribute('value').should.equal(false);
+    it('attr() setter: value syncs normalized property and attribute values', function() {
+        playground().innerHTML = '<input type="text">';
+        let input = playground().querySelector('input');
+        for (let value of ['hello', 42, true, false]) {
+            htmx.live.attr(input, 'value', value);
+            input.value.should.equal(String(value));
+            input.getAttribute('value').should.equal(String(value));
+        }
+        htmx.live.attr(input, 'value', null);
+        input.value.should.equal('');
+        input.hasAttribute('value').should.equal(false);
     });
 
     it('attr() setter: regular attr null removes', function() {
@@ -1667,6 +1788,125 @@ describe('hx-live extension', function () {
     // Simple form: :attr / hx-live:attr
     // -------------------------------------------------------------------------
 
+    it('does not rewrite unchanged typed attribute results', async function() {
+        playground().innerHTML = `
+            <section id="state" data-shift-key="false" data-open="false" data-value="5">
+                <div id="items"><i class="item"></i></div>
+                <div id="drag" :draggable="!data.shiftKey"></div>
+                <output id="count" :data-count="q('.item').count"></output>
+                <button :aria-expanded="data.open"></button>
+                <div role="slider" :aria-valuenow="data.value"></div>
+            </section>
+            <i id="unrelated"></i>
+        `;
+        htmx.process(playground());
+        let state = playground().querySelector('#state');
+        let records = [];
+        let observer = new MutationObserver(mutations => records.push(...mutations));
+        observer.observe(playground(), {
+            attributes: true,
+            subtree: true,
+            attributeFilter: ['draggable', 'data-count', 'aria-expanded', 'aria-valuenow']
+        });
+
+        playground().querySelector('#unrelated').setAttribute('data-tick', '1');
+        await htmx.timeout(5);
+        records.push(...observer.takeRecords());
+        records.length.should.equal(0);
+
+        state.dataset.shiftKey = 'true';
+        state.dataset.open = 'true';
+        state.dataset.value = '6';
+        let item = document.createElement('i');
+        item.className = 'item';
+        playground().querySelector('#items').appendChild(item);
+        await htmx.timeout(5);
+        records.push(...observer.takeRecords());
+
+        records.length.should.equal(4);
+        playground().querySelector('#drag').getAttribute('draggable').should.equal('false');
+        playground().querySelector('#count').dataset.count.should.equal('2');
+        playground().querySelector('button').getAttribute('aria-expanded').should.equal('true');
+        playground().querySelector('[role="slider"]').getAttribute('aria-valuenow').should.equal('6');
+        observer.disconnect();
+    });
+
+    it('does not rewrite unchanged value, style, text, or HTML results', async function() {
+        playground().innerHTML = `
+            <section id="state" data-label="hello">
+                <input id="source" value="hello">
+                <input id="value" :value="q('#source').value">
+                <input id="range" type="range" value="50">
+                <div id="style" :style="{ width: q('#range').value + '%', opacity: '0.5' }"></div>
+                <div id="class" class="external active" :class="{ active: data.label === 'hello' }"></div>
+                <output id="text" :text="data.label"></output>
+                <output id="html" :html="'<span>' + data.label + '</span>'"></output>
+            </section>
+            <i id="unrelated"></i>
+        `;
+        htmx.process(playground());
+        let state = playground().querySelector('#state');
+        let source = playground().querySelector('#source');
+        let value = playground().querySelector('#value');
+        let range = playground().querySelector('#range');
+        let style = playground().querySelector('#style').style;
+        let classOutput = playground().querySelector('#class');
+        let textOutput = playground().querySelector('#text');
+        let htmlOutput = playground().querySelector('#html');
+        let child = htmlOutput.firstElementChild;
+        let descriptor = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value');
+        let propertyWrites = 0;
+        Object.defineProperty(value, 'value', {
+            configurable: true,
+            get: () => descriptor.get.call(value),
+            set: result => { propertyWrites++; descriptor.set.call(value, result); }
+        });
+        let styleWrites = [];
+        let setProperty = CSSStyleDeclaration.prototype.setProperty;
+        CSSStyleDeclaration.prototype.setProperty = function(name, ...args) {
+            if (this === style) styleWrites.push(name);
+            return setProperty.call(this, name, ...args);
+        };
+        let records = [];
+        let observer = new MutationObserver(mutations => records.push(...mutations));
+        observer.observe(value, { attributes: true, attributeFilter: ['value'] });
+        observer.observe(classOutput, { attributes: true, attributeFilter: ['class'] });
+        observer.observe(textOutput, { childList: true, characterData: true, subtree: true });
+        observer.observe(htmlOutput, { childList: true, subtree: true });
+
+        try {
+            playground().querySelector('#unrelated').setAttribute('data-tick', '1');
+            await htmx.timeout(5);
+            records.push(...observer.takeRecords());
+            records.length.should.equal(0);
+            propertyWrites.should.equal(0);
+            styleWrites.should.deep.equal([]);
+            htmlOutput.firstElementChild.should.equal(child);
+
+            source.value = 'world';
+            range.value = '60';
+            state.dataset.label = 'world';
+            source.dispatchEvent(new Event('change', { bubbles: true }));
+            await htmx.timeout(5);
+            records.push(...observer.takeRecords());
+
+            assert.isAtLeast(records.length, 3);
+            propertyWrites.should.equal(1);
+            styleWrites.should.deep.equal(['width']);
+            value.value.should.equal('world');
+            value.getAttribute('value').should.equal('world');
+            style.width.should.equal('60%');
+            style.opacity.should.equal('0.5');
+            classOutput.className.should.equal('external');
+            textOutput.textContent.should.equal('world');
+            htmlOutput.firstElementChild.should.not.equal(child);
+            htmlOutput.innerHTML.should.equal('<span>world</span>');
+        } finally {
+            observer.disconnect();
+            CSSStyleDeclaration.prototype.setProperty = setProperty;
+        }
+    });
+
     it(':hidden truthy sets attribute, falsy removes', async function() {
         playground().innerHTML = `
             <input id="src" type="checkbox">
@@ -1864,6 +2104,57 @@ describe('hx-live extension', function () {
         pr.style.getPropertyValue('--pct').should.equal('0.7');
     });
 
+    it(':style applies declarations in order without replaying an unchanged result', async function() {
+        playground().innerHTML = `
+            <div style="color: blue !important"
+                 :style="'color: red; color: invalid; border: 1px solid red; border-left-color: blue'"></div>
+        `;
+        htmx.process(playground());
+        let div = playground().querySelector('div');
+        let style = div.style;
+        style.color.should.equal('red');
+        style.getPropertyPriority('color').should.equal('');
+        style.borderTop.should.equal('1px solid red');
+        style.borderLeft.should.equal('1px solid blue');
+
+        let writes = [];
+        let setProperty = CSSStyleDeclaration.prototype.setProperty;
+        CSSStyleDeclaration.prototype.setProperty = function(name, ...args) {
+            if (this === style) writes.push(name);
+            return setProperty.call(this, name, ...args);
+        };
+        let records = [];
+        let observer = new MutationObserver(mutations => records.push(...mutations));
+        observer.observe(div, { attributes: true, attributeFilter: ['style'] });
+
+        try {
+            htmx.live.refresh();
+            await htmx.timeout(5);
+            records.push(...observer.takeRecords());
+            writes.should.deep.equal([]);
+            records.should.deep.equal([]);
+        } finally {
+            observer.disconnect();
+            CSSStyleDeclaration.prototype.setProperty = setProperty;
+        }
+    });
+
+    it(':style reads object values once', function() {
+        let reads = 0;
+        window.__styles = {};
+        Object.defineProperty(window.__styles, 'color', {
+            enumerable: true,
+            get: () => { reads++; return 'red'; }
+        });
+        try {
+            playground().innerHTML = '<div :style="window.__styles"></div>';
+            htmx.process(playground());
+            reads.should.equal(1);
+        } finally {
+            delete window.__styles;
+        }
+    });
+
     it(':style re-renders drop managed properties no longer in expression', async function() {
         playground().innerHTML = `
             <input id="src" value="a">
@@ -1880,6 +2171,34 @@ describe('hx-live extension', function () {
         await htmx.timeout(5);
         div.style.width.should.equal('');
         div.style.height.should.equal('20px');
+    });
+
+    it(':style replaces overlapping shorthand and longhand properties', async function() {
+        playground().innerHTML = `
+            <input id="src" value="a">
+            <div :style="q('#src').value === 'a'
+                ? 'border: 1px solid red; border-left-color: blue'
+                : q('#src').value === 'b'
+                    ? 'border-left-color: green'
+                    : 'border: 1px solid red'"></div>
+        `;
+        htmx.process(playground());
+        let input = playground().querySelector('#src');
+        let style = playground().querySelector('div').style;
+        style.borderTop.should.equal('1px solid red');
+        style.borderLeft.should.equal('1px solid blue');
+
+        input.value = 'b';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        await htmx.timeout(5);
+        style.borderTop.should.equal('');
+        style.borderLeftColor.should.equal('green');
+
+        input.value = 'c';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        await htmx.timeout(5);
+        style.borderTop.should.equal('1px solid red');
+        style.borderLeft.should.equal('1px solid red');
     });
 
     it(':style overlap: binding overwrites matching static property', async function() {

--- a/test/tests/ext/hx-live.js
+++ b/test/tests/ext/hx-live.js
@@ -101,8 +101,14 @@ describe('hx-live extension', function () {
         htmx.live.refresh();
         await flushMicrotasks();
         let clock = installFakeTimeouts();
+        let addEventListener = document.addEventListener;
         let removeEventListener = document.removeEventListener;
-        let removed = false;
+        let addedListeners = {};
+        let removedListeners = {};
+        document.addEventListener = function(type, listener, ...args) {
+            if (type === 'input' || type === 'change') addedListeners[type] = listener;
+            return addEventListener.call(this, type, listener, ...args);
+        };
         delete htmx.config.live.inputDebounce;
         window.__liveInputCount = 0;
         try {
@@ -126,20 +132,22 @@ describe('hx-live extension', function () {
 
             input.dispatchEvent(new Event('input', { bubbles: true }));
 
-            document.removeEventListener = function(type, ...args) {
-                if (type === 'input') removed = true;
-                return removeEventListener.call(this, type, ...args);
+            document.removeEventListener = function(type, listener, ...args) {
+                if (type === 'input' || type === 'change') removedListeners[type] = listener;
+                return removeEventListener.call(this, type, listener, ...args);
             };
             htmx.__cleanup(playground());
             htmx.live.refresh();
             await flushMicrotasks();
-            removed.should.equal(true);
+            removedListeners.input.should.equal(addedListeners.input);
+            removedListeners.change.should.equal(addedListeners.change);
             clock.timers().length.should.equal(0);
             clock.run();
             await flushMicrotasks();
             window.__liveInputCount.should.equal(initial + 1);
         } finally {
             htmx.config.live.inputDebounce = 0;
+            document.addEventListener = addEventListener;
             document.removeEventListener = removeEventListener;
             clock.restore();
             delete window.__liveInputCount;

--- a/www/src/content/extensions/06-hx-live.md
+++ b/www/src/content/extensions/06-hx-live.md
@@ -533,26 +533,32 @@ Client state:
 
 ### Re-run triggers
 
-A single document-wide `MutationObserver` and `input` / `change` listeners trigger a recompute of every live expression. Any of these schedule one:
+A single document-wide `MutationObserver` and `input` / `change` listeners trigger a recompute pass. Each pass runs every live expression. Any of these schedule one:
 
 - DOM additions, removals, attribute changes, and text changes, immediately
 - `change` events from any control, immediately
 - `input` events from any control, after [`config.live.inputDebounce`](#configliveinputdebounce)
-- completion of an htmx swap (recomputes pause mid-swap, run once at the end)
+- completion of an htmx swap (recompute passes pause mid-swap, then run once at the end)
 
-All expressions run in a single microtask, so multiple synchronous mutations coalesce into one recompute. Multiple input events within the debounce window also coalesce.
+All expressions run in a single microtask, so multiple synchronous mutations coalesce into one recompute pass. Multiple input events within the debounce window also coalesce.
 
 ### Self-mutation is safe
 
 When an expression writes to the DOM, the observer drains its own pending records inside the same microtask. Writes made by `hx-live` cannot trigger a feedback loop.
 
-### Runaway cap
+### Diagnose slow updates
 
-If recomputes exceed 50/sec, the extension logs a warning. Bindings continue running. Tune your expression or add `debounce`.
+hx-live warns when one recompute pass exceeds 16 ms:
 
-### Coordinating with htmx swaps
+```text
+htmx: hx-live overloaded: 17.0ms pass; 50 expr/pass
+```
 
-Recomputes are deferred between [`htmx:before:swap`](/reference/events/htmx-before-swap) and [`htmx:finally:swap`](/reference/events/htmx-finally-swap). One consolidated recompute runs when the swap finishes, regardless of how much markup changed.
+The timing covers synchronous work in the page-wide recompute pass.
+
+### Coordinate with htmx swaps
+
+Recompute passes are deferred between [`htmx:before:swap`](/reference/events/htmx-before-swap) and [`htmx:finally:swap`](/reference/events/htmx-finally-swap). One consolidated pass runs when the swap finishes, regardless of how much markup changed.
 
 ### Cleanup
 
@@ -625,7 +631,7 @@ htmx.live.attr('.row', 'hidden', true)
 htmx.live.take('.tab.active', '.active', '.tab')
 ```
 
-`htmx.live.refresh()` forces a recompute. Use it when an expression reads from a source the observer cannot see (a JS variable, a getter, an external store) and you've just mutated it.
+`htmx.live.refresh()` forces a recompute pass. Use it when an expression reads from a source the observer cannot see (a JS variable, a getter, an external store) and you've just mutated it.
 
 ```js
 window.appState = 'loading';

--- a/www/src/content/extensions/06-hx-live.md
+++ b/www/src/content/extensions/06-hx-live.md
@@ -249,14 +249,13 @@ attr('data-x', null)                        // remove
 
 ### `toggle(name, values?)`
 
-Toggle (no `values`) or cycle (with `values`) a class or attribute on this element.
+Toggle a class or attribute on this element. Pass `values` to cycle an attribute.
 
 ```js
 toggle('.active')                      // toggle class
 toggle('aria-expanded')                // flip "true" ↔ "false"
 toggle('hidden')                       // toggle attribute presence
 toggle('data-view', 'grid|list|table') // cycle attribute through values
-toggle('.size', 'sm|md|lg')            // cycle classes (only one at a time)
 toggle('data-open', 'on|')             // cycle: 'on' ↔ absent
 ```
 

--- a/www/src/content/extensions/06-hx-live.md
+++ b/www/src/content/extensions/06-hx-live.md
@@ -535,11 +535,12 @@ Client state:
 
 A single document-wide `MutationObserver` and `input` / `change` listeners trigger a recompute of every live expression. Any of these schedule one:
 
-- DOM additions, removals, attribute changes, text changes
-- `input` or `change` events from any control
+- DOM additions, removals, attribute changes, and text changes, immediately
+- `change` events from any control, immediately
+- `input` events from any control, after [`config.live.inputDebounce`](#configliveinputdebounce)
 - completion of an htmx swap (recomputes pause mid-swap, run once at the end)
 
-All expressions run in a single microtask, so multiple synchronous mutations coalesce into one recompute.
+All expressions run in a single microtask, so multiple synchronous mutations coalesce into one recompute. Multiple input events within the debounce window also coalesce.
 
 ### Self-mutation is safe
 
@@ -634,6 +635,16 @@ htmx.live.refresh();
 Selector directionals (`next`, `previous`, `closest`) need an anchor and only work inside `hx-live` / `hx-on`, not from `htmx.live.q`.
 
 ## Configuration
+
+### `config.live.inputDebounce`
+
+Debounces recomputes from `input` events. Defaults to `100ms`.
+
+```html
+<meta name="htmx-config" content="live.inputDebounce:20ms">
+```
+
+Accepts an interval (`20ms`, `0.5s`) or a number of milliseconds. Set `0` to recompute on the next task. Other triggers remain immediate.
 
 ### `config.live.bindPrefix`
 


### PR DESCRIPTION
## Description

Follow-up to #3891.

Make sure that in even more scenarios, we skip unnecessary work.

| Binding result | #3891 | This PR |
|---|:---:|:---:|
| Text and HTML | ✅ | ✅ |
| String and boolean attributes | ✅ | ✅ |
| Boolean and string class bindings | ✅ | ✅ |
| Normalized attribute values | | ✅ |
| ARIA attributes | | ✅ |
| `checked`, `selected`, and `value` | | ✅ |
| Object class bindings | | ✅ |
| Style bindings | | ✅ |

### Input debounce

Rename the `live.inputDebounceMs` config from #3891 to `live.inputDebounce`, and enable both numbers and HCON intervals.

```html
<meta name="htmx-config" content="live.inputDebounce:20ms"
```

### Recompute warning

Made the automatic warning appear based on main-thread cost rather than expression count.

Previously, you'd get warnings for 50x (cheap) recompute passes that took e.g. 0.1ms in total (negligible). 

Now, you get a warning when one single recompute pass exceeds 16ms (expensive), or recomputes consume over 100ms/s for 2 consecutive seconds.