### PR TITLE
Add multipart resume cursors

### DIFF
--- a/src/ext/hx-multipart.js
+++ b/src/ext/hx-multipart.js
@@ -97,6 +97,7 @@
             abort: ctx.request.abort,
             abortController: null,
             iterator: null,
+            lastPartId: null,
             delayCanceller: null,
             visibilityHandler: null,
             unpauseResolver: null,
@@ -171,8 +172,16 @@
                     let ac = new AbortController();
                     connection.abortController = ac;
                     try {
+                        let headers = {...ctx.request.headers};
+                        if (connection.lastPartId != null) {
+                            for (let name in headers) {
+                                if (name.toLowerCase() === 'hx-last-part-id') delete headers[name];
+                            }
+                            if (connection.lastPartId) headers['HX-Last-Part-ID'] = connection.lastPartId;
+                        }
                         currentResponse = await fetch(ctx.request.action, {
                             ...ctx.request,
+                            headers,
                             signal: ac.signal
                         });
                     } catch (error) {
@@ -215,6 +224,8 @@
                 }
 
                 let pending = new Set();
+                let checkpoints = [];
+                let checkpointIndex = 0;
                 let iterator = currentResponse.parts()[Symbol.asyncIterator]();
                 connection.iterator = iterator;
 
@@ -246,8 +257,11 @@
                             reswap,   // HX-Reswap
                             retarget, // HX-Retarget
                             reselect, // HX-Reselect
+                            partId,   // HX-Part-ID
                             ...actions // other HX-* headers in camelCase
                         } = extractPartActions(part.headers);
+                        let checkpoint = {id: partId, completed: false};
+                        checkpoints.push(checkpoint);
 
                         // Let part headers override envelope and request defaults.
                         swap = reswap ?? swap ?? defaultSwap;
@@ -272,6 +286,16 @@
                                 });
                             }
 
+                            checkpoint.completed = true;
+                            while (checkpoints[checkpointIndex]?.completed) {
+                                let completed = checkpoints[checkpointIndex++];
+                                if (completed.id !== undefined) connection.lastPartId = completed.id;
+                            }
+                            if (checkpointIndex === checkpoints.length) {
+                                checkpoints.length = 0;
+                                checkpointIndex = 0;
+                            }
+
                             api.triggerHtmxEvent(ctx.sourceElement, 'htmx:multipart:after:part', {ctx, part});
                         })();
 
@@ -287,6 +311,7 @@
                     }
                     await Promise.all(pending);
                 } catch (error) {
+                    await Promise.allSettled(pending);
                     if (!connection.cancelled) {
                         api.triggerHtmxEvent(element, 'htmx:multipart:error', {
                             error,

--- a/test/tests/ext/hx-multipart.js
+++ b/test/tests/ext/hx-multipart.js
@@ -244,6 +244,200 @@ describe('hx-multipart extension', function() {
         assert.equal(closeReason, 'removed');
     });
 
+    it('sends the last completed part ID on reconnect and supports reset', async function() {
+        let requestHeaders = [];
+        let requestCount = 0;
+        fetchMock.mockResponse('GET', '/resume', () => {
+            requestHeaders.push({...fetchMock.getLastCall().request.headers});
+            requestCount++;
+
+            if (requestCount === 1) {
+                return new Response([
+                    '--updates\r\n',
+                    'Content-Type: text/html\r\n',
+                    'HX-Part-ID: part-1\r\n',
+                    '\r\n',
+                    'First',
+                    '\r\n--updates--\r\n'
+                ].join(''), {
+                    headers: {'Content-Type': 'multipart/mixed; boundary=updates'}
+                });
+            }
+            if (requestCount === 2) {
+                return new Response([
+                    '--updates\r\n',
+                    'Content-Type: text/html\r\n',
+                    'HX-Part-ID:\r\n',
+                    '\r\n',
+                    'Reset',
+                    '\r\n--updates--\r\n'
+                ].join(''), {
+                    headers: {'Content-Type': 'multipart/mixed; boundary=updates'}
+                });
+            }
+            return new Response(new ReadableStream(), {
+                headers: {'Content-Type': 'multipart/mixed; boundary=updates'}
+            });
+        });
+
+        let source = createProcessedHTML([
+            '<div id="resume-source" hx-multipart:connect="/resume" hx-trigger="click" ',
+            'hx-config="multipart.reconnectDelay:1ms multipart.reconnectMaxDelay:1ms multipart.reconnectJitter:0"></div>'
+        ].join(''));
+        source.click();
+
+        assert.isTrue(await waitUntil(() => requestCount >= 3, 500));
+        assert.equal(requestHeaders[1]['HX-Last-Part-ID'], 'part-1');
+        assert.isUndefined(requestHeaders[2]['HX-Last-Part-ID']);
+        assert.equal(source._htmx.multipart.lastPartId, '');
+        await deleteWithSwap('#resume-source');
+    });
+
+    it('keeps the previous part ID when a reset part fails', async function() {
+        let requestHeaders = [];
+        let requestCount = 0;
+        fetchMock.mockResponse('GET', '/failed-reset', () => {
+            requestHeaders.push({...fetchMock.getLastCall().request.headers});
+            requestCount++;
+
+            if (requestCount === 1) {
+                return new Response([
+                    '--updates\r\n',
+                    'Content-Type: text/html\r\n',
+                    'HX-Part-ID: part-1\r\n',
+                    '\r\n',
+                    'First',
+                    '\r\n--updates--\r\n'
+                ].join(''), {
+                    headers: {'Content-Type': 'multipart/mixed; boundary=updates'}
+                });
+            }
+            if (requestCount === 2) {
+                return new Response([
+                    '--updates\r\n',
+                    'Content-Type: text/html\r\n',
+                    'HX-Part-ID:\r\n',
+                    '\r\n',
+                    'Reset',
+                    '\r\n--updates--\r\n'
+                ].join(''), {
+                    headers: {'Content-Type': 'multipart/mixed; boundary=updates'}
+                });
+            }
+            return new Response(new ReadableStream(), {
+                headers: {'Content-Type': 'multipart/mixed; boundary=updates'}
+            });
+        });
+
+        let source = createProcessedHTML([
+            '<div id="failed-reset-source" hx-multipart:connect="/failed-reset" hx-trigger="click" ',
+            'hx-config="multipart.reconnectDelay:1ms multipart.reconnectMaxDelay:1ms multipart.reconnectJitter:0"></div>'
+        ].join(''));
+        source.addEventListener('htmx:multipart:before:part', event => {
+            if (requestCount === 2) event.detail.waitUntil(Promise.reject(new Error('part failed')));
+        });
+        source.click();
+
+        assert.isTrue(await waitUntil(() => requestCount >= 3, 500));
+        assert.equal(requestHeaders[2]['HX-Last-Part-ID'], 'part-1');
+        assert.equal(source._htmx.multipart.lastPartId, 'part-1');
+        await deleteWithSwap('#failed-reset-source');
+    });
+
+    it('does not record a cancelled part ID', async function() {
+        let requestHeaders = [];
+        let requestCount = 0;
+        fetchMock.mockResponse('GET', '/cancelled-part', () => {
+            requestHeaders.push({...fetchMock.getLastCall().request.headers});
+            requestCount++;
+
+            if (requestCount === 1) {
+                return new Response([
+                    '--updates\r\n',
+                    'Content-Type: text/html\r\n',
+                    'HX-Part-ID: skipped\r\n',
+                    '\r\n',
+                    'Skipped',
+                    '\r\n--updates--\r\n'
+                ].join(''), {
+                    headers: {'Content-Type': 'multipart/mixed; boundary=updates'}
+                });
+            }
+            return new Response(new ReadableStream(), {
+                headers: {'Content-Type': 'multipart/mixed; boundary=updates'}
+            });
+        });
+
+        let source = createProcessedHTML([
+            '<div id="cancelled-part-source" hx-multipart:connect="/cancelled-part" hx-trigger="click" ',
+            'hx-config="multipart.reconnectDelay:1ms multipart.reconnectMaxDelay:1ms multipart.reconnectJitter:0"></div>'
+        ].join(''));
+        source.addEventListener('htmx:multipart:before:part', event => event.preventDefault());
+        source.click();
+
+        assert.isTrue(await waitUntil(() => requestCount >= 2, 500));
+        assert.isUndefined(requestHeaders[1]['HX-Last-Part-ID']);
+        assert.isNull(source._htmx.multipart.lastPartId);
+        await deleteWithSwap('#cancelled-part-source');
+    });
+
+    it('records parallel part IDs in wire order', async function() {
+        let requestHeaders = [];
+        let requestCount = 0;
+        fetchMock.mockResponse('GET', '/parallel-resume', () => {
+            requestHeaders.push({...fetchMock.getLastCall().request.headers});
+            requestCount++;
+
+            if (requestCount === 1) {
+                return new Response([
+                    '--updates\r\n',
+                    'Content-Type: text/html\r\n',
+                    'HX-Target: #parallel-resume-one\r\n',
+                    'HX-Swap: innerHTML swap:100ms settle:0\r\n',
+                    'HX-Part-ID: part-1\r\n',
+                    '\r\n',
+                    'First',
+                    '\r\n--updates\r\n',
+                    'Content-Type: text/html\r\n',
+                    'HX-Target: #parallel-resume-two\r\n',
+                    'HX-Swap: innerHTML settle:0\r\n',
+                    'HX-Part-ID: part-2\r\n',
+                    '\r\n',
+                    'Second',
+                    '\r\n--updates--\r\n'
+                ].join(''), {
+                    headers: {'Content-Type': 'multipart/parallel; boundary=updates'}
+                });
+            }
+            return new Response(new ReadableStream(), {
+                headers: {'Content-Type': 'multipart/parallel; boundary=updates'}
+            });
+        });
+
+        let source = createProcessedHTML([
+            '<div id="parallel-resume-source" hx-multipart:connect="/parallel-resume" hx-trigger="click" ',
+            'hx-config="multipart.reconnectDelay:1ms multipart.reconnectMaxDelay:1ms multipart.reconnectJitter:0"></div>',
+            '<div id="parallel-resume-one"></div>',
+            '<div id="parallel-resume-two"></div>'
+        ].join(''));
+        let completed = [];
+        source.addEventListener('htmx:multipart:after:part', event => {
+            completed.push({
+                id: event.detail.part.headers.get('HX-Part-ID'),
+                lastPartId: source._htmx.multipart.lastPartId
+            });
+        });
+        source.click();
+
+        assert.isTrue(await waitUntil(() => requestCount >= 2, 500));
+        assert.deepEqual(completed, [
+            {id: 'part-2', lastPartId: null},
+            {id: 'part-1', lastPartId: 'part-2'}
+        ]);
+        assert.equal(requestHeaders[1]['HX-Last-Part-ID'], 'part-2');
+        await deleteWithSwap('#parallel-resume-source');
+    });
+
     it('reconnects hx-multipart:connect after a broken stream', async function() {
         let requestCount = 0;
         let encoder = new TextEncoder();

--- a/www/src/content/extensions/01-hx-multipart.md
+++ b/www/src/content/extensions/01-hx-multipart.md
@@ -273,6 +273,34 @@ The part still swaps, then the connection stops:
 <div id="status">Complete</div>
 ```
 
+#### Resume Connections
+
+Identify each part so a reconnect can start after the last successful update:
+
+```http
+--...
+Content-Type: text/html
+HX-Part-ID: event-42
+
+<p>New message</p>
+```
+
+After the part's actions and swap finish, the next reconnect includes:
+
+```http
+HX-Last-Part-ID: event-42
+```
+
+The server should return parts after that ID. The client processes every returned part without deduplicating IDs.
+
+Reset the cursor with an empty header:
+
+```http
+HX-Part-ID:
+```
+
+A missing `HX-Part-ID` leaves the cursor unchanged. A failed or cancelled part does not update it.
+
 #### Configure Connections
 
 You can configure `hx-multipart` in three places:
@@ -427,6 +455,28 @@ Closes a connection after a part fires the named [`HX-Trigger`](/reference/heade
 
 ## Headers
 
+### `HX-Part-ID`
+
+Identifies a response part for reconnecting:
+
+```http
+HX-Part-ID: event-42
+```
+
+The extension records the value after the part's actions and swap finish. A missing header leaves the current ID unchanged. An empty value resets it.
+
+With `multipart/parallel`, the recorded ID advances only after that part and every earlier accepted part finishes successfully.
+
+### `HX-Last-Part-ID`
+
+Identifies the last completed part in a reconnect request:
+
+```http
+HX-Last-Part-ID: event-42
+```
+
+The server decides how to resume after that ID. The header is omitted after [`HX-Part-ID`](#hx-part-id) resets the cursor.
+
 ### `HX-*` Headers
 
 The envelope is a normal HTTP response. It may include ordinary HTTP headers and any htmx response header.
@@ -540,6 +590,8 @@ Part 2                       [read][actions][swap][finished]
 
 `multipart/mixed` waits for each part's swap to finish before reading the next body. `multipart/parallel` runs each part's actions in arrival order, starts its swap, then reads the next body without waiting for that swap to finish.
 
+The [`HX-Part-ID`](#hx-part-id) cursor still advances in wire order. A later completed part waits for every earlier accepted part to finish successfully.
+
 When every swap finishes immediately, both formats usually look the same. See [Overlap Swaps](#overlap-swaps) for a visible comparison.
 
 Use `multipart/parallel` when:
@@ -568,6 +620,7 @@ Connection events expose:
 event.detail.connection = {
   url,
   config,
+  lastPartId,
   attempt,
   status,
   cancelled
@@ -717,7 +770,7 @@ Close the request while the page is hidden and reconnect when it becomes visible
 <meta name="htmx-config" content="multipart.pauseOnBackground:false">
 ```
 
-Defaults to `true` for `hx-multipart:connect` and `false` for normal htmx requests.
+Defaults to `true` for `hx-multipart:connect` and `false` for normal htmx requests. Use [`HX-Part-ID`](#hx-part-id) and server-side replay to recover parts sent while disconnected.
 
 ## How `multipart/mixed` Works
 


### PR DESCRIPTION
Adds resume support to `hx-multipart` using `HX-Part-ID` and `HX-Last-Part-ID`.

- Records IDs only after successful part handling
- Supports empty `HX-Part-ID` cursor resets
- Preserves wire-order checkpoints for `multipart/parallel`
- Documents replay behavior and the lack of client deduplication

Tests:
- Multipart suite passes in Chromium, Firefox, and WebKit
- Full htmx Chromium suite passes
- Content checks and website build pass
- One unrelated website history test flaked in the full run and passed alone