### PR TITLE
implement hx:hold and hx:release custom sse events to control request lifecycle

### DIFF
--- a/src/ext/hx-sse.js
+++ b/src/ext/hx-sse.js
@@ -114,10 +114,18 @@
 
     // Starts streaming from a response. Handles reconnection by re-fetching
     // with the saved request context (no full pipeline re-run).
-    async function handleSSEResponse(ctx) {
+    async function handleSSEResponse(ctx, releaseRequest) {
         let element = ctx.sourceElement;
         let config = getConfig(element);
         let reconnectRequested = false;
+        let held = false;
+
+        function release() {
+            if (releaseRequest) {
+                releaseRequest();
+                releaseRequest = null;
+            }
+        }
 
         let connection = {
             url: ctx.request.action,
@@ -270,6 +278,15 @@
 
                         if (msg.retry != null) config.reconnectDelay = msg.retry;
 
+                        // Lifecycle: hx:hold blocks release until hx:release
+                        if (detail.message.event === 'hx:hold') {
+                            held = true;
+                            detail.message.event = '';
+                        } else if (detail.message.event === 'hx:release') {
+                            held = false;
+                            detail.message.event = '';
+                        }
+
                         if (detail.message.event) {
                             htmx.trigger(element, detail.message.event, {data: detail.message.data, id: detail.message.id});
                             api.triggerHtmxEvent(element, 'htmx:sse:after:message', {connection, message: detail.message});
@@ -289,10 +306,11 @@
                         // ensures OOB-only messages don't clear target (regardless of allowEmptySwapAfterOOB)
                         if (!ctx.swap.includes('swapEmpty')) ctx.swap += ' swapEmpty:false';
                         await htmx.swap(ctx);
+                        if (!held) release();
                         api.triggerHtmxEvent(element, 'htmx:sse:after:message', {connection, message: detail.message});
                     }
                 } catch (e) {
-                    if (!connection.abortController?.signal?.aborted) {
+                    if (!connection.abortController?.signal?.aborted && e.name !== 'AbortError') {
                         api.triggerHtmxEvent(element, 'htmx:sse:error', {connection, error: e});
                     }
                 }
@@ -303,6 +321,7 @@
             }
         } finally {
             cleanup(element, element.isConnected ? 'ended' : 'removed');
+            release();  // Ensure request is released if stream ends
         }
     }
 
@@ -377,10 +396,14 @@
             let contentType = ctx.response.raw.headers.get('Content-Type');
             if (!contentType?.includes('text/event-stream')) return;
 
-            // Take over; core will return without calling response.text()
-            handleSSEResponse(ctx).catch(e => {
-                api.triggerHtmxEvent(element, 'htmx:sse:error', {error: e, url: ctx.request.action});
-                cleanup(element);
+            // Take over streaming; use extensionPromise to hold the request open
+            clearTimeout(ctx.requestTimeout);
+            let releaseRequest;
+            ctx.extensionPromise = new Promise(resolve => releaseRequest = resolve);
+            handleSSEResponse(ctx, releaseRequest).catch(e => {
+                if (e.name !== 'AbortError') {
+                    api.triggerHtmxEvent(element, 'htmx:sse:error', {error: e, url: ctx.request.action});
+                }
             });
             return false;
         },

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -613,6 +613,7 @@ var htmx = (() => {
                 ctx.status = "error: " + error;
                 this.__trigger(elt, "htmx:error", {ctx, error})
             } finally {
+                await ctx.extensionPromise?.catch(() => {});
                 clearTimeout(ctx.requestTimeout);
                 if (ctx.hx?.trigger) { // HX-Trigger
                     this.__handleTriggerHeader(ctx.hx.trigger, ctx.sourceElement);

--- a/test/tests/ext/hx-sse.js
+++ b/test/tests/ext/hx-sse.js
@@ -972,9 +972,14 @@ describe('hx-sse SSE extension', function() {
 
         await htmx.timeout(1);
 
+        // Set up listener for child's request completion BEFORE triggering
+        let childRequestComplete = new Promise(resolve => {
+            find('#child').addEventListener('htmx:finally:request', resolve, {once: true});
+        });
+
         stream.send('payload', 'update');
         await waitForEvent('htmx:sse:after:message');
-        await forRequest();
+        await childRequestComplete;  // Wait for the CHILD's request, not the parent's
 
         assertTextContentIs('#child', 'Updated!');
 
@@ -1518,5 +1523,299 @@ describe('hx-sse SSE extension', function() {
         console.warn = originalWarn;
 
         assert.equal(warnings.filter(warning => warning.includes('sse-swap')).length, 1);
+    });
+
+    // ========================================
+    // hx:hold / hx:release lifecycle tests
+    // ========================================
+
+    it('releases after first message when no hx:hold is sent', async function() {
+        const stream = mockStreamResponse('/no-begin');
+        createProcessedHTML('<button hx-get="/no-begin" hx-swap="innerHTML">Go</button>');
+
+        find('button').click();
+        await htmx.timeout(1);
+
+        // Register listener AFTER click to avoid catching events from previous tests
+        let finallyFired = false;
+        onDoc('htmx:finally:request', () => { finallyFired = true; });
+
+        assert.isFalse(finallyFired, 'finally should not fire before first message');
+
+        stream.send('first message');
+        await waitForEvent('htmx:sse:after:message');
+        await htmx.timeout(10);
+
+        assert.isTrue(finallyFired, 'finally should fire after first message');
+        assertTextContentIs('button', 'first message');
+
+        // Subsequent messages still work (background streaming)
+        stream.send('second message');
+        await waitForEvent('htmx:sse:after:message');
+        assertTextContentIs('button', 'second message');
+
+        stream.close();
+    });
+
+    it('hx:hold blocks until hx:release', async function() {
+        const stream = mockStreamResponse('/begin-ready');
+        createProcessedHTML('<button hx-get="/begin-ready" hx-swap="innerHTML">Go</button>');
+
+        find('button').click();
+        await htmx.timeout(1);
+
+        // Register listener AFTER click to avoid catching events from previous tests
+        let finallyFired = false;
+        onDoc('htmx:finally:request', () => { finallyFired = true; });
+
+        // Send hx:hold
+        stream.send('Loading...', 'hx:hold');
+        await waitForEvent('htmx:sse:after:message');
+        await htmx.timeout(10);
+
+        assert.isFalse(finallyFired, 'finally should NOT fire after hx:hold');
+        assertTextContentIs('button', 'Loading...');
+
+        // Send more messages while blocked
+        stream.send('Still loading...');
+        await waitForEvent('htmx:sse:after:message');
+        await htmx.timeout(10);
+
+        assert.isFalse(finallyFired, 'finally should still NOT fire during blocking');
+        assertTextContentIs('button', 'Still loading...');
+
+        // Send hx:release to release
+        stream.send('Done!', 'hx:release');
+        await waitForEvent('htmx:sse:after:message');
+        await htmx.timeout(10);
+
+        assert.isTrue(finallyFired, 'finally should fire after hx:release');
+        assertTextContentIs('button', 'Done!');
+
+        stream.close();
+    });
+
+    it('hx:hold/hx:release allows background streaming after release', async function() {
+        const stream = mockStreamResponse('/begin-ready-bg');
+        createProcessedHTML('<button hx-get="/begin-ready-bg" hx-swap="innerHTML">Go</button>');
+
+        find('button').click();
+        await htmx.timeout(1);
+
+        stream.send('Loading...', 'hx:hold');
+        await waitForEvent('htmx:sse:after:message');
+
+        stream.send('Complete', 'hx:release');
+        await waitForEvent('htmx:sse:after:message');
+        await htmx.timeout(10);
+
+        // Background streaming should continue
+        stream.send('Background update 1');
+        await waitForEvent('htmx:sse:after:message');
+        assertTextContentIs('button', 'Background update 1');
+
+        stream.send('Background update 2');
+        await waitForEvent('htmx:sse:after:message');
+        assertTextContentIs('button', 'Background update 2');
+
+        stream.close();
+    });
+
+    it('hx:hold with empty data still blocks', async function() {
+        const stream = mockStreamResponse('/begin-empty');
+        createProcessedHTML('<button hx-get="/begin-empty" hx-swap="innerHTML">Original</button>');
+
+        let finallyFired = false;
+        onDoc('htmx:finally:request', () => { finallyFired = true; });
+
+        find('button').click();
+        await htmx.timeout(1);
+
+        // Send hx:hold with no data
+        stream.sendRaw('event: hx:hold\ndata:\n\n');
+        await waitForEvent('htmx:sse:after:message');
+        await htmx.timeout(10);
+
+        assert.isFalse(finallyFired, 'finally should NOT fire after empty hx:hold');
+        assertTextContentIs('button', 'Original'); // No swap for empty data
+
+        stream.send('Ready!', 'hx:release');
+        await waitForEvent('htmx:sse:after:message');
+        await htmx.timeout(10);
+
+        assert.isTrue(finallyFired, 'finally should fire after hx:release');
+        assertTextContentIs('button', 'Ready!');
+
+        stream.close();
+    });
+
+    it('hx:release with empty data still releases', async function() {
+        const stream = mockStreamResponse('/ready-empty');
+        createProcessedHTML('<button hx-get="/ready-empty" hx-swap="innerHTML">Original</button>');
+
+        let finallyFired = false;
+        onDoc('htmx:finally:request', () => { finallyFired = true; });
+
+        find('button').click();
+        await htmx.timeout(1);
+
+        stream.send('Loading...', 'hx:hold');
+        await waitForEvent('htmx:sse:after:message');
+
+        // Send hx:release with no data
+        stream.sendRaw('event: hx:release\ndata:\n\n');
+        await waitForEvent('htmx:sse:after:message');
+        await htmx.timeout(10);
+
+        assert.isTrue(finallyFired, 'finally should fire after empty hx:release');
+        assertTextContentIs('button', 'Loading...'); // Content from hx:hold
+
+        stream.close();
+    });
+
+    it('indicators stay visible during hx:hold/hx:release blocking phase', async function() {
+        const stream = mockStreamResponse('/indicator-test');
+        createProcessedHTML(`
+            <button hx-get="/indicator-test" hx-swap="innerHTML" hx-indicator="#spinner">Go</button>
+            <div id="spinner" class="htmx-indicator">Loading...</div>
+        `);
+
+        find('button').click();
+        await htmx.timeout(1);
+
+        // Indicator should be visible
+        assert.isTrue(find('#spinner').classList.contains('htmx-request'), 'Indicator should be visible initially');
+
+        stream.send('Starting...', 'hx:hold');
+        await waitForEvent('htmx:sse:after:message');
+        await htmx.timeout(10);
+
+        // Indicator should STILL be visible during blocking
+        assert.isTrue(find('#spinner').classList.contains('htmx-request'), 'Indicator should stay visible during blocking');
+
+        stream.send('Done!', 'hx:release');
+        await waitForEvent('htmx:sse:after:message');
+        await htmx.timeout(10);
+
+        // Indicator should be hidden after release
+        assert.isFalse(find('#spinner').classList.contains('htmx-request'), 'Indicator should hide after hx:release');
+
+        stream.close();
+    });
+
+    it('disabled elements stay disabled during hx:hold/hx:release blocking phase', async function() {
+        const stream = mockStreamResponse('/disable-test');
+        createProcessedHTML(`
+            <form hx-get="/disable-test" hx-swap="innerHTML" hx-target="#output" hx-disable="find input, find button">
+                <input type="text" value="test">
+                <button type="submit">Submit</button>
+            </form>
+            <div id="output"></div>
+        `);
+
+        find('button').click();
+        await htmx.timeout(1);
+
+        // Elements should be disabled
+        assert.isTrue(find('input').disabled, 'Input should be disabled initially');
+        assert.isTrue(find('button').disabled, 'Button should be disabled initially');
+
+        stream.send('Processing...', 'hx:hold');
+        await waitForEvent('htmx:sse:after:message');
+        await htmx.timeout(10);
+
+        // Elements should STILL be disabled during blocking
+        assert.isTrue(find('input').disabled, 'Input should stay disabled during blocking');
+        assert.isTrue(find('button').disabled, 'Button should stay disabled during blocking');
+
+        stream.send('Complete!', 'hx:release');
+        await waitForEvent('htmx:sse:after:message');
+        await htmx.timeout(10);
+
+        // Elements should be re-enabled after release
+        assert.isFalse(find('input').disabled, 'Input should be enabled after hx:release');
+        assert.isFalse(find('button').disabled, 'Button should be enabled after hx:release');
+
+        stream.close();
+    });
+
+    it('stream ending during blocking phase still cleans up', async function() {
+        let ctrl;
+        fetchMock.mockResponse('GET', '/end-during-block', () => {
+            const body = new ReadableStream({ start(c) { ctrl = c; } });
+            const response = new MockResponse(body, {
+                headers: { 'Content-Type': 'text/event-stream' }
+            });
+            response.body = body;
+            return response;
+        });
+
+        createProcessedHTML('<button hx-get="/end-during-block" hx-swap="innerHTML">Go</button>');
+
+        let closeFired = false;
+        let closeReason = null;
+        onDoc('htmx:sse:close', (e) => {
+            closeFired = true;
+            closeReason = e.detail.reason;
+        });
+
+        find('button').click();
+        await htmx.timeout(1);
+
+        // Send hx:hold
+        const enc = new TextEncoder();
+        ctrl.enqueue(enc.encode('event: hx:hold\ndata: Loading...\n\n'));
+        await waitForEvent('htmx:sse:after:message');
+
+        // Close stream without sending hx:release
+        ctrl.close();
+        await waitForEvent('htmx:sse:close');
+
+        assert.isTrue(closeFired, 'close event should fire');
+        assert.equal(closeReason, 'ended', 'Close reason should be "ended"');
+    });
+
+    it('hx-sse:close during blocking phase closes connection', async function() {
+        const stream = mockStreamResponse('/close-during-block');
+        createProcessedHTML('<button hx-get="/close-during-block" hx-sse:close="done" hx-swap="innerHTML">Go</button>');
+
+        let closeFired = false;
+        onDoc('htmx:sse:close', () => { closeFired = true; });
+
+        find('button').click();
+        await htmx.timeout(1);
+
+        stream.send('Loading...', 'hx:hold');
+        await waitForEvent('htmx:sse:after:message');
+
+        // Send close event during blocking
+        stream.send('Closing', 'done');
+        await waitForEvent('htmx:sse:close');
+
+        assert.isTrue(closeFired, 'Connection should close on matching event during blocking');
+    });
+
+    it('multiple messages between hx:hold and hx:release all swap', async function() {
+        const stream = mockStreamResponse('/multi-swap');
+        createProcessedHTML('<div id="target" hx-get="/multi-swap" hx-swap="beforeend">Start:</div>');
+
+        find('#target').click();
+        await htmx.timeout(1);
+
+        stream.send('<span>1</span>', 'hx:hold');
+        await waitForEvent('htmx:sse:after:message');
+
+        stream.send('<span>2</span>');
+        await waitForEvent('htmx:sse:after:message');
+
+        stream.send('<span>3</span>');
+        await waitForEvent('htmx:sse:after:message');
+
+        stream.send('<span>4</span>', 'hx:release');
+        await waitForEvent('htmx:sse:after:message');
+
+        assertTextContentIs('#target', 'Start:1234');
+
+        stream.close();
     });
 });

--- a/www/src/content/extensions/02-hx-sse.md
+++ b/www/src/content/extensions/02-hx-sse.md
@@ -303,6 +303,36 @@ event-43  ------------------->  replayed
 
 The server decides which messages to replay. `hx-sse` processes every event it receives and does not deduplicate replays.
 
+### Control Request Lifecycle
+
+By default, htmx completes the request lifecycle after the first SSE message arrives. Use `hx:hold` and `hx:release` events to keep the request open longer.
+
+Send `hx:hold` as the first message to block the request lifecycle:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: text/event-stream
+
+event: hx:hold
+data:
+
+data: First chunk
+
+data: Second chunk
+
+event: hx:release
+data:
+
+```
+
+The request stays open until `hx:release` arrives. This keeps:
+
+- The `.htmx-request` class on the element
+- The element disabled (when [`hx-disable`](/reference/attributes/hx-disable) is used)
+- Request indicators visible
+
+Without `hx:hold`, the request completes after the first message and indicators disappear while streaming continues.
+
 ### Trigger Client Events
 
 An SSE `event` field dispatches a DOM event instead of swapping its data:
@@ -503,6 +533,30 @@ document.addEventListener('htmx:sse:after:message', event => {
   console.log('Received:', event.detail.message.data)
 })
 ```
+
+### `hx:hold`
+
+A named SSE event that blocks the request lifecycle until `hx:release` arrives.
+
+```http
+event: hx:hold
+data:
+
+```
+
+Must be the first message in the stream. The request stays open, keeping `.htmx-request` on the element and indicators visible.
+
+### `hx:release`
+
+A named SSE event that releases a request blocked by `hx:hold`.
+
+```http
+event: hx:release
+data:
+
+```
+
+After this event, the request lifecycle completes normally. If `hx:hold` was not sent, this event is ignored.
 
 ### `htmx:sse:close`
 


### PR DESCRIPTION


## Problem

When using SSE for user-initiated streaming (LLM chat, report generation), indicators disappear and inputs re-enable as soon as headers arrive—before any content appears. For long streams (30-60s+), blocking until stream end makes the UI feel broken.

## Solution

Two new SSE events give servers control over when the request lifecycle ends:

- `hx:hold` — Keep indicators visible and elements disabled
- `hx:release` — Release the request lifecycle, allow new interactions

**Default behavior** (no lifecycle events): Release after first message swaps—not on headers, not on stream end.

## Usage

```html
<button hx-post="/chat" sse-swap="message" 
        hx-indicator="#spinner" hx-disabled="this">
  Ask
</button>
```

Server can optionally control timing:
```
event: hx:hold
data: <div>Processing...</div>

data: <p>First paragraph...</p>

event: hx:release
data: <p>Ready for next question</p>

data: <p>Still streaming details...</p>
```

## Behavior Summary

| Scenario | Release Trigger |
|----------|-----------------|
| No lifecycle events | After first message |
| `hx:hold` sent | On `hx:release` or stream end |

Backward compatible—existing SSE usage works unchanged with better default timing.


Corresponding issue:

## Testing
Added new sse tests for the new timing behaviour

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
