### PR TITLE
Add reset trigger and swap modifiers to reset the closest form

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -508,6 +508,7 @@ var htmx = (() => {
             })
 
             if (!this.__trigger(elt, "htmx:config:request", {ctx: ctx})) return
+            if (elt._htmx?.triggerSpecs?.some(s => s.reset)) elt.closest?.('form')?.reset();
             if (ctx.request.method === 'DIALOG') return
 
             let javascriptContent = this.__extractJavascriptContent(ctx.request.action);
@@ -1347,6 +1348,7 @@ var htmx = (() => {
             }
             let swapStyle = swapSpec.style;
             if (swapStyle === 'none') return;
+            if (swapSpec.reset) task.sourceElement?.closest?.('form')?.reset();
             // full-page response: fragment has a <body> wrapper, so upgrade outerHTML to outerSync, strip for everything else
             if (fragment.firstElementChild?.tagName === 'BODY') {
                 if (swapStyle === 'outerHTML') swapStyle = 'outerSync';

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -508,7 +508,6 @@ var htmx = (() => {
             })
 
             if (!this.__trigger(elt, "htmx:config:request", {ctx: ctx})) return
-            if (elt._htmx?.triggerSpecs?.some(s => s.reset)) elt.closest?.('form')?.reset();
             if (ctx.request.method === 'DIALOG') return
 
             let javascriptContent = this.__extractJavascriptContent(ctx.request.action);
@@ -753,6 +752,7 @@ var htmx = (() => {
                     if (spec.once) {
                         for (let info of spec.listeners) info.fromElt.removeEventListener(info.eventName, info.handler, info);
                     }
+                    if (spec.reset) elt.closest?.('form')?.reset();
                     handler(evt);
                 };
 

--- a/test/tests/attributes/hx-swap.js
+++ b/test/tests/attributes/hx-swap.js
@@ -8,6 +8,31 @@ describe('hx-swap modifiers', function() {
         cleanupTest()
     })
 
+    it('reset modifier resets form after swap', async function () {
+        mockResponse('POST', '/test', '<div id="result">Done</div>')
+        createProcessedHTML('<form id="f" hx-post="/test" hx-swap="beforeend reset" hx-target="#out"><input name="msg" value=""/></form><div id="out"></div>')
+        let input = find('input')
+        input.value = 'typed'
+        find('#f').dispatchEvent(new Event('submit', {bubbles: true, cancelable: true}))
+        // Form should NOT be reset yet (safe - waits for swap)
+        input.value.should.equal('typed')
+        await forRequest()
+        // Now form should be reset after successful swap
+        input.value.should.equal('')
+        find('#result').textContent.should.equal('Done')
+    })
+
+    it('swap:none with reset does not reset (no-op)', async function () {
+        mockResponse('POST', '/test', 'ignored')
+        createProcessedHTML('<form id="f" hx-post="/test" hx-swap="none reset"><input name="msg" value=""/></form>')
+        let input = find('input')
+        input.value = 'typed'
+        find('#f').dispatchEvent(new Event('submit', {bubbles: true, cancelable: true}))
+        await forRequest()
+        // swap:none means no swap happens, so reset should not fire
+        input.value.should.equal('typed')
+    })
+
     it('properly parses various swap specifications', function() {
         assert.equal(htmx.__parseSwapSpec('innerHTML').style, 'innerHTML')
         assert.equal(htmx.__parseSwapSpec('innerHTML').swap, undefined)

--- a/test/tests/attributes/hx-trigger.js
+++ b/test/tests/attributes/hx-trigger.js
@@ -6,6 +6,27 @@ describe('hx-trigger attribute', function() {
         cleanupTest()
     })
 
+    it('reset modifier resets form before request', async function () {
+        mockResponse('POST', '/test', 'Done')
+        let form = createProcessedHTML('<form hx-post="/test" hx-trigger="submit reset"><input name="msg" value=""/></form>')
+        let input = form.querySelector('input')
+        input.value = 'changed'
+        form.dispatchEvent(new Event('submit', {bubbles: true, cancelable: true}))
+        // Form should be reset immediately (optimistic) - back to default value (empty)
+        input.value.should.equal('')
+        await forRequest()
+    })
+
+    it('reset modifier works on button inside form', async function () {
+        mockResponse('POST', '/test', 'Done')
+        createProcessedHTML('<form id="f"><input name="msg" value=""/><button hx-post="/test" hx-trigger="click reset">Send</button></form>')
+        let input = find('input')
+        input.value = 'typed'
+        find('button').click()
+        input.value.should.equal('')
+        await forRequest()
+    })
+
     it('non-default triggers work', async function () {
         mockResponse('GET', '/test', 'Clicked!')
         createProcessedHTML('<form hx-get="/test" hx-trigger="click">Click Me!</form>')

--- a/www/src/content/reference/01-attributes/07-hx-trigger.md
+++ b/www/src/content/reference/01-attributes/07-hx-trigger.md
@@ -216,6 +216,19 @@ Tells the browser the handler won't call `preventDefault()`, so the browser can 
 <div hx-trigger="scroll passive" hx-get="...">...</div>
 ```
 
+### `reset`
+
+Resets the enclosing form to return all input values to their defaults when the trigger fires (before the request is sent).
+
+```html
+<form hx-post="/chat" hx-trigger="submit reset">
+  <input name="message">
+  <button>Send</button>
+</form>
+```
+
+This is "optimistic" - the form resets immediately, even if the request fails. For safer reset after a successful response, use [`hx-swap`](/reference/attributes/hx-swap#reset) instead.
+
 ### Example
 
 A search box that searches on `input`, but only if the value has [`changed`](#changed) and the user hasn't typed anything new for 1 second ([`delay`](#delay)):

--- a/www/src/content/reference/01-attributes/08-hx-swap.md
+++ b/www/src/content/reference/01-attributes/08-hx-swap.md
@@ -353,6 +353,24 @@ Use `swapEmpty` to keep the target or clear it:
 
 Default behavior: skip if partials or OOB swaps were extracted (unless [`htmx.config.allowEmptySwapAfterOOB`](/reference/config/htmx-config-allowEmptySwapAfterOOB) is `true`)
 
+### `reset`
+
+Resets the enclosing form after a successful swap.
+
+```html
+<form hx-post="/chat" hx-swap="beforeend reset" hx-target="#messages">
+  <input name="message">
+  <button>Send</button>
+</form>
+```
+
+The form only resets after the response is received and swapped. For "optimistic" reset before the request, use [`hx-trigger`](/reference/attributes/hx-trigger#reset) instead.
+
+The form won't reset when no swap occurs:
+- `swap:none`
+- Status codes in [`htmx.config.noSwap`](/reference/config/htmx-config-noSwap) (default: 204, 304)
+- [`hx-status`](/reference/attributes/hx-status) overrides to `swap:none`
+
 ## Caveats
 
 - On `<body>`, `outerHTML` behaves like [`outerSync`](#outersync):


### PR DESCRIPTION
## Description
Add new modifiers to swap and trigger that reset the closest form input values by just using hx-trigger="submit reset" or hx-swap="innerHTML reset".  Trigger form happens at trigger event just before it sends the request and the swap form happens after a valid swap happens which is safer if the request fails but is not as instant.

Corresponding issue:

## Testing
Added basic tests.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
