### PR TITLE
Fix: outerHTML swap with body fragment corrupts non-body targets

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1347,7 +1347,6 @@ var htmx = (() => {
             }
             let swapStyle = swapSpec.style;
             if (swapStyle === 'none') return;
-            if (swapSpec.reset) task.sourceElement?.closest?.('form')?.reset();
             // Body fragment: strip wrapper unless outer* swap on document.body
             if (fragment.firstElementChild?.tagName === 'BODY') {
                 const keepBody = target === document.body && swapStyle.startsWith('outer')

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1347,10 +1347,12 @@ var htmx = (() => {
             }
             let swapStyle = swapSpec.style;
             if (swapStyle === 'none') return;
-            // full-page response: fragment has a <body> wrapper, so upgrade outerHTML to outerSync, strip for everything else
+            if (swapSpec.reset) task.sourceElement?.closest?.('form')?.reset();
+            // Body fragment: strip wrapper unless outer* swap on document.body
             if (fragment.firstElementChild?.tagName === 'BODY') {
-                if (swapStyle === 'outerHTML') swapStyle = 'outerSync';
-                else if (!swapStyle.startsWith('outer')) swapSpec.strip = true;
+                const keepBody = target === document.body && swapStyle.startsWith('outer')
+                if (keepBody && swapStyle === 'outerHTML') swapStyle = 'outerSync'
+                swapSpec.strip ??= !keepBody
             }
             if (swapSpec.strip && fragment.firstElementChild) {
                 fragment = document.createDocumentFragment();

--- a/test/tests/attributes/hx-swap.js
+++ b/test/tests/attributes/hx-swap.js
@@ -95,4 +95,40 @@ describe('hx-swap modifiers', function() {
         assert.equal(find('#target').className, 'test')
         assert.equal(find('#target').textContent, 'New Text')
     })
+
+    it('outerHTML with body fragment on non-body target strips body wrapper', async function () {
+        mockResponse('GET', '/test', '<body class="from-response"><p>New content</p></body>')
+        createProcessedHTML('<button id="btn" hx-get="/test" hx-target="#target" hx-swap="outerHTML">Get</button><div id="target" class="original">Old</div>');
+        find('#btn').click()
+        await forRequest()
+        // Target should be replaced by <p>, body wrapper stripped
+        assert.isUndefined(find('#target'), 'Target should be replaced')
+        let p = find('p')
+        assert.exists(p)
+        assert.equal(p.textContent, 'New content')
+        assert.equal(p.parentElement.id, 'test-playground')
+    })
+
+    it('outerHTML with full HTML document on non-body target strips body wrapper', async function () {
+        mockResponse('GET', '/test', '<!DOCTYPE html><html><head><title>Page</title></head><body class="page"><div class="content">Content</div></body></html>')
+        createProcessedHTML('<button id="btn" hx-get="/test" hx-target="#target" hx-swap="outerHTML">Get</button><div id="target" class="widget">Widget</div>');
+        find('#btn').click()
+        await forRequest()
+        assert.isUndefined(find('#target'), 'Target should be replaced')
+        let content = find('.content')
+        assert.exists(content)
+        assert.equal(content.parentElement.id, 'test-playground')
+    })
+
+    it('innerHTML with body fragment strips body wrapper', async function () {
+        mockResponse('GET', '/test', '<body class="ignored"><span>A</span><span>B</span></body>')
+        createProcessedHTML('<button id="btn" hx-get="/test" hx-target="#target" hx-swap="innerHTML">Get</button><div id="target" class="keep-me">Old</div>');
+        find('#btn').click()
+        await forRequest()
+        let target = find('#target')
+        assert.exists(target)
+        assert.equal(target.className, 'keep-me', 'Target keeps its attributes')
+        assert.equal(target.children.length, 2)
+        assert.equal(target.children[0].tagName, 'SPAN')
+    })
 })


### PR DESCRIPTION
## Description
When a server response contains `<body>` as the first element (e.g., full HTML documents from frameworks like Drupal), htmx incorrectly upgrades `outerHTML` to `outerSync` regardless of the target element. This causes:

- Target element loses its `id` and other attributes
- `<body>`'s attributes get copied onto the target
- DOM corruption for non-body targets

## Example

```html
<!-- Page -->
<div id="widget" class="my-class" hx-get="/api" hx-swap="outerHTML">Old</div>

<!-- Response -->
<body class="page-class"><p>New content</p></body>

<!-- Before fix (broken): widget's id removed, body attrs copied -->
<div class="page-class"><p>New content</p></div>

<!-- After fix: body stripped, inner content replaces target -->
<p>New content</p>
```

## Fix

```js
// Before (buggy)
if (fragment.firstElementChild?.tagName === 'BODY') {
    if (swapStyle === 'outerHTML') swapStyle = 'outerSync';
    else if (!swapStyle.startsWith('outer')) swapSpec.strip = true;
}

// After (fixed)
if (fragment.firstElementChild?.tagName === 'BODY') {
    const keepBody = target === document.body && swapStyle.startsWith('outer')
    if (keepBody && swapStyle === 'outerHTML') swapStyle = 'outerSync'
    swapSpec.strip ??= !keepBody
}
```

## Logic

1. Only upgrade `outerHTML` → `outerSync` when `target === document.body`
2. Strip body wrapper for everything **except** `outer*` styles targeting `document.body`
3. Respect user's explicit `strip` modifier setting via `??=`

## Tests

Added 3 tests to `test/tests/attributes/hx-swap.js`:
- `outerHTML with body fragment on non-body target strips body wrapper`
- `outerHTML with full HTML document on non-body target strips body wrapper`
- `innerHTML with body fragment strips body wrapper`

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
