### PR TITLE
support extended css selectors in hx-partial

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1176,7 +1176,7 @@ var htmx = (() => {
                     if (targetSelector) {
                         this.__processScripts(templateElt.content);
                         let swapSpec = this.__parseSwapSpec(this.__attr(templateElt, 'hx-swap') || this.config.defaultSwap);
-                        for (let target of document.querySelectorAll(targetSelector)) {
+                        for (let target of this.__findAllExt(ctx.sourceElement, targetSelector)) {
                             tasks.push({
                                 type: 'partial',
                                 fragment: templateElt.content.cloneNode(true),
@@ -1888,7 +1888,7 @@ var htmx = (() => {
 
         __findAllExt(eltOrSelector, maybeSelector, thisAttr, global) {
             let selector = maybeSelector ?? eltOrSelector;
-            let elt = maybeSelector ? this.__normalizeElement(eltOrSelector) : document;
+            let elt = maybeSelector ? (this.__normalizeElement(eltOrSelector) || document.body) : document;
             if (selector.startsWith('global ')) {
                 return this.__findAllExt(elt, selector.slice(7), thisAttr, true);
             }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1176,7 +1176,8 @@ var htmx = (() => {
                     if (targetSelector) {
                         this.__processScripts(templateElt.content);
                         let swapSpec = this.__parseSwapSpec(this.__attr(templateElt, 'hx-swap') || this.config.defaultSwap);
-                        for (let target of this.__findAllExt(ctx.sourceElement, targetSelector)) {
+                        let targets = this.__findAllExt(ctx.sourceElement, targetSelector);
+                        for (let target of targets.length ? targets : [null]) {
                             tasks.push({
                                 type: 'partial',
                                 fragment: templateElt.content.cloneNode(true),

--- a/test/tests/unit/swap.js
+++ b/test/tests/unit/swap.js
@@ -468,6 +468,15 @@ describe('swap() unit tests', function() {
         find('#target_oob').textContent.should.equal("OOB Updated");
     })
 
+    it('does not swap main target when partial target is not found', async function () {
+        createProcessedHTML("<div id='target'>Original</div>")
+        await htmx.swap({
+            "target":"#target",
+            "text":"<hx-partial hx-target='#nonexistent' hx-swap='innerHTML'><div>Should Not Appear</div></hx-partial>"
+        })
+        find('#target').textContent.should.equal("Original");
+    })
+
     it('does not swap main target when only whitespace and partial present', async function () {
         createProcessedHTML("<div id='target'>Original</div><div id='target_oob'>OOB</div>")
         await htmx.swap({

--- a/test/tests/unit/swap.js
+++ b/test/tests/unit/swap.js
@@ -683,6 +683,16 @@ describe('swap() unit tests', function() {
         target.textContent.should.equal('response')
     })
 
+    it('hx-partial hx-target resolves closest relative to sourceElement', async function () {
+        createProcessedHTML("<ul><li id='item-1'>Item 1 <button id='btn'>Edit</button></li></ul>")
+        await htmx.swap({
+            target: find('#btn'),
+            sourceElement: find('#btn'),
+            text: "<hx-partial hx-target='closest li' hx-swap='innerHTML'>Updated</hx-partial>"
+        })
+        find('#item-1').innerText.should.equal('Updated')
+    })
+
     it('swaps partial to all elements matching a class selector', async function () {
         createProcessedHTML("<div class='target'>A</div><div class='target'>B</div>")
         await htmx.swap({"target":"#test-playground", "text":"<hx-partial hx-target='.target' hx-swap='innerHTML'>Updated</hx-partial>"})

--- a/www/src/content/reference/06-tags/01-hx-partial.md
+++ b/www/src/content/reference/06-tags/01-hx-partial.md
@@ -20,11 +20,29 @@ The `<hx-partial>` tag lets you update multiple elements from a single response,
 
 ## Attributes
 
-- [`hx-target`](/reference/attributes/hx-target) - CSS selector for where to place content
+- [`hx-target`](/reference/attributes/hx-target) - Where to place content. Accepts any CSS selector or htmx extended selector, resolved relative to the element that triggered the request
 - `id` - Shorthand alternative to `hx-target`. Targets the element with that ID (e.g. `<hx-partial id="messages">` targets `#messages`)
 - [`hx-swap`](/reference/attributes/hx-swap) - Swap style (defaults to `innerHTML`)
 
 Either `hx-target` or `id` is required. If both are present, `hx-target` takes precedence.
+
+## Relative Targeting
+
+`hx-target` supports the full htmx extended selector vocabulary — `closest`, `next`, `previous`, `find`, `findAll` — resolved relative to the element that triggered the request. This lets the server express structural intent without requiring stable IDs:
+
+```html
+<!-- replace the list row containing the button that was clicked -->
+<hx-partial hx-target="closest li" hx-swap="outerHTML">
+    <li>Updated item <button hx-post="/edit/2">Edit</button></li>
+</hx-partial>
+
+<!-- update the error element after the input that triggered validation -->
+<hx-partial hx-target="next .error">
+    <span class="error">Required</span>
+</hx-partial>
+```
+
+Avoid targeting an ancestor that the main swap is also replacing — the partial would be swapping into a detached node.
 
 ## Responses Without Main Content
 


### PR DESCRIPTION
## Description
Found we can easily support extended selectors in hx-partial targeting.  This allows you to target elements relative to the triggering source element using all the htmx enhanced selectors like closest, previous, next etc.

Also fixed a bug in the same code where if you only have hx-partial's and they don't find valid targets it would not do the expected behaviour of blocking the empty main swap.  we just need to make sure it always emits a partial task so the auto empty detection code works.

Corresponding issue:

## Testing
added a basic test

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
