### PR TITLE
Add `waitUntil` to `htmx:before:response`

### DIFF
--- a/src/ext/hx-sse.js
+++ b/src/ext/hx-sse.js
@@ -377,11 +377,18 @@
             let contentType = ctx.response.raw.headers.get('Content-Type');
             if (!contentType?.includes('text/event-stream')) return;
 
-            // Take over; core will return without calling response.text()
+            clearTimeout(ctx.requestTimeout);
+            let releaseRequest;
+            let requestComplete = new Promise(resolve => releaseRequest = resolve);
+            element.addEventListener('htmx:sse:request:release', releaseRequest, {once: true});
             handleSSEResponse(ctx).catch(e => {
                 api.triggerHtmxEvent(element, 'htmx:sse:error', {error: e, url: ctx.request.action});
                 cleanup(element);
+            }).finally(() => {
+                element.removeEventListener('htmx:sse:request:release', releaseRequest);
+                releaseRequest();
             });
+            detail.waitUntil(requestComplete);
             return false;
         },
 

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -555,6 +555,7 @@ var htmx = (() => {
 
             let indicators = [];
             let disableElements = [];
+            let responseWork = [];
             try {
                 // Handle confirmation
                 if (ctx.confirm) {
@@ -586,7 +587,7 @@ var htmx = (() => {
                     headers: response.headers,
                 }
                 this.__extractHxHeaders(ctx);
-                if (!this.__trigger(elt, "htmx:before:response", {ctx})) return;
+                if (!this.__trigger(elt, "htmx:before:response", {ctx, waitUntil: promise => responseWork.push(Promise.resolve(promise))})) return;
                 ctx.text = await response.text();
                 if (!this.__trigger(elt, "htmx:after:request", {ctx})) return;
 
@@ -613,6 +614,7 @@ var htmx = (() => {
                 ctx.status = "error: " + error;
                 this.__trigger(elt, "htmx:error", {ctx, error})
             } finally {
+                await Promise.allSettled(responseWork);
                 clearTimeout(ctx.requestTimeout);
                 if (ctx.hx?.trigger) { // HX-Trigger
                     this.__handleTriggerHeader(ctx.hx.trigger, ctx.sourceElement);

--- a/test/tests/ext/hx-sse.js
+++ b/test/tests/ext/hx-sse.js
@@ -62,6 +62,51 @@ describe('hx-sse SSE extension', function() {
         stream.close();
     });
 
+    it('holds the request until the stream ends', async function() {
+        const stream = mockStreamResponse('/request-lifecycle');
+        let button = createProcessedHTML('<button hx-get="/request-lifecycle" hx-disable="this" hx-swap="innerHTML">Stream</button>');
+        let finallyFired = false;
+        button.addEventListener('htmx:finally:request', () => finallyFired = true);
+
+        button.click();
+        await htmx.timeout(1);
+        assert.isTrue(button.disabled);
+        assert.isFalse(finallyFired);
+
+        stream.send('message');
+        await waitForEvent('htmx:sse:after:message');
+        assert.isTrue(button.disabled);
+        assert.isFalse(finallyFired);
+
+        let finalized = waitForEvent('htmx:finally:request');
+        stream.close();
+        await finalized;
+        assert.isFalse(button.disabled);
+        assert.isTrue(finallyFired);
+    });
+
+    it('releases the request while the stream continues', async function() {
+        const stream = mockStreamResponse('/release-request');
+        let button = createProcessedHTML('<button hx-get="/release-request" hx-disable="this" hx-swap="innerHTML">Stream</button>');
+
+        button.click();
+        await htmx.timeout(1);
+        stream.send('shell');
+        await waitForEvent('htmx:sse:after:message');
+        assertTextContentIs('button', 'shell');
+        assert.isTrue(button.disabled);
+
+        let finalized = waitForEvent('htmx:finally:request');
+        stream.send('', 'htmx:sse:request:release');
+        await finalized;
+        assert.isFalse(button.disabled);
+
+        stream.send('late message');
+        await waitForEvent('htmx:sse:after:message');
+        assertTextContentIs('button', 'late message');
+        stream.close();
+    });
+
     it('continuous stream reconnects with exponential backoff', async function() {
         const stream = mockStreamResponse('/reconnect');
         createProcessedHTML('<button hx-get="/reconnect" hx-config="sse.reconnect:true sse.reconnectDelay:50ms sse.reconnectMaxAttempts:3 sse.reconnectJitter:0" hx-swap="innerHTML">Connect</button>');

--- a/test/tests/unit/__issueRequest.js
+++ b/test/tests/unit/__issueRequest.js
@@ -271,6 +271,39 @@ describe('__issueRequest unit tests', function() {
         assert.isTrue(finallyFired)
     })
 
+    it('waits for all htmx:before:response work before finalizing', async function () {
+        let div = createProcessedHTML('<button hx-get="/test" hx-disable="this" hx-swap="none">Go</button>')
+        let ctx = htmx.__createRequestContext(div, new Event('click'))
+        let rejectFirst
+        let resolveSecond
+        let first = new Promise((resolve, reject) => rejectFirst = reject)
+        let second = new Promise(resolve => resolveSecond = resolve)
+        let finallyFired = false
+
+        ctx.fetch = async () => ({status: 200, headers: new Headers(), text: async () => ''})
+        div.addEventListener('htmx:before:response', event => {
+            event.detail.waitUntil(first)
+            event.detail.waitUntil(second)
+            event.preventDefault()
+        })
+        div.addEventListener('htmx:finally:request', () => finallyFired = true)
+
+        let request = htmx.__issueRequest(ctx)
+        await htmx.timeout(1)
+        assert.isTrue(div.disabled)
+        assert.isFalse(finallyFired)
+
+        rejectFirst(new Error('extension failed'))
+        await htmx.timeout(1)
+        assert.isTrue(div.disabled)
+        assert.isFalse(finallyFired)
+
+        resolveSecond()
+        await request
+        assert.isFalse(div.disabled)
+        assert.isTrue(finallyFired)
+    })
+
     it('updates ctx.status through request lifecycle', async function () {
         let div = createProcessedHTML('<div hx-get="/test" hx-swap="none"></div>')
         let ctx = htmx.__createRequestContext(div, new Event('click'))


### PR DESCRIPTION
> **This PR was drafted by AI.**
>
> **I have not fully reviewed it.**

`waitUntil(promise)` follows the pattern of [`ExtendableEvent.waitUntil()`](https://developer.mozilla.org/en-US/docs/Web/API/ExtendableEvent/waitUntil) in Service Workers. It lets an event listener extend the lifetime of the operation associated with that event.

The same pattern already exists on SSE messages and multipart parts. This applies it to `htmx:before:response`, so extensions can delay request cleanup without adding an extension-specific promise to `ctx`:

```js
event.detail.waitUntil(promise)
```

`hx-sse` waits until the stream ends by default. An `htmx:sse:request:release` event releases the request earlier while later messages continue in the background.

Alternative to #3970.
