### PR TITLE
handle request abort on cleanup in sse extension

### DIFF
--- a/src/ext/hx-sse.js
+++ b/src/ext/hx-sse.js
@@ -122,7 +122,7 @@
         let connection = {
             url: ctx.request.action,
             config: config,
-            abortController: null,
+            abortController: { abort: ctx.request.abort, signal: ctx.request.signal },
             reader: null,
             lastEventId: '',
             delayCanceller: null,

--- a/test/tests/ext/hx-sse.js
+++ b/test/tests/ext/hx-sse.js
@@ -1507,6 +1507,36 @@ describe('hx-sse SSE extension', function() {
         assert.equal(warnings.filter(warning => warning.includes('sse-close')).length, 1);
     });
 
+    it('cleanup aborts the initial connection fetch when element is swapped out', async function() {
+        const stream = mockStreamResponse('/abort-initial');
+        mockResponse('GET', '/replace', '<div id="replacement">Replaced</div>');
+        
+        createProcessedHTML('<div id="container" hx-get="/replace" hx-trigger="click" hx-swap="innerHTML"><div id="sse" hx-sse:connect="/abort-initial" hx-swap="innerHTML">Waiting</div></div>');
+
+        await htmx.timeout(1);
+
+        stream.send('connected');
+        await waitForEvent('htmx:sse:after:message');
+        assertTextContentIs('#sse', 'connected');
+
+        // Grab the connection before cleanup
+        let connection = find('#sse')._htmx.sse;
+        assert.isNotNull(connection.abortController, 'Initial connection should have abortController');
+        assert.isNotNull(connection.abortController.signal, 'abortController should have signal');
+        assert.isFalse(connection.abortController.signal.aborted, 'Signal should not be aborted yet');
+
+        let closeFired = false;
+        onDoc('htmx:sse:close', () => { closeFired = true; });
+
+        // Trigger htmx swap which should call htmx_before_cleanup on the SSE element
+        find('#container').click();
+        await forRequest();
+
+        assertTextContentIs('#container', 'Replaced');
+        assert.isTrue(closeFired, 'htmx:sse:close should fire');
+        assert.isTrue(connection.abortController.signal.aborted, 'Cleanup should abort the initial connection');
+    });
+
     it('warns once for removed sse-swap attribute', function() {
         let warnings = [];
         let originalWarn = console.warn;


### PR DESCRIPTION
## Description
Fix in src/ext/hx-sse.js:

// Before (line ~125):
abortController: null,

// After:
abortController: { abort: ctx.request.abort, signal: ctx.request.signal },

This wires up the initial connection to use htmx core's abort controller, so when cleanup() calls connection.abortController?.abort(), it actually aborts the underlying fetch.

Corresponding issue:
#3974

## Testing
Added test 

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
