### PR TITLE
Add `connection` to `hx-sse` and `hx-multipart` event details

### DIFF
--- a/src/editors/jetbrains/htmx.web-types.json
+++ b/src/editors/jetbrains/htmx.web-types.json
@@ -552,7 +552,7 @@
         },
         {
           "name": "sse:error",
-          "description": "Fires when an SSE stream error occurs. `detail.error`, `detail.url`, and sometimes `detail.status` describe the failure.",
+          "description": "Fires when an SSE stream error occurs. `detail.connection` identifies the failed stream when available; `detail.url` identifies setup failures; `detail.error` and sometimes `detail.status` describe the failure.",
           "doc-url": "https://four.htmx.org/extensions/hx-sse#htmxsseerror"
         },
         {

--- a/src/editors/jetbrains/htmx.web-types.json
+++ b/src/editors/jetbrains/htmx.web-types.json
@@ -557,12 +557,12 @@
         },
         {
           "name": "sse:before:message",
-          "description": "Fires before an SSE message is processed. `detail.message` contains `data`, `event`, `id`, and `cancelled`.",
+          "description": "Fires before an SSE message is processed. `detail.connection` identifies the stream; `detail.message` contains `data`, `event`, `id`, and `cancelled`.",
           "doc-url": "https://four.htmx.org/extensions/hx-sse#htmxssebeforemessage"
         },
         {
           "name": "sse:after:message",
-          "description": "Fires after an SSE message is processed. `detail.message` contains `data`, `event`, and `id`.",
+          "description": "Fires after an SSE message is processed. `detail.connection` identifies the stream; `detail.message` contains `data`, `event`, and `id`.",
           "doc-url": "https://four.htmx.org/extensions/hx-sse#htmxsseaftermessage"
         },
         {

--- a/src/ext/hx-multipart.js
+++ b/src/ext/hx-multipart.js
@@ -236,6 +236,7 @@
 
                         let pendingWork = [];
                         let detail = {
+                            connection,
                             ctx,
                             part,
                             cancelled: false,
@@ -296,7 +297,7 @@
                                 checkpointIndex = 0;
                             }
 
-                            api.triggerHtmxEvent(ctx.sourceElement, 'htmx:multipart:after:part', {ctx, part});
+                            api.triggerHtmxEvent(ctx.sourceElement, 'htmx:multipart:after:part', {connection, ctx, part});
                         })();
 
                         if (type === 'multipart/parallel') {

--- a/src/ext/hx-multipart.js
+++ b/src/ext/hx-multipart.js
@@ -187,8 +187,8 @@
                     } catch (error) {
                         if (!ac.signal.aborted) {
                             api.triggerHtmxEvent(element, 'htmx:multipart:error', {
-                                error,
-                                url: ctx.request.action
+                                connection,
+                                error
                             });
                         }
                         connection.attempt++;
@@ -197,9 +197,9 @@
 
                     if (!currentResponse.ok) {
                         api.triggerHtmxEvent(element, 'htmx:multipart:error', {
+                            connection,
                             error: new Error(`Multipart reconnect failed with status ${currentResponse.status}`),
-                            status: currentResponse.status,
-                            url: ctx.request.action
+                            status: currentResponse.status
                         });
                         connection.attempt++;
                         continue;
@@ -209,9 +209,9 @@
                     let nextType = contentType.split(';', 1)[0].trim().toLowerCase();
                     if (nextType !== type) {
                         api.triggerHtmxEvent(element, 'htmx:multipart:error', {
+                            connection,
                             error: new Error(`Multipart reconnect returned ${nextType || 'no Content-Type'}`),
-                            status: currentResponse.status,
-                            url: ctx.request.action
+                            status: currentResponse.status
                         });
                         connection.attempt++;
                         continue;
@@ -315,8 +315,8 @@
                     await Promise.allSettled(pending);
                     if (!connection.cancelled) {
                         api.triggerHtmxEvent(element, 'htmx:multipart:error', {
-                            error,
-                            url: ctx.request.action
+                            connection,
+                            error
                         });
                     }
                 } finally {

--- a/src/ext/hx-sse.js
+++ b/src/ext/hx-sse.js
@@ -218,7 +218,7 @@
                         });
                     } catch (e) {
                         if (ac.signal.aborted) break;
-                        api.triggerHtmxEvent(element, 'htmx:sse:error', {error: e, url: ctx.request.action});
+                        api.triggerHtmxEvent(element, 'htmx:sse:error', {connection, error: e});
                         reconnectRequested = false;
                         connection.attempt++;
                         continue;
@@ -226,9 +226,9 @@
 
                     if (!currentResponse.ok) {
                         api.triggerHtmxEvent(element, 'htmx:sse:error', {
+                            connection,
                             error: new Error(`SSE reconnect failed with status ${currentResponse.status}`),
-                            status: currentResponse.status,
-                            url: ctx.request.action
+                            status: currentResponse.status
                         });
                         reconnectRequested = false;
                         connection.attempt++;
@@ -289,7 +289,7 @@
                     }
                 } catch (e) {
                     if (!connection.abortController?.signal?.aborted) {
-                        api.triggerHtmxEvent(element, 'htmx:sse:error', {error: e, url: ctx.request.action});
+                        api.triggerHtmxEvent(element, 'htmx:sse:error', {connection, error: e});
                     }
                 }
 

--- a/src/ext/hx-sse.js
+++ b/src/ext/hx-sse.js
@@ -257,6 +257,7 @@
                         if (!msg.hasData && !msg.event) continue;
 
                         let detail = {
+                            connection,
                             message: {data: msg.data, event: msg.event, id: msg.id, cancelled: false}
                         };
                         if (!api.triggerHtmxEvent(element, 'htmx:sse:before:message', detail) || detail.message.cancelled) continue;

--- a/test/tests/ext/hx-multipart.js
+++ b/test/tests/ext/hx-multipart.js
@@ -244,6 +244,39 @@ describe('hx-multipart extension', function() {
         assert.equal(closeReason, 'removed');
     });
 
+    it('includes the connection in reconnect errors', async function() {
+        let requestCount = 0;
+        let connection;
+        let errorDetail;
+        let saveConnection = event => {
+            connection = event.detail.connection;
+        };
+        let saveError = event => {
+            errorDetail = event.detail;
+        };
+        document.addEventListener('htmx:multipart:before:connection', saveConnection);
+        document.addEventListener('htmx:multipart:error', saveError);
+        fetchMock.mockResponse('GET', '/reconnect-error', () => {
+            requestCount++;
+            return new Response(requestCount === 1 ? '--updates--\r\n' : '', {
+                status: requestCount === 1 ? 200 : 500,
+                headers: {'Content-Type': 'multipart/mixed; boundary=updates'}
+            });
+        });
+
+        let source = createProcessedHTML([
+            '<div id="reconnect-error-source" hx-multipart:connect="/reconnect-error" ',
+            'hx-config="multipart.reconnectDelay:1ms multipart.reconnectMaxAttempts:1 multipart.reconnectJitter:0"></div>'
+        ].join(''));
+
+        assert.isTrue(await waitUntil(() => errorDetail != null, 500));
+        assert.equal(errorDetail.status, 500);
+        assert.strictEqual(errorDetail.connection, connection);
+        await deleteWithSwap('#reconnect-error-source');
+        document.removeEventListener('htmx:multipart:before:connection', saveConnection);
+        document.removeEventListener('htmx:multipart:error', saveError);
+    });
+
     it('sends the last completed part ID on reconnect and supports reset', async function() {
         let requestHeaders = [];
         let requestCount = 0;

--- a/test/tests/ext/hx-multipart.js
+++ b/test/tests/ext/hx-multipart.js
@@ -662,14 +662,23 @@ describe('hx-multipart extension', function() {
         let button = createProcessedHTML('<button hx-get="/mixed-data">Go</button><div id="result"></div>');
         let json;
         let handledParts = 0;
+        let connection;
+        let partConnections = [];
 
+        button.addEventListener('htmx:multipart:before:connection', event => {
+            connection = event.detail.connection;
+        });
         button.addEventListener('htmx:multipart:before:part', event => {
+            partConnections.push(event.detail.connection);
             if (event.detail.part.headers.get('Content-Type') !== 'application/json') return;
 
             event.preventDefault();
             event.detail.waitUntil(event.detail.part.json().then(value => json = value));
         });
-        button.addEventListener('htmx:multipart:after:part', () => handledParts++);
+        button.addEventListener('htmx:multipart:after:part', event => {
+            partConnections.push(event.detail.connection);
+            handledParts++;
+        });
 
         fetchMock.mockResponse('GET', '/mixed-data', new Response([
             '--updates\r\n',
@@ -693,6 +702,7 @@ describe('hx-multipart extension', function() {
         assertTextContentIs('#result', 'Done');
         assert.equal(button.textContent, 'Go');
         assert.equal(handledParts, 1);
+        assert.isTrue(partConnections.every(value => value === connection));
     });
 
     it('lets another extension take over a part', async function() {

--- a/test/tests/ext/hx-sse.js
+++ b/test/tests/ext/hx-sse.js
@@ -983,6 +983,7 @@ describe('hx-sse SSE extension', function() {
 
     it('htmx:sse:error fires on stream errors', async function() {
         let fetchCount = 0;
+        let connection;
         fetchMock.mockResponse('GET', '/error-test', () => {
             fetchCount++;
             if (fetchCount === 1) {
@@ -1005,6 +1006,9 @@ describe('hx-sse SSE extension', function() {
 
         let errorFired = false;
         let errorDetail = null;
+        onDoc('htmx:sse:before:connection', (e) => {
+            connection = e.detail.connection;
+        });
         onDoc('htmx:sse:error', (e) => {
             errorFired = true;
             errorDetail = e.detail;
@@ -1015,11 +1019,13 @@ describe('hx-sse SSE extension', function() {
 
         assert.isTrue(errorFired, 'htmx:sse:error should fire on stream error');
         assert.isNotNull(errorDetail.error, 'Error detail should contain error object');
+        assert.strictEqual(errorDetail.connection, connection);
     });
 
     it('htmx:sse:error fires on non-2xx reconnect response', async function() {
         this.timeout(5000);
         let fetchCount = 0;
+        let connection;
         fetchMock.mockResponse('GET', '/status-error', () => {
             fetchCount++;
             if (fetchCount === 1) {
@@ -1046,17 +1052,21 @@ describe('hx-sse SSE extension', function() {
         createProcessedHTML('<button hx-get="/status-error" hx-config="sse.reconnect:true sse.reconnectDelay:20ms sse.reconnectMaxAttempts:1" hx-swap="innerHTML">Go</button>');
 
         let errorFired = false;
-        let errorStatus = null;
+        let errorDetail = null;
+        onDoc('htmx:sse:before:connection', (e) => {
+            connection = e.detail.connection;
+        });
         onDoc('htmx:sse:error', (e) => {
             errorFired = true;
-            errorStatus = e.detail.status;
+            errorDetail = e.detail;
         });
 
         find('button').click();
         await new Promise(r => setTimeout(r, 200));
 
         assert.isTrue(errorFired, 'htmx:sse:error should fire for non-2xx reconnect');
-        assert.equal(errorStatus, 500, 'Error detail should include status code');
+        assert.equal(errorDetail.status, 500, 'Error detail should include status code');
+        assert.strictEqual(errorDetail.connection, connection);
     });
 
     it('htmx:sse:before:message cancellation prevents swap', async function() {

--- a/test/tests/ext/hx-sse.js
+++ b/test/tests/ext/hx-sse.js
@@ -284,10 +284,21 @@ describe('hx-sse SSE extension', function() {
         let beforeConnectFired = false;
         let beforeMessageFired = false;
         let afterMessageFired = false;
+        let connection;
+        let messageConnections = [];
 
-        onDoc('htmx:sse:before:connection', () => { beforeConnectFired = true; });
-        onDoc('htmx:sse:before:message', () => { beforeMessageFired = true; });
-        onDoc('htmx:sse:after:message', () => { afterMessageFired = true; });
+        onDoc('htmx:sse:before:connection', event => {
+            beforeConnectFired = true;
+            connection = event.detail.connection;
+        });
+        onDoc('htmx:sse:before:message', event => {
+            beforeMessageFired = true;
+            messageConnections.push(event.detail.connection);
+        });
+        onDoc('htmx:sse:after:message', event => {
+            afterMessageFired = true;
+            messageConnections.push(event.detail.connection);
+        });
 
         find('button').click();
         await htmx.timeout(1);
@@ -299,6 +310,7 @@ describe('hx-sse SSE extension', function() {
 
         assert.isTrue(beforeMessageFired, 'sse:before:message should fire');
         assert.isTrue(afterMessageFired, 'sse:after:message should fire');
+        assert.isTrue(messageConnections.every(value => value === connection));
         assertTextContentIs('button', 'test');
 
         stream.close();

--- a/www/src/content/extensions/01-hx-multipart.md
+++ b/www/src/content/extensions/01-hx-multipart.md
@@ -669,6 +669,7 @@ Cancel either way:
 
 Event detail includes:
 
+- `connection`: the multipart connection
 - `ctx`: the htmx request context
 - `part`: the [`BodyPart`](#handle-parts-yourself)
 - `cancelled`: set to `true` to cancel without `preventDefault()`
@@ -683,6 +684,8 @@ document.addEventListener('htmx:multipart:after:part', event => {
   console.log('Handled:', event.detail.part.headers)
 })
 ```
+
+Event detail includes `connection`, `ctx`, and `part`.
 
 ### `htmx:multipart:close`
 

--- a/www/src/content/extensions/01-hx-multipart.md
+++ b/www/src/content/extensions/01-hx-multipart.md
@@ -709,7 +709,7 @@ document.addEventListener('htmx:multipart:error', event => {
 })
 ```
 
-- `url`: the request URL
+- `connection`: the failed connection
 - `error`: the error value
 - `status`: the HTTP status when available
 

--- a/www/src/content/extensions/02-hx-sse.md
+++ b/www/src/content/extensions/02-hx-sse.md
@@ -439,11 +439,14 @@ event.detail.connection = {
 Message events expose:
 
 ```js
-event.detail.message = {
-  data,
-  event,
-  id,
-  cancelled // before processing only
+event.detail = {
+  connection,
+  message: {
+    data,
+    event,
+    id,
+    cancelled // before processing only
+  }
 }
 ```
 

--- a/www/src/content/extensions/02-hx-sse.md
+++ b/www/src/content/extensions/02-hx-sse.md
@@ -529,7 +529,8 @@ document.addEventListener('htmx:sse:error', event => {
 })
 ```
 
-- `url`: the SSE URL
+- `connection`: the failed connection, when available
+- `url`: the SSE URL when setup fails before a connection exists
 - `error`: the error value
 - `status`: the HTTP status for a failed reconnect response, when available
 


### PR DESCRIPTION
PR #3910 exposes the connection on `hx-ws` message and error events.

This aligns `hx-sse` and `hx-multipart`:

- SSE message events include `connection`.
- Multipart part events include `connection`.
- Stream and reconnect errors include `connection`.
- SSE setup errors keep `url` because no connection exists yet.

The event's connection is the same object exposed by its before/after connection events.
