### PR TITLE
Fix stray NBSP indentation in src/htmx.js

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1177,7 +1177,7 @@ var htmx = (() => {
                         this.__processScripts(templateElt.content);
                         let swapSpec = this.__parseSwapSpec(this.__attr(templateElt, 'hx-swap') || this.config.defaultSwap);
                         let targets = this.__findAllExt(ctx.sourceElement, targetSelector);
-                        for (let target of targets.length ? targets : [null]) {
+                        for (let target of targets.length ? targets : [null]) {
                             tasks.push({
                                 type: 'partial',
                                 fragment: templateElt.content.cloneNode(true),


### PR DESCRIPTION
## Description
Line 1180 was indented with non-breaking-space characters (U+00A0) instead of regular
spaces — almost certainly a copy-paste typo from #3924. Harmless to JS engines (NBSP is
valid whitespace), but if both the embedding page and this script lack a declared charset,
Chromium decodes the script as Windows-1252, mangling those bytes into a stray "Â" and
throwing a SyntaxError before `window.htmx` is ever defined. Reproduced live to confirm.

Swapped the NBSPs for normal spaces.

## Testing
Confirmed no NBSP left in the file. Reproduced the failure in real Chromium (page + script
both charset-less) before the fix, confirmed it's gone after. Full suite: 1615 passed / 2
flaky, unrelated failures (reran those two alone, both pass).

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded