### PR TITLE
fix ajax so that target works but does not override source

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1588,20 +1588,14 @@ var htmx = (() => {
                 return Promise.reject(new Error('Source not found'));
             }
 
-            // Resolve explicit target if provided; otherwise __createRequestContext
-            // will resolve from hx-target on the source element
-            if (options.target) {
-                let target = this.__resolveTarget(document.body, options.target);
-                if (!target) {
-                    return Promise.reject(new Error('Target not found'));
-                }
-                sourceElt ||= target;
-            }
             sourceElt ||= document.body;
 
             let ctx = this.__createRequestContext(sourceElt, options.event || {});
             Object.assign(ctx, options);
-            if (options.target) ctx.target = this.__resolveTarget(document.body, options.target);
+            if (options.target) {
+                ctx.target = this.__resolveTarget(document.body, options.target);
+                if (!ctx.target) return Promise.reject(new Error('Target not found'));
+            }
             Object.assign(ctx.request, {action: path, method: verb.toUpperCase()});
             if (options.headers) Object.assign(ctx.request.headers, options.headers);
 
@@ -1816,10 +1810,10 @@ var htmx = (() => {
             let inputs = [];
             if (tag === 'BUTTON' || tag.includes('-')) {
                 inputs = [elt]; // send own value only, never collect children
-            } else if (['INPUT', 'SELECT', 'TEXTAREA', 'FIELDSET'].includes(tag) || !isGet) {
+            } else if (['INPUT', 'SELECT', 'TEXTAREA', 'FIELDSET'].includes(tag) || (!isGet && elt !== document.body)) {
                 inputs = this.__queryEltAndDescendants(elt, '[name]:not(button)');
             }
-            // GET on non-form-control containers (div, etc.) sends nothing; use hx-include for explicit inclusion
+            // GET on non-form-control containers sends nothing; POST on body sends nothing; use hx-include for explicit inclusion
 
             for (let input of inputs) {
                 let name = input.name || input.getAttribute?.('name');

--- a/test/tests/unit/__handleHxHeadersAndMaybeReturnEarly.js
+++ b/test/tests/unit/__handleHxHeadersAndMaybeReturnEarly.js
@@ -80,7 +80,12 @@ describe('__handleHxHeadersAndMaybeReturnEarly unit tests', function() {
         let source = createProcessedHTML('<div><div id="destination"></div><button id="source" hx-get="/test">Go</button></div>')
             .querySelector('#source')
         let requestFinished = new Promise(resolve => {
-            find('#destination').addEventListener('htmx:finally:request', resolve, {once: true})
+            document.addEventListener('htmx:finally:request', function handler(evt) {
+                if (evt.detail?.ctx?.request?.action === '/location-replaced') {
+                    document.removeEventListener('htmx:finally:request', handler)
+                    resolve()
+                }
+            })
         })
         let originalPushState = history.pushState
         let originalReplaceState = history.replaceState

--- a/test/tests/unit/ajax.js
+++ b/test/tests/unit/ajax.js
@@ -256,13 +256,8 @@ describe('ajax() unit Tests', function() {
         let beforeRequestFired = false;
         let afterRequestFired = false;
         
-        div.addEventListener('htmx:before:request', () => {
-            beforeRequestFired = true;
-        });
-        
-        div.addEventListener('htmx:after:request', () => {
-            afterRequestFired = true;
-        });
+        document.addEventListener('htmx:before:request', () => { beforeRequestFired = true; }, {once: true});
+        document.addEventListener('htmx:after:request', () => { afterRequestFired = true; }, {once: true});
         
         await htmx.ajax('GET', '/test', {target: div, swap: 'innerHTML'});
         
@@ -350,6 +345,31 @@ describe('ajax() unit Tests', function() {
         await htmx.timeout(50);
         assert.isTrue(capturedAction.startsWith('https://other-domain.com/api'));
         assert.include(capturedAction, 'foo=bar');
+    });
+
+    it('ajax does not collect inputs from target element', async function() {
+        mockResponse('POST', '/test', 'ok');
+        createProcessedHTML('<div id="target"><input name="secret" value="should-not-send"/></div>');
+        await htmx.ajax('POST', '/test', {
+            target: '#target',
+            swap: 'innerHTML'
+        });
+        const params = new URLSearchParams(lastFetch().request.body);
+        assert.isNull(params.get('secret'));
+    });
+
+    it('ajax explicit target overrides hx-target on source element', async function() {
+        mockResponse('GET', '/test', 'targeted!');
+        createProcessedHTML('<div id="source" hx-target="#other"></div><div id="other"></div><div id="explicit"></div>');
+        const explicit = find('#explicit');
+        const other = find('#other');
+        await htmx.ajax('GET', '/test', {
+            source: '#source',
+            target: '#explicit',
+            swap: 'innerHTML'
+        });
+        assert.equal(explicit.innerHTML, 'targeted!');
+        assert.equal(other.innerHTML, '');
     });
 
     it('triggers htmx:error when __createRequestContext throws', async function() {


### PR DESCRIPTION
## Description
Fix ajax() using target element as source when no source provided

When calling htmx.ajax() with only a target and no explicit source, the
target element was being used as the source for the request context. This
caused hx-target, hx-vals, hx-headers and other attributes on the target
to bleed into the request, and inputs inside the target to be collected
as form data on POST requests.

Fix: fall back to document.body as source when none is provided, and
resolve the explicit target after Object.assign so it always wins over
any hx-target read from the source element. Also guard document.body
against collecting descendant inputs on POST, since it is only ever a
fallback and should never vacuum up all inputs on the page.

Corresponding issue:
#4005

## Testing
Added tests

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
