### PR TITLE
Fix minor documentation error

### DIFF
--- a/www/src/content/docs.md
+++ b/www/src/content/docs.md
@@ -71,7 +71,7 @@ One thing to note: the `hx-trigger` here is redundant.  If it was omitted htmx w
 which, in the case of buttons, is a click.
 
 One important thing to understand is that htmx expects _HTML_ from the server.  In this case the server would
-return a _partial_ bit of HTML, say a `<div>`, to replace the button.  What htmx does _not_ expect is JSON.
+return a _partial_ bit of HTML, say a `<div>`, to replace the target element (```<output id="output">```).  What htmx does _not_ expect is JSON.
 
 Because htmx works in terms of HTML it follows the [original web programming model](https://www.ics.uci.edu/~fielding/pubs/dissertation/rest_arch_style.htm), using [Hypertext As The Engine Of Application State](https://en.wikipedia.org/wiki/HATEOAS) (HATEOAS).
 


### PR DESCRIPTION
There is an error in the v4 documentation. This example is given:

```
<button hx-post="/clicked"
        hx-trigger="click"
        hx-target="#output"
        hx-swap="outerHTML">
    Click Me
</button>
<output id="output"></output>
```

The documentation states that the button is replaced when the button is clicked, but that is obviously not true. The complete ```<output id="output"></output>``` block is being replaced.