### PR TITLE
fix css settle of checked state of radio buttons breaking state

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -2303,6 +2303,7 @@ var htmx = (() => {
         }
 
         __startCSSTransitions(fragment, root) {
+            let cssAttrs = ['class', 'style', 'width', 'height'];
             let idElements = root.querySelectorAll("[id]");
             let existingElementsById = Object.fromEntries([...idElements].map(e => [e.id, e]));
             let newElementsWithIds = fragment.querySelectorAll("[id]");
@@ -2311,7 +2312,7 @@ var htmx = (() => {
                 let existing = existingElementsById[elt.id];
                 if (existing?.tagName === elt.tagName) {
                     let clone = elt.cloneNode(false); // shallow clone node
-                    this.__copyAttributes(elt, existing)
+                    for (let a of cssAttrs) existing.hasAttribute(a) ? elt.setAttribute(a, existing.getAttribute(a)) : elt.removeAttribute(a);
                     restoreTasks.push(()=>{
                         this.__copyAttributes(elt, clone)
                     })

--- a/test/tests/ext/hx-multipart.js
+++ b/test/tests/ext/hx-multipart.js
@@ -905,7 +905,7 @@ describe('hx-multipart extension', function() {
     it('handles the next parallel part while an earlier part settles', async function() {
         let button = createProcessedHTML([
             '<button hx-get="/parallel">Go</button>',
-            '<div id="one"><span id="state" data-phase="old">one</span></div>',
+            '<div id="one"><span id="state" class="old">one</span></div>',
             '<div id="two">two</div>'
         ].join(''));
         fetchMock.mockResponse('GET', '/parallel', new Response([
@@ -914,7 +914,7 @@ describe('hx-multipart extension', function() {
             'HX-Target: #one\r\n',
             'HX-Swap: innerHTML settle:100ms\r\n',
             '\r\n',
-            '<span id="state" data-phase="new">First</span>',
+            '<span id="state" class="new">First</span>',
             '\r\n--updates\r\n',
             'Content-Type: text/html\r\n',
             'HX-Target: #two\r\n',
@@ -930,8 +930,8 @@ describe('hx-multipart extension', function() {
 
         assert.isTrue(await waitUntil(() => htmx.find('#two').textContent === 'Second', 500));
         assertTextContentIs('#state', 'First');
-        assert.equal(find('#state').getAttribute('data-phase'), 'old');
+        assert.isTrue(find('#state').classList.contains('old'));
         assert.isNotNull(await done, 'parallel request did not finish');
-        assert.equal(find('#state').getAttribute('data-phase'), 'new');
+        assert.isTrue(find('#state').classList.contains('new'));
     });
 });

--- a/test/tests/unit/swap.js
+++ b/test/tests/unit/swap.js
@@ -250,6 +250,26 @@ describe('swap() unit tests', function() {
         replaced.getAttribute('data-value').should.equal('2');
     })
 
+    it('CSS transitions do not reset radio checked state', async function () {
+        createProcessedHTML(`
+            <div id="target">
+                <input type="radio" id="r1" name="status" value="a" checked>
+                <input type="radio" id="r2" name="status" value="b">
+            </div>
+        `)
+        find('#r2').checked = true;
+        await htmx.swap({
+            target: '#target',
+            text: `
+                <input type="radio" id="r1" name="status" value="a">
+                <input type="radio" id="r2" name="status" value="b" checked>
+            `
+        })
+        await htmx.timeout(10);
+        find('#r2').checked.should.be.true;
+        find('#r1').checked.should.be.false;
+    })
+
     it('triggers CSS transitions during swap', async function () {
         this.skip(); //fails on firefox for some reason
         createProcessedHTML("<style>#d1 { transition: opacity 100ms; }</style><div id='d1' style='opacity: 1;'>Old</div>")


### PR DESCRIPTION
## Description
during css settle phase we update id'ed elements with their old attribute state so that we can then apply the final change and trigger any css transitions after waiting 1ms.  But we copy all attributes not just the css transition ones like class, style, width and height like htmx 2.0 did.  Turns out this can break radio buttons checked state as it unsets the checked state as one radio can undo other radio's state and this side effect breaks things leaving all radios unchecked.  view transitions or skipped settle phase solves this but the proper fix is to only copy over the 4 css transition attributes only which resolves the issue.

Corresponding issue:
#4055

## Testing
Added a test for the regression that fails without the fix

## Checklist

* [x] I have read the contribution guidelines
* [x] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [x] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
