### PR TITLE
docs: fix dead sinon fake-xhr link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ At this point you can modify `/src/htmx.js` to add features, and then add tests 
 * `/test/manual` - manual tests that cannot be automated
 
 htmx uses the [mocha](https://mochajs.org/) testing framework, the [chai](https://www.chaijs.com/) assertion framework
-and [sinon](https://sinonjs.org/releases/v9/fake-xhr-and-server/) to mock out AJAX requests.  They are all OK.
+and [sinon](https://web.archive.org/web/20250114212846/https://sinonjs.org/releases/v9/fake-xhr-and-server/) to mock out AJAX requests.  They are all OK.
 
 ## haiku
 


### PR DESCRIPTION
The sinon "fake XHR and server" link in the README returns **HTTP 404** — sinonjs.org was rebuilt and no longer hosts any `/releases/vN/fake-xhr-and-server/` pages (the functionality was split into the `nise` package and the doc has no live equivalent). Replaced with the Internet Archive snapshot of the referenced page (HTTP 200, "Fake XHR and server - Sinon.JS").
