### PR TITLE
Accept intervals for `hx-live` input debounce

### DIFF
--- a/src/ext/hx-live.js
+++ b/src/ext/hx-live.js
@@ -20,12 +20,15 @@
     const OBSERVE_OPTIONS = { childList: true, subtree: true, attributes: true, characterData: true };
 
     let inputDebounceId = null;
-    const INPUT_DEBOUNCE_MS = htmx.config.live?.inputDebounceMs ?? 100;
 
     function ensureActive() {
         if (observer) return;
         recomputeBound = () => schedule();
-        inputBound = () => { clearTimeout(inputDebounceId); inputDebounceId = setTimeout(schedule, INPUT_DEBOUNCE_MS); };
+        let inputDelay = htmx.parseInterval(htmx.config.live?.inputDebounce ?? 100) ?? 100;
+        inputBound = () => {
+            clearTimeout(inputDebounceId);
+            inputDebounceId = setTimeout(schedule, inputDelay);
+        };
         document.addEventListener('input', inputBound, true);
         document.addEventListener('change', recomputeBound, true);
         observer = new MutationObserver(recomputeBound);

--- a/src/htmx.d.ts
+++ b/src/htmx.d.ts
@@ -1,10 +1,10 @@
 /** Configures the hx-live extension. */
 export interface HtmxLiveConfig {
   /**
-   * Debounces `input` events in milliseconds.
+   * Debounces `input` events by a number of milliseconds or an interval string.
    * @default 100
    */
-  inputDebounceMs?: number;
+  inputDebounce?: number | string;
   /**
    * Sets the short binding prefix (`':'` -> `:text`, `'hx:'` -> `hx:text`, `''`/`false` -> disabled).
    * Alpine.js detection disables the default.

--- a/test/tests/ext/hx-live.js
+++ b/test/tests/ext/hx-live.js
@@ -1,9 +1,17 @@
 describe('hx-live extension', function () {
 
     let extBackup;
+    let liveConfigBackup;
+
+    async function flushMicrotasks() {
+        await Promise.resolve();
+        await Promise.resolve();
+    }
 
     before(async () => {
         extBackup = backupExtensions();
+        liveConfigBackup = htmx.config.live;
+        htmx.config.live = { ...liveConfigBackup, inputDebounce: 0 };
         clearExtensions();
         htmx.config.extensions = 'hx-live';
         htmx.__approvedExt = 'hx-live';
@@ -18,6 +26,8 @@ describe('hx-live extension', function () {
 
     after(() => {
         restoreExtensions(extBackup);
+        if (liveConfigBackup === undefined) delete htmx.config.live;
+        else htmx.config.live = liveConfigBackup;
     });
 
     beforeEach(() => { setupTest(this.currentTest); });
@@ -61,6 +71,26 @@ describe('hx-live extension', function () {
         sel.dispatchEvent(new Event('change', { bubbles: true }));
         await htmx.timeout(5);
         out.dataset.v.should.equal('b');
+    });
+
+    it('parses the configured input debounce', async function() {
+        htmx.live.refresh();
+        await flushMicrotasks();
+        let setTimeout = window.setTimeout;
+        let delay;
+        htmx.config.live.inputDebounce = '20ms';
+        window.setTimeout = (_fn, value) => {
+            delay = value;
+            return 0;
+        };
+        try {
+            let input = createProcessedHTML('<input><output hx-live=""></output>');
+            input.dispatchEvent(new Event('input', { bubbles: true }));
+            delay.should.equal(20);
+        } finally {
+            htmx.config.live.inputDebounce = 0;
+            window.setTimeout = setTimeout;
+        }
     });
 
     it('recomputes on DOM mutation (attribute change)', async function() {

--- a/www/src/content/extensions/06-hx-live.md
+++ b/www/src/content/extensions/06-hx-live.md
@@ -635,6 +635,14 @@ Selector directionals (`next`, `previous`, `closest`) need an anchor and only wo
 
 ## Configuration
 
+### `config.live.inputDebounce`
+
+Set how long hx-live waits after an `input` event. Use a number of milliseconds or an interval string. The default is `100ms`.
+
+```html
+<meta name="htmx-config" content="live.inputDebounce:20ms">
+```
+
 ### `config.live.bindPrefix`
 
 Controls the short-form prefix for binding attributes. Defaults to `':'` (or disabled automatically if Alpine.js is detected).


### PR DESCRIPTION
## Why

The setting accepts only a number of milliseconds:

```ts
inputDebounceMs: 20
```

This change also accepts htmx interval strings:

```html
<meta name="htmx-config" content="live.inputDebounce:20ms">
```

## Changes

1. Rename `live.inputDebounceMs` to `live.inputDebounce`.
2. Accept a number or an interval string:

   ```ts
   inputDebounce: 20
   inputDebounce: '20ms'
   ```
