### PR TITLE
fix: hx-swap-oob colon form supports spaces in selectors

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1077,9 +1077,9 @@ var htmx = (() => {
 
         __createOOBTask(tasks, elt, oobValue, sourceElement) {
             let targetSelector = elt.id ? '#' + CSS.escape(elt.id) : null;
-            if (oobValue !== 'true' && oobValue && !oobValue.includes(' ')) {
-                [oobValue, targetSelector = targetSelector] = oobValue.split(/:(.*)/);
-            }
+            // if oobValue is in "swapStyle:selector" form (no space before colon), split it; otherwise treat as HCON
+            let [, style, sel] = oobValue.match(/^(\S+):(.+)/) ?? [];
+            if (style) [oobValue, targetSelector] = [style, sel || targetSelector];
             if (oobValue === 'true' || !oobValue) oobValue = 'outerHTML';
 
             let swapSpec = this.__parseSwapSpec(oobValue);
@@ -2192,7 +2192,7 @@ var htmx = (() => {
                     if (!this.__triggerExtensions(destination, 'htmx:before:morph:attr', { attrName: attr.name, newValue: attr.value })) continue;
                     destination.setAttribute(attr.name, attr.value);
                     if (attr.name === "value" && destination instanceof HTMLInputElement && destination.type !== "file" && document.activeElement !== destination) {
-                        destination.value = attr.value;
+                            destination.value = attr.value;
                     }
                 }
             }

--- a/test/tests/attributes/hx-swap-oob.js
+++ b/test/tests/attributes/hx-swap-oob.js
@@ -73,6 +73,41 @@ describe('hx-swap-oob', function() {
         playground().querySelectorAll('.target').forEach(el => el.innerText.should.equal('Updated'))
     })
 
+    it('swaps oob with colon form selector containing a space', async function () {
+        mockResponse('GET', '/test', '<div>Main</div><div hx-swap-oob="innerHTML:.outer .inner">New Content</div>')
+        createProcessedHTML('<div hx-get="/test">Click</div><div class="outer"><div class="inner">Original</div></div>');
+        find('[hx-get]').click()
+        await forRequest()
+        assertTextContentIs('.outer .inner', 'New Content')
+    })
+
+    it('swaps oob with colon form using closest extended selector', async function () {
+        mockResponse('GET', '/test', '<div>Main</div><div hx-swap-oob="innerHTML:closest #container">New Content</div>')
+        createProcessedHTML('<div id="container"><div hx-get="/test">Click</div><div>Original</div></div>');
+        find('[hx-get]').click()
+        await forRequest()
+        assertTextContentIs('#container', 'New Content')
+    })
+
+    it('swaps oob with global selector crossing shadow root boundary', async function () {
+        mockResponse('GET', '/test', '<div hx-swap-oob="innerHTML:global #outside">New Content</div>Clicked')
+        let name = 'oob-global-shadow'
+        if (!customElements.get(name)) {
+            customElements.define(name, class extends HTMLElement {
+                connectedCallback() {
+                    let root = this.attachShadow({mode: 'open'})
+                    root.innerHTML = `<button hx-get="/test" hx-target="next div">Click me!</button><div></div>`
+                    htmx.process(root)
+                }
+            })
+        }
+        createProcessedHTML(`<${name}></${name}><div id="outside">Original</div>`)
+        let wc = find(name)
+        wc.shadowRoot.querySelector('button').click()
+        await forRequest()
+        assertTextContentIs('#outside', 'New Content')
+    })
+
     it('swaps an oob target inside the shadow root of the triggering element', async function () {
         mockResponse('GET', '/test', '<div hx-swap-oob="innerHTML:#oob-target">new contents</div>Clicked')
         let name = 'oob-shadow-scoped'


### PR DESCRIPTION


## Description
fix: hx-swap-oob colon form supports spaces in selectors

Fixes #4029.

The swapStyle:selector colon form in hx-swap-oob now correctly supports selectors containing spaces (e.g. innerHTML:.outer .inner, innerHTML:closest div, innerHTML:global #foo) by checking for a space only in the swap style part (before the colon) rather than the entire value. Values with a space before the colon fall through to HCON parsing as before, enabling the target:'...' form.

recent change was already fixed and just needed a test:
OOB swap targets are now resolved via __findAllExt instead of document.querySelectorAll, giving parity with partials — shadow root scoping, global, host, and all extended selectors work correctly. Ports the htmx 2 fix from #2846.

Tests added for: space-containing selectors, closest extended selector, and global crossing shadow root boundaries.

Corresponding issue:
#4029


## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
