### PR TITLE
add config for sse.releaseOn:end to allow control of when requests unblock

### DIFF
--- a/src/ext/hx-sse.js
+++ b/src/ext/hx-sse.js
@@ -17,7 +17,7 @@
             reconnectMaxAttempts: Infinity,
             reconnectJitter: 0.3,
             pauseOnBackground: hasHxSseConnect,
-            releaseOn: hasHxSseConnect ? 'immediate' : 'first',
+            releaseOn: hasHxSseConnect ? 'immediate' : 'end',
             ...htmx.config.sse,
             ...hxConfig
         };

--- a/src/ext/hx-sse.js
+++ b/src/ext/hx-sse.js
@@ -17,6 +17,7 @@
             reconnectMaxAttempts: Infinity,
             reconnectJitter: 0.3,
             pauseOnBackground: hasHxSseConnect,
+            releaseOn: hasHxSseConnect ? 'immediate' : 'first',
             ...htmx.config.sse,
             ...hxConfig
         };
@@ -114,10 +115,19 @@
 
     // Starts streaming from a response. Handles reconnection by re-fetching
     // with the saved request context (no full pipeline re-run).
-    async function handleSSEResponse(ctx) {
+    async function handleSSEResponse(ctx, releaseRequest) {
         let element = ctx.sourceElement;
         let config = getConfig(element);
         let reconnectRequested = false;
+
+        function release() {
+            if (releaseRequest) {
+                releaseRequest();
+                releaseRequest = null;
+            }
+        }
+
+        if (config.releaseOn === 'immediate') release();
 
         let connection = {
             url: ctx.request.action,
@@ -271,6 +281,9 @@
                         if (msg.retry != null) config.reconnectDelay = msg.retry;
 
                         if (detail.message.event) {
+                            // hx:release triggers early release
+                            if (detail.message.event === 'hx:release') release();
+
                             htmx.trigger(element, detail.message.event, {data: detail.message.data, id: detail.message.id});
                             api.triggerHtmxEvent(element, 'htmx:sse:after:message', {connection, message: detail.message});
 
@@ -289,6 +302,7 @@
                         // ensures OOB-only messages don't clear target (regardless of allowEmptySwapAfterOOB)
                         if (!ctx.swap.includes('swapEmpty')) ctx.swap += ' swapEmpty:false';
                         await htmx.swap(ctx);
+                        if (config.releaseOn === 'first') release();
                         api.triggerHtmxEvent(element, 'htmx:sse:after:message', {connection, message: detail.message});
                     }
                 } catch (e) {
@@ -303,6 +317,7 @@
                 connection.attempt++;
             }
         } finally {
+            release();  // Always release when stream ends
             cleanup(element, element.isConnected ? 'ended' : 'removed');
         }
     }
@@ -378,16 +393,15 @@
             let contentType = ctx.response.raw.headers.get('Content-Type');
             if (!contentType?.includes('text/event-stream')) return;
 
-            // Take over; core will return without calling response.text().
-            // A stream has no fixed duration, so drop the request timeout, and
-            // hand core a promise so it holds the request open until we finish.
+            // Take over streaming; use extensionPromise to hold the request open
             clearTimeout(ctx.requestTimeout);
-            ctx.extensionPromise = handleSSEResponse(ctx).catch(e => {
+            let releaseRequest;
+            ctx.extensionPromise = new Promise(resolve => releaseRequest = resolve);
+            handleSSEResponse(ctx, releaseRequest).catch(e => {
                 // an aborted stream is a normal end, not an error
                 if (e.name !== 'AbortError') {
                     api.triggerHtmxEvent(element, 'htmx:sse:error', {error: e, url: ctx.request.action});
                 }
-                cleanup(element);
             });
             return false;
         },

--- a/test/tests/ext/hx-sse.js
+++ b/test/tests/ext/hx-sse.js
@@ -1519,4 +1519,140 @@ describe('hx-sse SSE extension', function() {
 
         assert.equal(warnings.filter(warning => warning.includes('sse-swap')).length, 1);
     });
+
+    // ========================================
+    // releaseOn / hx:release tests
+    // ========================================
+
+    it('releases after first message by default (releaseOn:first)', async function() {
+        const stream = mockStreamResponse('/no-begin');
+        createProcessedHTML('<button hx-get="/no-begin" hx-swap="innerHTML">Go</button>');
+
+        find('button').click();
+        await htmx.timeout(1);
+
+        let finallyFired = false;
+        onDoc('htmx:finally:request', () => { finallyFired = true; });
+
+        assert.isFalse(finallyFired, 'finally should not fire before first message');
+
+        stream.send('first message');
+        await waitForEvent('htmx:sse:after:message');
+        await htmx.timeout(10);
+
+        assert.isTrue(finallyFired, 'finally should fire after first message');
+        assertTextContentIs('button', 'first message');
+
+        // Subsequent messages still work (background streaming)
+        stream.send('second message');
+        await waitForEvent('htmx:sse:after:message');
+        assertTextContentIs('button', 'second message');
+
+        stream.close();
+    });
+
+    it('hx:release event triggers early release', async function() {
+        const stream = mockStreamResponse('/release-test');
+        createProcessedHTML('<button hx-get="/release-test" hx-config="sse.releaseOn:end" hx-swap="innerHTML" hx-indicator="#spinner">Go</button><div id="spinner" class="htmx-indicator">Loading...</div>');
+
+        find('button').click();
+        await htmx.timeout(1);
+
+        // Indicator should be visible
+        assert.isTrue(find('#spinner').classList.contains('htmx-request'), 'Indicator should be visible initially');
+
+        stream.send('Still streaming...');
+        await waitForEvent('htmx:sse:after:message');
+        await htmx.timeout(10);
+
+        // Indicator should still be visible (releaseOn:end)
+        assert.isTrue(find('#spinner').classList.contains('htmx-request'), 'Indicator should stay visible with releaseOn:end');
+
+        // Send hx:release event to trigger early release
+        stream.send('', 'hx:release');
+        await waitForEvent('htmx:sse:after:message');
+        await htmx.timeout(10);
+
+        // Indicator should be hidden after hx:release
+        assert.isFalse(find('#spinner').classList.contains('htmx-request'), 'Indicator should hide after hx:release');
+
+        // But streaming should continue
+        stream.send('More content');
+        await waitForEvent('htmx:sse:after:message');
+        assertTextContentIs('button', 'More content');
+
+        stream.close();
+    });
+
+    it('releaseOn:immediate releases right away for hx-sse:connect', async function() {
+        const stream = mockStreamResponse('/immediate-test');
+        createProcessedHTML('<div hx-sse:connect="/immediate-test" hx-swap="innerHTML" hx-indicator="#spinner">Waiting</div><div id="spinner" class="htmx-indicator">Loading...</div>');
+
+        await htmx.timeout(10);
+
+        // Indicator should already be hidden (immediate release)
+        assert.isFalse(find('#spinner').classList.contains('htmx-request'), 'Indicator should hide immediately for hx-sse:connect');
+
+        // But streaming should work
+        stream.send('content');
+        await waitForEvent('htmx:sse:after:message');
+        assertTextContentIs('div', 'content');
+
+        stream.close();
+    });
+
+    it('releaseOn:end releases when stream closes', async function() {
+        const stream = mockStreamResponse('/end-test');
+        createProcessedHTML('<button hx-get="/end-test" hx-config="sse.releaseOn:end" hx-swap="innerHTML" hx-indicator="#spinner">Go</button><div id="spinner" class="htmx-indicator">Loading...</div>');
+
+        find('button').click();
+        await htmx.timeout(1);
+
+        stream.send('message 1');
+        await waitForEvent('htmx:sse:after:message');
+        await htmx.timeout(10);
+
+        // Indicator should still be visible
+        assert.isTrue(find('#spinner').classList.contains('htmx-request'), 'Indicator should stay visible during streaming');
+
+        stream.send('message 2');
+        await waitForEvent('htmx:sse:after:message');
+        await htmx.timeout(10);
+
+        // Still visible
+        assert.isTrue(find('#spinner').classList.contains('htmx-request'), 'Indicator should stay visible after multiple messages');
+
+        stream.close();
+        await waitForEvent('htmx:sse:close');
+        await htmx.timeout(10);
+
+        // Now hidden
+        assert.isFalse(find('#spinner').classList.contains('htmx-request'), 'Indicator should hide when stream closes');
+    });
+
+    it('multiple hx:release events are idempotent', async function() {
+        const stream = mockStreamResponse('/multi-release');
+        createProcessedHTML('<button hx-get="/multi-release" hx-config="sse.releaseOn:end" hx-swap="innerHTML">Go</button>');
+
+        find('button').click();
+        await htmx.timeout(1);
+
+        stream.send('content');
+        await waitForEvent('htmx:sse:after:message');
+
+        // Send multiple hx:release events - should not cause errors
+        stream.send('', 'hx:release');
+        await waitForEvent('htmx:sse:after:message');
+        stream.send('', 'hx:release');
+        await waitForEvent('htmx:sse:after:message');
+        stream.send('', 'hx:release');
+        await waitForEvent('htmx:sse:after:message');
+
+        // Streaming should still work
+        stream.send('more content');
+        await waitForEvent('htmx:sse:after:message');
+        assertTextContentIs('button', 'more content');
+
+        stream.close();
+    });
 });

--- a/test/tests/ext/hx-sse.js
+++ b/test/tests/ext/hx-sse.js
@@ -1524,24 +1524,51 @@ describe('hx-sse SSE extension', function() {
     // releaseOn / hx:release tests
     // ========================================
 
-    it('releases after first message by default (releaseOn:first)', async function() {
-        const stream = mockStreamResponse('/no-begin');
-        createProcessedHTML('<button hx-get="/no-begin" hx-swap="innerHTML">Go</button>');
+    it('releases when stream closes by default (releaseOn:end)', async function() {
+        const stream = mockStreamResponse('/default-release');
+        createProcessedHTML('<button hx-get="/default-release" hx-swap="innerHTML" hx-indicator="#spinner">Go</button><div id="spinner" class="htmx-indicator">Loading...</div>');
 
         find('button').click();
         await htmx.timeout(1);
-
-        let finallyFired = false;
-        onDoc('htmx:finally:request', () => { finallyFired = true; });
-
-        assert.isFalse(finallyFired, 'finally should not fire before first message');
 
         stream.send('first message');
         await waitForEvent('htmx:sse:after:message');
         await htmx.timeout(10);
 
-        assert.isTrue(finallyFired, 'finally should fire after first message');
-        assertTextContentIs('button', 'first message');
+        // Indicator should still be visible (default is releaseOn:end)
+        assert.isTrue(find('#spinner').classList.contains('htmx-request'), 'Indicator should stay visible during streaming');
+
+        stream.send('second message');
+        await waitForEvent('htmx:sse:after:message');
+        await htmx.timeout(10);
+
+        // Still visible
+        assert.isTrue(find('#spinner').classList.contains('htmx-request'), 'Indicator should stay visible after multiple messages');
+
+        stream.close();
+        await waitForEvent('htmx:sse:close');
+        await htmx.timeout(10);
+
+        // Now hidden
+        assert.isFalse(find('#spinner').classList.contains('htmx-request'), 'Indicator should hide when stream closes');
+    });
+
+    it('releaseOn:first releases after first message', async function() {
+        const stream = mockStreamResponse('/first-release');
+        createProcessedHTML('<button hx-get="/first-release" hx-config="sse.releaseOn:first" hx-swap="innerHTML" hx-indicator="#spinner">Go</button><div id="spinner" class="htmx-indicator">Loading...</div>');
+
+        find('button').click();
+        await htmx.timeout(1);
+
+        // Indicator should be visible before first message
+        assert.isTrue(find('#spinner').classList.contains('htmx-request'), 'Indicator should be visible initially');
+
+        stream.send('first message');
+        await waitForEvent('htmx:sse:after:message');
+        await htmx.timeout(10);
+
+        // Indicator should be hidden after first message
+        assert.isFalse(find('#spinner').classList.contains('htmx-request'), 'Indicator should hide after first message with releaseOn:first');
 
         // Subsequent messages still work (background streaming)
         stream.send('second message');
@@ -1601,34 +1628,6 @@ describe('hx-sse SSE extension', function() {
         stream.close();
     });
 
-    it('releaseOn:end releases when stream closes', async function() {
-        const stream = mockStreamResponse('/end-test');
-        createProcessedHTML('<button hx-get="/end-test" hx-config="sse.releaseOn:end" hx-swap="innerHTML" hx-indicator="#spinner">Go</button><div id="spinner" class="htmx-indicator">Loading...</div>');
-
-        find('button').click();
-        await htmx.timeout(1);
-
-        stream.send('message 1');
-        await waitForEvent('htmx:sse:after:message');
-        await htmx.timeout(10);
-
-        // Indicator should still be visible
-        assert.isTrue(find('#spinner').classList.contains('htmx-request'), 'Indicator should stay visible during streaming');
-
-        stream.send('message 2');
-        await waitForEvent('htmx:sse:after:message');
-        await htmx.timeout(10);
-
-        // Still visible
-        assert.isTrue(find('#spinner').classList.contains('htmx-request'), 'Indicator should stay visible after multiple messages');
-
-        stream.close();
-        await waitForEvent('htmx:sse:close');
-        await htmx.timeout(10);
-
-        // Now hidden
-        assert.isFalse(find('#spinner').classList.contains('htmx-request'), 'Indicator should hide when stream closes');
-    });
 
     it('multiple hx:release events are idempotent', async function() {
         const stream = mockStreamResponse('/multi-release');

--- a/www/src/content/extensions/02-hx-sse.md
+++ b/www/src/content/extensions/02-hx-sse.md
@@ -656,7 +656,7 @@ Defaults to `true` for `hx-sse:connect` and `false` for normal htmx requests. Us
 Control when the request lifecycle ends (indicators hide, elements re-enable).
 
 ```html
-<meta name="htmx-config" content="sse.releaseOn:end">
+<meta name="htmx-config" content="sse.releaseOn:first">
 ```
 
 Values:
@@ -665,9 +665,20 @@ Values:
 - `first`: release after the first message swaps
 - `end`: release when the stream closes
 
-Defaults to `immediate` for `hx-sse:connect` and `first` for normal htmx requests.
+Defaults to `immediate` for `hx-sse:connect` and `end` for normal htmx requests.
 
-The server can release early by sending an `hx:release` event:
+With the default `end`, indicators stay visible and [`hx-disable`](/reference/attributes/hx-disable) keeps elements disabled until the stream closes. This works well for LLM streaming where you want to prevent duplicate submissions.
+
+Use `first` if you want the UI to become interactive as soon as content starts arriving:
+
+```html
+<button hx-post="/generate"
+        hx-config="sse.releaseOn:first">
+  Generate
+</button>
+```
+
+The server can also release early by sending an [`hx:release`](#hxrelease) event:
 
 ```http
 event: hx:release

--- a/www/src/content/extensions/02-hx-sse.md
+++ b/www/src/content/extensions/02-hx-sse.md
@@ -376,6 +376,7 @@ Defaults:
 - [`hx-trigger="load"`](/reference/attributes/hx-trigger#load)
 - [`sse.reconnect:true`](#ssereconnect)
 - [`sse.pauseOnBackground:true`](#ssepauseonbackground)
+- [`sse.releaseOn:immediate`](#ssereleaseon)
 - [`swapEmpty:false`](/reference/attributes/hx-swap#swapempty) for each message
 
 ### `hx-sse:close`
@@ -537,6 +538,46 @@ document.addEventListener('htmx:sse:error', event => {
 - `error`: the error value
 - `status`: the HTTP status for a failed reconnect response, when available
 
+### `hx:release`
+
+A server-sent event that ends the request lifecycle early. Only useful with [`sse.releaseOn:end`](#ssereleaseon).
+
+```http
+event: hx:release
+data:
+
+```
+
+When the server sends this event, htmx hides indicators and re-enables elements immediately. The stream continues running in the background.
+
+This is useful for LLM streaming where you want to:
+- Show a loading indicator until the model starts responding
+- Let the user interact with the page while tokens continue streaming
+
+```html
+<button hx-post="/generate"
+        hx-target="#output"
+        hx-swap="beforeend"
+        hx-config="sse.releaseOn:end"
+        hx-indicator="#spinner">
+  Generate
+</button>
+```
+
+The server streams:
+
+```http
+data: First token
+
+event: hx:release
+data:
+
+data: more tokens...
+
+```
+
+The indicator hides after `hx:release`, but tokens keep appending.
+
 ## Config
 
 ### `sse.reconnect`
@@ -609,6 +650,30 @@ Close the stream while the page is hidden and reconnect when it becomes visible.
 ```
 
 Defaults to `true` for `hx-sse:connect` and `false` for normal htmx requests. Use event IDs and server-side replay to recover messages sent while disconnected.
+
+### `sse.releaseOn`
+
+Control when the request lifecycle ends (indicators hide, elements re-enable).
+
+```html
+<meta name="htmx-config" content="sse.releaseOn:end">
+```
+
+Values:
+
+- `immediate`: release when SSE takes over (after headers arrive)
+- `first`: release after the first message swaps
+- `end`: release when the stream closes
+
+Defaults to `immediate` for `hx-sse:connect` and `first` for normal htmx requests.
+
+The server can release early by sending an `hx:release` event:
+
+```http
+event: hx:release
+data:
+
+```
 
 ## Migration
 

--- a/www/src/content/patterns/01-llm-streaming-response.md
+++ b/www/src/content/patterns/01-llm-streaming-response.md
@@ -82,7 +82,6 @@ server.get("/demo", () => `
        class="h-[200px] overflow-y-auto p-3 text-sm leading-relaxed border border-neutral-200 dark:border-neutral-800 rounded-lg text-neutral-600 dark:text-neutral-400"></div>
   <form class="flex gap-2"
         hx-get="/generate" hx-target="#conversation" hx-swap="beforeend scroll:bottom"
-        hx-config="sse.releaseOn:end"
         hx-disable="find fieldset"
         hx-on::before:request="this.reset()">
     <fieldset class="flex flex-1 gap-2 disabled:opacity-50 transition-opacity">
@@ -119,7 +118,6 @@ The code is pretty simple: the form targets the transcript and appends to it, ex
 
 <form hx-get="/generate"
       hx-target="#conversation" hx-swap="beforeend scroll:bottom"
-      hx-config="sse.releaseOn:end"
       hx-disable="find fieldset"
       hx-on::before:request="this.reset()">
 
@@ -137,8 +135,7 @@ The code is pretty simple: the form targets the transcript and appends to it, ex
 - The request lives on the `<form>`, so it fires on submit and carries the form fields. Enter works as well as the button.
 - [`hx-swap`](/reference/attributes/hx-swap)=[`"beforeend"`](/reference/attributes/hx-swap#beforeend--append) appends each event, so turns build up instead of replacing each other. [`scroll:bottom`](/reference/attributes/hx-swap#scroll) keeps the newest text in view.
 - [`hx-target`](/reference/attributes/hx-target) points at the transcript.
-- [`hx-config`](/reference/attributes/hx-config)=`"sse.releaseOn:end"` keeps the request lifecycle open until the stream ends, so `hx-disable` stays in effect.
-- [`hx-disable`](/reference/attributes/hx-disable)=`"find fieldset"` disables the prompt and the Ask button until the reply finishes. A `<fieldset>` disables everything inside it, so one attribute covers both.
+- [`hx-disable`](/reference/attributes/hx-disable)=`"find fieldset"` disables the prompt and the Ask button until the reply finishes. A `<fieldset>` disables everything inside it, so one attribute covers both. This works because SSE defaults to [`sse.releaseOn:end`](/extensions/hx-sse#ssereleaseon).
 - Clear sits outside the fieldset, so it stays available while a reply is arriving.
 - There is no `hx-sse:connect` here. The extension handles any response that arrives as `text/event-stream`, so a normal request is enough.
 

--- a/www/src/content/patterns/01-llm-streaming-response.md
+++ b/www/src/content/patterns/01-llm-streaming-response.md
@@ -82,6 +82,7 @@ server.get("/demo", () => `
        class="h-[200px] overflow-y-auto p-3 text-sm leading-relaxed border border-neutral-200 dark:border-neutral-800 rounded-lg text-neutral-600 dark:text-neutral-400"></div>
   <form class="flex gap-2"
         hx-get="/generate" hx-target="#conversation" hx-swap="beforeend scroll:bottom"
+        hx-config="sse.releaseOn:end"
         hx-disable="find fieldset"
         hx-on::before:request="this.reset()">
     <fieldset class="flex flex-1 gap-2 disabled:opacity-50 transition-opacity">
@@ -118,6 +119,7 @@ The code is pretty simple: the form targets the transcript and appends to it, ex
 
 <form hx-get="/generate"
       hx-target="#conversation" hx-swap="beforeend scroll:bottom"
+      hx-config="sse.releaseOn:end"
       hx-disable="find fieldset"
       hx-on::before:request="this.reset()">
 
@@ -135,9 +137,12 @@ The code is pretty simple: the form targets the transcript and appends to it, ex
 - The request lives on the `<form>`, so it fires on submit and carries the form fields. Enter works as well as the button.
 - [`hx-swap`](/reference/attributes/hx-swap)=[`"beforeend"`](/reference/attributes/hx-swap#beforeend--append) appends each event, so turns build up instead of replacing each other. [`scroll:bottom`](/reference/attributes/hx-swap#scroll) keeps the newest text in view.
 - [`hx-target`](/reference/attributes/hx-target) points at the transcript.
+- [`hx-config`](/reference/attributes/hx-config)=`"sse.releaseOn:end"` keeps the request lifecycle open until the stream ends, so `hx-disable` stays in effect.
 - [`hx-disable`](/reference/attributes/hx-disable)=`"find fieldset"` disables the prompt and the Ask button until the reply finishes. A `<fieldset>` disables everything inside it, so one attribute covers both.
 - Clear sits outside the fieldset, so it stays available while a reply is arriving.
 - There is no `hx-sse:connect` here. The extension handles any response that arrives as `text/event-stream`, so a normal request is enough.
+
+To let users type ahead while tokens are still arriving, have the server send [`hx:release`](/extensions/hx-sse#hxrelease) after initial response is in place. The fieldset re-enables but tokens keep appending.
 
 The server side answers with a response type of `text/event-stream`, which causes the SSE extension to take over.  It
 treats each unnamed event as content to be swapped into the target:


### PR DESCRIPTION
## Description
Add support for sse.releaseOn config that defaults to end but allows immediate or first options that control when to complete the htmx request and resolve any indicators and disabled elements.  There is also a hx:release custom server sent event you can send to release the request lifecycle early.  The first option is powerful as it allows the request to resolve and complete once the first main response swaps allowing further async responses to update the page while the requesting element is now free to make another request.

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
