### PR TITLE
Respect disabled history during swaps

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1697,6 +1697,7 @@ var htmx = (() => {
         }
 
         __handleHistoryUpdate(ctx) {
+            if (!this.config.history) return;
             let action = this.__resolveHistoryAction(ctx);
             if (!action) return;
 

--- a/test/tests/ext/hx-history-cache.js
+++ b/test/tests/ext/hx-history-cache.js
@@ -49,6 +49,21 @@ describe('hx-history-cache extension', function () {
     // saveCurrentPage / basic read-back
     // -------------------------------------------------------------------------
 
+    it('does not cache a page when history is disabled', async function () {
+        let originalHistory = htmx.config.history;
+        htmx.config.history = false;
+        mockResponse('GET', '/page2', '<p>page 2</p>');
+        let button = createProcessedHTML('<button hx-get="/page2" hx-push-url="/page2">go</button>');
+
+        try {
+            button.click();
+            await forRequest();
+            assert.deepEqual(readCache(), []);
+        } finally {
+            htmx.config.history = originalHistory;
+        }
+    });
+
     it('saves current page on htmx:before:history:update', async function () {
         let savedDetail = null;
         document.addEventListener('htmx:history:cache:after:save', e => { savedDetail = e.detail; }, { once: true });


### PR DESCRIPTION
## Description

When `htmx.config.history` is `false`, swaps still emit history update events around a no-op URL update. The history cache extension handles those events and saves the outgoing page despite history being disabled.

Return before resolving or emitting a history update when history is disabled.

Corresponding issue: none

## Testing

Added an integration test that performs an `hx-push-url` request with history disabled and verifies the history cache stays empty.

Chromium: 1,588 passed, 0 failed, 6 skipped.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct htmx 4 development branch (`four-dev`)
* [x] This is a bugfix
* [x] I ran the test suite locally and verified that it succeeded