### PR TITLE
Fix `hx-live` form reset state

### DIFF
--- a/src/ext/hx-live.js
+++ b/src/ext/hx-live.js
@@ -134,7 +134,11 @@
                     : (value ? 'true' : 'false');
                 e.setAttribute(name, attrVal);
             } else if (isPropAttr) {
-                if (value === false || value == null) {
+                if (name === 'checked' || name === 'selected') {
+                    let present = !!value;
+                    e[name] = present;
+                    e.toggleAttribute(name, present);
+                } else if (value === false || value == null) {
                     e[name] = (typeof e[name] === 'boolean') ? false : '';
                     e.removeAttribute(name);
                 } else if (value === true) {

--- a/test/tests/ext/hx-live.js
+++ b/test/tests/ext/hx-live.js
@@ -1927,6 +1927,19 @@ describe('hx-live extension', function () {
         mirror.hasAttribute('checked').should.equal(true);
     });
 
+    it('keeps checked and selected false after form reset when the result is zero', function() {
+        playground().innerHTML = `
+            <form>
+                <input type="checkbox" :checked="0">
+                <select multiple><option :selected="0">One</option></select>
+            </form>
+        `;
+        htmx.process(playground());
+        playground().querySelector('form').reset();
+        playground().querySelector('input').checked.should.equal(false);
+        playground().querySelector('option').selected.should.equal(false);
+    });
+
     it(':value syncs property and attribute', async function() {
         playground().innerHTML = `
             <input id="src" value="hello">


### PR DESCRIPTION
## Why

A `checked` binding can return `0`:

```html
<input type="checkbox" :checked="items.length">
```

The input is unchecked, but `hx-live` also writes `checked="0"`. HTML treats the attribute as true. A form reset then checks the input:

```text
Before reset: unchecked
After reset:  checked
```

A `selected` binding has the same problem.

## Change

Convert `checked` and `selected` results to booleans. Use the boolean to set the DOM property and add or remove the HTML attribute.

```text
Before reset: unchecked
After reset:  unchecked
```
