### PR TITLE
morph preserves input value on active element

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2172,7 +2172,7 @@ var htmx = (() => {
             if (!this.__triggerExtensions(oldNode, "htmx:before:morph:node", {oldNode, newNode})) return;
                 
             this.__copyAttributes(oldNode, newNode);
-            if (oldNode instanceof HTMLTextAreaElement && oldNode.defaultValue != newNode.defaultValue) {
+            if (oldNode instanceof HTMLTextAreaElement && document.activeElement !== oldNode && oldNode.defaultValue != newNode.defaultValue) {
                 oldNode.value = newNode.value;
             }
             let skipChildren = this.config.morphSkipChildren && oldNode.matches?.(this.config.morphSkipChildren);

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2191,7 +2191,7 @@ var htmx = (() => {
                     if (isHxAttr(attr.name)) needsReinit = true;
                     if (!this.__triggerExtensions(destination, 'htmx:before:morph:attr', { attrName: attr.name, newValue: attr.value })) continue;
                     destination.setAttribute(attr.name, attr.value);
-                    if (attr.name === "value" && destination instanceof HTMLInputElement && destination.type !== "file") {
+                    if (attr.name === "value" && destination instanceof HTMLInputElement && destination.type !== "file" && document.activeElement !== destination) {
                         destination.value = attr.value;
                     }
                 }

--- a/test/tests/unit/morph.js
+++ b/test/tests/unit/morph.js
@@ -411,6 +411,22 @@ describe('Morph Swap Styles Tests', function() {
             assert.equal(input.value, 'hello', 'focused input value should not be overwritten by stale server value');
         });
 
+        it('preserves focused textarea value when server sends stale content during live typing', async function() {
+            const div = createProcessedHTML('<div id="target"><textarea id="notes">old</textarea></div>');
+            const textarea = div.querySelector('#notes');
+            textarea.value = 'user typed this';
+            textarea.focus();
+
+            await htmx.swap({
+                target: '#target',
+                text: '<textarea id="notes">stale</textarea>',
+                swap: 'innerMorph',
+                sourceElement: div
+            });
+
+            assert.equal(div.querySelector('#notes'), textarea, 'textarea node should be preserved');
+            assert.equal(textarea.value, 'user typed this', 'focused textarea value should not be overwritten');
+        });
 
     });
 

--- a/test/tests/unit/morph.js
+++ b/test/tests/unit/morph.js
@@ -415,20 +415,6 @@ describe('Morph Swap Styles Tests', function() {
     });
 
     describe('element reordering with ids', function() {
-        it('button can replace itself with morph', async function() {
-            mockResponse('GET', '/test', '<button id="btn" class="clicked">Clicked!</button>');
-            const container = createProcessedHTML('<div id="container"><button id="btn" hx-get="/test" hx-swap="outerMorph">Click me</button></div>');
-            const btn = container.querySelector('#btn');
-            
-            btn.click();
-            await forRequest();
-            
-            const newBtn = container.querySelector('#btn');
-            assert.equal(newBtn, btn, 'Button should be same element after morph');
-            assert.equal(newBtn.className, 'clicked');
-            assert.equal(newBtn.textContent, 'Clicked!');
-        });
-
         it('reorders elements with ids correctly', async function() {
             mockResponse('GET', '/test', '<div id="c">C</div><div id="b">B</div><div id="a">A</div>');
             const div = createProcessedHTML('<div id="target"><div id="a">A</div><div id="b">B</div><div id="c">C</div></div>');

--- a/test/tests/unit/morph.js
+++ b/test/tests/unit/morph.js
@@ -392,10 +392,43 @@ describe('Morph Swap Styles Tests', function() {
             assert.isNull(div.querySelector('button'), 'button should be removed');
         });
 
+        it('preserves focused input value when server sends stale value during live typing', async function() {
+            // Simulates live search: user types "hello" but server response echoes "hel"
+            // back in the value attribute - should not overwrite the focused input
+            const div = createProcessedHTML('<div id="target"><input id="search" value=""></div>');
+            const input = div.querySelector('#search');
+            input.value = 'hello';  // user typed this
+            input.focus();
+
+            await htmx.swap({
+                target: '#target',
+                text: '<input id="search" value="hel">',  // stale server response with different value attr
+                swap: 'innerMorph',
+                sourceElement: div
+            });
+
+            assert.equal(div.querySelector('#search'), input, 'input node should be preserved');
+            assert.equal(input.value, 'hello', 'focused input value should not be overwritten by stale server value');
+        });
+
 
     });
 
     describe('element reordering with ids', function() {
+        it('button can replace itself with morph', async function() {
+            mockResponse('GET', '/test', '<button id="btn" class="clicked">Clicked!</button>');
+            const container = createProcessedHTML('<div id="container"><button id="btn" hx-get="/test" hx-swap="outerMorph">Click me</button></div>');
+            const btn = container.querySelector('#btn');
+            
+            btn.click();
+            await forRequest();
+            
+            const newBtn = container.querySelector('#btn');
+            assert.equal(newBtn, btn, 'Button should be same element after morph');
+            assert.equal(newBtn.className, 'clicked');
+            assert.equal(newBtn.textContent, 'Clicked!');
+        });
+
         it('reorders elements with ids correctly', async function() {
             mockResponse('GET', '/test', '<div id="c">C</div><div id="b">B</div><div id="a">A</div>');
             const div = createProcessedHTML('<div id="target"><div id="a">A</div><div id="b">B</div><div id="c">C</div></div>');

--- a/www/src/content/docs/morphing-swaps-guide.md
+++ b/www/src/content/docs/morphing-swaps-guide.md
@@ -5,7 +5,7 @@ description: "How morph swaps work, when to use them, and how to control them."
 
 ## DOM Morphing
 
-DOM Morphing is a technique where existing DOM elements are "morphed" to match new conent.   A morph walks the old DOM 
+DOM Morphing is a technique where existing DOM elements are "morphed" to match new content.   A morph walks the old DOM 
 and edits it into the shape of a new one, which allows nodes that are unchanged to (usually) retain their identity.
 
 This can be very nice from a users perspective: Things like focus, text selection, scroll position and video
@@ -80,14 +80,25 @@ Some times you may wish to skip elements while morphing.  For this there are two
 <div hx-morph-skip-children class="chart">...</div>
 ```
 
-You can also specify a global selector:
+You can also extend the global selectors:
 
 ```javascript
-htmx.config.morphSkip         = 'custom-widget, .frozen';
-htmx.config.morphSkipChildren = 'lit-component, .sortable';
+htmx.config.morphSkip         = '[hx-morph-skip], custom-widget, .frozen';
+htmx.config.morphSkipChildren = '[hx-morph-skip-children], lit-component, .sortable';
 ```
 
 This lets you opt out of morphing for third party widgets, web components, etc.
+
+## Input Values and Focus
+
+Morph can be very useful for replacing or updating forms for dynamic validation.
+
+Morph swaps automatically preserve the value of the currently focused input or textarea, even when the server
+returns a different value. This prevents stale responses from overwriting what the user is typing.
+
+For unfocused inputs, htmx preserves the user's value unless the `value` attribute changes between old and new content.
+This differs from idiomorph's default behavior, which resets the `.value` property to match the `value` attribute on every morph.
+To preserve all input values, have your server return inputs without changing the `value` attribute, or add `'value'` to `htmx.config.morphIgnore`.
 
 ## Configuring
 
@@ -105,4 +116,6 @@ positional (non-id) match.  Lower is faster, but will miss more matches.
 - [`hx-swap`](/reference/attributes/hx-swap)
 - [`hx-preserve`](/reference/attributes/hx-preserve)
 - [`hx-morph-skip`](/reference/attributes/hx-morph-skip)
+- [`hx-morph-skip-children`](/reference/attributes/hx-morph-skip-children)
 - [`htmx.config.morphSkip`](/reference/config/htmx-config-morphSkip)
+- [`htmx.config.morphSkipChildren`](/reference/config/htmx-config-morphSkipChildren)


### PR DESCRIPTION
## Description
When we morph inputs values that have changed there default value we also push an update to the inputs internal value property to respect the server request to update the values input.  But if the input is active and focused with the user editing it right now we can block this value update to preserve the end users active input text they may have just changed.  This allows you to morph an active form with the last input change events data returned from the server without losing any text changed during the time it takes for the request to complete.

Corresponding issue:

## Testing
Added a basic test

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
