### PR TITLE
fix renamed afterSettle event on upgrade-check.py

### DIFF
--- a/src/scripts/upgrade-check.py
+++ b/src/scripts/upgrade-check.py
@@ -52,7 +52,7 @@ EVENT_RENAMES = {
     "htmx:afterOnLoad": "htmx:after:init",
     "htmx:afterProcessNode": "htmx:after:init",
     "htmx:afterRequest": "htmx:after:request",
-    "htmx:afterSettle": "htmx:after:swap",
+    "htmx:afterSettle": "htmx:after:settle",
     "htmx:afterSwap": "htmx:after:swap",
     "htmx:beforeCleanupElement": "htmx:before:cleanup",
     "htmx:beforeHistorySave": "htmx:before:history:update",


### PR DESCRIPTION
Fix bug on 
Upgrade check tool

## Description 
upgrade check tool was instructing to rename htmx:afterSettle event to htmx:after:swap instead of htmx:after:settle

## Checklist

* [ ✓] I have read the contribution guidelines
* [ ✓] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ✗] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ✗] I ran the test suite locally (`npm run test`) and verified that it succeeded
