### PR TITLE
fix: handle skipped view transition ready rejection

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2288,7 +2288,11 @@ var htmx = (() => {
                 if (document.startViewTransition) {
                     let detail = {task, ctx};
                     this.__trigger(ctx.sourceElement, "htmx:before:viewTransition", detail)
-                    await document.startViewTransition(detail.task).finished;
+                    let vt = document.startViewTransition(detail.task);
+                    // ready rejects when the document is hidden; unfinished catch
+                    // still produces unhandledrejection unless we handle ready too
+                    vt.ready?.catch(() => {});
+                    await vt.finished;
                     this.__trigger(ctx.sourceElement, "htmx:after:viewTransition", detail)
                 } else {
                     await task();

--- a/test/tests/unit/swap.js
+++ b/test/tests/unit/swap.js
@@ -879,6 +879,30 @@ describe('swap() unit tests', function() {
         assert.isTrue(true);
     })
 
+    it('does not emit unhandledrejection when view transition ready rejects', async function() {
+        let unhandled = 0;
+        let onUnhandled = () => { unhandled++; };
+        window.addEventListener('unhandledrejection', onUnhandled);
+        const originalStartViewTransition = document.startViewTransition;
+        document.startViewTransition = (cb) => {
+            let finished = Promise.resolve().then(() => cb());
+            let ready = Promise.reject(new DOMException('Skipped ViewTransition due to document being hidden', 'InvalidStateError'));
+            return { ready, finished, skipped: Promise.resolve(), updateCallbackDone: finished };
+        };
+        try {
+            await htmx.swap({
+                target: "#test-playground",
+                text: "<div id='d1'>Content</div>",
+                swap: "innerHTML transition:true"
+            });
+            await htmx.timeout(50);
+            assert.equal(unhandled, 0);
+        } finally {
+            window.removeEventListener('unhandledrejection', onUnhandled);
+            document.startViewTransition = originalStartViewTransition;
+        }
+    })
+
     // Gap #12: Extension content transformation result
     it('uses array result from extension handle_swap', async function() {
         mockResponse('GET', '/test', '<div>Content</div>');


### PR DESCRIPTION
## Description

`document.startViewTransition().ready` rejects when the document is hidden. htmx only awaited `.finished`, so a skipped transition still completed the swap but emitted `unhandledrejection` (`InvalidStateError`).

Corresponding issue: #3989

Demo: https://manwithacat.github.io/htmx/demos/view-transition-hidden/

## Testing

New unit test mocks `startViewTransition` with a rejecting `ready` and asserts no `unhandledrejection`.

Local `npm test` (Chromium, same as CI `htmx_tests`): 87 files, 1739 passed, 0 failed, 5 skipped.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against `four-dev`
* [x] This is a bugfix
* [x] Full browser suite — CI; new swap unit test covers the ready-rejection path
