### PR TITLE
Fix hx-sse last event ID handling

### DIFF
--- a/src/ext/hx-sse.js
+++ b/src/ext/hx-sse.js
@@ -22,15 +22,22 @@
         return {...defaults, ...global, ...perElement};
     }
 
+    function clearLastEventIdHeader(headers) {
+        for (let name of Object.keys(headers)) {
+            if (name.toLowerCase() === 'last-event-id') delete headers[name];
+        }
+    }
+
     // ========================================
     // SSE PARSER
     // ========================================
 
-    async function* parseSSE(reader) {
+    async function* parseSSE(reader, lastEventId = '') {
         let decoder = new TextDecoder();
         let buffer = '';
         let hasData = false;
-        let message = {data: '', event: '', id: '', retry: null};
+        let hasId = false;
+        let message = {data: '', event: '', retry: null};
         let firstChunk = true;
 
         try {
@@ -52,11 +59,12 @@
 
                 for (let line of lines) {
                     if (!line) {
-                        if (hasData) {
-                            yield message;
-                            hasData = false;
-                            message = {data: '', event: '', id: '', retry: null};
+                        if (hasData || hasId) {
+                            yield {...message, id: lastEventId, hasData};
                         }
+                        hasData = false;
+                        hasId = false;
+                        message = {data: '', event: '', retry: null};
                         continue;
                     }
 
@@ -80,7 +88,10 @@
                     } else if (field === 'event') {
                         message.event = value;
                     } else if (field === 'id') {
-                        if (!value.includes('\0')) message.id = value;
+                        if (!value.includes('\0')) {
+                            lastEventId = value;
+                            hasId = true;
+                        }
                     } else if (field === 'retry') {
                         let retryValue = parseInt(value, 10);
                         if (!isNaN(retryValue)) message.retry = retryValue;
@@ -108,7 +119,7 @@
             config: config,
             abortController: null,
             reader: null,
-            lastEventId: null,
+            lastEventId: '',
             delayCanceller: null,
             visibilityHandler: null,
             attempt: 0,
@@ -194,6 +205,7 @@
                     let ac = new AbortController();
                     connection.abortController = ac;
                     try {
+                        clearLastEventIdHeader(ctx.request.headers);
                         if (connection.lastEventId) ctx.request.headers['Last-Event-ID'] = connection.lastEventId;
                         currentResponse = await fetch(ctx.request.action, {
                             ...ctx.request,
@@ -229,17 +241,22 @@
                 try {
                     connection.reader = currentResponse.body.getReader();
 
-                    for await (let msg of parseSSE(connection.reader)) {
+                    for await (let msg of parseSSE(connection.reader, connection.lastEventId)) {
                         if (!element.isConnected || reconnectRequested) break;
+
+                        if (!msg.hasData) {
+                            connection.lastEventId = msg.id;
+                            if (!msg.id) clearLastEventIdHeader(ctx.request.headers);
+                            continue;
+                        }
 
                         let detail = {
                             message: {data: msg.data, event: msg.event, id: msg.id, cancelled: false}
                         };
                         if (!api.triggerHtmxEvent(element, 'htmx:before:sse:message', detail) || detail.message.cancelled) continue;
 
-                        if (msg.id) {
-                            connection.lastEventId = msg.id;
-                        }
+                        connection.lastEventId = msg.id;
+                        if (!msg.id) clearLastEventIdHeader(ctx.request.headers);
                         if (msg.retry != null) config.reconnectDelay = msg.retry;
 
                         if (detail.message.event) {

--- a/test/tests/ext/hx-sse.js
+++ b/test/tests/ext/hx-sse.js
@@ -125,6 +125,182 @@ describe('hx-sse SSE extension', function() {
         stream.close();
     });
 
+    it('events without id inherit the buffered event ID', async function() {
+        const stream = mockStreamResponse('/inherited-id');
+        createProcessedHTML('<button hx-get="/inherited-id" hx-swap="innerHTML">Connect</button>');
+
+        let ids = [];
+        onDoc('htmx:before:sse:message', (e) => {
+            ids.push(e.detail.message.id);
+        });
+
+        find('button').click();
+        await htmx.timeout(1);
+
+        stream.sendRaw('id: 42\ndata: first\n\n');
+        await waitForEvent('htmx:after:sse:message');
+        stream.sendRaw('data: second\n\n');
+        await waitForEvent('htmx:after:sse:message');
+
+        assert.deepEqual(ids, ['42', '42']);
+        stream.close();
+    });
+
+    it('empty id clears the connection cursor', async function() {
+        const stream = mockStreamResponse('/clear-id');
+        createProcessedHTML('<button hx-get="/clear-id" hx-swap="innerHTML">Connect</button>');
+
+        let lastMessageId = null;
+        onDoc('htmx:before:sse:message', (e) => {
+            lastMessageId = e.detail.message.id;
+        });
+
+        find('button').click();
+        await htmx.timeout(1);
+
+        stream.sendRaw('id: 42\ndata: first\n\n');
+        await waitForEvent('htmx:after:sse:message');
+        stream.sendRaw('id:\ndata: reset\n\n');
+        await waitForEvent('htmx:after:sse:message');
+
+        assert.equal(lastMessageId, '');
+        assert.equal(find('button')._htmx.sse.lastEventId, '');
+        stream.close();
+    });
+
+    it('clearing the event ID removes a stale reconnect header', async function() {
+        this.timeout(5000);
+        const stream = mockStreamResponse('/clear-reconnect-id');
+        createProcessedHTML('<button hx-get="/clear-reconnect-id" hx-config="sse.reconnect:true sse.reconnectDelay:10ms sse.reconnectMaxAttempts:2 sse.reconnectJitter:0" hx-swap="innerHTML">Connect</button>');
+
+        find('button').click();
+        await htmx.timeout(1);
+
+        stream.sendRaw('id: 42\ndata: first\n\n');
+        await waitForEvent('htmx:after:sse:message');
+        stream.close();
+        await waitForEvent('htmx:after:sse:connection', 1000);
+
+        let reconnectCall = fetchMock.getLastCall();
+        assert.equal(reconnectCall.request.headers['Last-Event-ID'], '42');
+
+        stream.sendRaw('id:\ndata: reset\n\n');
+        await waitForEvent('htmx:after:sse:message');
+        stream.close();
+        await waitForEvent('htmx:after:sse:connection', 1000);
+
+        reconnectCall = fetchMock.getLastCall();
+        assert.isFalse(
+            Object.keys(reconnectCall.request.headers).some(name => name.toLowerCase() === 'last-event-id'),
+            'Cleared Last-Event-ID header should not be sent'
+        );
+    });
+
+    it('id-only blocks update the reconnect cursor without message events', async function() {
+        this.timeout(5000);
+        const stream = mockStreamResponse('/id-only');
+        createProcessedHTML('<button hx-get="/id-only" hx-config="sse.reconnect:true sse.reconnectDelay:10ms sse.reconnectMaxAttempts:1 sse.reconnectJitter:0" hx-swap="innerHTML">Connect</button>');
+
+        let beforeMessages = 0;
+        let afterMessages = 0;
+        onDoc('htmx:before:sse:message', () => { beforeMessages++; });
+        onDoc('htmx:after:sse:message', () => { afterMessages++; });
+
+        find('button').click();
+        await htmx.timeout(1);
+
+        stream.sendRaw('id: cursor-7\n\n');
+        await htmx.timeout(20);
+
+        assert.equal(find('button')._htmx.sse.lastEventId, 'cursor-7');
+        assert.equal(beforeMessages, 0);
+        assert.equal(afterMessages, 0);
+        assertTextContentIs('button', 'Connect');
+
+        stream.close();
+        await waitForEvent('htmx:after:sse:connection', 1000);
+
+        assert.equal(fetchMock.getLastCall().request.headers['Last-Event-ID'], 'cursor-7');
+    });
+
+    it('empty id-only blocks clear the reconnect cursor', async function() {
+        this.timeout(5000);
+        const stream = mockStreamResponse('/empty-id-only');
+        createProcessedHTML('<button hx-get="/empty-id-only" hx-config="sse.reconnect:true sse.reconnectDelay:10ms sse.reconnectMaxAttempts:1 sse.reconnectJitter:0" hx-swap="innerHTML">Connect</button>');
+
+        find('button').click();
+        await htmx.timeout(1);
+
+        stream.sendRaw('id: 42\ndata: first\n\n');
+        await waitForEvent('htmx:after:sse:message');
+
+        let beforeMessages = 0;
+        let afterMessages = 0;
+        onDoc('htmx:before:sse:message', () => { beforeMessages++; });
+        onDoc('htmx:after:sse:message', () => { afterMessages++; });
+
+        stream.sendRaw('id:\n\n');
+        await htmx.timeout(20);
+
+        assert.equal(find('button')._htmx.sse.lastEventId, '');
+        assert.equal(beforeMessages, 0);
+        assert.equal(afterMessages, 0);
+
+        stream.close();
+        await waitForEvent('htmx:after:sse:connection', 1000);
+
+        assert.isFalse(
+            Object.keys(fetchMock.getLastCall().request.headers).some(name => name.toLowerCase() === 'last-event-id'),
+            'Empty ID-only block should clear Last-Event-ID header'
+        );
+    });
+
+    it('event IDs containing NULL remain ignored', async function() {
+        const stream = mockStreamResponse('/null-id');
+        createProcessedHTML('<button hx-get="/null-id" hx-swap="innerHTML">Connect</button>');
+
+        let ids = [];
+        onDoc('htmx:before:sse:message', (e) => {
+            ids.push(e.detail.message.id);
+        });
+
+        find('button').click();
+        await htmx.timeout(1);
+
+        stream.sendRaw('id: 42\ndata: first\n\n');
+        await waitForEvent('htmx:after:sse:message');
+        stream.sendRaw('id: bad\0id\ndata: second\n\n');
+        await waitForEvent('htmx:after:sse:message');
+
+        assert.deepEqual(ids, ['42', '42']);
+        assert.equal(find('button')._htmx.sse.lastEventId, '42');
+        stream.close();
+    });
+
+    it('cancelled messages do not advance or clear the connection cursor', async function() {
+        const stream = mockStreamResponse('/cancelled-id');
+        createProcessedHTML('<button hx-get="/cancelled-id" hx-swap="innerHTML">Connect</button>');
+
+        onDoc('htmx:before:sse:message', (e) => {
+            if (e.detail.message.data !== 'first') e.detail.message.cancelled = true;
+        });
+
+        find('button').click();
+        await htmx.timeout(1);
+
+        stream.sendRaw('id: 42\ndata: first\n\n');
+        await waitForEvent('htmx:after:sse:message');
+        stream.sendRaw('id: 43\ndata: advance\n\n');
+        await htmx.timeout(20);
+        assert.equal(find('button')._htmx.sse.lastEventId, '42');
+
+        stream.sendRaw('id:\ndata: clear\n\n');
+        await htmx.timeout(20);
+        assert.equal(find('button')._htmx.sse.lastEventId, '42');
+
+        stream.close();
+    });
+
     it('events fire correctly and can cancel operations', async function() {
         const stream = mockStreamResponse('/cancelable');
         createProcessedHTML('<button hx-get="/cancelable" hx-swap="innerHTML">Go</button>');

--- a/www/src/content/extensions/02-hx-sse.md
+++ b/www/src/content/extensions/02-hx-sse.md
@@ -278,7 +278,13 @@ data: <p>New message</p>
 
 ```
 
-On reconnect, `hx-sse` automatically includes the [`Last-Event-ID`](#last-event-id) header:
+The stream keeps the current event ID:
+
+- An event without `id` inherits the current ID.
+- An empty `id:` clears the ID.
+- An ID-only block ending with a blank line updates or clears the ID without dispatching a message.
+
+On reconnect, `hx-sse` includes [`Last-Event-ID`](#last-event-id) when the current ID is not empty:
 
 ```http
 Last-Event-ID: event-42
@@ -294,6 +300,8 @@ event-43  --------X             disconnected
           <-------------------  Last-Event-ID: event-42
 event-43  ------------------->  replayed
 ```
+
+The server decides which messages to replay. `hx-sse` processes every event it receives and does not deduplicate replays.
 
 ### Trigger Client Events
 
@@ -407,7 +415,9 @@ Identifies the last received SSE event during reconnection.
 Last-Event-ID: event-42
 ```
 
-The extension sends this header after a message supplies an `id` field. The server decides how to replay later messages.
+The extension sends this header while the current event ID is not empty. Events without `id` inherit that ID, while an empty `id:` removes the header from later reconnects.
+
+The server decides how to replay later messages. The client does not deduplicate them.
 
 ## Events
 


### PR DESCRIPTION
Make it so that sending `id:` (empty) from the server properly clears `Last-Event-ID` (according to spec).