### PR TITLE
add migration rule to change preload to hx-preload in upgrade checker

### DIFF
--- a/src/scripts/upgrade-check.py
+++ b/src/scripts/upgrade-check.py
@@ -101,6 +101,7 @@ WS_EVENT_RENAMES = {
 
 # Extension attribute renames
 EXT_ATTR_RENAMES = {
+    "preload": "rename to hx-preload",
     "sse-connect": "rename to hx-sse:connect",
     "sse-close": "rename to hx-sse:close",
     "sse-swap": "removed — SSE now integrates with standard htmx request pipeline",


### PR DESCRIPTION
## Description
*Please describe what changes you made, and why you feel they are necessary. Make sure to include
code examples, where applicable.*

Htmx 2 docs recommend calling the extension with the `preload` attribute ( [https://htmx.org/extensions/preload/),](https://htmx.org/extensions/preload/), "‌") while in htmx 4 you need to call the attribute `hx-preload`. This PR adds a migration rule to the Upgrade Checker to warn the user of this change.

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

I had this issue in a codebase which uses HTMX, and ran `./upgrade-check.js` against my repo to make sure it found any usage of `preload` instead of `hx-preload`.

I ran `npm test` locally to make sure all 87 test files passed. 

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
