### PR TITLE
handle vary caching for nonced responses for hx-csp

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -411,7 +411,6 @@ var htmx = (() => {
                 HCON.merge(sourceElement._htmx.boosted, ctx);
             }
             ctx.target = this.__resolveTarget(sourceElement, ctx.target);
-            ctx.request.headers["HX-Request-Type"] = (ctx.target === document.body || ctx.select) ? "full" : "partial";
             if (ctx.target) {
                 ctx.request.headers["HX-Target"] = this.__buildIdentifier(ctx.target);
             }
@@ -575,6 +574,8 @@ var htmx = (() => {
                 disableElements = this.__disableElements(elt);
 
                 ctx.fetch ||= window.fetch.bind(window)
+                // Set HX-Request-Type based on final target/select (after all modifications)
+                ctx.request.headers["HX-Request-Type"] = (ctx.target === document.body || ctx.select) ? "full" : "partial";
                 if (!this.__trigger(elt, "htmx:before:request", {ctx})) return;
 
                 let response = await ctx.fetch(ctx.request.action, ctx.request);

--- a/test/tests/end2end/basic-history.js
+++ b/test/tests/end2end/basic-history.js
@@ -511,10 +511,56 @@ describe('scroll restoration on history traversal', function() {
     });
 });
 
+describe('HX-Request-Type header in history restore', function() {
+
+    beforeEach(function() { setupTest(); });
+    afterEach(function() { cleanupTest(); });
+
+    it('sends HX-Request-Type: full for history restore to body', async function() {
+        mockResponse('GET', '/restore-test', '<div>restored</div>', { headers: { 'HX-Reswap': 'none' } });
+
+        htmx.__restoreHistory({htmx: true}, '/restore-test');
+        await forRequest();
+
+        assert.equal(lastFetch().request.headers['HX-Request-Type'], 'full');
+    });
+
+    it('sends HX-Request-Type: full for history restore with hx-history-elt', async function() {
+        playground().innerHTML = '<main hx-history-elt><p>old</p></main>';
+        htmx.process(playground());
+
+        mockResponse('GET', '/restore-test', '<html><body><main hx-history-elt><p>new</p></main></body></html>', { headers: { 'HX-Reswap': 'none' } });
+
+        htmx.__restoreHistory({htmx: true}, '/restore-test');
+        await forRequest();
+
+        assert.equal(lastFetch().request.headers['HX-Request-Type'], 'full');
+    });
+
+    it('sends HX-History-Restore-Request: true for history restore', async function() {
+        mockResponse('GET', '/restore-test', '<div>restored</div>', { headers: { 'HX-Reswap': 'none' } });
+
+        htmx.__restoreHistory({htmx: true}, '/restore-test');
+        await forRequest();
+
+        assert.equal(lastFetch().request.headers['HX-History-Restore-Request'], 'true');
+    });
+
+    it('does not send HX-Request header for history restore (so servers return full pages)', async function() {
+        mockResponse('GET', '/restore-test', '<div>restored</div>', { headers: { 'HX-Reswap': 'none' } });
+
+        htmx.__restoreHistory({htmx: true}, '/restore-test');
+        await forRequest();
+
+        // HX-Request is intentionally omitted so servers return full pages
+        assert.isUndefined(lastFetch().request.headers['HX-Request']);
+    });
+});
+
 describe('history restore edge cases', function() {
 
-    beforeEach(() => { setupTest(this.currentTest); });
-    afterEach(() => { cleanupTest(); });
+    beforeEach(function() { setupTest(); });
+    afterEach(function() { cleanupTest(); });
 
     it('a second back aborts the in-flight restore', async function() {
         this.timeout(5000);

--- a/test/tests/unit/headers.js
+++ b/test/tests/unit/headers.js
@@ -65,39 +65,45 @@ describe('Request Headers', function() {
     describe('HX-Request-Type header', function() {
 
         it('sets to partial for regular element target', async function() {
-            createProcessedHTML('<div id="result"></div><button hx-get="js:" hx-target="#result"></button>');
+            mockResponse('GET', '/test', 'ok');
+            createProcessedHTML('<div id="result"></div><button hx-get="/test" hx-target="#result"></button>');
             let btn = document.querySelector('button');
-            let ctx = htmx.__createRequestContext(btn, new Event('click'));
-            await htmx.__handleTriggerEvent(ctx);
-            ctx.request.headers['HX-Request-Type'].should.equal('partial');
+            btn.click();
+            await forRequest();
+            lastFetch().request.headers['HX-Request-Type'].should.equal('partial');
         });
 
         it('sets to partial when targeting self', async function() {
-            let btn = createProcessedHTML('<button hx-get="js:"></button>');
-            let ctx = htmx.__createRequestContext(btn, new Event('click'));
-            await htmx.__handleTriggerEvent(ctx);
-            ctx.request.headers['HX-Request-Type'].should.equal('partial');
+            mockResponse('GET', '/test', 'ok');
+            let btn = createProcessedHTML('<button hx-get="/test"></button>');
+            btn.click();
+            await forRequest();
+            lastFetch().request.headers['HX-Request-Type'].should.equal('partial');
         });
 
         it('sets to full when targeting body', async function() {
-            let btn = createProcessedHTML('<button hx-get="js:" hx-target="body"></button>');
-            let ctx = htmx.__createRequestContext(btn, new Event('click'));
-            await htmx.__handleTriggerEvent(ctx);
-            ctx.request.headers['HX-Request-Type'].should.equal('full');
+            mockResponse('GET', '/test', 'ok');
+            let btn = createProcessedHTML('<button hx-get="/test" hx-target="body" hx-swap="none"></button>');
+            btn.click();
+            await forRequest();
+            lastFetch().request.headers['HX-Request-Type'].should.equal('full');
         });
 
         it('sets to full when hx-select is present', async function() {
-            let btn = createProcessedHTML('<button hx-get="js:" hx-select="#content"></button>');
-            let ctx = htmx.__createRequestContext(btn, new Event('click'));
-            await htmx.__handleTriggerEvent(ctx);
-            ctx.request.headers['HX-Request-Type'].should.equal('full');
+            mockResponse('GET', '/test', '<div id="content">ok</div>');
+            createProcessedHTML('<div id="result"></div><button hx-get="/test" hx-target="#result" hx-select="#content"></button>');
+            let btn = document.querySelector('button');
+            btn.click();
+            await forRequest();
+            lastFetch().request.headers['HX-Request-Type'].should.equal('full');
         });
 
         it('sets to full when hx-select and body target both present', async function() {
-            let btn = createProcessedHTML('<button hx-get="js:" hx-target="body" hx-select="#content"></button>');
-            let ctx = htmx.__createRequestContext(btn, new Event('click'));
-            await htmx.__handleTriggerEvent(ctx);
-            ctx.request.headers['HX-Request-Type'].should.equal('full');
+            mockResponse('GET', '/test', '<div id="content">ok</div>');
+            let btn = createProcessedHTML('<button hx-get="/test" hx-target="body" hx-select="#content" hx-swap="none"></button>');
+            btn.click();
+            await forRequest();
+            lastFetch().request.headers['HX-Request-Type'].should.equal('full');
         });
 
     });

--- a/www/src/content/extensions/14-hx-csp.md
+++ b/www/src/content/extensions/14-hx-csp.md
@@ -119,6 +119,19 @@ The server cannot know the page nonce — it only knows its own per-response non
 
 The risk: unlike `<script nonce>`, `hx-nonce` attributes are not blanked by browsers after parse, so they are a possible additional nonce exposure surface. The scrub step is a defence-in-depth measure to ensure a stolen nonce cannot be pre-stamped into injected content to pass nonce checks.
 
+## Caching Nonced Responses
+
+If you cache nonced responses, you must ensure that the initial page load and subsequent htmx requests are cached separately. Otherwise, the nonce reuse protection will block legitimate responses — when a user navigates back to a cached page via history restore, the cached response will contain the same nonce as the current page, triggering the scrub step.
+
+htmx sends an `HX-Request-Type` header with every request (`full` or `partial`). Add `Vary: HX-Request-Type` to separate the cache:
+
+```http
+Cache-Control: public, max-age=3600
+Vary: HX-Request-Type
+```
+
+This ensures initial page loads and htmx requests are cached separately, so the response nonce will always differ from the page nonce.
+
 ## Inline Scripts in Swapped Content
 
 When htmx swaps in HTML containing `<script>` tags, it re-creates them to trigger execution. The `hx-csp` extension ensures the response nonce is rewritten to the page nonce before parsing, so script nonces are correctly promoted and execute under a strict `script-src 'nonce-<nonce>'` policy.


### PR DESCRIPTION
## Add HX-Request-Type header for cache separation

Moves `HX-Request-Type` header setting from `__createRequestContext` to `__issueRequest`, right before the fetch. This ensures the header reflects the final target/select values after all modifications (ajax options, events, etc.) and eliminates duplication in `__restoreHistory`.

### Changes

- `HX-Request-Type` is now set once in `__issueRequest` based on final `ctx.target` and `ctx.select`
- History restore will now also send `HX-Request-Type` so its cache can be seperated
- Added tests for `HX-Request-Type` header in regular requests and history restore
- Updated hx-csp extension docs to explain `Vary: HX-Request-Type` for caching nonced responses

### Why

The `HX-Request-Type` header enables proper cache separation when using CSP nonces. Without it, a cached response from the initial page load could be served for a history restore request, triggering nonce reuse protection since the cached nonce matches the page nonce.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
