### PR TITLE
fix: escape IDs in restorePreservedElements, selectOOB, and anchor scroll

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1518,7 +1518,7 @@ var htmx = (function() {
     const pantry = find('#--htmx-preserve-pantry--')
     if (pantry) {
       for (const preservedElt of [...pantry.children]) {
-        const existingElement = find('#' + preservedElt.id)
+        const existingElement = find('#' + CSS.escape(preservedElt.id))
         // @ts-ignore - use proposed moveBefore feature
         existingElement.parentNode.moveBefore(preservedElt, existingElement)
         existingElement.remove()
@@ -1926,7 +1926,7 @@ var htmx = (function() {
               id = id.substring(1)
             }
             const oobValue = oobSelectValue[1] || 'true'
-            const oobElement = fragment.querySelector('#' + id)
+            const oobElement = fragment.querySelector('#' + CSS.escape(id))
             if (oobElement) {
               oobSwap(oobValue, oobElement, settleInfo, rootNode)
             }
@@ -2001,7 +2001,7 @@ var htmx = (function() {
         })
 
         if (swapOptions.anchor) {
-          const anchorTarget = asElement(resolveTarget('#' + swapOptions.anchor))
+          const anchorTarget = asElement(resolveTarget('#' + CSS.escape(swapOptions.anchor)))
           if (anchorTarget) {
             anchorTarget.scrollIntoView({ block: 'start', behavior: 'auto' })
           }

--- a/test/attributes/hx-preserve.js
+++ b/test/attributes/hx-preserve.js
@@ -76,4 +76,14 @@ describe('hx-preserve attribute', function() {
     htmx._('handlePreservedElements')(fragment)
     fragment.firstChild.innerHTML.should.equal('Old Content')
   })
+
+  it('handles hx-preserve on elements with dotted IDs', function() {
+    this.server.respondWith('GET', '/test', "<div id='d1.sub' hx-preserve>New Content</div><div id='d2'>New Content</div>")
+    var div = make("<div hx-get='/test'><div id='d1.sub' hx-preserve>Old Content</div><div id='d2'>Old Content</div></div>")
+    div.click()
+    this.server.respond()
+    var preserved = document.querySelector('[id="d1.sub"]')
+    preserved.innerHTML.should.equal('Old Content')
+    byId('d2').innerHTML.should.equal('New Content')
+  })
 })

--- a/test/attributes/hx-select-oob.js
+++ b/test/attributes/hx-select-oob.js
@@ -45,4 +45,13 @@ describe('hx-select-oob attribute', function() {
     var div2 = byId('d2')
     div2.innerHTML.should.equal('')
   })
+
+  it('handles elements with IDs containing dots in hx-select-oob', function() {
+    this.server.respondWith('GET', '/test', "Normal Content<div id='d2.sub'><div id='d3'>New oob Content</div></div>")
+    var div1 = make("<div id='d1' hx-get='/test' hx-select-oob='#d2.sub'>Click Me!</div>")
+    make("<div id='d2.sub'><div id='d3'>Old Content</div></div>")
+    div1.click()
+    this.server.respond()
+    byId('d3').innerHTML.should.equal('New oob Content')
+  })
 })


### PR DESCRIPTION
## Description

Three remaining call sites build a CSS selector from a raw element id without `CSS.escape()`, causing failures when the id contains CSS-special characters (`.`, `/`, `:`, etc.):

1. **`restorePreservedElements`** (line ~1521) — `find('#' + preservedElt.id)` → `querySelector('#' + id)`. On browsers with `moveBefore` (Chrome), htmx moves the preserved element into the pantry div during `handlePreservedElements`, then `restorePreservedElements` looks it back up by id to put it in place. A dotted id like `payment.parcelas` becomes the selector `#payment.parcelas` (id=payment AND class=parcelas), matches nothing, and the next line throws `TypeError: Cannot read properties of null (reading 'parentNode')`, aborting the swap.

2. **`selectOOB` handling** (line ~1929) — `fragment.querySelector('#' + id)`. Same pattern: the id from `hx-select-oob` is interpolated raw.

3. **Anchor scroll** (line ~2004) — `resolveTarget('#' + swapOptions.anchor)` → `find()` → `querySelector()`. An anchor id with special chars hits the same parse error.

The sibling call sites in `oobSwap` (fixed by #3304) and `handleAttributes` (fixed by #3752) already use `CSS.escape()` correctly — these three were missed.

### Repro (restorePreservedElements — the most visible one)

```html
<div hx-get="/update">
  <input id="payment.amount" hx-preserve value="typed-value">
</div>
```

On Chrome (moveBefore path): swap replaces the content, `handlePreservedElements` stashes the input in the pantry via `getElementById` (works fine — getElementById treats id as opaque), then `restorePreservedElements` tries `querySelector('#payment.amount')` → no match → TypeError on `.parentNode`. The preserved element is stranded in the pantry div and all subsequent swaps on the page may break.

On Firefox/Safari (replaceChild path): `handlePreservedElements` takes the else branch and calls `replaceChild` directly — `restorePreservedElements` is never called, so the bug is latent.

Corresponding issues: the same bug class as #1537 (oobSwap) and the settle-lookup in #3752, applied to the three remaining unescaped sites.

## Testing

- Added `handles hx-preserve on elements with dotted IDs` to `test/attributes/hx-preserve.js`
- Added `handles elements with IDs containing dots in hx-select-oob` to `test/attributes/hx-select-oob.js`
- Full test suite: 849 passed, 0 failed, 3 skipped (Chrome)

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`dev` for source changes)
* [x] This is a bugfix
* [x] I ran the test suite locally (`npm run test:chrome`) and verified that it succeeded