### PR TITLE
fix: prevent stale continue() from clearing queue after hx-sync replace/abort

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -116,13 +116,15 @@ var htmx = (() => {
             return "queued"
         }
 
-        continue() {
+        continue(abortFn) {
+            if (this.#current?.abort !== abortFn) return
             this.#current = null    // free current slot
             this.#queue.shift()?.() // run next request
         }
 
         abort() {
             this.#current?.abort?.()
+            this.continue(this.#current?.abort)
         }
     }
 
@@ -545,10 +547,12 @@ var htmx = (() => {
             let requestQueue = this.__getRequestQueue(elt);
             this.__initializeAbortListener(elt);
 
+            let abortFn = () => ctx.request?.abort?.()
+
             if (requestQueue.admit(
                 syncStrategy,
                 () => this.__issueRequest(ctx), // run when ready
-                () => ctx.request?.abort?.()    // abort if replaced
+                abortFn                         // abort if replaced
             ) !== "run") return
 
             ctx.status = "issuing"
@@ -626,7 +630,7 @@ var htmx = (() => {
                     this.__enableElements(disableElements);
                 }
 
-                requestQueue.continue()
+                requestQueue.continue(abortFn)
             }
         }
 

--- a/test/tests/unit/__getRequestQueue.js
+++ b/test/tests/unit/__getRequestQueue.js
@@ -41,15 +41,17 @@ describe('__getRequestQueue / RequestQueue unit tests', function() {
         let div = createProcessedHTML('<div hx-get="/test"></div>')
         let queue = htmx.__getRequestQueue(div)
         let started = []
+        let abort1 = () => {}
+        let abort2 = () => {}
 
-        queue.admit('queue last', () => started.push(1), noop)
-        queue.admit('queue last', () => started.push(2), noop)
+        queue.admit('queue last', () => started.push(1), abort1)
+        queue.admit('queue last', () => started.push(2), abort2)
         let result = queue.admit('queue last', () => started.push(3), noop)
 
         assert.equal(result, 'queued')
 
-        queue.continue()
-        queue.continue()
+        queue.continue(abort1)
+        queue.continue(abort2)
 
         assert.deepEqual(started, [3])
     })
@@ -70,16 +72,18 @@ describe('__getRequestQueue / RequestQueue unit tests', function() {
         let div = createProcessedHTML('<div hx-get="/test"></div>')
         let queue = htmx.__getRequestQueue(div)
         let started = []
+        let abort1 = () => {}
+        let abort2 = () => {}
 
-        queue.admit('queue first', () => started.push(1), noop)
-        let second = queue.admit('queue first', () => started.push(2), noop)
+        queue.admit('queue first', () => started.push(1), abort1)
+        let second = queue.admit('queue first', () => started.push(2), abort2)
         let third = queue.admit('queue first', () => started.push(3), noop)
 
         assert.equal(second, 'queued')
         assert.equal(third, 'dropped')
 
-        queue.continue()
-        queue.continue()
+        queue.continue(abort1)
+        queue.continue(abort2)
 
         assert.deepEqual(started, [2])
     })
@@ -88,12 +92,13 @@ describe('__getRequestQueue / RequestQueue unit tests', function() {
         let div = createProcessedHTML('<div hx-get="/test"></div>')
         let queue = htmx.__getRequestQueue(div)
         let started = []
+        let abort1 = () => {}
 
-        queue.admit('queue all', () => started.push(1), noop)
+        queue.admit('queue all', () => started.push(1), abort1)
         queue.admit('queue all', () => started.push(2), noop)
         queue.admit('queue all', () => started.push(3), noop)
 
-        queue.continue()
+        queue.continue(abort1)
 
         assert.deepEqual(started, [2])
     })
@@ -102,17 +107,44 @@ describe('__getRequestQueue / RequestQueue unit tests', function() {
         let div = createProcessedHTML('<div hx-get="/test"></div>')
         let queue = htmx.__getRequestQueue(div)
 
-        queue.continue()
+        queue.continue(noop)
+    })
+
+    it('continue ignores stale calls from replaced requests', function () {
+        let div = createProcessedHTML('<div hx-get="/test"></div>')
+        let queue = htmx.__getRequestQueue(div)
+        let abort1 = () => {}
+        let abort2 = () => {}
+
+        queue.admit('replace', noop, abort1)
+        queue.admit('replace', noop, abort2) // replaces abort1
+
+        queue.continue(abort1) // stale — should be ignored
+
+        assert.equal(queue.admit('drop', noop, noop), 'dropped') // slot still occupied
     })
 
     it('continue clears the current request', function () {
         let div = createProcessedHTML('<div hx-get="/test"></div>')
         let queue = htmx.__getRequestQueue(div)
+        let abort1 = () => {}
 
-        queue.admit('queue first', noop, noop)
-        queue.continue()
+        queue.admit('queue first', noop, abort1)
+        queue.continue(abort1)
 
         assert.equal(queue.admit('queue first', noop, noop), 'run')
+    })
+
+    it('abort clears the slot and advances the queue', function () {
+        let div = createProcessedHTML('<div hx-get="/test"></div>')
+        let queue = htmx.__getRequestQueue(div)
+        let nextStarted = false
+
+        queue.admit('queue first', noop, noop)
+        queue.admit('queue first', () => { nextStarted = true }, noop)
+        queue.abort()
+
+        assert.isTrue(nextStarted)
     })
 
     it('abort calls abort on the current request', function () {
@@ -341,22 +373,45 @@ describe('__getRequestQueue / RequestQueue unit tests', function() {
         assert.equal(htmx.__getRequestQueue(a), htmx.__getRequestQueue(b))
     })
 
+    for (let strategy of ['replace', 'abort']) {
+        it(`ignores cleanup of a replaced ${strategy} request`, async function () {
+            let div = createProcessedHTML('<div hx-get="/test"></div>')
+            let queue = htmx.__getRequestQueue(div)
+            let cleanup
+            let abortFirst = () => { cleanup = Promise.resolve().then(() => queue.continue(abortFirst)) }
+            let secondAborted = false
+            let abortSecond = () => { secondAborted = true }
+            let queuedStarted = false
+
+            assert.equal(queue.admit(strategy, noop, abortFirst), 'run')
+            assert.equal(queue.admit('replace', noop, abortSecond), 'run')
+            assert.equal(queue.admit('queue all', () => { queuedStarted = true }, noop), 'queued')
+            await cleanup
+
+            assert.isFalse(queuedStarted)
+            assert.equal(queue.admit('drop', noop, noop), 'dropped')
+            assert.equal(queue.admit('replace', noop, noop), 'run')
+            assert.isTrue(secondAborted)
+        })
+    }
+
     it('replace strategy clears queued requests when aborting current', function () {
         let div = createProcessedHTML('<div hx-get="/test"></div>')
         let queue = htmx.__getRequestQueue(div)
         let aborted = false
         let started = []
+        let abortReplace = () => {}
 
         queue.admit('drop', noop, () => { aborted = true })
         queue.admit('queue all', () => started.push(2), noop)
         queue.admit('queue all', () => started.push(3), noop)
 
-        let result = queue.admit('replace', noop, noop)
+        let result = queue.admit('replace', noop, abortReplace)
 
         assert.equal(result, 'run')
         assert.isTrue(aborted)
 
-        queue.continue()
+        queue.continue(abortReplace)
 
         assert.deepEqual(started, [])
     })


### PR DESCRIPTION
## Description

When `hx-sync="replace"` (or `abort`) causes an in-flight request to be cancelled, its `finally` block still runs and calls `requestQueue.continue()`. This prematurely clears the slot that now belongs to the newer request, corrupting queue state and causing the newer request's own `continue()` to advance the queue a second time — potentially running queued requests out of order or skipping them entirely.

A second latent bug: firing `htmx:abort` called `abort()` which cancelled the fetch but never cleared `#current` or advanced the queue, permanently stalling any queued requests.

## Fix

`continue(abortFn)` now takes an identity token — the same function reference passed to `admit()`. It returns early if the caller is no longer the current owner:

```js
continue(abortFn) {
    if (this.#current?.abort !== abortFn) return
    this.#current = null
    this.#queue.shift()?.()
}
```

`abort()` delegates to `continue()` passing the current abort fn, which always matches, fixing the queue-stall bug with no duplicated logic:

```js
abort() {
    this.#current?.abort?.()
    this.continue(this.#current?.abort)
}
```

Corresponding issue:
#4027 

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
