### PR TITLE
handle hx-request-type header generation in hx-preload

### DIFF
--- a/src/ext/hx-preload.js
+++ b/src/ext/hx-preload.js
@@ -42,6 +42,8 @@
             });
             if (valsResult) await valsResult;
 
+            ctx.request.headers["HX-Request-Type"] = (ctx.target === document.body || ctx.select) ? "full" : "partial";
+
             let action = ctx.request.action.replace?.(/#.*$/, '');
 
             let params = new URLSearchParams(body);

--- a/test/tests/ext/hx-preload.js
+++ b/test/tests/ext/hx-preload.js
@@ -152,6 +152,14 @@ describe('hx-preload attribute', function() {
         assert.equal(fetchCount, 1, 'click should reuse preload, not fetch again')
     })
 
+    it('includes HX-Request-Type header in preload fetch', async function () {
+        mockResponse('GET', '/test', 'Response')
+        let btn = createProcessedHTML('<button hx-get="/test" hx-preload="mouseenter">Click</button>');
+        btn.dispatchEvent(new Event('mouseenter'))
+        await htmx.timeout(20)
+        assert.equal(lastFetch().request.headers['HX-Request-Type'], 'partial')
+    })
+
     it('reuses preload with URL containing fragment', async function () {
         let fetchCount = 0;
         mockResponse('GET', '/test', () => { fetchCount++; return 'Response'; })


### PR DESCRIPTION
## Description
preload needs to manually set hx-request-type header as this is now set last minute to make it accurate but this change was not adopted into hx-preload where it manually has to generate the query the same itself 

Corresponding issue:
#3997 

## Testing
Added test

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
