### PR TITLE
Align `hx-sse` events with `hx-multipart` & `hx-ws`

### DIFF
--- a/src/editors/jetbrains/htmx.web-types.json
+++ b/src/editors/jetbrains/htmx.web-types.json
@@ -562,7 +562,7 @@
         },
         {
           "name": "sse:before:message",
-          "description": "Fires before an SSE message is processed. `detail.connection` identifies the stream; `detail.message` contains `data`, `event`, `id`, and `cancelled`.",
+          "description": "Fires before an SSE message is processed. `detail.connection` identifies the stream; `detail.message` contains `data`, `event`, and `id`. Use `detail.waitUntil()` to delay processing or set `detail.cancelled` to cancel.",
           "doc-url": "https://four.htmx.org/extensions/hx-sse#htmxssebeforemessage"
         },
         {

--- a/src/ext/hx-sse.js
+++ b/src/ext/hx-sse.js
@@ -256,18 +256,23 @@
 
                         if (!msg.hasData && !msg.event) continue;
 
+                        let pendingWork = [];
                         let detail = {
                             connection,
-                            message: {data: msg.data, event: msg.event, id: msg.id, cancelled: false}
+                            message: {data: msg.data, event: msg.event, id: msg.id},
+                            cancelled: false,
+                            waitUntil: promise => pendingWork.push(Promise.resolve(promise))
                         };
-                        if (!api.triggerHtmxEvent(element, 'htmx:sse:before:message', detail) || detail.message.cancelled) continue;
+                        let shouldProcess = api.triggerHtmxEvent(element, 'htmx:sse:before:message', detail);
+
+                        await Promise.all(pendingWork);
+                        if (!shouldProcess || detail.cancelled) continue;
 
                         if (msg.retry != null) config.reconnectDelay = msg.retry;
 
                         if (detail.message.event) {
                             htmx.trigger(element, detail.message.event, {data: detail.message.data, id: detail.message.id});
-                            delete detail.message.cancelled;
-                            api.triggerHtmxEvent(element, 'htmx:sse:after:message', detail);
+                            api.triggerHtmxEvent(element, 'htmx:sse:after:message', {connection, message: detail.message});
 
                             // hx-sse:close="eventname": close connection on matching event
                             let closeEvent = api.attributeValue(element, 'hx-sse:close');
@@ -284,8 +289,7 @@
                         // ensures OOB-only messages don't clear target (regardless of allowEmptySwapAfterOOB)
                         if (!ctx.swap.includes('swapEmpty')) ctx.swap += ' swapEmpty:false';
                         await htmx.swap(ctx);
-                        delete detail.message.cancelled;
-                        api.triggerHtmxEvent(element, 'htmx:sse:after:message', detail);
+                        api.triggerHtmxEvent(element, 'htmx:sse:after:message', {connection, message: detail.message});
                     }
                 } catch (e) {
                     if (!connection.abortController?.signal?.aborted) {

--- a/test/tests/ext/hx-sse.js
+++ b/test/tests/ext/hx-sse.js
@@ -1116,6 +1116,29 @@ describe('hx-sse SSE extension', function() {
         stream.close();
     });
 
+    it('processes messages in arrival order while waiting', async function() {
+        const stream = mockStreamResponse('/ordered-msg');
+        createProcessedHTML('<button hx-get="/ordered-msg" hx-swap="innerHTML">Original</button>');
+        let messages = [];
+
+        onDoc('htmx:sse:before:message', event => {
+            if (event.detail.message.data === 'first') event.detail.waitUntil(htmx.timeout(20));
+        });
+        onDoc('htmx:sse:after:message', event => messages.push(event.detail.message.data));
+
+        find('button').click();
+        await htmx.timeout(1);
+
+        stream.send('first');
+        stream.send('second');
+        await htmx.timeout(40);
+
+        assert.deepEqual(messages, ['first', 'second']);
+        assertTextContentIs('button', 'second');
+
+        stream.close();
+    });
+
     it('htmx:sse:before:message cancellation via preventDefault', async function() {
         const stream = mockStreamResponse('/cancel-prevent');
         createProcessedHTML('<button hx-get="/cancel-prevent" hx-swap="innerHTML">Original</button>');

--- a/test/tests/ext/hx-sse.js
+++ b/test/tests/ext/hx-sse.js
@@ -1139,6 +1139,34 @@ describe('hx-sse SSE extension', function() {
         stream.close();
     });
 
+    it('reconnects after waitUntil rejects', async function() {
+        const stream = mockStreamResponse('/rejected-work');
+        createProcessedHTML('<button hx-get="/rejected-work" hx-config="sse.reconnect:true sse.reconnectDelay:1ms" hx-swap="innerHTML">Original</button>');
+        let reject = true;
+
+        onDoc('htmx:sse:before:message', event => {
+            if (reject) {
+                reject = false;
+                event.detail.waitUntil(Promise.reject(new Error('message failed')));
+            }
+        });
+
+        find('button').click();
+        await htmx.timeout(1);
+
+        let error = waitForEvent('htmx:sse:error');
+        let reconnected = waitForEvent('htmx:sse:after:connection');
+        stream.send('Rejected');
+        assert.isNotNull(await error);
+        assert.isNotNull(await reconnected);
+
+        stream.send('Recovered');
+        assert.isNotNull(await waitForEvent('htmx:sse:after:message'));
+        assertTextContentIs('button', 'Recovered');
+
+        stream.close();
+    });
+
     it('htmx:sse:before:message cancellation via preventDefault', async function() {
         const stream = mockStreamResponse('/cancel-prevent');
         createProcessedHTML('<button hx-get="/cancel-prevent" hx-swap="innerHTML">Original</button>');

--- a/test/tests/ext/hx-sse.js
+++ b/test/tests/ext/hx-sse.js
@@ -1075,7 +1075,7 @@ describe('hx-sse SSE extension', function() {
 
         onDoc('htmx:sse:before:message', (e) => {
             if (e.detail.message.data === 'skip me') {
-                e.detail.message.cancelled = true;
+                e.detail.cancelled = true;
             }
         });
 
@@ -1089,6 +1089,29 @@ describe('hx-sse SSE extension', function() {
         stream.send('keep me');
         await waitForEvent('htmx:sse:after:message');
         assertTextContentIs('button', 'keep me', 'Non-cancelled message should swap');
+
+        stream.close();
+    });
+
+    it('htmx:sse:before:message waits for async work', async function() {
+        const stream = mockStreamResponse('/wait-msg');
+        createProcessedHTML('<button hx-get="/wait-msg" hx-swap="innerHTML">Original</button>');
+
+        onDoc('htmx:sse:before:message', event => {
+            event.detail.waitUntil(htmx.timeout(20).then(() => {
+                event.detail.message.data = 'Changed';
+            }));
+        });
+
+        find('button').click();
+        await htmx.timeout(1);
+
+        stream.send('Ignored');
+        await htmx.timeout(5);
+        assertTextContentIs('button', 'Original');
+
+        await waitForEvent('htmx:sse:after:message');
+        assertTextContentIs('button', 'Changed');
 
         stream.close();
     });

--- a/www/src/content/extensions/02-hx-sse.md
+++ b/www/src/content/extensions/02-hx-sse.md
@@ -444,9 +444,10 @@ event.detail = {
   message: {
     data,
     event,
-    id,
-    cancelled // before processing only
-  }
+    id
+  },
+  waitUntil(), // before processing only
+  cancelled    // before processing only
 }
 ```
 
@@ -490,6 +491,8 @@ document.addEventListener('htmx:sse:before:message', event => {
 ```
 
 Changing `message.data` changes the swap or named event data. Changing `message.event` changes whether the message swaps or dispatches a DOM event.
+
+`detail.waitUntil(promise)` delays processing until asynchronous work finishes. Cancel with `event.preventDefault()` or `detail.cancelled = true`.
 
 ### `htmx:sse:after:message`
 
@@ -692,3 +695,5 @@ RC1 namespaces SSE lifecycle events:
 | `htmx:after:sse:connection` | [`htmx:sse:after:connection`](#htmxsseafterconnection) |
 | `htmx:before:sse:message` | [`htmx:sse:before:message`](#htmxssebeforemessage) |
 | `htmx:after:sse:message` | [`htmx:sse:after:message`](#htmxsseaftermessage) |
+
+Message cancellation moved from `detail.message.cancelled` to `detail.cancelled`. Before-message hooks can delay processing with `detail.waitUntil(promise)`.


### PR DESCRIPTION
Aligns SSE message hooks with the other streaming extensions.

```js
// htmx:sse:before:message
{ message, cancelled, waitUntil }

// htmx:sse:after:message
{ message }
```

Adds:
- `waitUntil(promise)` to delay processing
- `cancelled = true` or `preventDefault()` to skips the message

PR #3960 separately adds `connection` to event detail.
