### PR TITLE
Fix default prevention for delayed triggers

### DIFF
--- a/src/htmx.js
+++ b/src/htmx.js
@@ -797,8 +797,8 @@ var htmx = (() => {
                         }
                         if (!changed) return;
                     }
+                    if (this.__shouldCancel(evt)) evt.preventDefault();
                     if (filter) {
-                        if (this.__shouldCancel(evt)) evt.preventDefault();
                         let evtArgs = {}; for (let k in evt) evtArgs[k] = evt[k];
                         if (!this.__executeJavaScript(elt, evtArgs, filter, true, false)) return;
                     }

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -783,6 +783,7 @@ var htmx = (() => {
 
                 // Guarded: pre-timing checks that determine if event should proceed
                 spec.handler = (evt) => {
+                    if (this.__shouldCancel(evt)) evt.preventDefault();
                     if (spec.from === 'self' && evt.target !== elt) return;
                     if (spec.from === 'outside' && elt.contains(evt.target)) return;
                     if (spec.target && !evt.target?.matches?.(spec.target)) return;
@@ -797,7 +798,6 @@ var htmx = (() => {
                         }
                         if (!changed) return;
                     }
-                    if (this.__shouldCancel(evt)) evt.preventDefault();
                     if (filter) {
                         let evtArgs = {}; for (let k in evt) evtArgs[k] = evt[k];
                         if (!this.__executeJavaScript(elt, evtArgs, filter, true, false)) return;

--- a/test/tests/end2end/cancel-behavior.js
+++ b/test/tests/end2end/cancel-behavior.js
@@ -193,6 +193,23 @@ describe('Cancel behavior integration tests', function() {
         playground().innerText.should.equal('Submitted');
     });
 
+    it('delayed form submit prevents default submission immediately', async function() {
+        let defaultPrevented = null;
+        mockResponse('GET', '/test', 'Submitted')
+        const form = createProcessedHTML('<form action="/native" hx-get="/test" hx-trigger="submit delay:20ms"><button id="btn">Submit</button></form>');
+
+        form.addEventListener('submit', (evt) => {
+            defaultPrevented = evt.defaultPrevented;
+            evt.preventDefault();
+        });
+
+        find('#btn').click()
+        defaultPrevented.should.equal(true);
+        fetchMock.calls.length.should.equal(0);
+        await forRequest();
+        fetchMock.calls.length.should.equal(1);
+    });
+
     it('does not submit with false condition on form', async function() {
         let defaultPrevented = null;
         mockResponse('POST', '/test', 'Submitted')

--- a/test/tests/end2end/cancel-behavior.js
+++ b/test/tests/end2end/cancel-behavior.js
@@ -128,6 +128,34 @@ describe('Cancel behavior integration tests', function() {
         defaultPrevented.should.equal(false);
     });
 
+    it('from:self trigger outside scope still prevents default navigation', function() {
+        let defaultPrevented = null;
+        const link = createProcessedHTML('<a href="/native" hx-get="/test" hx-trigger="click from:self"><span id="child">Click me</span></a>');
+
+        link.addEventListener('click', (evt) => {
+            defaultPrevented = evt.defaultPrevented;
+            evt.preventDefault();
+        });
+
+        find('#child').click();
+        defaultPrevented.should.equal(true);
+        fetchMock.calls.length.should.equal(0);
+    });
+
+    it('target trigger outside scope still prevents default navigation', function() {
+        let defaultPrevented = null;
+        const link = createProcessedHTML('<a href="/native" hx-get="/test" hx-trigger="click target:.match"><span id="child">Click me</span></a>');
+
+        link.addEventListener('click', (evt) => {
+            defaultPrevented = evt.defaultPrevented;
+            evt.preventDefault();
+        });
+
+        find('#child').click();
+        defaultPrevented.should.equal(true);
+        fetchMock.calls.length.should.equal(0);
+    });
+
     it('anchor with fragment identifier (#foo) does not prevent default', async function() {
         let defaultPrevented = null;
         createProcessedHTML('<a id="test-link" href="#section" hx-get="/test">Jump to section</a>');


### PR DESCRIPTION
Fixes #4057

Call `.preventDefault()` synchronously after trigger target checks, before delay or throttle. This keeps delayed form submissions from submitting natively.

+ a regression test verifying that delayed form submission is prevented immediately and the htmx request is still delayed.
