### PR TITLE
trigger hx-trigger on new element instead of document

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1299,6 +1299,10 @@ var htmx = (() => {
 
                 await Promise.all(swapPromises);
 
+                if (!ctx.sourceElement?.isConnected && mainSwap?.target?.isConnected) {
+                    ctx.sourceElement = mainSwap.target;
+                }
+
                 this.__trigger(ctx.sourceElement, "htmx:after:swap", {ctx});
                 if (ctx.title && !mainSwap?.swapSpec?.ignoreTitle) document.title = ctx.title;
                 this.__handleAnchorScroll(ctx);
@@ -1451,6 +1455,7 @@ var htmx = (() => {
             } finally {
                 this.__removeClass(target, "htmx-swapping")
             }
+            task.target = target;
             this.__restorePreservedElements(pantry);
             if (focusInfo && !focusInfo.elt.matches(':focus')) {
                 let newElt = document.getElementById(focusInfo.elt.id);

--- a/test/tests/end2end/events.js
+++ b/test/tests/end2end/events.js
@@ -58,18 +58,18 @@ describe('htmx events', function() {
         assert.isFalse(firedOnSource)
     })
 
-    it('htmx:after:swap triggers on document when element is removed from DOM by swap', async function () {
-        mockResponse('GET', '/test', 'Response')
+    it('htmx:after:swap triggers on replacement element when source is removed by outerHTML swap', async function () {
+        mockResponse('GET', '/test', '<span id="replacement">Response</span>')
         let div = createProcessedHTML('<div hx-get="/test" hx-swap="outerHTML"></div>')
-        let firedOnDocument = false
+        let swapTarget = null
         document.addEventListener('htmx:after:swap', (e) => {
-            if (e.target === document) {
-                firedOnDocument = true
-            }
+            swapTarget = e.target
         }, {once: true})
         div.click()
         await forRequest()
-        assert.isTrue(firedOnDocument)
+        let replacement = find('#replacement')
+        assert.isNotNull(replacement)
+        assert.equal(swapTarget, replacement)
     })
 
 

--- a/test/tests/unit/__issueRequest.js
+++ b/test/tests/unit/__issueRequest.js
@@ -194,6 +194,28 @@ describe('__issueRequest unit tests', function() {
         assert.isTrue(triggerFired)
     })
 
+    it('fires HX-Trigger on replacement element after outerHTML swap', async function () {
+        let div = createProcessedHTML('<div id="source" hx-get="/test" hx-swap="outerHTML"></div>')
+        let source = find('#source')
+        let ctx = htmx.__createRequestContext(source, new Event('click'))
+
+        let triggerTarget = null
+        document.addEventListener('myEvent', (e) => triggerTarget = e.target)
+
+        ctx.fetch = async () => ({
+            status: 200,
+            headers: new Headers({ 'HX-Trigger': 'myEvent' }),
+            text: async () => '<span id="replacement">New</span>'
+        })
+
+        await htmx.__issueRequest(ctx)
+
+        let replacement = find('#replacement')
+        assert.isNotNull(replacement)
+        assert.isFalse(source.isConnected)
+        assert.equal(triggerTarget, replacement)
+    })
+
     it('always triggers htmx:finally:request', async function () {
         let div = createProcessedHTML('<div hx-get="/test" hx-swap="none"></div>')
         let ctx = htmx.__createRequestContext(div, new Event('click'))


### PR DESCRIPTION
## Description
We moved the hx-trigger event triggering to after the swap to cover more use cases but now the sourceElement it triggers on can get removed via outerHTML swaps making the event only trigger on document.  This mean manual events listened on from:body will not get the events!

To fix this we can store the target of the main swap in insertContent and then in swap use this target if its connected and the source element is disconnected.  This also fixes a few other post swap events which used to always fire on document if the trigger elt is removed.

Corresponding issue:

## Testing
added a test for hx-trigger and adjusted another test that now handles the correct element triggering as well.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
