### PR TITLE
fix: changed modifier permanently suppressed requests on form elements

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -789,9 +789,11 @@ var htmx = (() => {
                     if (spec.changed) {
                         let values = spec.values ??= new WeakMap();
                         let target = evt.target;
-                        let value = target?.value;
-                        if (values.has(target) && values.get(target) === value) return;
-                        values.set(target, value);
+                        if (!['checkbox', 'radio'].includes(target?.type)) {
+                            let value = target?.value;
+                            if (values.has(target) && values.get(target) === value) return;
+                            values.set(target, value);
+                        }
                     }
                     if (filter) {
                         if (this.__shouldCancel(evt)) evt.preventDefault();

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -790,8 +790,7 @@ var htmx = (() => {
                         let values = spec.values ??= new WeakMap();
                         let target = evt.target;
                         let value = target?.value;
-                        if (!values.has(target)) values.set(target, target?.value);
-                        if (values.get(target) === value) return;
+                        if (values.has(target) && values.get(target) === value) return;
                         values.set(target, value);
                     }
                     if (filter) {

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -788,14 +788,11 @@ var htmx = (() => {
                     if (spec.target && !evt.target?.matches?.(spec.target)) return;
                     if (spec.changed) {
                         let values = spec.values ??= new WeakMap();
-                        let changed = false;
-                        for (let fromElt of fromElts) {
-                            if (values.get(fromElt) !== fromElt.value) {
-                                changed = true;
-                                values.set(fromElt, fromElt.value);
-                            }
-                        }
-                        if (!changed) return;
+                        let target = evt.target;
+                        let value = target?.value;
+                        if (!values.has(target)) values.set(target, target?.value);
+                        if (values.get(target) === value) return;
+                        values.set(target, value);
                     }
                     if (filter) {
                         if (this.__shouldCancel(evt)) evt.preventDefault();

--- a/test/tests/attributes/hx-trigger.js
+++ b/test/tests/attributes/hx-trigger.js
@@ -109,51 +109,66 @@ describe('hx-trigger attribute', function() {
 
     it('changed modifier suppresses request when input value is unchanged', async function () {
         mockResponse('GET', '/test', 'Changed!')
+        mockResponse('GET', '/test', 'Changed!')
         let input = createProcessedHTML('<input hx-get="/test" hx-trigger="keydown changed" value="hello">')
-        input.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true}))
-        fetchMock.calls.length.should.equal(0)
-        input.value = 'world'
+        // first fire records value and fires
         input.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true}))
         await forRequest()
         fetchMock.calls.length.should.equal(1)
+        // same value — suppressed
+        input.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true}))
+        fetchMock.calls.length.should.equal(1)
+        // changed value — fires
+        input.value = 'world'
+        input.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true}))
+        await forRequest()
+        fetchMock.calls.length.should.equal(2)
     })
 
     it('changed modifier fires on form keydown when child input value changes', async function () {
         mockResponse('GET', '/test', 'Changed!')
-        let form = createProcessedHTML('<form hx-get="/test" hx-trigger="keydown changed"><input id="i" value="hello"></form>')
+        mockResponse('GET', '/test', 'Changed!')
+        let form = createProcessedHTML('<form hx-get="/test" hx-swap="none" hx-trigger="keydown changed"><input id="i" value="hello"></form>')
         let input = find('#i')
-        input.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true}))
-        fetchMock.calls.length.should.equal(0)
-        input.value = 'world'
+        // first fire records value and fires
         input.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true}))
         await forRequest()
         fetchMock.calls.length.should.equal(1)
+        // same value — suppressed
+        input.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true}))
+        fetchMock.calls.length.should.equal(1)
+        // changed value — fires
+        input.value = 'world'
+        input.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true}))
+        await forRequest()
+        fetchMock.calls.length.should.equal(2)
     })
 
     it('changed modifier tracks each input independently', async function () {
         mockResponse('GET', '/test', 'Changed!')
         mockResponse('GET', '/test', 'Changed!')
+        mockResponse('GET', '/test', 'Changed!')
         let form = createProcessedHTML('<form hx-get="/test" hx-swap="none" hx-trigger="keydown changed"><input id="i1" value="a"><input id="i2" value="b"></form>')
         let i1 = find('#i1'), i2 = find('#i2')
-        // fire from i1 unchanged — no request
+        // first fire from i1 records value and fires
         i1.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true}))
-        fetchMock.calls.length.should.equal(0)
-        // change i1, fire — request fires
+        await forRequest()
+        fetchMock.calls.length.should.equal(1)
+        // fire from i1 unchanged — suppressed
+        i1.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true}))
+        fetchMock.calls.length.should.equal(1)
+        // change i1, fire — fires
         i1.value = 'x'
         i1.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true}))
         await forRequest()
-        fetchMock.calls.length.should.equal(1)
-        // fire from i1 again unchanged — no new request
-        i1.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true}))
-        fetchMock.calls.length.should.equal(1)
-        // fire from i2 unchanged — no request (i2 not yet seen)
-        i2.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true}))
-        fetchMock.calls.length.should.equal(1)
-        // change i2, fire — request fires
-        i2.value = 'y'
+        fetchMock.calls.length.should.equal(2)
+        // first fire from i2 records value and fires
         i2.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true}))
         await forRequest()
-        fetchMock.calls.length.should.equal(2)
+        fetchMock.calls.length.should.equal(3)
+        // fire from i2 unchanged — suppressed
+        i2.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true}))
+        fetchMock.calls.length.should.equal(3)
     })
 
     it('load event triggers on element creation', async function () {

--- a/test/tests/attributes/hx-trigger.js
+++ b/test/tests/attributes/hx-trigger.js
@@ -107,6 +107,55 @@ describe('hx-trigger attribute', function() {
         find('#d3').innerText.should.equal('bar')
     })
 
+    it('changed modifier suppresses request when input value is unchanged', async function () {
+        mockResponse('GET', '/test', 'Changed!')
+        let input = createProcessedHTML('<input hx-get="/test" hx-trigger="keydown changed" value="hello">')
+        input.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true}))
+        fetchMock.calls.length.should.equal(0)
+        input.value = 'world'
+        input.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true}))
+        await forRequest()
+        fetchMock.calls.length.should.equal(1)
+    })
+
+    it('changed modifier fires on form keydown when child input value changes', async function () {
+        mockResponse('GET', '/test', 'Changed!')
+        let form = createProcessedHTML('<form hx-get="/test" hx-trigger="keydown changed"><input id="i" value="hello"></form>')
+        let input = find('#i')
+        input.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true}))
+        fetchMock.calls.length.should.equal(0)
+        input.value = 'world'
+        input.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true}))
+        await forRequest()
+        fetchMock.calls.length.should.equal(1)
+    })
+
+    it('changed modifier tracks each input independently', async function () {
+        mockResponse('GET', '/test', 'Changed!')
+        mockResponse('GET', '/test', 'Changed!')
+        let form = createProcessedHTML('<form hx-get="/test" hx-swap="none" hx-trigger="keydown changed"><input id="i1" value="a"><input id="i2" value="b"></form>')
+        let i1 = find('#i1'), i2 = find('#i2')
+        // fire from i1 unchanged — no request
+        i1.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true}))
+        fetchMock.calls.length.should.equal(0)
+        // change i1, fire — request fires
+        i1.value = 'x'
+        i1.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true}))
+        await forRequest()
+        fetchMock.calls.length.should.equal(1)
+        // fire from i1 again unchanged — no new request
+        i1.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true}))
+        fetchMock.calls.length.should.equal(1)
+        // fire from i2 unchanged — no request (i2 not yet seen)
+        i2.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true}))
+        fetchMock.calls.length.should.equal(1)
+        // change i2, fire — request fires
+        i2.value = 'y'
+        i2.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true}))
+        await forRequest()
+        fetchMock.calls.length.should.equal(2)
+    })
+
     it('load event triggers on element creation', async function () {
         debug(this)
         mockResponse('GET', '/test', 'Loaded!')

--- a/test/tests/attributes/hx-trigger.js
+++ b/test/tests/attributes/hx-trigger.js
@@ -171,6 +171,34 @@ describe('hx-trigger attribute', function() {
         fetchMock.calls.length.should.equal(3)
     })
 
+    it('changed modifier on checkbox fires on each click', async function () {
+        mockResponse('GET', '/test', 'Changed!')
+        mockResponse('GET', '/test', 'Changed!')
+        mockResponse('GET', '/test', 'Changed!')
+        let input = createProcessedHTML('<input type="checkbox" hx-get="/test" hx-trigger="click changed">')
+        input.click()
+        await forRequest()
+        fetchMock.calls.length.should.equal(1)
+        input.click()
+        await forRequest()
+        fetchMock.calls.length.should.equal(2)
+        input.click()
+        await forRequest()
+        fetchMock.calls.length.should.equal(3)
+    })
+
+    it('changed modifier on radio fires on each click', async function () {
+        mockResponse('GET', '/test', 'Changed!')
+        mockResponse('GET', '/test', 'Changed!')
+        let input = createProcessedHTML('<input type="radio" hx-get="/test" hx-trigger="click changed">')
+        input.click()
+        await forRequest()
+        fetchMock.calls.length.should.equal(1)
+        input.click()
+        await forRequest()
+        fetchMock.calls.length.should.equal(2)
+    })
+
     it('load event triggers on element creation', async function () {
         debug(this)
         mockResponse('GET', '/test', 'Loaded!')


### PR DESCRIPTION
## Description
# Fix `changed` modifier on forms (closes #4033)

## What was broken

`hx-trigger="keydown changed"` on a `<form>` silently suppresses every request. Doesn't matter what you type — nothing fires. Works fine on a bare `<input>`, so it's easy to miss until you try the natural pattern of triggering on the form itself.

## Why

The `changed` block checked `.value` on the element carrying `hx-trigger`. For a form that's `form.value`, which is always `undefined`:

```javascript
for (let fromElt of fromElts) {
    if (values.get(fromElt) !== fromElt.value) {  // undefined !== undefined — always false
        changed = true;
    }
}
if (!changed) return;  // always hits this
```

## The fix

Track `evt.target` instead — the actual input the user typed in. That's always correct regardless of whether the listener is on the input directly, a parent form, or a `from:` element. Seed on first sight so we don't fire before anything has actually changed.

```javascript
if (spec.changed) {
    let values = spec.values ??= new WeakMap();
    let target = evt.target;
    let value = target?.value;
    if (!values.has(target)) { values.set(target, value); return; }
    if (values.get(target) === value) return;
    values.set(target, value);
}
```

Three tests added: direct input suppression, the form bubbling case from #4033, and two inputs in one form tracked independently.


Corresponding issue:
#4033

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
