### PR TITLE
rfc: strict HCON grammar (not wired in)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,16 @@ jobs:
       - run: bunx playwright install --with-deps chromium
       - run: bun run test
 
+  hcon_grammar:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Strict HCON grammar (Node only, no Playwright)
+        run: node --test hcon/test/*.test.js
+
   website_tests:
     runs-on: ubuntu-latest
     defaults:

--- a/hcon/GRAMMAR.md
+++ b/hcon/GRAMMAR.md
@@ -1,0 +1,103 @@
+# HCON grammar (strict)
+
+A closed, non-Turing-complete map language for htmx attributes.
+Implemented by recursive descent in `src/hcon.js`. Regex is not part of
+the grammar; `test/no-regex.test.js` fails the build if a regex literal
+or `RegExp` call appears in the parser.
+
+This is a proposal, not a description of shipping htmx 4.0.0. The 4.0.0
+parser is a global regex plus per-attribute peelers. This document is
+the language we think HCON should be.
+
+## Non-goals
+
+- CSS. Selectors are string values (`target:'#table tbody'` or
+  `from:<#table tbody/>`). The grammar does not parse combinators.
+- JavaScript. Trigger filters (`click[shiftKey]`) are outside HCON.
+  They `eval`. That is a host concern, not this language.
+- Arrays and nested `{...}` inside HCON. JSON remains the full-fidelity
+  form (`parse` of a string that starts with `{` is `JSON.parse`).
+- Mixing JSON and HCON in one string.
+
+## Start symbols
+
+Comma cannot mean two things. Two start symbols share one tokenizer:
+
+| Start | Used by | Pair separator | Item separator |
+|---|---|---|---|
+| `Map` | `hx-swap` modifiers, `hx-vals`, `hx-config`, `hx-headers`, `hx-swap-oob` | whitespace | — |
+| `List` | `hx-trigger` | whitespace inside each map | comma |
+
+So `delay:100ms throttle:200ms` is one map, and
+`click delay:500ms, keyup` is a list of two maps.
+`delay:100ms, throttle:200ms` as a **Map** is a syntax error (comma).
+As a **List** it is two maps. Hosts pick the start symbol.
+
+## EBNF
+
+```
+input     := ws* ( json | map ) ws*
+list      := ws* map ( comma ws* map )* ws*
+
+json      := '{' … '}'          (* JSON.parse of the whole input *)
+
+map       := pair ( ws+ pair )*
+pair      := key ( ':' ws* value )?          (* missing value => true *)
+
+key       := string | dotted
+dotted    := ident ( '.' ident )*
+value     := string | number | boolean | ident
+
+string    := '"' chars '"' | "'" chars "'" | '<' hs-chars '/>'
+ident     := ident-char+
+ident-char:= any char except whitespace, ':' , ','
+
+number    := '-'? digits ( '.' digits )? ( [eE] [+-]? digits )?
+boolean   := 'true' | 'false'
+
+ws        := space | tab | CR | LF
+comma     := ','
+```
+
+`hs-chars` is any run that does not contain the two-character closer
+`/>`. That is the existing hyperscript quoting form, kept because it
+does not fight HTML attribute quotes.
+
+Quoted values are **always strings**. `count:42` is a number;
+`count:"42"` is the string `"42"`. The shipping parser JSON-parses
+every value, so quotes do not control type.
+
+Leftover input that is not a pair is an error. Unquoted spaces do **not**
+produce leftover: `beforeend:#table tbody` is a well-formed Map
+`{beforeend:"#table", tbody:true}`. That is why colon form cannot be
+rejected in the grammar. `interpretSwap` / `interpretOob` reject a
+swap-style key whose value is not `true` — hosts interpret, they do
+not re-tokenize.
+
+The shipping parser `matchAll`s and drops unmatched text.
+
+## Interpretation (not parsing)
+
+A map is data. Attribute hosts look up vocabularies:
+
+- `hx-swap="innerHTML swap:200ms target:'#table tbody'"`
+  → `{innerHTML: true, swap: "200ms", target: "#table tbody"}`
+  → the unique key that is a swap style becomes `style`.
+- `hx-swap-oob="beforeend target:'#table tbody'"` is the same map.
+  Colon form `beforeend:#table tbody` is **not** HCON.
+- `hx-trigger` uses `List`. Each map’s unique event-name flag is
+  `name`. `every:2s` is a pair, not the shipping `every 2s` peel.
+
+## Complexity
+
+The grammar is regular over tokens plus one-token lookahead (LL(1)).
+No recursion in values except JSON (a different language). No loops,
+functions, or substitutions. That is the non-Turing bound: HCON cannot
+express computation; hosts may still `eval` filters, which this parser
+refuses to tokenize.
+
+## Compatibility
+
+`src/legacy.js` is a copy of the 4.0.0 regex parser. `test/corpus.json`
+classifies strings as `both`, `legacy_only`, or `strict_error`. CI
+fails if the classifications drift without an explicit corpus edit.

--- a/hcon/README.md
+++ b/hcon/README.md
@@ -1,0 +1,25 @@
+> RFC. This directory is a proposed grammar, parser, and Node test
+> corpus. It is **not** wired into `src/htmx.js`. Shipping HCON is
+> unchanged. See GRAMMAR.md.
+
+# Strict HCON
+
+A testable, LL(1), non-Turing-complete grammar for htmx's attribute config
+language. Recursive descent. No regex. Shipping htmx 4.0.0 HCON is a
+global regex plus per-attribute peelers; this is the language we think
+it should be.
+
+```bash
+make hcon          # from the community wrapper root
+# or
+cd hcon && npm test
+```
+
+- Spec: [`GRAMMAR.md`](GRAMMAR.md)
+- Parser: [`src/hcon.js`](src/hcon.js)
+- Hosts interpret maps, they do not re-tokenize: [`src/interpret.js`](src/interpret.js)
+- 4.0.0 regex copy, comparison only: [`src/legacy.js`](src/legacy.js)
+- Compatibility classifications: [`test/corpus.json`](test/corpus.json)
+
+CI is `.github/workflows/hcon.yml` (Node, no Playwright). The associated
+htmx RFC branch adds the same job next to `htmx_tests`.

--- a/hcon/package.json
+++ b/hcon/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "hcon-grammar",
+  "private": true,
+  "type": "module",
+  "description": "Strict, regex-free HCON grammar for htmx attributes",
+  "scripts": {
+    "test": "node --test test/*.test.js"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/hcon/src/hcon.js
+++ b/hcon/src/hcon.js
@@ -1,0 +1,315 @@
+/**
+ * Strict HCON: recursive-descent map language.
+ * No regex. Spec: ../GRAMMAR.md
+ */
+
+export class HconError extends Error {
+    constructor(message, index, input) {
+        super(message)
+        this.name = 'HconError'
+        this.index = index
+        this.input = input
+    }
+}
+
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
+function isWs(c) {
+    return c === ' ' || c === '\t' || c === '\n' || c === '\r'
+}
+
+function isIdentChar(c) {
+    return c != null && c !== ':' && c !== ',' && !isWs(c)
+}
+
+function isDigit(c) {
+    return c >= '0' && c <= '9'
+}
+
+class Parser {
+    constructor(input) {
+        this.s = input == null ? '' : String(input)
+        this.i = 0
+    }
+
+    peek() {
+        return this.s[this.i]
+    }
+
+    eof() {
+        return this.i >= this.s.length
+    }
+
+    eat() {
+        return this.s[this.i++]
+    }
+
+    fail(message) {
+        throw new HconError(message + ' at ' + this.i, this.i, this.s)
+    }
+
+    skipWs() {
+        while (isWs(this.peek())) this.i++
+    }
+
+    parseInput() {
+        this.skipWs()
+        if (this.eof()) return {}
+        if (this.peek() === '{') return this.parseJson()
+        let map = this.parseMap()
+        this.skipWs()
+        if (!this.eof()) this.fail('leftover input ' + JSON.stringify(this.s.slice(this.i)))
+        return map
+    }
+
+    parseList() {
+        this.skipWs()
+        if (this.eof()) return []
+        if (this.peek() === '{') return [this.parseJson()]
+        let maps = [this.parseMap()]
+        this.skipWs()
+        while (this.peek() === ',') {
+            this.eat()
+            this.skipWs()
+            if (this.eof()) this.fail('trailing comma in list')
+            maps.push(this.parseMap())
+            this.skipWs()
+        }
+        if (!this.eof()) this.fail('leftover input ' + JSON.stringify(this.s.slice(this.i)))
+        return maps
+    }
+
+    parseJson() {
+        try {
+            return JSON.parse(this.s)
+        } catch (e) {
+            throw new HconError('invalid JSON: ' + e.message, this.i, this.s)
+        }
+    }
+
+    parseMap() {
+        let map = {}
+        let pair = this.parsePair()
+        this.assign(map, pair)
+        for (;;) {
+            let start = this.i
+            this.skipWs()
+            if (this.eof() || this.peek() === ',') {
+                this.i = start
+                break
+            }
+            if (!isIdentChar(this.peek()) && this.peek() !== '"' && this.peek() !== "'") {
+                this.i = start
+                break
+            }
+            pair = this.parsePair()
+            this.assign(map, pair)
+        }
+        return map
+    }
+
+    parsePair() {
+        let keyInfo = this.parseKey()
+        this.skipWs()
+        let value = true
+        if (this.peek() === ':') {
+            this.eat()
+            this.skipWs()
+            value = this.parseValue()
+        }
+        return { keyInfo, value }
+    }
+
+    parseKey() {
+        if (this.peek() === '"' || this.peek() === "'") {
+            return { key: this.parseQuoted(), dotted: false }
+        }
+        let ident = this.parseIdent()
+        if (ident.includes('.')) {
+            return { key: ident, dotted: true }
+        }
+        return { key: ident, dotted: false }
+    }
+
+    parseValue() {
+        let c = this.peek()
+        if (c === '"' || c === "'") return this.parseQuoted()
+        if (c === '<') return this.parseHyperscript()
+        if (c === '-' || isDigit(c)) {
+            let num = this.tryNumber()
+            if (num !== null) return num
+        }
+        let ident = this.parseIdent()
+        if (ident === 'true') return true
+        if (ident === 'false') return false
+        return ident
+    }
+
+    parseQuoted() {
+        let q = this.eat()
+        let out = ''
+        while (!this.eof()) {
+            let c = this.eat()
+            if (c === q) return out
+            if (c === '\\') {
+                if (this.eof()) this.fail('unterminated escape')
+                let n = this.eat()
+                if (n === q || n === '\\') out += n
+                else out += n
+            } else {
+                out += c
+            }
+        }
+        this.fail('unterminated ' + q + ' string')
+    }
+
+    parseHyperscript() {
+        this.eat()
+        let out = ''
+        while (!this.eof()) {
+            if (this.peek() === '/' && this.s[this.i + 1] === '>') {
+                this.i += 2
+                return out
+            }
+            out += this.eat()
+        }
+        this.fail('unterminated <.../> string')
+    }
+
+    parseIdent() {
+        if (!isIdentChar(this.peek())) this.fail('expected ident')
+        let start = this.i
+        while (isIdentChar(this.peek())) this.eat()
+        return this.s.slice(start, this.i)
+    }
+
+    tryNumber() {
+        let start = this.i
+        if (this.peek() === '-') this.eat()
+        if (!isDigit(this.peek())) {
+            this.i = start
+            return null
+        }
+        while (isDigit(this.peek())) this.eat()
+        if (this.peek() === '.') {
+            let dot = this.i
+            this.eat()
+            if (!isDigit(this.peek())) {
+                this.i = start
+                return null
+            }
+            while (isDigit(this.peek())) this.eat()
+            void dot
+        }
+        if (this.peek() === 'e' || this.peek() === 'E') {
+            let e = this.i
+            this.eat()
+            if (this.peek() === '+' || this.peek() === '-') this.eat()
+            if (!isDigit(this.peek())) {
+                this.i = start
+                return null
+            }
+            while (isDigit(this.peek())) this.eat()
+            void e
+        }
+        if (isIdentChar(this.peek())) {
+            this.i = start
+            return null
+        }
+        return Number(this.s.slice(start, this.i))
+    }
+
+    assign(map, { keyInfo, value }) {
+        if (keyInfo.dotted) {
+            let segs = keyInfo.key.split('.')
+            if (segs.some((s) => FORBIDDEN_KEYS.has(s))) return
+            let cur = map
+            for (let i = 0; i < segs.length - 1; i++) {
+                let seg = segs[i]
+                if (cur[seg] == null || typeof cur[seg] !== 'object') cur[seg] = {}
+                cur = cur[seg]
+            }
+            let last = segs[segs.length - 1]
+            if (!FORBIDDEN_KEYS.has(last)) cur[last] = value
+            return
+        }
+        if (FORBIDDEN_KEYS.has(keyInfo.key)) return
+        map[keyInfo.key] = value
+    }
+}
+
+export function parse(input) {
+    return new Parser(input).parseInput()
+}
+
+export function parseList(input) {
+    return new Parser(input).parseList()
+}
+
+export function stringify(map) {
+    if (map == null || typeof map !== 'object' || Array.isArray(map)) {
+        return JSON.stringify(map)
+    }
+    let parts = []
+    stringifyInto(map, '', parts)
+    return parts.join(' ')
+}
+
+function stringifyInto(obj, prefix, parts) {
+    for (let [k, v] of Object.entries(obj)) {
+        if (FORBIDDEN_KEYS.has(k)) continue
+        let path = prefix ? prefix + '.' + k : k
+        if (v && typeof v === 'object' && !Array.isArray(v)) {
+            stringifyInto(v, path, parts)
+        } else {
+            parts.push(formatPair(path, v))
+        }
+    }
+}
+
+function formatPair(key, value) {
+    let k = needsQuote(key) ? '"' + escapeStr(key) + '"' : key
+    if (value === true) return k
+    if (value === false) return k + ':false'
+    if (typeof value === 'number') return k + ':' + String(value)
+    if (typeof value === 'string') {
+        if (value === 'true' || value === 'false' || looksLikeNumber(value) || needsQuote(value)) {
+            return k + ':"' + escapeStr(value) + '"'
+        }
+        return k + ':' + value
+    }
+    return k + ':' + JSON.stringify(value)
+}
+
+function needsQuote(s) {
+    if (s.length === 0) return true
+    for (let i = 0; i < s.length; i++) {
+        let c = s[i]
+        if (isWs(c) || c === ':' || c === ',' || c === '"' || c === "'") return true
+    }
+    return false
+}
+
+function looksLikeNumber(s) {
+    if (s.length === 0) return false
+    let i = 0
+    if (s[i] === '-') i++
+    if (i >= s.length || !isDigit(s[i])) return false
+    while (i < s.length && isDigit(s[i])) i++
+    if (s[i] === '.') {
+        i++
+        if (!isDigit(s[i])) return false
+        while (i < s.length && isDigit(s[i])) i++
+    }
+    return i === s.length
+}
+
+function escapeStr(s) {
+    let out = ''
+    for (let i = 0; i < s.length; i++) {
+        let c = s[i]
+        if (c === '"' || c === '\\') out += '\\' + c
+        else out += c
+    }
+    return out
+}

--- a/hcon/src/interpret.js
+++ b/hcon/src/interpret.js
@@ -1,0 +1,87 @@
+/**
+ * Attribute hosts interpret maps. They do not re-tokenize.
+ */
+
+import { HconError, parse, parseList } from './hcon.js'
+
+export const SWAP_STYLES = new Set([
+    'innerHTML', 'outerHTML', 'textContent',
+    'beforebegin', 'afterbegin', 'beforeend', 'afterend',
+    'before', 'after', 'prepend', 'append',
+    'innerMorph', 'outerMorph', 'outerSync',
+    'delete', 'none', 'upsert',
+])
+
+export function normalizeSwapStyle(style) {
+    return style === 'before' ? 'beforebegin'
+        : style === 'after' ? 'afterend'
+        : style === 'prepend' ? 'afterbegin'
+        : style === 'append' ? 'beforeend'
+        : style
+}
+
+export function interpretSwap(map, defaultStyle = 'innerHTML') {
+    if (map == null || typeof map !== 'object') {
+        throw new HconError('interpretSwap expects a map', 0, '')
+    }
+    for (let k of Object.keys(map)) {
+        if (k !== 'style' && SWAP_STYLES.has(normalizeSwapStyle(k)) && map[k] !== true) {
+            throw new HconError(
+                "colon form is not HCON: " + k + ":" + map[k] + " — write `" + k + " target:'…'`",
+                0,
+                '',
+            )
+        }
+    }
+    let rest = { ...map }
+    let style
+    if (typeof rest.style === 'string') {
+        style = rest.style
+        delete rest.style
+    } else {
+        let flags = Object.keys(rest).filter((k) => rest[k] === true && SWAP_STYLES.has(normalizeSwapStyle(k)))
+        if (flags.length > 1) {
+            throw new HconError('multiple swap styles: ' + flags.join(', '), 0, '')
+        }
+        if (flags.length === 1) {
+            style = flags[0]
+            delete rest[flags[0]]
+        }
+    }
+    return { style: normalizeSwapStyle(style || defaultStyle), ...rest }
+}
+
+export function interpretOob(map, defaultTarget, defaultStyle = 'outerHTML') {
+    let spec = interpretSwap(map, defaultStyle)
+    let target = spec.target || defaultTarget
+    delete spec.target
+    if (!target) throw new HconError('oob swap has no target', 0, '')
+    return { ...spec, target }
+}
+
+export function interpretTrigger(map) {
+    if (typeof map.every === 'string') {
+        let { every, ...rest } = map
+        return { name: 'every', interval: every, ...rest }
+    }
+    let flags = Object.keys(map).filter((k) => map[k] === true)
+    if (flags.length === 0) {
+        throw new HconError('trigger map has no event name', 0, '')
+    }
+    let name = flags[0]
+    let rest = { ...map }
+    delete rest[name]
+    return { name, ...rest }
+}
+
+export function parseSwap(input, defaultStyle = 'innerHTML') {
+    return interpretSwap(parse(input), defaultStyle)
+}
+
+export function parseOob(input, defaultTarget) {
+    return interpretOob(parse(input), defaultTarget)
+}
+
+export function parseTriggers(input) {
+    return parseList(input).map(interpretTrigger)
+}

--- a/hcon/src/legacy.js
+++ b/hcon/src/legacy.js
@@ -1,0 +1,46 @@
+/**
+ * Shipping htmx 4.0.0 HCON, copied for corpus comparison only.
+ * Not used by the strict parser.
+ */
+export const legacy = {
+    parse(string) {
+        if (!string) return {}
+        if (string.startsWith('{')) return JSON.parse(string)
+        let pattern = /(?:"([^"]+)"|'([^']+)'|([^\s,:]+))(?:\s*:\s*(?:"([^"]*)"|'([^']*)'|<((?:[^/]|\/(?!>))+)\/>|([^\s,]+)))?(?=\s|,|$)/g
+        let result = {}
+        for (let match of string.matchAll(pattern)) {
+            let [,
+                doubleQuotedKey,
+                singleQuotedKey,
+                bareKey,
+                doubleQuotedValue,
+                singleQuotedValue,
+                hyperscriptValue,
+                bareValue,
+            ] = match
+            let key = doubleQuotedKey ?? singleQuotedKey ?? bareKey
+            let value = (doubleQuotedValue ?? singleQuotedValue ?? hyperscriptValue ?? bareValue ?? 'true').trim()
+            try { value = JSON.parse(value) } catch {}
+            let isDottedPath = bareKey?.includes('.')
+            let pair = isDottedPath
+                ? key.split('.').reduceRight((acc, segment) => ({ [segment]: acc }), value)
+                : { [key]: value }
+            legacy.merge(pair, result)
+        }
+        return result
+    },
+    split(string) {
+        return string.split(/,(?![^\[]*\])(?![^(]*\))(?![^<]*\/>)(?=(?:[^"']|"[^"]*"|'[^']*')*$)/)
+    },
+    merge(source, target) {
+        if (typeof source === 'string') source = legacy.parse(source)
+        for (let [key, val] of Object.entries(source)) {
+            if (['__proto__', 'constructor', 'prototype'].includes(key)) continue
+            let sourceIsObject = val?.constructor === Object
+            let targetIsObject = target[key]?.constructor === Object
+            if (sourceIsObject && targetIsObject) legacy.merge(val, target[key])
+            else target[key] = val
+        }
+        return target
+    },
+}

--- a/hcon/test/corpus.json
+++ b/hcon/test/corpus.json
@@ -1,0 +1,61 @@
+{
+  "both": [
+    ["delay:100ms", {"delay": "100ms"}],
+    ["once", {"once": true}],
+    ["once:false", {"once": false}],
+    ["count:42", {"count": 42}],
+    ["delay:100ms throttle:200ms", {"delay": "100ms", "throttle": "200ms"}],
+    ["target:\"#foo .bar\"", {"target": "#foo .bar"}],
+    ["target:'#foo .bar'", {"target": "#foo .bar"}],
+    ["sse.mode:once", {"sse": {"mode": "once"}}],
+    ["sse.mode:once sse.maxRetries:5", {"sse": {"mode": "once", "maxRetries": 5}}],
+    ["{\"delay\":\"100ms\",\"throttle\":\"200ms\"}", {"delay": "100ms", "throttle": "200ms"}],
+    ["foo:bar", {"foo": "bar"}],
+    ["\"a.b\":1", {"a.b": 1}],
+    ["from:<.foo/>", {"from": ".foo"}],
+    ["from:<div p/>", {"from": "div p"}],
+    ["from:<ul > li/>", {"from": "ul > li"}],
+    ["from:<.a, .b, .c/>", {"from": ".a, .b, .c"}],
+    ["from:<ul > li/> throttle:50ms", {"from": "ul > li", "throttle": "50ms"}],
+    ["innerHTML swap:200ms", {"innerHTML": true, "swap": "200ms"}],
+    ["beforeend target:'#table tbody'", {"beforeend": true, "target": "#table tbody"}],
+    ["credentials:\"include\" timeout:5000", {"credentials": "include", "timeout": 5000}],
+    ["validate", {"validate": true}],
+    ["token:abc retry:3", {"token": "abc", "retry": 3}],
+    ["innerHTML:#legacy", {"innerHTML": "#legacy"}],
+    ["beforeend:#table tbody", {"beforeend": "#table", "tbody": true}],
+    ["message:hello world", {"message": "hello", "world": true}]
+  ],
+  "legacy_only": [
+    {
+      "input": "delay:100ms, throttle:200ms",
+      "legacy": {"delay": "100ms", "throttle": "200ms"},
+      "why": "comma is a Map pair separator in 4.0.0; strict Map forbids comma (List start symbol)"
+    },
+    {
+      "input": "count:\"42\"",
+      "legacy": {"count": 42},
+      "why": "4.0.0 JSON-parses quoted values; strict quoted values are strings"
+    },
+    {
+      "input": "x:\"[1, 2, 3]\"",
+      "legacy": {"x": [1, 2, 3]},
+      "why": "quoted JSON array becomes a real array in 4.0.0"
+    }
+  ],
+  "strict_error": [
+    ["delay:100ms, throttle:200ms", "comma in a Map"]
+  ],
+  "interpret_error": [
+    ["beforeend:#table tbody", "colon form: style key holds a string, plus a stray flag"],
+    ["innerHTML:#outer div", "colon form plus space"],
+    ["innerHTML:#legacy", "colon form without space"]
+  ],
+  "list_both": [
+    ["click", [{"click": true}]],
+    ["click delay:500ms", [{"click": true, "delay": "500ms"}]],
+    ["click delay:500ms, keyup", [{"click": true, "delay": "500ms"}, {"keyup": true}]],
+    ["click from:'.a, .b', change", [{"click": true, "from": ".a, .b"}, {"change": true}]],
+    ["click from:<ul > li/>, change", [{"click": true, "from": "ul > li"}, {"change": true}]]
+  ]
+}

--- a/hcon/test/corpus.test.js
+++ b/hcon/test/corpus.test.js
@@ -1,0 +1,49 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { parse, parseList, HconError } from '../src/hcon.js'
+import { parseOob } from '../src/interpret.js'
+import { legacy } from '../src/legacy.js'
+
+const corpus = JSON.parse(readFileSync(join(dirname(fileURLToPath(import.meta.url)), 'corpus.json'), 'utf8'))
+
+test('corpus: both parsers agree', () => {
+    for (let [input, expected] of corpus.both) {
+        assert.deepEqual(parse(input), expected, 'strict ' + JSON.stringify(input))
+        assert.deepEqual(legacy.parse(input), expected, 'legacy ' + JSON.stringify(input))
+    }
+})
+
+test('corpus: legacy_only — 4.0.0 accepts, strict differs or errors', () => {
+    for (let row of corpus.legacy_only) {
+        assert.deepEqual(legacy.parse(row.input), row.legacy, row.why)
+        let strict
+        try {
+            strict = parse(row.input)
+        } catch (e) {
+            assert.ok(e instanceof HconError, row.input)
+            continue
+        }
+        assert.notDeepEqual(strict, row.legacy, 'strict should not match legacy for ' + row.input)
+    }
+})
+
+test('corpus: strict_error', () => {
+    for (let [input] of corpus.strict_error) {
+        assert.throws(() => parse(input), HconError, input)
+    }
+})
+
+test('corpus: interpret_error', () => {
+    for (let [input] of corpus.interpret_error) {
+        assert.throws(() => parseOob(input, '#x'), HconError, input)
+    }
+})
+
+test('corpus: list_both', () => {
+    for (let [input, expected] of corpus.list_both) {
+        assert.deepEqual(parseList(input), expected, input)
+    }
+})

--- a/hcon/test/domain.test.js
+++ b/hcon/test/domain.test.js
@@ -1,0 +1,54 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseSwap, parseOob, parseTriggers } from '../src/interpret.js'
+import { parse } from '../src/hcon.js'
+import { HconError } from '../src/hcon.js'
+
+test('docs: hx-swap innerHTML swap:200ms settle:100ms scroll:top', () => {
+    let spec = parseSwap('innerHTML swap:200ms settle:100ms scroll:top')
+    assert.equal(spec.style, 'innerHTML')
+    assert.equal(spec.swap, '200ms')
+    assert.equal(spec.settle, '100ms')
+    assert.equal(spec.scroll, 'top')
+})
+
+test('docs: hx-config timeout:30000', () => {
+    assert.deepEqual(parse('timeout:30000'), { timeout: 30000 })
+})
+
+test('docs: meta htmx-config', () => {
+    assert.deepEqual(parse('defaultSwap:outerHTML transitions:true'), {
+        defaultSwap: 'outerHTML',
+        transitions: true,
+    })
+})
+
+test('docs: HX-Location path:"/new-page" push:"true"', () => {
+    assert.deepEqual(parse('path:"/new-page" push:"true"'), {
+        path: '/new-page',
+        push: 'true',
+    })
+})
+
+test('docs: hx-vals token:"abc" retry:3', () => {
+    assert.deepEqual(parse('token:"abc" retry:3'), { token: 'abc', retry: 3 })
+})
+
+test('issue 4029: documented colon form is a Map, interpret rejects it', () => {
+    assert.deepEqual(parse('beforeend:#table tbody'), { beforeend: '#table', tbody: true })
+    assert.throws(() => parseOob('beforeend:#table tbody'), HconError)
+    let spec = parseOob("beforeend target:'#table tbody'")
+    assert.equal(spec.style, 'beforeend')
+    assert.equal(spec.target, '#table tbody')
+})
+
+test('issue 2846: global selector is a quoted value', () => {
+    let spec = parseOob("innerHTML target:'global #outside'", '#x')
+    assert.equal(spec.target, 'global #outside')
+})
+
+test('hx-trigger from quoted descendant', () => {
+    let [spec] = parseTriggers("keyup from:'closest form'")
+    assert.equal(spec.name, 'keyup')
+    assert.equal(spec.from, 'closest form')
+})

--- a/hcon/test/interpret.test.js
+++ b/hcon/test/interpret.test.js
@@ -1,0 +1,67 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseSwap, parseOob, parseTriggers } from '../src/interpret.js'
+import { parse } from '../src/hcon.js'
+
+test('hx-swap: style flag then modifiers', () => {
+    assert.deepEqual(parseSwap('innerHTML swap:200ms'), {
+        style: 'innerHTML',
+        swap: '200ms',
+    })
+})
+
+test('hx-swap: alias append → beforeend', () => {
+    assert.equal(parseSwap('append').style, 'beforeend')
+})
+
+test('hx-swap: JSON style key', () => {
+    assert.deepEqual(parseSwap('{"style":"outerHTML","swap":"200ms"}'), {
+        style: 'outerHTML',
+        swap: '200ms',
+    })
+})
+
+test('hx-swap: quoted target', () => {
+    let spec = parseSwap("innerHTML target:'#table tbody'")
+    assert.equal(spec.style, 'innerHTML')
+    assert.equal(spec.target, '#table tbody')
+})
+
+test('hx-swap-oob: HCON target, not colon form', () => {
+    let spec = parseOob("beforeend target:'#table tbody'")
+    assert.equal(spec.style, 'beforeend')
+    assert.equal(spec.target, '#table tbody')
+})
+
+test('hx-swap-oob: innerHTML:#legacy is NOT colon form', () => {
+    let map = parse('innerHTML:#legacy')
+    assert.deepEqual(map, { innerHTML: '#legacy' })
+    let spec = parseOob('innerHTML target:#legacy', '#id')
+    assert.equal(spec.style, 'innerHTML')
+    assert.equal(spec.target, '#legacy')
+})
+
+test('hx-swap-oob: default target when no target key', () => {
+    let spec = parseOob('true', '#alerts')
+    assert.equal(spec.style, 'outerHTML')
+    assert.equal(spec.target, '#alerts')
+})
+
+test('hx-trigger list', () => {
+    let specs = parseTriggers('click delay:500ms, keyup once')
+    assert.equal(specs.length, 2)
+    assert.equal(specs[0].name, 'click')
+    assert.equal(specs[0].delay, '500ms')
+    assert.equal(specs[1].name, 'keyup')
+    assert.equal(specs[1].once, true)
+})
+
+test('hx-trigger every:2s', () => {
+    let [spec] = parseTriggers('every:2s')
+    assert.equal(spec.name, 'every')
+    assert.equal(spec.interval, '2s')
+})
+
+test('multiple swap style flags error', () => {
+    assert.throws(() => parseSwap('innerHTML outerHTML'))
+})

--- a/hcon/test/no-regex.test.js
+++ b/hcon/test/no-regex.test.js
@@ -1,0 +1,33 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const FILES = ['src/hcon.js', 'src/interpret.js']
+
+const FORBIDDEN = [
+    'new RegExp',
+    '.matchAll(',
+    '.match(',
+    '.split(/',
+    '.search(',
+    '.replace(/',
+    '.test(',
+]
+
+test('parser surface has no regex', () => {
+    let hits = []
+    for (let rel of FILES) {
+        let text = readFileSync(join(root, rel), 'utf8')
+        let lines = text.split('\n')
+        lines.forEach((line, i) => {
+            if (line.trimStart().startsWith('*') || line.trimStart().startsWith('//')) return
+            for (let needle of FORBIDDEN) {
+                if (line.includes(needle)) hits.push(rel + ':' + (i + 1) + ' ' + needle)
+            }
+        })
+    }
+    assert.deepEqual(hits, [])
+})

--- a/hcon/test/parse.test.js
+++ b/hcon/test/parse.test.js
@@ -1,0 +1,90 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { parse, parseList, stringify, HconError } from '../src/hcon.js'
+
+test('empty', () => {
+    assert.deepEqual(parse(''), {})
+    assert.deepEqual(parse('   '), {})
+    assert.deepEqual(parseList(''), [])
+})
+
+test('flag', () => {
+    assert.deepEqual(parse('once'), { once: true })
+})
+
+test('false', () => {
+    assert.deepEqual(parse('once:false'), { once: false })
+})
+
+test('number vs duration', () => {
+    assert.deepEqual(parse('count:42'), { count: 42 })
+    assert.deepEqual(parse('delay:100ms'), { delay: '100ms' })
+    assert.deepEqual(parse('n:-3.5'), { n: -3.5 })
+})
+
+test('quoted values stay strings', () => {
+    assert.deepEqual(parse('count:"42"'), { count: '42' })
+    assert.deepEqual(parse('flag:"true"'), { flag: 'true' })
+    assert.deepEqual(parse('x:"[1, 2, 3]"'), { x: '[1, 2, 3]' })
+})
+
+test('quoted selector', () => {
+    assert.deepEqual(parse("target:'#foo .bar'"), { target: '#foo .bar' })
+    assert.deepEqual(parse('target:"#foo .bar"'), { target: '#foo .bar' })
+})
+
+test('hyperscript selector', () => {
+    assert.deepEqual(parse('from:<#table tbody/>'), { from: '#table tbody' })
+    assert.deepEqual(parse('from:<ul > li:not(.a, .b)/>'), { from: 'ul > li:not(.a, .b)' })
+})
+
+test('dotted keys', () => {
+    assert.deepEqual(parse('sse.mode:once'), { sse: { mode: 'once' } })
+    assert.deepEqual(parse('"a.b":1'), { 'a.b': 1 })
+})
+
+test('JSON fallback', () => {
+    assert.deepEqual(parse('{"delay":"100ms"}'), { delay: '100ms' })
+})
+
+test('unquoted space is a second pair, not leftover', () => {
+    assert.deepEqual(parse('message:hello world'), { message: 'hello', world: true })
+    assert.deepEqual(parse('beforeend:#table tbody'), { beforeend: '#table', tbody: true })
+})
+
+test('comma in a Map is an error', () => {
+    assert.throws(() => parse('delay:100ms, throttle:200ms'), HconError)
+})
+
+test('unterminated string errors', () => {
+    assert.throws(() => parse('x:"abc'), HconError)
+    assert.throws(() => parse('from:<div'), HconError)
+})
+
+test('comma is list separator not map separator', () => {
+    assert.deepEqual(parseList('click delay:500ms, keyup'), [
+        { click: true, delay: '500ms' },
+        { keyup: true },
+    ])
+    assert.deepEqual(parseList("click from:'.a, .b', change"), [
+        { click: true, from: '.a, .b' },
+        { change: true },
+    ])
+})
+
+test('trailing comma in list errors', () => {
+    assert.throws(() => parseList('click,'), HconError)
+})
+
+test('prototype keys ignored', () => {
+    let before = ({}).polluted
+    parse('__proto__.polluted:true')
+    assert.equal(({}).polluted, before)
+})
+
+test('stringify round-trip for maps', () => {
+    for (let s of ['once', 'delay:100ms', 'innerHTML swap:200ms', "target:'#foo .bar'"]) {
+        let a = parse(s)
+        assert.deepEqual(parse(stringify(a)), a)
+    }
+})


### PR DESCRIPTION
## Description

RFC for a closed HCON grammar. **Not wired into `src/htmx.js`.** Shipping HCON is unchanged.

Discussion: https://github.com/bigskysoftware/htmx/discussions/4046
Related: #4029 (colon-form `hx-swap-oob` is a Map the host must reject, not a regex the parser should stretch).

Adds:

- `hcon/GRAMMAR.md` — LL(1) EBNF. Two start symbols (Map vs List) so comma is not overloaded.
- `hcon/src/hcon.js` — recursive descent, no regex. Quoted values are always strings. Leftover non-pairs error.
- `hcon/src/interpret.js` — `hx-swap` / `hx-swap-oob` / `hx-trigger` interpret maps. Colon form (`beforeend:#table tbody`) is a well-formed map that `interpretOob` rejects in favour of `beforeend target:'#table tbody'`.
- `hcon/test/` — 40 Node tests, including a corpus against the shipping regex and a no-regex gate on the parser surface.
- CI job `hcon_grammar`: `node --test hcon/test/*.test.js` (no Playwright, ~60ms).

This PR is a demonstration so the discussion has a runnable artefact. Please treat it as draft until the grammar is accepted (or rejected). If the direction is wrong, close it.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against `four-dev`
* [ ] This is a new feature — **RFC only**, see discussion #4046. Not proposed for merge yet.
* [x] Grammar tests: `node --test hcon/test/*.test.js` (40 passed)
