### PR TITLE
feat(hx-live): support boolean attribute binding with :?attr (#4019)

### DIFF
--- a/src/ext/hx-live.js
+++ b/src/ext/hx-live.js
@@ -781,6 +781,10 @@
 
     function writeAttrBinding(elt, attrName, value) {
         if (typeof value === 'function') throw new TypeError('hx-live: binding returned a function');
+        if (attrName.startsWith('?')) {
+            elt.toggleAttribute(attrName.slice(1), !!value);
+            return;
+        }
         if (attrName === 'text') {
             let s = value == null ? '' : String(value);
             if (elt.textContent !== s) elt.textContent = s;

--- a/test/tests/ext/hx-live.js
+++ b/test/tests/ext/hx-live.js
@@ -2449,6 +2449,75 @@ describe('hx-live extension', function () {
         btn.hasAttribute('disabled').should.equal(true);
     });
 
+    it(':?attr toggles boolean attribute presence based on truthiness', async function() {
+        playground().innerHTML = `
+            <input id="src" type="checkbox">
+            <custom-select id="target" :?multiple="q('#src').checked"></custom-select>
+        `;
+        htmx.process(playground());
+        let target = playground().querySelector('#target');
+        target.hasAttribute('multiple').should.equal(false);
+
+        let inp = playground().querySelector('#src');
+        inp.checked = true;
+        inp.dispatchEvent(new Event('change', { bubbles: true }));
+        await htmx.timeout(5);
+        target.hasAttribute('multiple').should.equal(true);
+
+        inp.checked = false;
+        inp.dispatchEvent(new Event('change', { bubbles: true }));
+        await htmx.timeout(5);
+        target.hasAttribute('multiple').should.equal(false);
+    });
+
+    it('hx-live:?attr (canonical form) works same as :?attr', async function() {
+        playground().innerHTML = `
+            <input id="src" type="checkbox">
+            <div id="target" hx-live:?custom-flag="q('#src').checked"></div>
+        `;
+        htmx.process(playground());
+        let target = playground().querySelector('#target');
+        target.hasAttribute('custom-flag').should.equal(false);
+
+        let inp = playground().querySelector('#src');
+        inp.checked = true;
+        inp.dispatchEvent(new Event('change', { bubbles: true }));
+        await htmx.timeout(5);
+        target.hasAttribute('custom-flag').should.equal(true);
+
+        inp.checked = false;
+        inp.dispatchEvent(new Event('change', { bubbles: true }));
+        await htmx.timeout(5);
+        target.hasAttribute('custom-flag').should.equal(false);
+    });
+
+    it(':?attr handles truthy and falsy values correctly', async function() {
+        playground().innerHTML = `
+            <input id="val" value="0">
+            <div id="target" :?active="q('#val').value === 'true' ? true : q('#val').value === 'banana' ? 'banana' : q('#val').value === '1' ? 1 : false"></div>
+        `;
+        htmx.process(playground());
+        let target = playground().querySelector('#target');
+        let inp = playground().querySelector('#val');
+
+        target.hasAttribute('active').should.equal(false);
+
+        inp.value = 'true';
+        inp.dispatchEvent(new Event('input', { bubbles: true }));
+        await htmx.timeout(5);
+        target.hasAttribute('active').should.equal(true);
+
+        inp.value = 'banana';
+        inp.dispatchEvent(new Event('input', { bubbles: true }));
+        await htmx.timeout(5);
+        target.hasAttribute('active').should.equal(true);
+
+        inp.value = '0';
+        inp.dispatchEvent(new Event('input', { bubbles: true }));
+        await htmx.timeout(5);
+        target.hasAttribute('active').should.equal(false);
+    });
+
     it(':aria-expanded writes "true"/"false", never removes', async function() {
         playground().innerHTML = `
             <input id="src" type="checkbox">

--- a/www/src/content/extensions/06-hx-live.md
+++ b/www/src/content/extensions/06-hx-live.md
@@ -178,6 +178,17 @@ The long form. Behaves identically to `:<attr>`.
 
 Use it if your build pipeline strips `:`-prefixed attributes.
 
+### `:?<attr>` / `hx-live:?<attr>`
+
+Explicit boolean attribute binding. Borrowing the `?` prefix syntax common in web components (such as Lit), truthy values add the attribute and falsy values remove it entirely via native `toggleAttribute()`.
+
+```html
+<custom-select :?multiple="q('#count').valueAsNumber > 1"></custom-select>
+<div hx-live:?custom-flag="q('#checkbox').checked"></div>
+```
+
+This is useful for custom elements, web components, or arbitrary attributes where DOM attribute *presence* dictates state rather than string value.
+
 ### `:.<class>`
 
 Bind a single class to an expression. Truthy adds it, falsy removes it.
@@ -1045,6 +1056,15 @@ When an `hx-live` element is removed, its expression drops out on the next sched
 <input   :readonly="falsyExpr">    <!-- <input>               -->
 <div     :inert="truthyExpr">      <!-- <div inert="">        -->
 <div     :inert="falsyExpr">       <!-- <div>                 -->
+```
+
+**Explicit boolean modifier** (`:?<attr>` or `hx-live:?<attr>`). Forces boolean toggle behavior for any attribute (such as custom elements and web components), invoking native `toggleAttribute()`. Truthy adds the attribute; falsy removes it.
+
+```html
+<custom-select :?multiple="truthyExpr">     <!-- <custom-select multiple=""> -->
+<custom-select :?multiple="falsyExpr">      <!-- <custom-select>             -->
+<div :?custom-flag="truthyExpr">            <!-- <div custom-flag="">        -->
+<div :?custom-flag="falsyExpr">             <!-- <div>                       -->
 ```
 
 **ARIA attributes** (`aria-*`). Values are stringified. `null` or `undefined` remove the attribute.


### PR DESCRIPTION
## Description
Adds support for an explicit boolean attribute binding modifier—`:?<attr>` and its canonical form `hx-live:?<attr>`—to `hx-live`.
While `hx-live` toggles native boolean attributes (`disabled`, `required`, etc.) based on truthiness, generic attributes stringify booleans (e.g. `:multiple="false"` writes `multiple="false"`). For Web Components (like Lit's `@property({ type: Boolean })`), Custom Elements, and custom boolean attributes where attribute *presence* dictates state rather than string value, this caused attributes to remain present when falsy.
Borrowing the `?` prefix convention from Lit and the Web Components ecosystem:
- Truthy values (`true`, non-empty strings, positive numbers) add/retain the attribute via native `toggleAttribute()`.
- Falsy values (`false`, `null`, `undefined`, `0`, `""`) remove the attribute entirely via native `toggleAttribute()`.
Example:
```html
<!-- Truthy adds multiple="", falsy removes multiple entirely -->
<custom-select :?multiple="q('#count').valueAsNumber > 1"></custom-select>
<!-- Canonical form for build pipelines stripping ':' -->
<div hx-live:?custom-flag="q('#checkbox').checked"></div>
```

Corresponding issue: Closes #4019

## Testing
1. Automated Unit Tests:
   - Added unit tests in `test/tests/ext/hx-live.js` covering `:?attr`, `hx-live:?attr`, and truthy/falsy evaluation rules.
   - Ran `npm run test` (all 1,739 tests passed across 87 test files with 100% code coverage).
   - Ran `npm run check:content` (all doc and API checks passed).
2. Manual Testing:
   - Tested interactively via `test/scratch/scratch.html` with real-time DOM mutation inspection on custom web components and standard elements.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is a new feature discussed with and guided by @MichaelWest22 in #4019
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
