### PR TITLE
Add RIFE2 to the Java server examples

### DIFF
--- a/www/content/server-examples.md
+++ b/www/content/server-examples.md
@@ -88,6 +88,12 @@ These examples may make it a bit easier to get started using htmx with your plat
 - <https://github.com/ia3andy/renotes>
 - <https://github.com/ia3andy/htmx-todo>
 
+### RIFE2
+
+- <https://rife2.com/demo/htmx>
+- <https://github.com/rife2/rife2/blob/main/examples/main/java/rife/examples/HelloHtmx.java>
+- <https://github.com/rife2/rife2-pokemon>
+
 ## ColdFusion (CFML - a JVM Language)
 
 ### CFWheels Framework


### PR DESCRIPTION
Adds [RIFE2](https://rife2.com) to the Java section of the server examples page.

RIFE2 is a full-stack, no-declaration, framework for Java web applications. It has htmx support built into the engine: a single route can answer both a browser and htmx, with `printHtmxFragment` choosing whether to send the whole page or just a template block, and declaring the matching `Vary` headers so a cache never serves one to the other.

Three links, in increasing order of size:

- <https://rife2.com/demo/htmx> is a live, interactive demo, no checkout needed.
- `HelloHtmx.java` is a self-contained ~25 line example in the framework's own example set.
- [rife2-pokemon](https://github.com/rife2/rife2-pokemon) is a full search-as-you-type app using htmx and tailwind.

This only touches `www/`, so per CONTRIBUTING it is made against `master`.