### PR TITLE
Separate request scheduling from request execution

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -87,58 +87,42 @@ var htmx = (() => {
         },
     };
 
-    class ReqQ {
-        #c = null
-        #q = []
+    class RequestQueue {
+        #current = null
+        #queue = []
 
-        issue(ctx, queueStrategy) {
-            ctx.queueStrategy = queueStrategy
-            if (!this.#c) {
-                this.#c = ctx
-                return true
-            } else {
-                // Replace strategy OR current is abortable: abort current and issue new
-                if (queueStrategy === "replace" || (queueStrategy !== "abort" && this.#c.queueStrategy === "abort")) {
-                    this.#q.forEach(value => value.status = "dropped");
-                    this.#q = []
-                    this.#c.request?.abort?.();
-                    this.#c = ctx
-                    return true
-                } else if (queueStrategy === "queue all") {
-                    this.#q.push(ctx)
-                    ctx.status = "queued";
-                } else if (queueStrategy === "drop") {
-                    // ignore the request
-                    ctx.status = "dropped";
-                } else if (queueStrategy === "queue last") {
-                    this.#q.forEach(value => value.status = "dropped");
-                    this.#q = [ctx]
-                    ctx.status = "queued";
-                } else if (this.#q.length === 0 && queueStrategy !== "abort") {
-                    // default queue first
-                    this.#q.push(ctx)
-                    ctx.status = "queued";
-                } else {
-                    ctx.status = "dropped";
-                }
-                return false
+        /** Returns "run", "queued", or "dropped" */
+        admit(strategy, runRequest, abortRequest) {
+            if (!this.#current) {
+                this.#current = {strategy, abort: abortRequest}
+                return "run"
             }
+            if (strategy === "replace" || (strategy !== "abort" && this.#current.strategy === "abort")) {
+                this.#queue = []
+                this.#current.abort?.()
+                this.#current = {strategy, abort: abortRequest}
+                return "run"
+            }
+            if (strategy === "queue all") {
+                this.#queue.push(runRequest)
+            } else if (strategy === "queue last") {
+                this.#queue = [runRequest]
+            } else if (strategy !== "abort" && strategy !== "drop" && this.#queue.length === 0) {
+                // default queue first
+                this.#queue.push(runRequest)
+            } else {
+                return "dropped"
+            }
+            return "queued"
         }
 
-        finish() {
-            this.#c = null
-        }
-
-        next() {
-            return this.#q.shift()
+        continue() {
+            this.#current = null    // free current slot
+            this.#queue.shift()?.() // run next request
         }
 
         abort() {
-            this.#c?.request?.abort?.()
-        }
-
-        more() {
-            return this.#q?.length
+            this.#current?.abort?.()
         }
     }
 
@@ -579,7 +563,11 @@ var htmx = (() => {
             let requestQueue = this.__getRequestQueue(elt);
             this.__initializeAbortListener(elt);
 
-            if (!requestQueue.issue(ctx, syncStrategy)) return
+            if (requestQueue.admit(
+                syncStrategy,
+                () => this.__issueRequest(ctx), // run when ready
+                () => ctx.request?.abort?.()    // abort if replaced
+            ) !== "run") return
 
             ctx.status = "issuing"
 
@@ -651,11 +639,7 @@ var htmx = (() => {
                     this.__enableElements(disableElements);
                 }
 
-                requestQueue.finish()
-                if (requestQueue.more()) {
-                    // intentionally not awaited; __issueRequest has its own try/catch
-                    this.__issueRequest(requestQueue.next())
-                }
+                requestQueue.continue()
             }
         }
 
@@ -720,7 +704,7 @@ var htmx = (() => {
                     : (/^(drop|abort|replace|queue)/.test(hxSync) ? null : hxSync);
                 if (selector) syncElt = this.__findOrWarn(elt, selector, "hx-sync") || elt;
             }
-            return this.__htmxState(syncElt).rq ||= new ReqQ()
+            return this.__htmxState(syncElt).rq ||= new RequestQueue()
         }
 
         __isModifierKeyClick(evt) {

--- a/test/tests/unit/__getRequestQueue.js
+++ b/test/tests/unit/__getRequestQueue.js
@@ -1,5 +1,7 @@
 describe('__getRequestQueue / RequestQueue unit tests', function() {
 
+    const noop = () => {}
+
     beforeEach(function() {
         setupTest();
     });
@@ -10,171 +12,118 @@ describe('__getRequestQueue / RequestQueue unit tests', function() {
 
     it('allows first request when queue is empty', function () {
         let div = createProcessedHTML('<div hx-get="/test"></div>')
-        let ctx = htmx.__createRequestContext(div, new Event('click'))
         let queue = htmx.__getRequestQueue(div)
 
-        let result = queue.issue(ctx, 'queue first')
-
-        assert.isTrue(result)
+        assert.equal(queue.admit('queue first', noop, noop), 'run')
     })
 
     it('queues request with "queue all" strategy', function () {
         let div = createProcessedHTML('<div hx-get="/test"></div>')
         let queue = htmx.__getRequestQueue(div)
 
-        // Issue first request
-        let ctx1 = htmx.__createRequestContext(div, new Event('click'))
-        queue.issue(ctx1, 'queue all')
+        queue.admit('queue all', noop, noop)
+        let result = queue.admit('queue all', noop, noop)
 
-        // Queue second request
-        let ctx2 = htmx.__createRequestContext(div, new Event('click'))
-        let result = queue.issue(ctx2, 'queue all')
-
-        assert.isFalse(result)
-        assert.equal(ctx2.status, 'queued')
+        assert.equal(result, 'queued')
     })
 
     it('drops request with "drop" strategy', function () {
         let div = createProcessedHTML('<div hx-get="/test"></div>')
         let queue = htmx.__getRequestQueue(div)
 
-        // Issue first request
-        let ctx1 = htmx.__createRequestContext(div, new Event('click'))
-        queue.issue(ctx1, 'drop')
+        queue.admit('drop', noop, noop)
+        let result = queue.admit('drop', noop, noop)
 
-        // Drop second request
-        let ctx2 = htmx.__createRequestContext(div, new Event('click'))
-        let result = queue.issue(ctx2, 'drop')
-
-        assert.isFalse(result)
-        assert.equal(ctx2.status, 'dropped')
+        assert.equal(result, 'dropped')
     })
 
     it('queues only last with "queue last" strategy', function () {
         let div = createProcessedHTML('<div hx-get="/test"></div>')
         let queue = htmx.__getRequestQueue(div)
+        let started = []
 
-        // Issue first request
-        let ctx1 = htmx.__createRequestContext(div, new Event('click'))
-        queue.issue(ctx1, 'queue last')
+        queue.admit('queue last', () => started.push(1), noop)
+        queue.admit('queue last', () => started.push(2), noop)
+        let result = queue.admit('queue last', () => started.push(3), noop)
 
-        // Queue second request
-        let ctx2 = htmx.__createRequestContext(div, new Event('click'))
-        queue.issue(ctx2, 'queue last')
+        assert.equal(result, 'queued')
 
-        // Queue third request (should drop ctx2)
-        let ctx3 = htmx.__createRequestContext(div, new Event('click'))
-        let result = queue.issue(ctx3, 'queue last')
+        queue.continue()
+        queue.continue()
 
-        assert.isFalse(result)
-        assert.equal(ctx2.status, 'dropped')
-        assert.equal(ctx3.status, 'queued')
+        assert.deepEqual(started, [3])
     })
 
     it('replaces current request with "replace" strategy', function () {
         let div = createProcessedHTML('<div hx-get="/test"></div>')
         let queue = htmx.__getRequestQueue(div)
+        let aborted = false
 
-        // Issue first request
-        let ctx1 = htmx.__createRequestContext(div, new Event('click'))
-        ctx1.request = {abort: () => { ctx1.aborted = true }}
-        queue.issue(ctx1, 'replace')
+        queue.admit('replace', noop, () => { aborted = true })
+        let result = queue.admit('replace', noop, noop)
 
-        // Replace with second request
-        let ctx2 = htmx.__createRequestContext(div, new Event('click'))
-        let result = queue.issue(ctx2, 'replace')
-
-        assert.isTrue(result)
-        assert.isTrue(ctx1.aborted)
+        assert.equal(result, 'run')
+        assert.isTrue(aborted)
     })
 
     it('defaults to "queue first" when strategy not specified', function () {
         let div = createProcessedHTML('<div hx-get="/test"></div>')
         let queue = htmx.__getRequestQueue(div)
+        let started = []
 
-        // Issue first request
-        let ctx1 = htmx.__createRequestContext(div, new Event('click'))
-        queue.issue(ctx1, 'queue first')
+        queue.admit('queue first', () => started.push(1), noop)
+        let second = queue.admit('queue first', () => started.push(2), noop)
+        let third = queue.admit('queue first', () => started.push(3), noop)
 
-        // Queue second request
-        let ctx2 = htmx.__createRequestContext(div, new Event('click'))
-        queue.issue(ctx2, 'queue first')
+        assert.equal(second, 'queued')
+        assert.equal(third, 'dropped')
 
-        // Third request should be dropped (not queued)
-        let ctx3 = htmx.__createRequestContext(div, new Event('click'))
-        let result = queue.issue(ctx3, 'queue first')
+        queue.continue()
+        queue.continue()
 
-        assert.isFalse(result)
-        assert.equal(ctx2.status, 'queued')
-        assert.equal(ctx3.status, 'dropped')
+        assert.deepEqual(started, [2])
     })
 
-    it('hasMore returns truthy when queue has requests', function () {
+    it('continue runs the next queued request once', function () {
+        let div = createProcessedHTML('<div hx-get="/test"></div>')
+        let queue = htmx.__getRequestQueue(div)
+        let started = []
+
+        queue.admit('queue all', () => started.push(1), noop)
+        queue.admit('queue all', () => started.push(2), noop)
+        queue.admit('queue all', () => started.push(3), noop)
+
+        queue.continue()
+
+        assert.deepEqual(started, [2])
+    })
+
+    it('continue does nothing when the queue is empty', function () {
         let div = createProcessedHTML('<div hx-get="/test"></div>')
         let queue = htmx.__getRequestQueue(div)
 
-        let ctx1 = htmx.__createRequestContext(div, new Event('click'))
-        queue.issue(ctx1, 'queue all')
-
-        let ctx2 = htmx.__createRequestContext(div, new Event('click'))
-        queue.issue(ctx2, 'queue all')
-
-        assert.isOk(queue.more())
+        queue.continue()
     })
 
-    it('hasMore returns falsey when queue is empty', function () {
+    it('continue clears the current request', function () {
         let div = createProcessedHTML('<div hx-get="/test"></div>')
         let queue = htmx.__getRequestQueue(div)
 
-        assert.isNotOk(queue.more())
+        queue.admit('queue first', noop, noop)
+        queue.continue()
+
+        assert.equal(queue.admit('queue first', noop, noop), 'run')
     })
 
-    it('finish returns next queued request', function () {
+    it('abort calls abort on the current request', function () {
         let div = createProcessedHTML('<div hx-get="/test"></div>')
         let queue = htmx.__getRequestQueue(div)
+        let aborted = false
 
-        let ctx1 = htmx.__createRequestContext(div, new Event('click'))
-        queue.issue(ctx1, 'queue all')
-
-        let ctx2 = htmx.__createRequestContext(div, new Event('click'))
-        queue.issue(ctx2, 'queue all')
-
-        queue.finish(ctx1)
-        let next = queue.next()
-
-        assert.equal(next, ctx2)
-    })
-
-    it('nextRequest clears current request', function () {
-        let div = createProcessedHTML('<div hx-get="/test"></div>')
-        let queue = htmx.__getRequestQueue(div)
-
-        let ctx1 = htmx.__createRequestContext(div, new Event('click'))
-        queue.issue(ctx1, 'queue all')
-
-        let ctx2 = htmx.__createRequestContext(div, new Event('click'))
-        queue.issue(ctx2, 'queue all')
-
-        queue.finish(ctx1)
-        queue.next()
-
-        // Should now allow a new request
-        let ctx3 = htmx.__createRequestContext(div, new Event('click'))
-        let result = queue.issue(ctx3, 'queue first')
-
-        assert.isTrue(result)
-    })
-
-    it('abortCurrentRequest calls abort on current request', function () {
-        let div = createProcessedHTML('<div hx-get="/test"></div>')
-        let queue = htmx.__getRequestQueue(div)
-
-        let ctx = htmx.__createRequestContext(div, new Event('click'))
-        queue.issue(ctx, 'queue first')
-
+        queue.admit('queue first', noop, () => { aborted = true })
         queue.abort()
 
-        assert.isTrue(ctx.request.signal.aborted)
+        assert.isTrue(aborted)
     })
 
     it('returns same queue for same element', function () {
@@ -199,28 +148,23 @@ describe('__getRequestQueue / RequestQueue unit tests', function() {
     it('hx-sync="drop" without selector uses drop strategy', function () {
         let div = createProcessedHTML('<div hx-get="/test" hx-sync="drop"></div>')
         let queue = htmx.__getRequestQueue(div)
-        let ctx1 = htmx.__createRequestContext(div, new Event('click'))
-        queue.issue(ctx1, htmx.__determineSyncStrategy(div))
 
-        let ctx2 = htmx.__createRequestContext(div, new Event('click'))
-        let result = queue.issue(ctx2, htmx.__determineSyncStrategy(div))
+        queue.admit(htmx.__determineSyncStrategy(div), noop, noop)
+        let result = queue.admit(htmx.__determineSyncStrategy(div), noop, noop)
 
-        assert.isFalse(result)
-        assert.equal(ctx2.status, 'dropped')
+        assert.equal(result, 'dropped')
     })
 
     it('hx-sync="abort" without selector uses abort strategy', function () {
         let div = createProcessedHTML('<div hx-get="/test" hx-sync="abort"></div>')
         let queue = htmx.__getRequestQueue(div)
-        let ctx1 = htmx.__createRequestContext(div, new Event('click'))
-        ctx1.request = {abort: () => { ctx1.aborted = true }}
-        queue.issue(ctx1, htmx.__determineSyncStrategy(div))
+        let aborted = false
 
-        let ctx2 = htmx.__createRequestContext(div, new Event('click'))
-        let result = queue.issue(ctx2, htmx.__determineSyncStrategy(div))
+        queue.admit(htmx.__determineSyncStrategy(div), noop, () => { aborted = true })
+        let result = queue.admit(htmx.__determineSyncStrategy(div), noop, noop)
 
-        assert.isFalse(result)
-        assert.equal(ctx2.status, 'dropped')
+        assert.equal(result, 'dropped')
+        assert.isFalse(aborted)
     })
 
     it('hx-sync="selector:drop" uses drop strategy', function () {
@@ -258,150 +202,91 @@ describe('__getRequestQueue / RequestQueue unit tests', function() {
         let div = createProcessedHTML('<div hx-get="/test"></div>')
         let queue = htmx.__getRequestQueue(div)
 
-        let ctx = htmx.__createRequestContext(div, new Event('click'))
-        ctx.request = {abort: () => { ctx.aborted = true }}
-        let result = queue.issue(ctx, 'abort')
-
-        assert.isTrue(result)
-        assert.equal(ctx.queueStrategy, 'abort')
+        assert.equal(queue.admit('abort', noop, noop), 'run')
     })
 
     it('abort strategy: any request can abort an abortable request', function () {
         let div = createProcessedHTML('<div hx-get="/test"></div>')
         let queue = htmx.__getRequestQueue(div)
+        let aborted = false
 
-        // Issue abort request
-        let ctx1 = htmx.__createRequestContext(div, new Event('click'))
-        ctx1.request = {abort: () => { ctx1.aborted = true }}
-        queue.issue(ctx1, 'abort')
+        queue.admit('abort', noop, () => { aborted = true })
+        let result = queue.admit('drop', noop, noop)
 
-        // Issue drop request - should abort the abort request
-        let ctx2 = htmx.__createRequestContext(div, new Event('click'))
-        ctx2.request = {abort: () => { ctx2.aborted = true }}
-        let result = queue.issue(ctx2, 'drop')
-
-        assert.isTrue(result)
-        assert.isTrue(ctx1.aborted)
+        assert.equal(result, 'run')
+        assert.isTrue(aborted)
     })
 
     it('abort strategy: another abort request drops when abort request is in flight', function () {
         let div = createProcessedHTML('<div hx-get="/test"></div>')
         let queue = htmx.__getRequestQueue(div)
+        let aborted = false
 
-        // Issue abort request
-        let ctx1 = htmx.__createRequestContext(div, new Event('click'))
-        ctx1.aborted = false
-        ctx1.request = {abort: () => { ctx1.aborted = true }}
-        queue.issue(ctx1, 'abort')
+        queue.admit('abort', noop, () => { aborted = true })
+        let result = queue.admit('abort', noop, noop)
 
-        // Issue another abort request - should be dropped
-        let ctx2 = htmx.__createRequestContext(div, new Event('click'))
-        ctx2.aborted = false
-        ctx2.request = {abort: () => { ctx2.aborted = true }}
-        let result = queue.issue(ctx2, 'abort')
-
-        assert.isFalse(result)
-        assert.equal(ctx2.status, 'dropped')
-        assert.isFalse(ctx1.aborted)
+        assert.equal(result, 'dropped')
+        assert.isFalse(aborted)
     })
 
     it('abort strategy: abort request drops itself if non-abortable request is in flight', function () {
         let div = createProcessedHTML('<div hx-get="/test"></div>')
         let queue = htmx.__getRequestQueue(div)
+        let aborted = false
 
-        // Issue drop request (not abortable)
-        let ctx1 = htmx.__createRequestContext(div, new Event('click'))
-        ctx1.aborted = false
-        ctx1.request = {abort: () => { ctx1.aborted = true }}
-        queue.issue(ctx1, 'drop')
+        queue.admit('drop', noop, () => { aborted = true })
+        let result = queue.admit('abort', noop, noop)
 
-        // Issue abort request - should be dropped
-        let ctx2 = htmx.__createRequestContext(div, new Event('click'))
-        ctx2.aborted = false
-        ctx2.request = {abort: () => { ctx2.aborted = true }}
-        let result = queue.issue(ctx2, 'abort')
-
-        assert.isFalse(result)
-        assert.equal(ctx2.status, 'dropped')
-        assert.isFalse(ctx1.aborted)
+        assert.equal(result, 'dropped')
+        assert.isFalse(aborted)
     })
 
     it('abort strategy: replace request can abort an abortable request', function () {
         let div = createProcessedHTML('<div hx-get="/test"></div>')
         let queue = htmx.__getRequestQueue(div)
+        let aborted = false
 
-        // Issue abort request
-        let ctx1 = htmx.__createRequestContext(div, new Event('click'))
-        ctx1.request = {abort: () => { ctx1.aborted = true }}
-        queue.issue(ctx1, 'abort')
+        queue.admit('abort', noop, () => { aborted = true })
+        let result = queue.admit('replace', noop, noop)
 
-        // Issue replace request - should abort the abort request
-        let ctx2 = htmx.__createRequestContext(div, new Event('click'))
-        ctx2.request = {abort: () => { ctx2.aborted = true }}
-        let result = queue.issue(ctx2, 'replace')
-
-        assert.isTrue(result)
-        assert.isTrue(ctx1.aborted)
+        assert.equal(result, 'run')
+        assert.isTrue(aborted)
     })
 
     it('abort strategy: queue-all request can abort an abortable request', function () {
         let div = createProcessedHTML('<div hx-get="/test"></div>')
         let queue = htmx.__getRequestQueue(div)
+        let aborted = false
 
-        // Issue abort request
-        let ctx1 = htmx.__createRequestContext(div, new Event('click'))
-        ctx1.request = {abort: () => { ctx1.aborted = true }}
-        queue.issue(ctx1, 'abort')
+        queue.admit('abort', noop, () => { aborted = true })
+        let result = queue.admit('queue all', noop, noop)
 
-        // Issue queue-all request - should abort the abort request
-        let ctx2 = htmx.__createRequestContext(div, new Event('click'))
-        ctx2.request = {abort: () => { ctx2.aborted = true }}
-        let result = queue.issue(ctx2, 'queue all')
-
-        assert.isTrue(result)
-        assert.isTrue(ctx1.aborted)
+        assert.equal(result, 'run')
+        assert.isTrue(aborted)
     })
 
     it('abort strategy: abort request drops itself when replace request is in flight', function () {
         let div = createProcessedHTML('<div hx-get="/test"></div>')
         let queue = htmx.__getRequestQueue(div)
+        let aborted = false
 
-        // Issue replace request
-        let ctx1 = htmx.__createRequestContext(div, new Event('click'))
-        ctx1.aborted = false
-        ctx1.request = {abort: () => { ctx1.aborted = true }}
-        queue.issue(ctx1, 'replace')
+        queue.admit('replace', noop, () => { aborted = true })
+        let result = queue.admit('abort', noop, noop)
 
-        // Issue abort request - should be dropped
-        let ctx2 = htmx.__createRequestContext(div, new Event('click'))
-        ctx2.aborted = false
-        ctx2.request = {abort: () => { ctx2.aborted = true }}
-        let result = queue.issue(ctx2, 'abort')
-
-        assert.isFalse(result)
-        assert.equal(ctx2.status, 'dropped')
-        assert.isFalse(ctx1.aborted)
+        assert.equal(result, 'dropped')
+        assert.isFalse(aborted)
     })
 
     it('abort strategy: abort request drops itself when queue-first request is in flight', function () {
         let div = createProcessedHTML('<div hx-get="/test"></div>')
         let queue = htmx.__getRequestQueue(div)
+        let aborted = false
 
-        // Issue queue-first request
-        let ctx1 = htmx.__createRequestContext(div, new Event('click'))
-        ctx1.aborted = false
-        ctx1.request = {abort: () => { ctx1.aborted = true }}
-        queue.issue(ctx1, 'queue first')
+        queue.admit('queue first', noop, () => { aborted = true })
+        let result = queue.admit('abort', noop, noop)
 
-        // Issue abort request - should be dropped
-        let ctx2 = htmx.__createRequestContext(div, new Event('click'))
-        ctx2.aborted = false
-        ctx2.request = {abort: () => { ctx2.aborted = true }}
-        let result = queue.issue(ctx2, 'abort')
-
-        assert.isFalse(result)
-        assert.equal(ctx2.status, 'dropped')
-        assert.isFalse(ctx1.aborted)
+        assert.equal(result, 'dropped')
+        assert.isFalse(aborted)
     })
 
     // hx-sync value parsing tests
@@ -456,34 +341,24 @@ describe('__getRequestQueue / RequestQueue unit tests', function() {
         assert.equal(htmx.__getRequestQueue(a), htmx.__getRequestQueue(b))
     })
 
-    it('abort strategy: clears queue when aborting current request', function () {
+    it('replace strategy clears queued requests when aborting current', function () {
         let div = createProcessedHTML('<div hx-get="/test"></div>')
         let queue = htmx.__getRequestQueue(div)
+        let aborted = false
+        let started = []
 
-        // Issue non-abortable request
-        let ctx1 = htmx.__createRequestContext(div, new Event('click'))
-        ctx1.aborted = false
-        ctx1.request = {abort: () => { ctx1.aborted = true }}
-        queue.issue(ctx1, 'drop')
+        queue.admit('drop', noop, () => { aborted = true })
+        queue.admit('queue all', () => started.push(2), noop)
+        queue.admit('queue all', () => started.push(3), noop)
 
-        // Queue some requests
-        let ctx2 = htmx.__createRequestContext(div, new Event('click'))
-        queue.issue(ctx2, 'queue all')
+        let result = queue.admit('replace', noop, noop)
 
-        let ctx3 = htmx.__createRequestContext(div, new Event('click'))
-        queue.issue(ctx3, 'queue all')
+        assert.equal(result, 'run')
+        assert.isTrue(aborted)
 
-        // Issue replace request - should clear queue
-        let ctx4 = htmx.__createRequestContext(div, new Event('click'))
-        ctx4.aborted = false
-        ctx4.request = {abort: () => { ctx4.aborted = true }}
-        let result = queue.issue(ctx4, 'replace')
+        queue.continue()
 
-        assert.isTrue(result)
-        assert.isTrue(ctx1.aborted)
-        assert.equal(ctx2.status, 'dropped')
-        assert.equal(ctx3.status, 'dropped')
-        assert.isNotOk(queue.more())
+        assert.deepEqual(started, [])
     })
 
 });

--- a/test/tests/unit/__issueRequest.js
+++ b/test/tests/unit/__issueRequest.js
@@ -85,6 +85,48 @@ describe('__issueRequest unit tests', function() {
         assert.isFalse(fetchCalled)
     })
 
+    it('replace aborts the active request and runs the replacement', async function () {
+        let div = createProcessedHTML('<div hx-get="/test" hx-swap="none" hx-sync="replace"></div>')
+        let ctx1 = htmx.__createRequestContext(div, new Event('click'))
+        ctx1.fetch = (url, options) => new Promise((resolve, reject) => {
+            options.signal.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')))
+        })
+        let ctx2 = htmx.__createRequestContext(div, new Event('click'))
+        let replacementRan = false
+        ctx2.fetch = async () => {
+            replacementRan = true
+            return {status: 200, headers: new Headers(), text: async () => ''}
+        }
+
+        let request1 = htmx.__issueRequest(ctx1)
+        let request2 = htmx.__issueRequest(ctx2)
+        await Promise.all([request1, request2])
+
+        assert.isTrue(ctx1.request.signal.aborted)
+        assert.isTrue(replacementRan)
+    })
+
+    it('a later request aborts an active abort request', async function () {
+        let parent = createProcessedHTML('<div id="sync"><div id="first" hx-get="/first" hx-swap="none" hx-sync="#sync:abort"></div><div id="second" hx-get="/second" hx-swap="none" hx-sync="#sync:drop"></div></div>')
+        let ctx1 = htmx.__createRequestContext(parent.querySelector('#first'), new Event('click'))
+        ctx1.fetch = (url, options) => new Promise((resolve, reject) => {
+            options.signal.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')))
+        })
+        let ctx2 = htmx.__createRequestContext(parent.querySelector('#second'), new Event('click'))
+        let secondRan = false
+        ctx2.fetch = async () => {
+            secondRan = true
+            return {status: 200, headers: new Headers(), text: async () => ''}
+        }
+
+        let request1 = htmx.__issueRequest(ctx1)
+        let request2 = htmx.__issueRequest(ctx2)
+        await Promise.all([request1, request2])
+
+        assert.isTrue(ctx1.request.signal.aborted)
+        assert.isTrue(secondRan)
+    })
+
     it('returns early if htmx:before:request is cancelled', async function () {
         let div = createProcessedHTML('<div hx-get="/test" hx-swap="none"></div>')
         let ctx = htmx.__createRequestContext(div, new Event('click'))


### PR DESCRIPTION
## Before

`ReqQ` owns request contexts and reaches into request state:

```javascript
class ReqQ {
  #current // ctx
  #queue   // ctx[]

  issue(ctx, strategy) // → boolean, mutates ctx.status
  finish()
  next()               // → ctx
  abort()              // calls ctx.request.abort()
  more()
}
```

## After

`RequestQueue` owns only the actions needed to schedule requests:

```javascript
class RequestQueue {
  #current // { strategy, abort }
  #queue   // runRequest[]

  admit(strategy, runRequest, abortRequest)
    // → "run" | "queued" | "dropped"

  continue()
  abort()
}
```

No queue behavior is intended to change.

## Size

```text
Brotli before: 11,655 bytes
Brotli after:  11,632 bytes
Saved:             23 bytes
```
