### PR TITLE
Add typed `aria.*` access to `hx-live`

### DIFF
--- a/src/ext/hx-live.js
+++ b/src/ext/hx-live.js
@@ -733,7 +733,6 @@
             if (--swaps === 0 && fns.size > 0) schedule();
         },
         htmx_scope: (elt, detail) => {
-            elt.aria = makeAriaProxy(elt, false);
             Object.assign(detail.scope, {
                 q: makeQ(elt),
                 forEvent: (...args) => forEvent(elt, ...args),

--- a/src/ext/hx-live.js
+++ b/src/ext/hx-live.js
@@ -232,16 +232,13 @@
         'relevant'
     ]);
 
-    function makeAriaProxy(elt, cascades = true) {
-        let findOwner = name => cascades
-            ? elt.closest('[' + name + ']')
-            : elt.hasAttribute(name) ? elt : null;
+    function makeAriaProxy(elt) {
         return new Proxy({}, {
             get: (_, prop) => {
                 if (typeof prop !== 'string') return undefined;
                 let key = prop.toLowerCase();
                 let name = 'aria-' + key;
-                let value = findOwner(name)?.getAttribute(name);
+                let value = elt.hasAttribute(name) ? elt.getAttribute(name) : undefined;
                 if (booleanAria.has(key) && (value === 'true' || value === 'false')) return value === 'true';
                 let number = Number(value);
                 let validNumber = numberAria.has(key) || (integerAria.has(key) && Number.isInteger(number));
@@ -253,15 +250,13 @@
                 if (typeof prop !== 'string') return false;
                 let key = prop.toLowerCase();
                 let name = 'aria-' + key;
-                let target = findOwner(name) || elt;
-                if (value == null) target.removeAttribute(name);
-                else target.setAttribute(name, listAria.has(key) && Array.isArray(value) ? value.join(' ') : String(value));
+                if (value == null) elt.removeAttribute(name);
+                else elt.setAttribute(name, listAria.has(key) && Array.isArray(value) ? value.join(' ') : String(value));
                 return true;
             },
             deleteProperty: (_, prop) => {
                 if (typeof prop !== 'string') return false;
-                let name = 'aria-' + prop.toLowerCase();
-                findOwner(name)?.removeAttribute(name);
+                elt.removeAttribute('aria-' + prop.toLowerCase());
                 return true;
             }
         });
@@ -545,7 +540,7 @@
                 };
                 if (p === 'data') return elts[0] ? makeDataProxy(elts[0]) : undefined;
                 if (arrayMethods.has(p)) return elts[p].bind(elts);
-                if (p === 'aria') return elts[0] ? makeAriaProxy(elts[0], false) : undefined;
+                if (p === 'aria') return elts[0] ? makeAriaProxy(elts[0]) : undefined;
                 let v = elts[0]?.[p];
                 if (typeof v === 'function') return (...a) => elts.map(e => e[p](...a))[0];
                 if (v && typeof v === 'object') return qProxy(elts.map(e => e[p]));

--- a/src/ext/hx-live.js
+++ b/src/ext/hx-live.js
@@ -96,7 +96,7 @@
      * attr('.active', cond)           // add/remove class
      * attr('class', 'foo bar')        // multi-class string
      * attr('class', { active: cond }) // multi-class object
-     * attr('aria-expanded', open)     // ARIA: always "true"/"false"
+     * attr('aria-expanded', open)     // ARIA: raw string value
      * attr('value', 'hello')          // sync DOM property + attribute
      * attr('contenteditable', false)  // "false", not removed
      * attr('data-x', null)            // remove attribute
@@ -112,7 +112,7 @@
             if (!e) return undefined;
             if (isClass) return e.classList.contains(name.slice(1));
             if (isMultiClass) return e.getAttribute('class');
-            if (isAria) return e.getAttribute(name) === 'true';
+            if (isAria) return e.getAttribute(name);
             if (BOOLEAN_ATTRS.has(name)) return e.hasAttribute(name);
             if (isPropAttr) return e[name];
             return e.getAttribute(name);
@@ -126,13 +126,8 @@
             } else if (isMultiClass) {
                 applyMultiClass(e, value);
             } else if (isAria) {
-                // Strings and numbers pass through (e.g. aria-current="page",
-                // aria-pressed="mixed", aria-valuenow="50"). Other values coerce
-                // to "true"/"false". Never removed.
-                let attrVal = (typeof value === 'string' || typeof value === 'number')
-                    ? String(value)
-                    : (value ? 'true' : 'false');
-                e.setAttribute(name, attrVal);
+                if (value == null) e.removeAttribute(name);
+                else e.setAttribute(name, String(value));
             } else if (isPropAttr) {
                 if (value === false || value == null) {
                     e[name] = (typeof e[name] === 'boolean') ? false : '';
@@ -190,6 +185,86 @@
 
     function camelToKebab(s) {
         return s.replace(/[A-Z]/g, m => '-' + m.toLowerCase());
+    }
+
+    let booleanAria = new Set([
+        'atomic',
+        'busy',
+        'checked',
+        'current',
+        'disabled',
+        'expanded',
+        'grabbed',
+        'haspopup',
+        'hidden',
+        'invalid',
+        'modal',
+        'multiline',
+        'multiselectable',
+        'pressed',
+        'readonly',
+        'required',
+        'selected'
+    ]);
+    let integerAria = new Set([
+        'colcount',
+        'colindex',
+        'colspan',
+        'level',
+        'posinset',
+        'rowcount',
+        'rowindex',
+        'rowspan',
+        'setsize'
+    ]);
+    let numberAria = new Set([
+        'valuemax',
+        'valuemin',
+        'valuenow'
+    ]);
+    let listAria = new Set([
+        'controls',
+        'describedby',
+        'dropeffect',
+        'flowto',
+        'labelledby',
+        'owns',
+        'relevant'
+    ]);
+
+    function makeAriaProxy(elt, cascades = true) {
+        let findOwner = name => cascades
+            ? elt.closest('[' + name + ']')
+            : elt.hasAttribute(name) ? elt : null;
+        return new Proxy({}, {
+            get: (_, prop) => {
+                if (typeof prop !== 'string') return undefined;
+                let key = prop.toLowerCase();
+                let name = 'aria-' + key;
+                let value = findOwner(name)?.getAttribute(name);
+                if (booleanAria.has(key) && (value === 'true' || value === 'false')) return value === 'true';
+                let number = Number(value);
+                let validNumber = numberAria.has(key) || (integerAria.has(key) && Number.isInteger(number));
+                if (validNumber && value?.trim() && Number.isFinite(number)) return number;
+                if (listAria.has(key) && value != null) return value.trim() ? value.trim().split(/\s+/) : [];
+                return value;
+            },
+            set: (_, prop, value) => {
+                if (typeof prop !== 'string') return false;
+                let key = prop.toLowerCase();
+                let name = 'aria-' + key;
+                let target = findOwner(name) || elt;
+                if (value == null) target.removeAttribute(name);
+                else target.setAttribute(name, listAria.has(key) && Array.isArray(value) ? value.join(' ') : String(value));
+                return true;
+            },
+            deleteProperty: (_, prop) => {
+                if (typeof prop !== 'string') return false;
+                let name = 'aria-' + prop.toLowerCase();
+                findOwner(name)?.removeAttribute(name);
+                return true;
+            }
+        });
     }
 
     // `data.foo` reads/writes to closest ancestor with `data-foo`.
@@ -470,6 +545,7 @@
                 };
                 if (p === 'data') return elts[0] ? makeDataProxy(elts[0]) : undefined;
                 if (arrayMethods.has(p)) return elts[p].bind(elts);
+                if (p === 'aria') return elts[0] ? makeAriaProxy(elts[0], false) : undefined;
                 let v = elts[0]?.[p];
                 if (typeof v === 'function') return (...a) => elts.map(e => e[p](...a))[0];
                 if (v && typeof v === 'object') return qProxy(elts.map(e => e[p]));
@@ -657,6 +733,7 @@
             if (--swaps === 0 && fns.size > 0) schedule();
         },
         htmx_scope: (elt, detail) => {
+            elt.aria = makeAriaProxy(elt, false);
             Object.assign(detail.scope, {
                 q: makeQ(elt),
                 forEvent: (...args) => forEvent(elt, ...args),
@@ -670,7 +747,8 @@
                 matches: (sel) => elt.matches(sel),
                 style: elt.style,
                 classList: elt.classList,
-                data: makeDataProxy(elt)
+                data: makeDataProxy(elt),
+                aria: makeAriaProxy(elt)
             });
             if (htmx.config.live?.useDollar) detail.scope.$ = detail.scope.q;
         }

--- a/test/tests/ext/hx-live.js
+++ b/test/tests/ext/hx-live.js
@@ -453,6 +453,7 @@ describe('hx-live extension', function () {
     it('q returns 0-count proxy when no match', function() {
         let proxy = htmx.live.q('.does-not-exist-anywhere');
         proxy.count.should.equal(0);
+        assert.isUndefined(proxy.aria);
     });
 
     it('q(element) wraps a single element', function() {
@@ -1057,10 +1058,21 @@ describe('hx-live extension', function () {
         htmx.live.attr('#b', 'disabled').should.equal(false);
     });
 
-    it('attr() getter: ARIA returns boolean from "true"/"false"', function() {
-        playground().innerHTML = '<div id="a" aria-expanded="true"></div><div id="b" aria-expanded="false"></div>';
-        htmx.live.attr('#a', 'aria-expanded').should.equal(true);
-        htmx.live.attr('#b', 'aria-expanded').should.equal(false);
+    it('attr() getter: ARIA returns raw strings or null', function() {
+        playground().innerHTML = `
+            <div id="a" aria-expanded="true"></div>
+            <div id="b" aria-expanded="false"></div>
+            <div id="c" aria-current="page"></div>
+            <div id="d" aria-valuenow="50"></div>
+            <div id="e" aria-controls="menu help"></div>
+            <div id="f"></div>
+        `;
+        htmx.live.attr('#a', 'aria-expanded').should.equal('true');
+        htmx.live.attr('#b', 'aria-expanded').should.equal('false');
+        htmx.live.attr('#c', 'aria-current').should.equal('page');
+        htmx.live.attr('#d', 'aria-valuenow').should.equal('50');
+        htmx.live.attr('#e', 'aria-controls').should.equal('menu help');
+        assert.isNull(htmx.live.attr('#f', 'aria-label'));
     });
 
     it('attr() getter: .class returns boolean (has class)', function() {
@@ -1102,16 +1114,15 @@ describe('hx-live extension', function () {
         playground().querySelector('#a').hasAttribute('disabled').should.equal(false);
     });
 
-    it('attr() setter: ARIA writes "true"/"false", never removes', function() {
+    it('attr() setter: ARIA stringifies values and null removes', function() {
         playground().innerHTML = '<div id="a"></div>';
         let div = playground().querySelector('#a');
         htmx.live.attr('#a', 'aria-expanded', true);
         div.getAttribute('aria-expanded').should.equal('true');
         htmx.live.attr('#a', 'aria-expanded', false);
         div.getAttribute('aria-expanded').should.equal('false');
-        // null/undefined also writes "false". ARIA is never removed.
         htmx.live.attr('#a', 'aria-expanded', null);
-        div.getAttribute('aria-expanded').should.equal('false');
+        div.hasAttribute('aria-expanded').should.equal(false);
     });
 
     it('attr() setter: aria-* strings and numbers pass through', function() {
@@ -1296,6 +1307,245 @@ describe('hx-live extension', function () {
 
     it('htmx.live.attr is exposed on public API', function() {
         assert.isFunction(htmx.live.attr);
+    });
+
+    // -------------------------------------------------------------------------
+    // cascading ARIA proxy
+    // -------------------------------------------------------------------------
+
+    it('aria.foo reacts to the closest ARIA state', async function() {
+        playground().innerHTML = `
+            <section aria-busy="true">
+                <form aria-busy="false">
+                    <button :disabled="aria.busy" hx-on:click="aria.busy = !aria.busy">Save</button>
+                </form>
+            </section>
+        `;
+        htmx.process(playground());
+        let button = playground().querySelector('button');
+        button.disabled.should.equal(false);
+        button.click();
+        await htmx.timeout(5);
+        button.disabled.should.equal(true);
+        playground().querySelector('form').getAttribute('aria-busy').should.equal('true');
+        playground().querySelector('section').getAttribute('aria-busy').should.equal('true');
+    });
+
+    it('q().aria uses only its first match', function() {
+        playground().innerHTML = `
+            <section aria-busy="false">
+                <form id="form" aria-checked="false"></form>
+            </section>
+        `;
+        let aria = htmx.live.q('#form').aria;
+        aria.checked.should.equal(false);
+        assert.isUndefined(aria.busy);
+        assert.isUndefined(aria.controls);
+        assert.isTrue(delete aria.label);
+
+        let ownerAria = htmx.live.q('#form').q('closest [aria-busy]').aria;
+        ownerAria.busy.should.equal(false);
+        ownerAria.busy = true;
+        aria.checked = true;
+        aria.busy = false;
+
+        playground().querySelector('form').getAttribute('aria-checked').should.equal('true');
+        playground().querySelector('form').getAttribute('aria-busy').should.equal('false');
+        playground().querySelector('section').getAttribute('aria-busy').should.equal('true');
+
+        aria.checked = null;
+        delete ownerAria.busy;
+        playground().querySelector('form').hasAttribute('aria-checked').should.equal(false);
+        playground().querySelector('section').hasAttribute('aria-busy').should.equal(false);
+    });
+
+    it('returns every boolean-like ARIA attribute as a boolean', function() {
+        playground().innerHTML = '<div id="booleans"></div>';
+        let values = {
+            atomic: true,
+            busy: false,
+            checked: true,
+            current: false,
+            disabled: true,
+            expanded: false,
+            grabbed: true,
+            hasPopup: false,
+            hidden: true,
+            invalid: false,
+            modal: true,
+            multiline: false,
+            multiselectable: true,
+            pressed: false,
+            readonly: true,
+            required: false,
+            selected: true
+        };
+        let state = playground().querySelector('#booleans');
+        for (let [name, value] of Object.entries(values)) {
+            state.setAttribute('aria-' + name.toLowerCase(), String(value));
+        }
+        let aria = htmx.live.q(state).aria;
+        for (let [name, value] of Object.entries(values)) {
+            aria[name].should.equal(value);
+        }
+    });
+
+    it('returns every numeric ARIA attribute as a number', function() {
+        playground().innerHTML = '<div id="state"></div>';
+        let values = {
+            colCount: 3,
+            colIndex: 2,
+            colSpan: 1,
+            level: 4,
+            posInSet: 5,
+            rowCount: 6,
+            rowIndex: 7,
+            rowSpan: 2,
+            setSize: 8,
+            valueMax: 100,
+            valueMin: 0,
+            valueNow: 51.5
+        };
+        let state = playground().querySelector('#state');
+        for (let [name, value] of Object.entries(values)) {
+            let attributeValue = name === 'valueNow' ? ' 51.5 ' : String(value);
+            state.setAttribute('aria-' + name.toLowerCase(), attributeValue);
+        }
+        let aria = htmx.live.q(state).aria;
+        for (let [name, value] of Object.entries(values)) {
+            aria[name].should.equal(value);
+        }
+    });
+
+    it('preserves missing and invalid numeric ARIA values', function() {
+        playground().innerHTML = `
+            <div id="invalid-numbers" aria-colspan="1.5" aria-level="many"
+                 aria-valuemax="" aria-valuemin="Infinity" aria-valuenow="unknown">
+            </div>
+        `;
+        let aria = htmx.live.q('#invalid-numbers').aria;
+        aria.colSpan.should.equal('1.5');
+        aria.level.should.equal('many');
+        aria.valueMax.should.equal('');
+        aria.valueMin.should.equal('Infinity');
+        aria.valueNow.should.equal('unknown');
+        assert.isUndefined(aria.rowCount);
+    });
+
+    it('does not coerce string ARIA attributes that look typed', function() {
+        playground().innerHTML = `
+            <div id="strings"
+                 aria-description="true" aria-label="false" aria-valuetext="51"
+                 aria-activedescendant="item" aria-details="details" aria-errormessage="error">
+            </div>
+        `;
+        let aria = htmx.live.q('#strings').aria;
+        aria.description.should.equal('true');
+        aria.label.should.equal('false');
+        aria.valueText.should.equal('51');
+        aria.activeDescendant.should.equal('item');
+        aria.details.should.equal('details');
+        aria.errorMessage.should.equal('error');
+    });
+
+    it('preserves non-boolean ARIA tokens', function() {
+        playground().innerHTML = '<div id="tokens" aria-checked="mixed" aria-current="page" aria-invalid="spelling"></div>';
+        let aria = htmx.live.q('#tokens').aria;
+        aria.checked.should.equal('mixed');
+        aria.current.should.equal('page');
+        aria.invalid.should.equal('spelling');
+    });
+
+    it('returns ARIA list attributes as arrays and joins array writes', function() {
+        playground().innerHTML = '<div id="lists"></div>';
+        let values = {
+            controls: ['menu', 'help'],
+            describedBy: ['hint', 'error'],
+            dropEffect: ['copy', 'move'],
+            flowTo: ['next', 'later'],
+            labelledBy: ['title', 'subtitle'],
+            owns: ['item-1', 'item-2'],
+            relevant: ['additions', 'text']
+        };
+        let state = playground().querySelector('#lists');
+        for (let [name, value] of Object.entries(values)) {
+            state.setAttribute('aria-' + name.toLowerCase(), value.join(' '));
+        }
+        state.setAttribute('aria-controls', '  menu   help  ');
+        let aria = htmx.live.q(state).aria;
+        for (let [name, value] of Object.entries(values)) {
+            aria[name].should.deep.equal(value);
+        }
+
+        aria.controls = ['dialog', 'help'];
+        aria.relevant = [];
+        aria.owns = 'item-3 item-4';
+        state.getAttribute('aria-controls').should.equal('dialog help');
+        state.getAttribute('aria-relevant').should.equal('');
+        state.getAttribute('aria-owns').should.equal('item-3 item-4');
+        aria.relevant.should.deep.equal([]);
+        aria.owns.should.deep.equal(['item-3', 'item-4']);
+    });
+
+    it('writes missing ARIA attributes on this and deletes the closest match', function() {
+        playground().innerHTML = `
+            <div aria-valuenow="50" aria-current="page">
+                <button hx-on:click="
+                    aria.valueNow = 51;
+                    aria.label = 'Save';
+                    delete aria.current
+                ">change</button>
+            </div>
+        `;
+        htmx.process(playground());
+        let button = playground().querySelector('button');
+        button.click();
+        playground().querySelector('div').getAttribute('aria-valuenow').should.equal('51');
+        playground().querySelector('div').hasAttribute('aria-current').should.equal(false);
+        button.getAttribute('aria-label').should.equal('Save');
+    });
+
+    it('this.aria only accesses the current element', function() {
+        playground().innerHTML = `
+            <section aria-busy="true">
+                <button type="button" hx-on:click="
+                    window.__localState = [this.aria.busy, aria.busy];
+                    this.aria.busy = false;
+                    window.__localAfter = this.aria.busy
+                ">change</button>
+            </section>
+        `;
+        htmx.process(playground());
+        let button = playground().querySelector('button');
+        button.click();
+        window.__localState.should.deep.equal([undefined, true]);
+        window.__localAfter.should.equal(false);
+        button.getAttribute('aria-busy').should.equal('false');
+        playground().querySelector('section').getAttribute('aria-busy').should.equal('true');
+        delete window.__localState;
+        delete window.__localAfter;
+    });
+
+    it('this stays the real element across async expressions', async function() {
+        playground().innerHTML = `
+            <section id="owner">
+                <button type="button" hx-on:click="
+                    window.__sameThis = this === event.currentTarget;
+                    window.__closestId = this.closest('section').id;
+                    await timeout(5);
+                    this.aria.busy = true
+                ">change</button>
+            </section>
+        `;
+        htmx.process(playground());
+        let button = playground().querySelector('button');
+        button.click();
+        await htmx.timeout(10);
+        window.__sameThis.should.equal(true);
+        window.__closestId.should.equal('owner');
+        button.getAttribute('aria-busy').should.equal('true');
+        delete window.__sameThis;
+        delete window.__closestId;
     });
 
     // -------------------------------------------------------------------------
@@ -1704,7 +1954,7 @@ describe('hx-live extension', function () {
         btn.hasAttribute('disabled').should.equal(true);
     });
 
-    it(':aria-expanded writes "true"/"false", never removes', async function() {
+    it(':aria-expanded writes boolean strings', async function() {
         playground().innerHTML = `
             <input id="src" type="checkbox">
             <button :aria-expanded="q('#src').checked">x</button>

--- a/test/tests/ext/hx-live.js
+++ b/test/tests/ext/hx-live.js
@@ -1505,13 +1505,13 @@ describe('hx-live extension', function () {
         button.getAttribute('aria-label').should.equal('Save');
     });
 
-    it('this.aria only accesses the current element', function() {
+    it('q(this).aria only accesses the current element', function() {
         playground().innerHTML = `
             <section aria-busy="true">
                 <button type="button" hx-on:click="
-                    window.__localState = [this.aria.busy, aria.busy];
-                    this.aria.busy = false;
-                    window.__localAfter = this.aria.busy
+                    window.__localState = [q(this).aria.busy, aria.busy];
+                    q(this).aria.busy = false;
+                    window.__localAfter = q(this).aria.busy
                 ">change</button>
             </section>
         `;
@@ -1526,23 +1526,26 @@ describe('hx-live extension', function () {
         delete window.__localAfter;
     });
 
-    it('this stays the real element across async expressions', async function() {
+    it('q(this).aria preserves application element properties after await', async function() {
         playground().innerHTML = `
             <section id="owner">
                 <button type="button" hx-on:click="
                     window.__sameThis = this === event.currentTarget;
                     window.__closestId = this.closest('section').id;
                     await timeout(5);
-                    this.aria.busy = true
+                    q(this).aria.busy = true
                 ">change</button>
             </section>
         `;
         htmx.process(playground());
         let button = playground().querySelector('button');
+        let applicationState = { owner: 'app' };
+        button.aria = applicationState;
         button.click();
         await htmx.timeout(10);
         window.__sameThis.should.equal(true);
         window.__closestId.should.equal('owner');
+        button.aria.should.equal(applicationState);
         button.getAttribute('aria-busy').should.equal('true');
         delete window.__sameThis;
         delete window.__closestId;

--- a/test/tests/ext/hx-live.js
+++ b/test/tests/ext/hx-live.js
@@ -1313,13 +1313,10 @@ describe('hx-live extension', function () {
     // cascading ARIA proxy
     // -------------------------------------------------------------------------
 
-    it('aria.foo reacts to the closest ARIA state', async function() {
+    it('aria.foo drives a binding on the same element', async function() {
         playground().innerHTML = `
-            <section aria-busy="true">
-                <form aria-busy="false">
-                    <button :disabled="aria.busy" hx-on:click="aria.busy = !aria.busy">Save</button>
-                </form>
-            </section>
+            <button aria-busy="false" :disabled="aria.busy"
+                    hx-on:click="aria.busy = !aria.busy">Save</button>
         `;
         htmx.process(playground());
         let button = playground().querySelector('button');
@@ -1327,8 +1324,18 @@ describe('hx-live extension', function () {
         button.click();
         await htmx.timeout(5);
         button.disabled.should.equal(true);
-        playground().querySelector('form').getAttribute('aria-busy').should.equal('true');
-        playground().querySelector('section').getAttribute('aria-busy').should.equal('true');
+        button.getAttribute('aria-busy').should.equal('true');
+    });
+
+    it('q("closest [aria-*]") shares ARIA state with an ancestor', function() {
+        playground().innerHTML = `
+            <section aria-busy="true">
+                <button hx-on:click="q('closest [aria-busy]').aria.busy = false">go</button>
+            </section>
+        `;
+        htmx.process(playground());
+        playground().querySelector('button').click();
+        playground().querySelector('section').getAttribute('aria-busy').should.equal('false');
     });
 
     it('q().aria uses only its first match', function() {
@@ -1487,43 +1494,35 @@ describe('hx-live extension', function () {
         aria.owns.should.deep.equal(['item-3', 'item-4']);
     });
 
-    it('writes missing ARIA attributes on this and deletes the closest match', function() {
+    it('writes, adds, and deletes ARIA attributes on this element', function() {
         playground().innerHTML = `
-            <div aria-valuenow="50" aria-current="page">
-                <button hx-on:click="
-                    aria.valueNow = 51;
-                    aria.label = 'Save';
-                    delete aria.current
-                ">change</button>
-            </div>
+            <button aria-valuenow="50" aria-current="page" hx-on:click="
+                aria.valueNow = 51;
+                aria.label = 'Save';
+                delete aria.current
+            ">change</button>
         `;
         htmx.process(playground());
         let button = playground().querySelector('button');
         button.click();
-        playground().querySelector('div').getAttribute('aria-valuenow').should.equal('51');
-        playground().querySelector('div').hasAttribute('aria-current').should.equal(false);
+        button.getAttribute('aria-valuenow').should.equal('51');
+        button.hasAttribute('aria-current').should.equal(false);
         button.getAttribute('aria-label').should.equal('Save');
     });
 
-    it('q(this).aria only accesses the current element', function() {
+    it('q(this).aria and bare aria are the same proxy target', function() {
         playground().innerHTML = `
-            <section aria-busy="true">
-                <button type="button" hx-on:click="
-                    window.__localState = [q(this).aria.busy, aria.busy];
-                    q(this).aria.busy = false;
-                    window.__localAfter = q(this).aria.busy
-                ">change</button>
-            </section>
+            <button type="button" aria-busy="true" hx-on:click="
+                q(this).aria.busy = false;
+                window.__ariaPair = [q(this).aria.busy, aria.busy]
+            ">change</button>
         `;
         htmx.process(playground());
         let button = playground().querySelector('button');
         button.click();
-        window.__localState.should.deep.equal([undefined, true]);
-        window.__localAfter.should.equal(false);
+        window.__ariaPair.should.deep.equal([false, false]);
         button.getAttribute('aria-busy').should.equal('false');
-        playground().querySelector('section').getAttribute('aria-busy').should.equal('true');
-        delete window.__localState;
-        delete window.__localAfter;
+        delete window.__ariaPair;
     });
 
     it('q(this).aria preserves application element properties after await', async function() {

--- a/www/src/content/extensions/06-hx-live.md
+++ b/www/src/content/extensions/06-hx-live.md
@@ -242,10 +242,14 @@ attr('.active')                             // has class .active?
 attr('.active', q('#src').checked)          // add/remove class
 attr('class', 'foo bar')                    // multi-class string
 attr('class', { active: matches('.tab') })  // multi-class object
-attr('aria-expanded', matches('.open'))     // any aria-*: writes "true"/"false"
+attr('aria-expanded')                       // raw string or null
+attr('aria-expanded', false)                // write "false"
+attr('aria-expanded', null)                 // remove
 attr('value', 'hello')                      // value/checked/selected: syncs property + attribute
 attr('data-x', null)                        // remove
 ```
+
+Use [`aria.*`](#aria) to read booleans, numbers, and lists.
 
 ### `toggle(name, values?)`
 
@@ -271,6 +275,126 @@ take('.selected', '.tab')              // become the selected tab among .tab
 take('aria-current', 'nav a')          // become the current nav item
 take('.active')                        // implicit scope: parent element's subtree
 ```
+
+### `aria`
+
+Read and write ARIA attributes on this element or an ancestor:
+
+```html
+<div aria-busy="false">
+    <button hx-on:click="aria.busy = !aria.busy">Toggle</button>
+    <output :hidden="!aria.busy">Busy</output>
+</div>
+```
+
+Both `aria.busy` expressions use `aria-busy` on the div. If no element has the attribute, a write adds it to the current element:
+
+```html
+<!-- This... -->
+<button hx-on:click="aria.pressed = true">Like</button>
+
+<!-- ...becomes this after click -->
+<button hx-on:click="aria.pressed = true" aria-pressed="true">Like</button>
+```
+
+Access ARIA attributes in three ways:
+
+```js
+aria.busy            // closest aria-busy, starting at this
+this.aria.busy       // aria-busy on this
+q('#form').aria.busy // aria-busy on the selected form
+```
+
+All three forms use the same value rules. You can use these values as booleans, numbers, and arrays:
+
+```html
+<button aria-busy="false"
+        aria-controls="panel status"
+        hx-on:click="
+            aria.busy = !aria.busy;
+            aria.controls = [...aria.controls, 'help'];
+            q('#progress').aria.valueNow++
+        ">
+    Update
+</button>
+
+<section id="panel">...</section>
+<p id="help">...</p>
+<output id="status"></output>
+<div id="progress" role="progressbar"
+     aria-valuemin="0" aria-valuemax="100" aria-valuenow="51"></div>
+```
+
+After one click:
+
+```html
+<button aria-busy="true" aria-controls="panel status help">Update</button>
+<div id="progress" role="progressbar"
+     aria-valuemin="0" aria-valuemax="100" aria-valuenow="52"></div>
+```
+
+Use either form to remove an attribute:
+
+```js
+aria.current = null
+delete aria.current
+```
+
+#### Value types
+
+hx-live uses the value types from [WAI-ARIA 1.2](https://www.w3.org/TR/wai-aria-1.2/).
+
+**Boolean**
+
+- `aria-atomic`
+- `aria-busy`
+- `aria-checked`
+- `aria-current`
+- `aria-disabled`
+- `aria-expanded`
+- `aria-grabbed`
+- `aria-haspopup`
+- `aria-hidden`
+- `aria-invalid`
+- `aria-modal`
+- `aria-multiline`
+- `aria-multiselectable`
+- `aria-pressed`
+- `aria-readonly`
+- `aria-required`
+- `aria-selected`
+
+**Number**
+
+- `aria-colcount`
+- `aria-colindex`
+- `aria-colspan`
+- `aria-level`
+- `aria-posinset`
+- `aria-rowcount`
+- `aria-rowindex`
+- `aria-rowspan`
+- `aria-setsize`
+- `aria-valuemax`
+- `aria-valuemin`
+- `aria-valuenow`
+
+**Token list (`string[]`)**
+
+- `aria-dropeffect`
+- `aria-relevant`
+
+**ID reference list (`string[]`)**
+
+- `aria-controls`
+- `aria-describedby`
+- `aria-flowto`
+- `aria-labelledby`
+- `aria-owns`
+
+All other `aria-*` attributes remain strings.
+
+You can use `aria.*` in `hx-live`, bindings, `hx-on`, `js:` attribute values, and `hx-trigger` filters.
 
 ### `data`
 
@@ -455,7 +579,7 @@ For a single inline section, native [`<details>`](https://developer.mozilla.org/
 <header>
     <button hx-on:click="toggle('aria-expanded')" aria-expanded="false">Menu</button>
 </header>
-<aside :hidden="!q('header button').attr('aria-expanded')">...</aside>
+<aside :hidden="!q('header button').aria.expanded">...</aside>
 ```
 
 **Toggle button.**

--- a/www/src/content/extensions/06-hx-live.md
+++ b/www/src/content/extensions/06-hx-live.md
@@ -297,15 +297,15 @@ Both `aria.busy` expressions use `aria-busy` on the div. If no element has the a
 <button hx-on:click="aria.pressed = true" aria-pressed="true">Like</button>
 ```
 
-Access ARIA attributes in three ways:
+Use bare `aria` for shared state. Use `q()` for one element:
 
 ```js
 aria.busy            // closest aria-busy, starting at this
-this.aria.busy       // aria-busy on this
+q(this).aria.busy    // aria-busy on this
 q('#form').aria.busy // aria-busy on the selected form
 ```
 
-All three forms use the same value rules. You can use these values as booleans, numbers, and arrays:
+Each form uses the same value rules. You can use these values as booleans, numbers, and arrays:
 
 ```html
 <button aria-busy="false"

--- a/www/src/content/extensions/06-hx-live.md
+++ b/www/src/content/extensions/06-hx-live.md
@@ -278,31 +278,33 @@ take('.active')                        // implicit scope: parent element's subtr
 
 ### `aria`
 
-Read and write ARIA attributes on this element or an ancestor:
+Read and write ARIA attributes on this element:
 
 ```html
-<div aria-busy="false">
-    <button hx-on:click="aria.busy = !aria.busy">Toggle</button>
-    <output :hidden="!aria.busy">Busy</output>
-</div>
+<button aria-pressed="false" hx-on:click="aria.pressed = !aria.pressed">Like</button>
 ```
 
-Both `aria.busy` expressions use `aria-busy` on the div. If no element has the attribute, a write adds it to the current element:
+Writing an attribute the element doesn't have yet adds it:
 
 ```html
 <!-- This... -->
-<button hx-on:click="aria.pressed = true">Like</button>
+<button hx-on:click="aria.busy = true">Load</button>
 
 <!-- ...becomes this after click -->
-<button hx-on:click="aria.pressed = true" aria-pressed="true">Like</button>
+<button hx-on:click="aria.busy = true" aria-busy="true">Load</button>
 ```
 
-Use bare `aria` for shared state. Use `q()` for one element:
+Use `q()` to reach another element:
 
 ```js
-aria.busy            // closest aria-busy, starting at this
-q(this).aria.busy    // aria-busy on this
+aria.busy            // aria-busy on this element
 q('#form').aria.busy // aria-busy on the selected form
+```
+
+Shared state on an ancestor is a query away:
+
+```js
+q('closest [aria-busy]').aria.busy
 ```
 
 Each form uses the same value rules. You can use these values as booleans, numbers, and arrays:


### PR DESCRIPTION
## Why

Before:

```html
<button aria-pressed="false" hx-on:click="
    attr('aria-pressed', attr('aria-pressed') !== 'true')
">Mute</button>
```

After:

```html
<button aria-pressed="false" hx-on:click="aria.pressed = !aria.pressed">Mute</button>
```

## Changes

1. Read and write ARIA attributes on an element:

   ```js
   aria.busy             // this element
   q('#form').aria.busy  // #form
   ```

2. Read each value as its ARIA type:

   ```js
   aria.busy     // false
   aria.valueNow // 50
   aria.controls // ['menu', 'help']
   ```

3. Use `attr()` to read or write the exact DOM text:

   ```js
   attr('aria-busy')        // 'false'
   attr('aria-valuenow')    // '50'
   attr('aria-controls')    // 'menu help'
   attr('aria-busy', false) // write 'false'
   attr('aria-busy', null)  // remove aria-busy
   ```

4. Use `null` or `delete` to remove an ARIA attribute:

   ```js
   aria.busy = null
   delete aria.busy
   ```

Related to #3931. Either PR can merge first.
