### PR TITLE
fix(swap): find oob targets in the document when the context element is detached

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1889,7 +1889,12 @@ var htmx = (function() {
       maybeCall(swapOptions.beforeSwapCallback)
 
       target = resolveTarget(target)
-      const rootNode = swapOptions.contextElement ? getRootNode(swapOptions.contextElement, false) : getDocument()
+      // A detached contextElement's own getRootNode() is its orphaned subtree, not
+      // the document, so OOB targets that are still live in the document would be
+      // unreachable through it - fall back to the document in that case.
+      const rootNode = (swapOptions.contextElement && swapOptions.contextElement.isConnected)
+        ? getRootNode(swapOptions.contextElement, false)
+        : getDocument()
 
       // preserve focus and selection
       const activeElt = document.activeElement

--- a/test/attributes/hx-swap-oob.js
+++ b/test/attributes/hx-swap-oob.js
@@ -25,6 +25,16 @@ describe('hx-swap-oob attribute', function() {
     })
   }
 
+  it('still finds an oob target still in the document when the triggering element is detached before the response arrives', function() {
+    this.server.respondWith('GET', '/test', "Clicked<div id='d1' hx-swap-oob='true'>Swapped0</div>")
+    var div = make('<div hx-get="/test">click me</div>')
+    make('<div id="d1"></div>')
+    div.click()
+    div.remove() // simulate the trigger's region re-rendering while the request is in flight
+    this.server.respond()
+    byId('d1').innerHTML.should.equal('Swapped0')
+  })
+
   for (const config of [{ allowNestedOobSwaps: true }, { allowNestedOobSwaps: false }]) {
     it('oob swap works when the response has a body tag with config ' + JSON.stringify(config), function() {
       Object.assign(htmx.config, config)


### PR DESCRIPTION
Fixes #3959.

## What

`swap()` picks the `rootNode` used for `hx-swap-oob` target lookup by calling `getRootNode()` on the request's `contextElement` (the element that issued it):

```js
const rootNode = swapOptions.contextElement ? getRootNode(swapOptions.contextElement, false) : getDocument()
```

That's correct while `contextElement` is still in the document - it's exactly what #2846 needed to make OOB swaps work inside shadow roots. But if `contextElement` has since been detached (its own region re-rendered while the request was in flight - e.g. a row in a list whose own `hx-get` is pending when the list itself gets replaced), `elt.getRootNode()` on a detached node returns its orphaned subtree's own root, not the document. `oobSwap()`'s `querySelectorAllExt(rootNode, selector, false)` then searches that orphaned root and finds nothing, so every OOB fragment in the response gets silently dropped (`htmx:oobErrorNoTarget` in the console is the only sign) - even though its target is still live in the document, and even though the response's main swap applies normally.

## Fix

```js
const rootNode = (swapOptions.contextElement && swapOptions.contextElement.isConnected)
  ? getRootNode(swapOptions.contextElement, false)
  : getDocument()
```

Falls back to the document when `contextElement` is disconnected, leaving the connected-trigger / shadow-root behavior #2846 added completely untouched.

## Testing

- Added a test to `test/attributes/hx-swap-oob.js`: click a trigger, detach it (`.remove()`) before the response lands, and assert a separate, still-in-document OOB target still receives its content.
- Negative control: reverted just `src/htmx.js`, kept the test - it fails with the target's `innerHTML` staying empty (the drop), all other 33 tests in the file still pass. Restored.
- Full suite: 848/848 passing (3 pre-existing skips, unrelated), including both existing shadow-DOM OOB tests from #2846 - confirming the connected/shadow-root case is untouched.
- `eslint` clean on both changed files.

PR targets `dev` per CONTRIBUTING.md.