### PR TITLE
Restore form state before deferred head scripts

### DIFF
--- a/src/ext/hx-head.js
+++ b/src/ext/hx-head.js
@@ -182,6 +182,9 @@
                     detail._deferredHeadScripts = deferred;
                 });
             }
+        },
+        htmx_history_cache_after_restore: (elt, detail) => {
+            for (const node of detail._deferredHeadScripts || []) appendNode(node)
         }
     })
 

--- a/src/ext/hx-history-cache.js
+++ b/src/ext/hx-history-cache.js
@@ -174,8 +174,7 @@
             target: restoreSwapTarget,
             swap: restoreSwapStyle,
             text: cachedHTML,
-            transition: false,
-            _deferredHeadScripts: detail._deferredHeadScripts
+            transition: false
         };
         await htmx.swap(ctx);
 
@@ -183,7 +182,8 @@
         requestAnimationFrame(() => {
             window.scrollTo(0, item.scroll || 0);
             restoreAnnotations(getHistoryTarget());
-            api.triggerHtmxEvent(document, 'htmx:history:cache:after:restore', { item });
+            detail.item = item;
+            api.triggerHtmxEvent(document, 'htmx:history:cache:after:restore', detail);
         });
     }
 

--- a/test/tests/ext/hx-head.js
+++ b/test/tests/ext/hx-head.js
@@ -216,3 +216,78 @@ describe('hx-head extension', function() {
         if (addedLink) addedHeadElts.push(addedLink);
     });
 });
+
+describe('hx-head + hx-history-cache integration', function () {
+
+    let extBackup;
+
+    before(async () => {
+        extBackup = backupExtensions();
+        clearExtensions();
+        htmx.config.extensions = 'history-cache,hx-head';
+        htmx.__approvedExt = 'history-cache,hx-head';
+
+        for (const src of ['../src/ext/hx-history-cache.js', '../src/ext/hx-head.js']) {
+            let script = document.createElement('script');
+            script.src = src;
+            await new Promise(resolve => {
+                script.onload = resolve;
+                document.head.appendChild(script);
+            });
+        }
+    });
+
+    after(() => {
+        restoreExtensions(extBackup);
+    });
+
+    beforeEach(() => {
+        setupTest();
+        sessionStorage.clear();
+        htmx.config.historyCache = {size: 10, refreshOnMiss: false, disable: false, swapStyle: 'outerSync'};
+    });
+
+    afterEach(() => {
+        document.getElementById('cached-deferred-script')?.remove();
+        delete window.cachedInputValueSeenByDeferred;
+        cleanupTest();
+        sessionStorage.clear();
+    });
+
+    it('runs deferred scripts after cached form state is restored', async function () {
+        let cachedPath = location.pathname + location.search;
+        createProcessedHTML(`
+            <div hx-history-elt><input id="cached-input"></div>
+            <button hx-get="/page2" hx-push-url="/page2">go</button>
+        `);
+        let historyElt = playground().querySelector('[hx-history-elt]');
+        historyElt.querySelector('input').value = 'restored value';
+
+        mockResponse('GET', '/page2', '<p>page 2</p>');
+        playground().querySelector('button').click();
+        await forRequest();
+
+        let index = JSON.parse(sessionStorage.getItem('htmx-history-index') || '[]');
+        let htmxId = index[index.length - 1];
+        history.replaceState({htmx: true, htmxId}, '', cachedPath);
+        historyElt.innerHTML = '<p>current page</p>';
+
+        document.addEventListener('htmx:history:cache:hit', event => {
+            let script = `<script id="cached-deferred-script" defer>
+                window.cachedInputValueSeenByDeferred = document.getElementById('cached-input').value;
+            <\/script>`;
+            event.detail.item.head = event.detail.item.head.replace('</head>', script + '</head>');
+        }, {once: true});
+
+        await new Promise(resolve => {
+            document.addEventListener('htmx:history:cache:after:restore', resolve, {once: true});
+            htmx.__restoreHistory(null, cachedPath);
+        });
+
+        assert.equal(
+            window.cachedInputValueSeenByDeferred,
+            'restored value',
+            'deferred cached head script must see restored input value'
+        );
+    });
+});


### PR DESCRIPTION
## Description

During a cached history restore, `hx-head` appends deferred head scripts from `htmx:after:swap`. Form annotations are restored afterward, so those scripts observe default form values instead of the cached values.

Carry the existing restore detail through `htmx:history:cache:after:restore` and append cached deferred scripts there, after form state restoration. The existing `detail.item` field is preserved.

Corresponding issue: none

## Testing

Added an integration test that restores a cached input and verifies a deferred head script reads its restored value.

Chromium: 1,588 passed, 0 failed, 6 skipped.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct htmx 4 development branch (`four-dev`)
* [x] This is a bugfix
* [x] I ran the test suite locally and verified that it succeeded