### PR TITLE
Allows hx-live to cache JS eval functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "check:content": "python3 src/scripts/content/check.py",
     "upgrade-check": "python3 src/scripts/upgrade-check.py",
     "upgrade-check:test": "python3 src/scripts/upgrade-check.py test/manual/upgrade/",
+    "benchmark:hx-live": "node test/benchmarks/hx-live.mjs",
     "test": "npm run test:chrome",
     "test:chrome": "web-test-runner --browsers chromium --config test/web-test-runner.config.mjs --playwright",
     "test:firefox": "web-test-runner --browsers firefox --config test/web-test-runner.config.mjs --playwright",

--- a/src/ext/hx-live.js
+++ b/src/ext/hx-live.js
@@ -533,13 +533,14 @@
                 ensureActive();
                 let code = elt.getAttribute(bodyAttr)
                 let debounce = getDebounce(elt);
+                let exec = api.executeJavaScript(elt, { debounce }, code, false, true);
                 let run = async () => {
                     if (!elt.isConnected) {
                         fns.delete(run);
                         return;
                     }
                     try {
-                        await api.executeJavaScript(elt, { debounce }, code, false);
+                        await exec();
                     } catch (e) {
                         if (e !== dbSym) console.error('htmx: hx-live expression threw', e, { elt });
                     }
@@ -571,26 +572,16 @@
         ensureActive();
         let debounce = getDebounce(elt);
         let isAsync = /\bawait\b/.test(code);
-        let run = isAsync ? async () => {
+        let exec = api.executeJavaScript(elt, { debounce }, code, true, isAsync);
+        let run = async () => {
             if (!elt.isConnected) {
                 fns.delete(run);
                 return;
             }
             try {
-                let value = await api.executeJavaScript(elt, { debounce }, code, true);
+                let value = isAsync ? await exec() : exec();
                 writeAttrBinding(elt, attrName, value);
-                observer?.takeRecords();
-            } catch (e) {
-                if (e !== dbSym) console.error('htmx: hx-live expression threw', e, { elt, attr: attrName });
-            }
-        } : () => {
-            if (!elt.isConnected) {
-                fns.delete(run);
-                return;
-            }
-            try {
-                let value = api.executeJavaScript(elt, { debounce }, code, true, false);
-                writeAttrBinding(elt, attrName, value);
+                if (isAsync) observer?.takeRecords();
             } catch (e) {
                 if (e !== dbSym) console.error('htmx: hx-live expression threw', e, { elt, attr: attrName });
             }

--- a/src/ext/hx-live.js
+++ b/src/ext/hx-live.js
@@ -533,13 +533,14 @@
                 ensureActive();
                 let code = elt.getAttribute(bodyAttr)
                 let debounce = getDebounce(elt);
-                let exec = api.executeJavaScript(elt, { debounce }, code, false, true);
+                let exec;
                 let run = async () => {
                     if (!elt.isConnected) {
                         fns.delete(run);
                         return;
                     }
                     try {
+                        exec ||= api.executeJavaScript(elt, { debounce }, code, false, true, true);
                         await exec();
                     } catch (e) {
                         if (e !== dbSym) console.error('htmx: hx-live expression threw', e, { elt });
@@ -572,13 +573,14 @@
         ensureActive();
         let debounce = getDebounce(elt);
         let isAsync = /\bawait\b/.test(code);
-        let exec = api.executeJavaScript(elt, { debounce }, code, true, isAsync);
+        let exec;
         let run = async () => {
             if (!elt.isConnected) {
                 fns.delete(run);
                 return;
             }
             try {
+                exec ||= api.executeJavaScript(elt, { debounce }, code, true, isAsync, true);
                 let value = isAsync ? await exec() : exec();
                 writeAttrBinding(elt, attrName, value);
                 if (isAsync) observer?.takeRecords();

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -550,7 +550,7 @@ var htmx = (() => {
             let javascriptContent = this.__extractJavascriptContent(ctx.request.action);
             if (javascriptContent != null) {
                 let data = Object.fromEntries(ctx.request.body);
-                await this.__executeJavaScript(ctx.sourceElement, data, javascriptContent, false)();
+                await this.__executeJavaScript(ctx.sourceElement, data, javascriptContent, false);
                 return
             } else if (usesQueryParams) {
                 let url = new URL(ctx.request.action, document.baseURI);
@@ -594,7 +594,7 @@ var htmx = (() => {
                         let detail = {ctx, issueRequest: () => resolve(true), dropRequest: () => resolve(false)};
                         if (this.__trigger(elt, "htmx:confirm", detail)) {
                             let js = this.__extractJavascriptContent(ctx.confirm);
-                            resolve(js ? this.__executeJavaScript(elt, {ctx}, js, true)() : window.confirm(ctx.confirm));
+                            resolve(js ? this.__executeJavaScript(elt, {ctx}, js, true) : window.confirm(ctx.confirm));
                         }
                     });
                     if (!confirmed) return;
@@ -830,7 +830,7 @@ var htmx = (() => {
                     if (filter) {
                         if (this.__shouldCancel(evt)) evt.preventDefault();
                         let evtArgs = {}; for (let k in evt) evtArgs[k] = evt[k];
-                        if (!this.__executeJavaScript(elt, evtArgs, filter, true, false)()) return;
+                        if (!this.__executeJavaScript(elt, evtArgs, filter, true, false)) return;
                     }
                     timed(evt);
                 };
@@ -923,7 +923,7 @@ var htmx = (() => {
             return bound;
         }
 
-        __executeJavaScript(thisArg, obj, code, expression = true, isAsync = true) {
+        __executeJavaScript(thisArg, obj, code, expression = true, isAsync = true, compile = false) {
             let args = {}
             Object.assign(args, this.__apiMethods(thisArg))
             let scope = {};
@@ -934,7 +934,7 @@ var htmx = (() => {
             let values = Object.values(args);
             let FunctionConstructor = isAsync ? this.#AsyncFunction : this.#Function;
             let func = new FunctionConstructor(...keys, expression ? `return (${code})` : code);
-            return () => func.call(thisArg, ...values);
+            return compile ? () => func.call(thisArg, ...values) : func.call(thisArg, ...values);
         }
 
         /**
@@ -1723,7 +1723,7 @@ var htmx = (() => {
             let handler = (code) => async (evt) => {
                 try {
                     await this.__executeJavaScript(node, { event: evt },
-                        `with(event?.detail||{}){${code}}`, false)();
+                        `with(event?.detail||{}){${code}}`, false);
                 } catch (e) {
                     if (typeof e !== 'symbol') this.__trigger(node, 'htmx:error', { error: e });
                 }
@@ -1872,7 +1872,7 @@ var htmx = (() => {
                     javascriptContent = '{' + javascriptContent + '}';
                 }
                 // Return promise for async evaluation
-                return this.__executeJavaScript(elt, scope, javascriptContent, true)().then(obj => {
+                return this.__executeJavaScript(elt, scope, javascriptContent, true).then(obj => {
                     callback(obj);
                 });
             } else {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -550,7 +550,7 @@ var htmx = (() => {
             let javascriptContent = this.__extractJavascriptContent(ctx.request.action);
             if (javascriptContent != null) {
                 let data = Object.fromEntries(ctx.request.body);
-                await this.__executeJavaScript(ctx.sourceElement, data, javascriptContent, false);
+                await this.__executeJavaScript(ctx.sourceElement, data, javascriptContent, false)();
                 return
             } else if (usesQueryParams) {
                 let url = new URL(ctx.request.action, document.baseURI);
@@ -594,7 +594,7 @@ var htmx = (() => {
                         let detail = {ctx, issueRequest: () => resolve(true), dropRequest: () => resolve(false)};
                         if (this.__trigger(elt, "htmx:confirm", detail)) {
                             let js = this.__extractJavascriptContent(ctx.confirm);
-                            resolve(js ? this.__executeJavaScript(elt, {ctx}, js, true) : window.confirm(ctx.confirm));
+                            resolve(js ? this.__executeJavaScript(elt, {ctx}, js, true)() : window.confirm(ctx.confirm));
                         }
                     });
                     if (!confirmed) return;
@@ -830,7 +830,7 @@ var htmx = (() => {
                     if (filter) {
                         if (this.__shouldCancel(evt)) evt.preventDefault();
                         let evtArgs = {}; for (let k in evt) evtArgs[k] = evt[k];
-                        if (!this.__executeJavaScript(elt, evtArgs, filter, true, false)) return;
+                        if (!this.__executeJavaScript(elt, evtArgs, filter, true, false)()) return;
                     }
                     timed(evt);
                 };
@@ -934,7 +934,7 @@ var htmx = (() => {
             let values = Object.values(args);
             let FunctionConstructor = isAsync ? this.#AsyncFunction : this.#Function;
             let func = new FunctionConstructor(...keys, expression ? `return (${code})` : code);
-            return func.call(thisArg, ...values);
+            return () => func.call(thisArg, ...values);
         }
 
         /**
@@ -1723,7 +1723,7 @@ var htmx = (() => {
             let handler = (code) => async (evt) => {
                 try {
                     await this.__executeJavaScript(node, { event: evt },
-                        `with(event?.detail||{}){${code}}`, false);
+                        `with(event?.detail||{}){${code}}`, false)();
                 } catch (e) {
                     if (typeof e !== 'symbol') this.__trigger(node, 'htmx:error', { error: e });
                 }
@@ -1872,7 +1872,7 @@ var htmx = (() => {
                     javascriptContent = '{' + javascriptContent + '}';
                 }
                 // Return promise for async evaluation
-                return this.__executeJavaScript(elt, scope, javascriptContent, true).then(obj => {
+                return this.__executeJavaScript(elt, scope, javascriptContent, true)().then(obj => {
                     callback(obj);
                 });
             } else {

--- a/test/benchmarks/hx-live.mjs
+++ b/test/benchmarks/hx-live.mjs
@@ -1,0 +1,175 @@
+import path from 'node:path'
+import { parseArgs } from 'node:util'
+import { chromium } from 'playwright'
+
+const { values } = parseArgs({
+    options: {
+        case: { type: 'string', multiple: true, default: [] },
+        rounds: { type: 'string', default: '6' },
+        samples: { type: 'string', default: '20' }
+    }
+})
+
+const cases = values.case.map(value => {
+    let separator = value.indexOf('=')
+    if (separator < 1 || separator === value.length - 1) {
+        throw new Error(`Invalid case: ${value}. Use name=path.`)
+    }
+    return {
+        name: value.slice(0, separator),
+        root: path.resolve(value.slice(separator + 1))
+    }
+})
+
+if (cases.length < 2) {
+    console.error('Usage: bun run benchmark:hx-live -- --case <name=repo> --case <name=repo> [...]')
+    process.exit(1)
+}
+
+const rounds = Number(values.rounds)
+const samples = Number(values.samples)
+const counts = [100, 500, 1000]
+
+const percentile = (values, value) => {
+    let sorted = values.toSorted((a, b) => a - b)
+    return sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * value))]
+}
+
+async function runRound(browser, root, expressionCount) {
+    let page = await browser.newPage()
+    await page.addScriptTag({ path: path.join(root, 'src/htmx.js') })
+    await page.evaluate(() => {
+        htmx.config.extensions = 'hx-live'
+        htmx.__approvedExt = 'hx-live'
+    })
+    await page.addScriptTag({ path: path.join(root, 'src/ext/hx-live.js') })
+
+    let result = await page.evaluate(async ({ expressionCount, samples }) => {
+        let rows = expressionCount / 10
+        document.body.innerHTML = `
+            <input id="quantity" type="number" value="2">
+            ${Array.from({ length: rows }, (_, index) => `
+                <article class="row" data-price="${index + 1}">
+                    <output :text="q('#quantity').value * data.price"></output>
+                    <button :disabled="q('#quantity').value == 0">Buy</button>
+                    <span :.bulk="q('#quantity').value >= 10">Bulk</span>
+                    <span :aria-hidden="q('#quantity').value == 0">Details</span>
+                    <output :data-total="q('#quantity').value * data.price"></output>
+                    <input :value="q('#quantity').value">
+                    <input type="checkbox" :checked="q('#quantity').value == 0">
+                    <span class="state-marker" :class="{ zero: q('#quantity').value == 0, bulk: q('#quantity').value >= 10 }"></span>
+                    <span :style="{ opacity: q('#quantity').value == 0 ? 0.5 : 1 }"></span>
+                    <output :html="'<b>' + q('#quantity').value + '</b>'"></output>
+                </article>
+            `).join('')}
+        `
+
+        let start = performance.now()
+        htmx.process(document.body)
+        let registration = performance.now() - start
+
+        let found = [...document.querySelectorAll('.row *')]
+            .flatMap(elt => elt.getAttributeNames())
+            .filter(name => name.startsWith(':')).length
+        if (found !== expressionCount) throw new Error(`Expected ${expressionCount} expressions, found ${found}`)
+
+        let refresh = async () => {
+            htmx.live.refresh()
+            // Flush the scheduled run and async binding continuations.
+            await Promise.resolve()
+            await Promise.resolve()
+        }
+
+        await new Promise(resolve => setTimeout(resolve))
+        for (let index = 0; index < 5; index++) await refresh()
+
+        let unchanged = []
+        for (let index = 0; index < samples; index++) {
+            start = performance.now()
+            await refresh()
+            unchanged.push(performance.now() - start)
+        }
+
+        let changed = []
+        let quantity = document.querySelector('#quantity')
+        let row = document.querySelector('.row')
+        let [text, total, html] = row.querySelectorAll('output')
+        let button = row.querySelector('button')
+        let bulk = row.querySelector('span')
+        let details = row.querySelector('span[aria-hidden]')
+        let [valueInput, checkedInput] = row.querySelectorAll('input')
+        let state = row.querySelector('.state-marker')
+        let styled = row.querySelector('span[style]')
+
+        for (let index = 0; index < samples; index++) {
+            let value = index % 2 ? 0 : 10
+            quantity.value = value
+            start = performance.now()
+            await refresh()
+            changed.push(performance.now() - start)
+
+            if (text.textContent !== String(value)) throw new Error('Text binding did not finish')
+            if (button.disabled !== (value === 0)) throw new Error('Boolean binding did not finish')
+            if (bulk.classList.contains('bulk') !== (value >= 10)) throw new Error('Class binding did not finish')
+            if (details.getAttribute('aria-hidden') !== String(value === 0)) throw new Error('ARIA binding did not finish')
+            if (total.dataset.total !== String(value)) throw new Error('Attribute binding did not finish')
+            if (valueInput.value !== String(value)) throw new Error('Value binding did not finish')
+            if (checkedInput.checked !== (value === 0)) throw new Error('Checked binding did not finish')
+            if (state.classList.contains('zero') !== (value === 0)) throw new Error('Object class binding did not finish')
+            if (state.classList.contains('bulk') !== (value >= 10)) throw new Error('Object class binding did not finish')
+            if (styled.style.opacity !== (value === 0 ? '0.5' : '1')) throw new Error('Style binding did not finish')
+            if (html.innerHTML !== `<b>${value}</b>`) throw new Error('HTML binding did not finish')
+        }
+
+        return { registration, unchanged, changed }
+    }, { expressionCount, samples })
+    await page.close()
+    return result
+}
+
+const emptyMeasurements = () => ({ registration: [], unchanged: [], changed: [] })
+for (let entry of cases) {
+    entry.results = new Map(counts.map(count => [count, emptyMeasurements()]))
+}
+
+const format = values => `${percentile(values, 0.5).toFixed(2)} / ${percentile(values, 0.95).toFixed(2)}`
+const speedup = (before, after) => `${(percentile(before, 0.5) / percentile(after, 0.5)).toFixed(1)}×`
+
+let browser = await chromium.launch({ headless: true })
+try {
+    for (let entry of cases) console.log(`${entry.name}: ${entry.root}`)
+    console.log(`Samples: ${rounds} rounds × ${samples}\n`)
+
+    for (let expressionCount of counts) {
+        for (let round = 0; round < rounds; round++) {
+            let offset = round % cases.length
+            let order = [...cases.slice(offset), ...cases.slice(0, offset)]
+            for (let entry of order) {
+                let run = await runRound(browser, entry.root, expressionCount)
+                let result = entry.results.get(expressionCount)
+                result.registration.push(run.registration)
+                result.unchanged.push(...run.unchanged)
+                result.changed.push(...run.changed)
+            }
+        }
+    }
+
+    console.log('Times are p50 / p95 milliseconds. Speedups compare with the first case.')
+    for (let expressionCount of counts) {
+        let before = cases[0].results.get(expressionCount)
+        console.log(`\n${expressionCount} expressions`)
+        console.table(cases.map(entry => {
+            let result = entry.results.get(expressionCount)
+            return {
+                case: entry.name,
+                registration: format(result.registration),
+                unchanged: format(result.unchanged),
+                changed: format(result.changed),
+                'unchanged speedup': speedup(before.unchanged, result.unchanged),
+                'changed speedup': speedup(before.changed, result.changed)
+            }
+        }))
+    }
+} finally {
+    await browser.close()
+}

--- a/test/tests/ext/hx-live.js
+++ b/test/tests/ext/hx-live.js
@@ -32,6 +32,18 @@ describe('hx-live extension', function () {
         elt.dataset.v.should.equal('init');
     });
 
+    it('continues after an invalid expression', function() {
+        let error = console.error;
+        console.error = () => {};
+        try {
+            playground().innerHTML = '<output :text="("></output><output id="valid" :text="\'ok\'"></output>';
+            assert.doesNotThrow(() => htmx.process(playground()));
+            playground().querySelector('#valid').textContent.should.equal('ok');
+        } finally {
+            console.error = error;
+        }
+    });
+
     it('recomputes on input event', async function() {
         playground().innerHTML = `
             <input id="src" value="hello">

--- a/test/tests/unit/__executeJavaScript.js
+++ b/test/tests/unit/__executeJavaScript.js
@@ -1,0 +1,16 @@
+describe('__executeJavaScript', function() {
+
+    it('returns the evaluated value by default', function() {
+        let elt = document.createElement('div');
+        htmx.__executeJavaScript(elt, { value: 41 }, 'value + 1', true, false).should.equal(42);
+    });
+
+    it('returns a reusable function when compile is true', function() {
+        let elt = document.createElement('div');
+        let run = htmx.__executeJavaScript(elt, { value: 41 }, 'value + 1', true, false, true);
+        assert.isFunction(run);
+        run().should.equal(42);
+        run().should.equal(42);
+    });
+
+});

--- a/www/src/content/extensions/06-hx-live.md
+++ b/www/src/content/extensions/06-hx-live.md
@@ -539,7 +539,7 @@ A single document-wide `MutationObserver` and `input` / `change` listeners trigg
 - `input` or `change` events from any control
 - completion of an htmx swap (recomputes pause mid-swap, run once at the end)
 
-All expressions run in a single microtask, so multiple synchronous mutations coalesce into one recompute.
+Each expression is pre-compiled once when registered. All pre-compiled expressions then run in a single microtask, so multiple synchronous mutations coalesce into one recompute.
 
 ### Self-mutation is safe
 


### PR DESCRIPTION
## Description
I found that we can get around a 23x speed improvment to hx-live expression evaluations by updating executeJavaScript function to return a function instead of the value which then allows hx-live to cache this function in its run closure

Corresponding issue:

## Testing
Tested performance and found it went from around 1.15s for 20,000 live bindings to 50ms.  No real function changes so tests all pass.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
