### PR TITLE
fix typo in 2026-08-28-htmx-4.0.0-is-released.md

### DIFF
--- a/www/src/content/announcements/2026-08-28-htmx-4.0.0-is-released.md
+++ b/www/src/content/announcements/2026-08-28-htmx-4.0.0-is-released.md
@@ -44,7 +44,7 @@ Internally, we migrated from `XMLHttpRequest` to `fetch()` but that should be tr
 
 #### Attribute Inheritance
 
-In htmx 2 many attributes where "inherited" by default. This allows you to place attributes on parent elements and
+In htmx 2 many attributes were "inherited" by default. This allows you to place attributes on parent elements and
 their behavior will apply to child elements. This behavior, which came from
 the [intercooler.js](https://intercoolerjs.org) days, was inspired by CSS and, unsurprisingly, worked out about the same
 as CSS: powerful but difficult to understand at times.


### PR DESCRIPTION
## Description
one char typo in docs

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [X] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
> I think four-dev might actually by the right branch based on the "Edit page" hyperlink in the article itself.

* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
