### PR TITLE
Fix preload action URL comparison in hx-preload.js

### DIFF
--- a/src/ext/hx-preload.js
+++ b/src/ext/hx-preload.js
@@ -78,7 +78,7 @@
         htmx_before_request: (elt, detail) => {
             let {ctx} = detail;
             if (elt._htmx?.preload &&
-                elt._htmx.preload.action === ctx.request.action &&
+                elt._htmx.preload.action === new URL(ctx.request.action, location.href).href &&
                 Date.now() < elt._htmx.preload.expiresAt) {
                 let prefetch = elt._htmx.preload.prefetch;
                 ctx.fetch = () => prefetch;


### PR DESCRIPTION
## Description
Fix `hx-preload` failing to reuse preloaded GET responses when the preload URL and the later htmx request URL use different URL formats.

The preload extension stores the fetched URL as an absolute URL, but the later htmx request can contain a relative URL.

Corresponding issue:
https://github.com/bigskysoftware/htmx/issues/3948

## Testing
Tested manually:
- Hovered over an `hx-preload="mouseover timeout:10s"` link.
- Waited for the preload request to complete.
- Clicked the link.
- Verified that the click reused the preload and did not send a second request.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
