### PR TITLE
Fix stale swaps after request replacement

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -116,7 +116,8 @@ var htmx = (() => {
             return "queued"
         }
 
-        continue() {
+        continue(abortRequest) {
+            if (this.#current?.abort !== abortRequest) return
             this.#current = null    // free current slot
             this.#queue.shift()?.() // run next request
         }
@@ -545,10 +546,12 @@ var htmx = (() => {
             let requestQueue = this.__getRequestQueue(elt);
             this.__initializeAbortListener(elt);
 
+            let abortRequest = () => ctx.request?.abort?.()
+
             if (requestQueue.admit(
                 syncStrategy,
                 () => this.__issueRequest(ctx), // run when ready
-                () => ctx.request?.abort?.()    // abort if replaced
+                abortRequest                  // abort if replaced
             ) !== "run") return
 
             ctx.status = "issuing"
@@ -626,7 +629,7 @@ var htmx = (() => {
                     this.__enableElements(disableElements);
                 }
 
-                requestQueue.continue()
+                requestQueue.continue(abortRequest)
             }
         }
 

--- a/test/tests/unit/__getRequestQueue.js
+++ b/test/tests/unit/__getRequestQueue.js
@@ -48,8 +48,8 @@ describe('__getRequestQueue / RequestQueue unit tests', function() {
 
         assert.equal(result, 'queued')
 
-        queue.continue()
-        queue.continue()
+        queue.continue(noop)
+        queue.continue(noop)
 
         assert.deepEqual(started, [3])
     })
@@ -78,8 +78,8 @@ describe('__getRequestQueue / RequestQueue unit tests', function() {
         assert.equal(second, 'queued')
         assert.equal(third, 'dropped')
 
-        queue.continue()
-        queue.continue()
+        queue.continue(noop)
+        queue.continue(noop)
 
         assert.deepEqual(started, [2])
     })
@@ -93,7 +93,7 @@ describe('__getRequestQueue / RequestQueue unit tests', function() {
         queue.admit('queue all', () => started.push(2), noop)
         queue.admit('queue all', () => started.push(3), noop)
 
-        queue.continue()
+        queue.continue(noop)
 
         assert.deepEqual(started, [2])
     })
@@ -102,7 +102,7 @@ describe('__getRequestQueue / RequestQueue unit tests', function() {
         let div = createProcessedHTML('<div hx-get="/test"></div>')
         let queue = htmx.__getRequestQueue(div)
 
-        queue.continue()
+        queue.continue(noop)
     })
 
     it('continue clears the current request', function () {
@@ -110,7 +110,7 @@ describe('__getRequestQueue / RequestQueue unit tests', function() {
         let queue = htmx.__getRequestQueue(div)
 
         queue.admit('queue first', noop, noop)
-        queue.continue()
+        queue.continue(noop)
 
         assert.equal(queue.admit('queue first', noop, noop), 'run')
     })
@@ -289,6 +289,28 @@ describe('__getRequestQueue / RequestQueue unit tests', function() {
         assert.isFalse(aborted)
     })
 
+    for (let strategy of ['replace', 'abort']) {
+        it(`ignores cleanup of a replaced ${strategy} request`, async function () {
+            let div = createProcessedHTML('<div hx-get="/test"></div>')
+            let queue = htmx.__getRequestQueue(div)
+            let cleanup
+            let abortFirst = () => { cleanup = Promise.resolve().then(() => queue.continue(abortFirst)) }
+            let secondAborted = false
+            let abortSecond = () => { secondAborted = true }
+            let queuedStarted = false
+
+            assert.equal(queue.admit(strategy, noop, abortFirst), 'run')
+            assert.equal(queue.admit('replace', noop, abortSecond), 'run')
+            assert.equal(queue.admit('queue all', () => { queuedStarted = true }, noop), 'queued')
+            await cleanup
+
+            assert.isFalse(queuedStarted)
+            assert.equal(queue.admit('drop', noop, noop), 'dropped')
+            assert.equal(queue.admit('replace', noop, noop), 'run')
+            assert.isTrue(secondAborted)
+        })
+    }
+
     // hx-sync value parsing tests
 
     it('hx-sync="this" defaults to queue first strategy', function () {
@@ -356,7 +378,7 @@ describe('__getRequestQueue / RequestQueue unit tests', function() {
         assert.equal(result, 'run')
         assert.isTrue(aborted)
 
-        queue.continue()
+        queue.continue(noop)
 
         assert.deepEqual(started, [])
     })


### PR DESCRIPTION
Ignore cleanup from a request that is no longer active. Add regression tests for the replace and abort strategies.

Fixes #4027

## Description

Fix a bug where `hx-sync="replace"` lets an older response overwrite the latest result.

The cleanup of a cancelled request can clear the active request from the queue. This change checks which request owns the queue before clearing it, so later requests can still cancel it.

Fixes #4027

## Testing

Added regression tests for `replace` and `abort`. Both fail without the fix and pass with it.

Ran `npm run test` in Chromium: 1,738 passed, 5 skipped.

Checked the browser repro with the patched build. B is cancelled and only C renders.

## Checklist

  - [x] I have read the contribution guidelines
  - [x] I have targeted this PR against `four-dev` for the htmx 4 fix
  - [x] This is a bugfix
  - [x] I ran the test suite locally (`npm run test`) and verified that it succeeded