### PR TITLE
Fix reset modifier timing and form lookup

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -368,9 +368,10 @@ var htmx = (() => {
         }
 
         __createHtmxEventHandler(elt) {
-            return async (evt) => {
+            return async (evt, spec) => {
                 try {
                     let ctx = this.__createRequestContext(elt, evt);
+                    ctx.reset = !!spec?.reset;
                     await this.__handleTriggerEvent(ctx);
                 } catch (e) {
                     this.__trigger(elt, 'htmx:error', { error: e });
@@ -568,6 +569,10 @@ var htmx = (() => {
                     if (!confirmed) return;
                 }
 
+                // reset the form only once the request is committed, and after
+                // __handleTriggerEvent collected the body
+                if (ctx.reset) (elt.form || elt.closest?.('form'))?.reset();
+
                 // initialize timeout & indicators after confirmation
                 this.__initTimeout(ctx);
                 indicators = this.__showIndicators(elt);
@@ -752,8 +757,7 @@ var htmx = (() => {
                     if (spec.once) {
                         for (let info of spec.listeners) info.fromElt.removeEventListener(info.eventName, info.handler, info);
                     }
-                    if (spec.reset) elt.closest?.('form')?.reset();
-                    handler(evt);
+                    handler(evt, spec);
                 };
 
                 // Wrap inner with delay/throttle if needed
@@ -1348,7 +1352,7 @@ var htmx = (() => {
             }
             let swapStyle = swapSpec.style;
             if (swapStyle === 'none') return;
-            if (swapSpec.reset) task.sourceElement?.closest?.('form')?.reset();
+            if (swapSpec.reset) (task.sourceElement?.form || task.sourceElement?.closest?.('form'))?.reset();
             // full-page response: fragment has a <body> wrapper, so upgrade outerHTML to outerSync, strip for everything else
             if (fragment.firstElementChild?.tagName === 'BODY') {
                 if (swapStyle === 'outerHTML') swapStyle = 'outerSync';

--- a/test/tests/attributes/hx-swap.js
+++ b/test/tests/attributes/hx-swap.js
@@ -22,6 +22,16 @@ describe('hx-swap modifiers', function() {
         find('#result').textContent.should.equal('Done')
     })
 
+    it('reset modifier resets a form the element points at with form=', async function () {
+        mockResponse('POST', '/test', 'Done')
+        createProcessedHTML('<div><form id="sf"><input name="msg" value=""/></form><button form="sf" hx-post="/test" hx-swap="beforeend reset" hx-target="#out">Send</button><div id="out"></div></div>')
+        let input = find('#sf input')
+        input.value = 'typed'
+        find('button').click()
+        await forRequest()
+        input.value.should.equal('')
+    })
+
     it('swap:none with reset does not reset (no-op)', async function () {
         mockResponse('POST', '/test', 'ignored')
         createProcessedHTML('<form id="f" hx-post="/test" hx-swap="none reset"><input name="msg" value=""/></form>')

--- a/test/tests/attributes/hx-trigger.js
+++ b/test/tests/attributes/hx-trigger.js
@@ -6,15 +6,14 @@ describe('hx-trigger attribute', function() {
         cleanupTest()
     })
 
-    it('reset modifier resets form before request', async function () {
+    it('reset modifier resets form when the request is issued', async function () {
         mockResponse('POST', '/test', 'Done')
         let form = createProcessedHTML('<form hx-post="/test" hx-trigger="submit reset"><input name="msg" value=""/></form>')
         let input = form.querySelector('input')
         input.value = 'changed'
         form.dispatchEvent(new Event('submit', {bubbles: true, cancelable: true}))
-        // Form should be reset immediately (optimistic) - back to default value (empty)
-        input.value.should.equal('')
         await forRequest()
+        input.value.should.equal('')
     })
 
     it('reset modifier works on button inside form', async function () {
@@ -23,8 +22,55 @@ describe('hx-trigger attribute', function() {
         let input = find('input')
         input.value = 'typed'
         find('button').click()
-        input.value.should.equal('')
         await forRequest()
+        input.value.should.equal('')
+    })
+
+    it('reset modifier sends the values before it clears them', async function () {
+        mockResponse('POST', '/test', 'Done')
+        let sent = null
+        let listener = (e) => { sent = e.detail.ctx.request.body }
+        document.addEventListener('htmx:before:request', listener)
+        try {
+            let form = createProcessedHTML('<form hx-post="/test" hx-trigger="submit reset"><input name="msg" value=""/></form>')
+            form.querySelector('input').value = 'typed'
+            form.dispatchEvent(new Event('submit', {bubbles: true, cancelable: true}))
+            await forRequest()
+            sent.get('msg').should.equal('typed')
+        } finally {
+            document.removeEventListener('htmx:before:request', listener)
+        }
+    })
+
+    it('reset modifier applies only to the spec that fired', async function () {
+        mockResponse('POST', '/test', 'Done')
+        let form = createProcessedHTML('<form hx-post="/test" hx-trigger="click, keyup reset"><input name="msg" value=""/></form>')
+        let input = form.querySelector('input')
+        input.value = 'typed'
+        form.click()
+        await forRequest()
+        input.value.should.equal('typed')
+    })
+
+    it('reset modifier does not reset when the confirm is cancelled', async function () {
+        mockResponse('POST', '/test', 'Done')
+        let form = createProcessedHTML('<form hx-post="/test" hx-confirm="sure?" hx-trigger="click reset"><input name="msg" value=""/></form>')
+        form.addEventListener('htmx:confirm', (e) => { e.preventDefault(); e.detail.dropRequest() })
+        let input = form.querySelector('input')
+        input.value = 'typed'
+        form.click()
+        await htmx.timeout(20)
+        input.value.should.equal('typed')
+    })
+
+    it('reset modifier resets a form the element points at with form=', async function () {
+        mockResponse('POST', '/test', 'Done')
+        createProcessedHTML('<div><form id="rf"><input name="msg" value=""/></form><button form="rf" hx-post="/test" hx-trigger="click reset">Send</button></div>')
+        let input = find('#rf input')
+        input.value = 'typed'
+        find('button').click()
+        await forRequest()
+        input.value.should.equal('')
     })
 
     it('non-default triggers work', async function () {

--- a/www/src/content/reference/01-attributes/07-hx-trigger.md
+++ b/www/src/content/reference/01-attributes/07-hx-trigger.md
@@ -218,7 +218,7 @@ Tells the browser the handler won't call `preventDefault()`, so the browser can 
 
 ### `reset`
 
-Resets the enclosing form to return all input values to their defaults when the trigger fires (before the request is sent).
+Resets the enclosing form to return all input values to their defaults. The reset occurs when htmx issues the request, after htmx collects the request body. The request sends the values that the user entered.
 
 ```html
 <form hx-post="/chat" hx-trigger="submit reset">
@@ -227,7 +227,11 @@ Resets the enclosing form to return all input values to their defaults when the 
 </form>
 ```
 
-This is "optimistic" - the form resets immediately, even if the request fails. For safer reset after a successful response, use [`hx-swap`](/reference/attributes/hx-swap#reset) instead.
+This is "optimistic". The form resets before the response arrives, and it stays reset if the request fails. For a reset after a successful response, use [`hx-swap`](/reference/attributes/hx-swap#reset) instead.
+
+The form does not reset if [`hx-confirm`](/reference/attributes/hx-confirm) cancels the request, or if [`hx-sync`](/reference/attributes/hx-sync) drops it.
+
+The modifier applies only to the trigger that fires. In `hx-trigger="click, keyup reset"`, a `keyup` resets the form and a `click` does not.
 
 ### Example
 

--- a/www/src/content/reference/01-attributes/08-hx-swap.md
+++ b/www/src/content/reference/01-attributes/08-hx-swap.md
@@ -355,7 +355,7 @@ Default behavior: skip if partials or OOB swaps were extracted (unless [`htmx.co
 
 ### `reset`
 
-Resets the enclosing form after a successful swap.
+Resets the enclosing form after a successful swap. If the element carries a `form` attribute, htmx resets the form that the attribute names.
 
 ```html
 <form hx-post="/chat" hx-swap="beforeend reset" hx-target="#messages">
@@ -364,7 +364,7 @@ Resets the enclosing form after a successful swap.
 </form>
 ```
 
-The form only resets after the response is received and swapped. For "optimistic" reset before the request, use [`hx-trigger`](/reference/attributes/hx-trigger#reset) instead.
+The form only resets after the response is received and swapped. For an "optimistic" reset when the request starts, use [`hx-trigger`](/reference/attributes/hx-trigger#reset) instead.
 
 The form won't reset when no swap occurs:
 - `swap:none`


### PR DESCRIPTION
Follow-up to #3977.

## Problem

The `reset` trigger modifier ran in the trigger listener, before htmx collected the request body. Three defects:

1. **The request sent empty values.** The form reset before `__handleTriggerEvent` collected the body, so a `<form hx-post hx-trigger="submit reset">` sent `msg=` instead of the value the user typed.
2. **A cancelled `hx-confirm` still reset the form.** The reset ran before the confirm gate.
3. **`elt.closest('form')` ignored `form="id"`.** An element that points at a form from outside it did not reset that form.

## Changes

`src/htmx.js`:

- `inner` no longer resets. It passes the firing `spec` to the handler.
- `__createHtmxEventHandler` records `ctx.reset` from that spec.
- The reset moved to `__issueRequest`, after the confirm gate. It runs only when the request is committed, and after the body is collected.
- Both the trigger and swap paths use `elt.form || elt.closest('form')`.

Tests: the two tests from #3977 asserted a synchronous reset, which no longer holds. Rewrote them and added four for the sent body, per-spec attribution, cancelled confirm, and `form="id"`.

Docs corrected on both reference pages. The old text promised a reset "before the request is sent", which was the bug.

1735 passed, 0 failed, 100 percent coverage.

## Open question

Not super happy with this, seems hard to get trigger info to the right spot. Maybe drop in favor of an `hx-reset` extension?

The spec is known in the trigger listener, but the reset must happen much later. The options I looked at:

- **Extra handler param (this PR).** Additive. `onTrigger(elt, spec, handler)` is internal API used by `hx-ws`, `hx-sse`, and `hx-multipart`, and all of them ignore the second arg.
- **Handler factory.** Cleaner in isolation, but silently breaks those three extensions.
- **Stash the spec on the event.** `detail` is a read-only number on `UIEvent`, so there is nowhere to put it on a `click`. Also racy, because `from:` fans one event to several specs and the read happens after an `await`.

Marked as a draft while we decide.
