### PR TITLE
Release sse request when stream setup throws

### DIFF
--- a/src/ext/hx-sse.js
+++ b/src/ext/hx-sse.js
@@ -398,6 +398,10 @@
             let releaseRequest;
             ctx.extensionPromise = new Promise(resolve => releaseRequest = resolve);
             handleSSEResponse(ctx, releaseRequest).catch(e => {
+                // a throw before the stream loop skips the finally, so release
+                // the request here and tear the connection down
+                releaseRequest();
+                cleanup(element);
                 // an aborted stream is a normal end, not an error
                 if (e.name !== 'AbortError') {
                     api.triggerHtmxEvent(element, 'htmx:sse:error', {error: e, url: ctx.request.action});

--- a/test/tests/ext/hx-sse.js
+++ b/test/tests/ext/hx-sse.js
@@ -62,6 +62,30 @@ describe('hx-sse SSE extension', function() {
         stream.close();
     });
 
+    it('releases the request when setup throws', async function() {
+        mockStreamResponse('/setup-throw');
+        createProcessedHTML('<button hx-get="/setup-throw" hx-swap="innerHTML" hx-indicator="#spin">Go</button><div id="spin" class="htmx-indicator">Loading</div>');
+
+        // a throw before the stream loop skips the finally that normally releases
+        let original = Object.getOwnPropertyDescriptor(htmx.config, 'sse');
+        Object.defineProperty(htmx.config, 'sse', {
+            configurable: true,
+            get() { throw new Error('config blew up') }
+        });
+
+        try {
+            find('button').click();
+            await htmx.timeout(50);
+            assert.isFalse(find('#spin').classList.contains('htmx-request'),
+                'Indicator must hide when setup throws');
+            assert.isUndefined(find('button')._htmx?.sse,
+                'Connection must not stay registered when setup throws');
+        } finally {
+            delete htmx.config.sse;
+            if (original) Object.defineProperty(htmx.config, 'sse', original);
+        }
+    });
+
     it('continuous stream reconnects with exponential backoff', async function() {
         const stream = mockStreamResponse('/reconnect');
         createProcessedHTML('<button hx-get="/reconnect" hx-config="sse.reconnect:true sse.reconnectDelay:50ms sse.reconnectMaxAttempts:3 sse.reconnectJitter:0" hx-swap="innerHTML">Connect</button>');


### PR DESCRIPTION
Follow-up to #3980.

## Problem

#3980 changed the extension to hand core a manually resolved promise instead of the `handleSSEResponse` promise:

```js
let releaseRequest;
ctx.extensionPromise = new Promise(resolve => releaseRequest = resolve);
handleSSEResponse(ctx, releaseRequest).catch(e => { ... });
```

`release()` is only reachable from the `finally` in `handleSSEResponse`, and that function does not open its `try` until line 181. Anything that throws between function entry and there skips the `finally`, and the `catch` does not release.

Core awaits `extensionPromise` at `src/htmx.js:618`, inside a `finally`, with `__hideIndicators` right after at line 625. So the await never returns. The indicator spins forever, the element stays in `htmx-request`, and no error surfaces to the user.

The window is real. `getConfig(element)` runs before `release` is even defined, so it hangs every mode, `immediate` included. `api.htmxProp(element).sse = connection` is also set before the `try`, and #3980 dropped the `cleanup(element)` that used to sit in the `catch`, so a throw there leaves the connection registered and blocks reconnects on that element.

Before #3980 this was safe. `extensionPromise` was the `handleSSEResponse` promise itself, so a rejection settled it and core continued.

## Fix

Release and clean up in the `catch`:

```js
handleSSEResponse(ctx, releaseRequest).catch(e => {
    releaseRequest();
    cleanup(element);
    ...
```

`release()` is already idempotent, so the normal path is unaffected.

## Testing

Added `releases the request when setup throws`. It forces a throw in the setup window and asserts both symptoms: the indicator hides, and `_htmx.sse` does not stay registered.

Verified the test fails without the fix:

```
AssertionError: Indicator must hide when setup throws: expected true to be false
```

Full suite: 1732 passed, 0 failed, 100 percent coverage.

Draft, since #3980 only just landed and you may prefer to fold this in there.
