### PR TITLE
Improve view transitions extension point

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2291,9 +2291,9 @@ var htmx = (() => {
 
             try {
                 if (document.startViewTransition) {
-                    this.__trigger(document, "htmx:before:viewTransition", {task})
-                    await document.startViewTransition(task).finished;
-                    this.__trigger(document, "htmx:after:viewTransition", {task})
+                    let detail = { task, transition: () => document.startViewTransition(task).finished };
+                    this.__triggerExtensions(document, "htmx:before:viewTransition", detail);
+                    await detail.transition();
                 } else {
                     await task();
                 }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2291,9 +2291,10 @@ var htmx = (() => {
 
             try {
                 if (document.startViewTransition) {
-                    let detail = { task, transition: () => document.startViewTransition(task).finished };
-                    this.__triggerExtensions(document, "htmx:before:viewTransition", detail);
-                    await detail.transition();
+                    let detail = {task};
+                    this.__trigger(document, "htmx:before:viewTransition", detail)
+                    await document.startViewTransition(detail.task).finished;
+                    this.__trigger(document, "htmx:after:viewTransition", detail)
                 } else {
                     await task();
                 }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1294,7 +1294,7 @@ var htmx = (() => {
                             await this.__insertContent(task, false)
                         }
                     }
-                    swapPromises.push(this.__submitTransitionTask(tasksWrapper));
+                    swapPromises.push(this.__submitTransitionTask(tasksWrapper, ctx));
                 }
 
                 await Promise.all(swapPromises);
@@ -2271,10 +2271,10 @@ var htmx = (() => {
             }
         }
 
-        __submitTransitionTask(task) {
+        __submitTransitionTask(task, ctx) {
             return new Promise((resolve) => {
                 this.#transitionQueue ||= [];
-                this.#transitionQueue.push({ task, resolve });
+                this.#transitionQueue.push({ task, resolve, ctx });
                 if (!this.#processingTransition) {
                     this.__processTransitionQueue();
                 }
@@ -2287,14 +2287,14 @@ var htmx = (() => {
             }
 
             this.#processingTransition = true;
-            let { task, resolve } = this.#transitionQueue.shift();
+            let { task, resolve, ctx } = this.#transitionQueue.shift();
 
             try {
                 if (document.startViewTransition) {
-                    let detail = {task};
-                    this.__trigger(document, "htmx:before:viewTransition", detail)
+                    let detail = {task, ctx};
+                    this.__trigger(ctx.sourceElement, "htmx:before:viewTransition", detail)
                     await document.startViewTransition(detail.task).finished;
-                    this.__trigger(document, "htmx:after:viewTransition", detail)
+                    this.__trigger(ctx.sourceElement, "htmx:after:viewTransition", detail)
                 } else {
                     await task();
                 }


### PR DESCRIPTION
## Description
Add an async extension point for view transitions by allowing the wrapping of the task object

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
