### PR TITLE
fix: honor htmx.config.transitions on history restore

### DIFF
--- a/src/ext/hx-history-cache.js
+++ b/src/ext/hx-history-cache.js
@@ -174,7 +174,7 @@
             target: restoreSwapTarget,
             swap: restoreSwapStyle,
             text: cachedHTML,
-            transition: false
+            transition: htmx.config.transitions ?? false
         };
         await htmx.swap(ctx);
 


### PR DESCRIPTION
## Description
honor htmx.config.transitions on history restore in history cache extension

Corresponding issue:
#4032

## Testing

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
