### PR TITLE
fix: abort timed-out requests with TimeoutError

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -671,7 +671,9 @@ var htmx = (() => {
                 ? this.parseInterval(ctx.request.timeout)
                 : this.config.defaultTimeout;
             if (timeout) {
-                ctx.requestTimeout = setTimeout(() => ctx.request?.abort?.(), timeout);
+                ctx.requestTimeout = setTimeout(() => {
+                    ctx.request?.abort?.(new DOMException("Request timed out", "TimeoutError"));
+                }, timeout);
             }
         }
 

--- a/test/tests/unit/__issueRequest.js
+++ b/test/tests/unit/__issueRequest.js
@@ -337,6 +337,23 @@ describe('__issueRequest unit tests', function() {
         await htmx.__issueRequest(ctx)
         assert.isTrue(errorFired)
         assert.isTrue(ctx.request.signal.aborted)
+        assert.equal(ctx.request.signal.reason?.name, 'TimeoutError')
+    })
+
+    it('timeout abort reason is distinguishable from hx-sync replace', async function () {
+        let div = createProcessedHTML('<div hx-get="/test" hx-swap="none" hx-sync="this:replace"></div>')
+        let ctx = htmx.__createRequestContext(div, new Event('click'))
+        ctx.fetch = (url, opts) => new Promise((_, reject) => {
+            opts.signal.addEventListener('abort', () => {
+                reject(opts.signal.reason || new DOMException('The operation was aborted', 'AbortError'))
+            })
+        })
+        let p = htmx.__issueRequest(ctx)
+        await new Promise(r => setTimeout(r, 10))
+        ctx.request.abort()
+        await p
+        assert.isTrue(ctx.request.signal.aborted)
+        assert.notEqual(ctx.request.signal.reason?.name, 'TimeoutError')
     })
 
     it('htmx:abort event aborts in-flight request', async function () {

--- a/www/src/content/reference/03-events/11-htmx-error.md
+++ b/www/src/content/reference/03-events/11-htmx-error.md
@@ -28,4 +28,6 @@ htmx.on('htmx:error', (evt) => {
 });
 ```
 
+Timeouts and intentional aborts (`hx-sync` replace/abort, `htmx:abort`) both surface as a failed `fetch()`. Distinguish them with `ctx.request.signal.reason`: a timeout uses `TimeoutError` (`"Request timed out"`); a user or sync abort remains `AbortError`.
+
 Use this for centralized error handling and user feedback.


### PR DESCRIPTION
## Description

Request timeouts called `AbortController.abort()` with no reason, so a timeout and an `hx-sync` replace were both `AbortError`. Pass `TimeoutError` (`"Request timed out"`) as the abort reason so apps can tell them apart via `ctx.request.signal.reason`.

Corresponding issue: #4021

Demo: https://manwithacat.github.io/htmx/demos/timeout-error-reason/

## Testing

Existing timeout test now asserts `signal.reason.name === 'TimeoutError'`. Added a replace-abort case that is not `TimeoutError`. Documented the discriminator on `htmx:error`.

Local `npm test` (Chromium, same as CI `htmx_tests`): 87 files, 1739 passed, 0 failed, 5 skipped.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against `four-dev`
* [x] This is a bugfix
* [x] Full browser suite — CI; `__issueRequest` unit tests cover timeout vs replace
