### PR TITLE
fix websocket close event code to 1000 from server only 1001 code

### DIFF
--- a/src/ext/hx-ws.js
+++ b/src/ext/hx-ws.js
@@ -610,7 +610,7 @@
         window.addEventListener('pagehide', () => {
             connections.forEach((connection) => {
                 if (connection.socket) {
-                    connection.socket.close(1001, 'page navigating away');
+                    connection.socket.close(1000, 'page navigating away');
                 }
             });
         });


### PR DESCRIPTION
## Description
update web socket close code to be 1000 instead of the server only 1001 which can get rejected as only 1000 and 3000-3999 are valid to be sent from JS client side libraries.

Corresponding issue:
#3904

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
